### PR TITLE
Add Gitleaks Secrets Detection workflow (#20)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,42 @@
+name: Gitleaks
+
+# Detect secrets in pull request diffs using gitleaks-action.
+#
+# Mirrors the canonical NEAT-AI pattern at
+# stSoftwareAU/NEAT-AI/.github/workflows/quality.yml. Third-party
+# actions are pinned to 40-character commit SHAs (Issue #1756) so a
+# hijacked tag cannot exfiltrate CI secrets.
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+      # Fetch the PR base branch so gitleaks-action's computed commit
+      # range (`<base_sha>^..<head_sha>`) resolves on the runner.
+      # Without this step the action fails with
+      # "fatal: Invalid revision range" because the base ref's parent
+      # is not in the shallow checkout (Issue #1756). Mirrors the
+      # NEAT-AI quality.yml pattern.
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}" || true
+      # gitleaks/gitleaks-action@v2.3.9
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Org-level Gitleaks Pro licence (Issue #1636). Required for
+          # repos under stSoftwareAU/*; without it gitleaks-action exits
+          # with ErrLicense before scanning. Configure in repo or org
+          # secrets.
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ target/
 .*
 *~
 !.gitignore
-!.github!.gitattributes
+!.github/
+!.github/**
 !.gitattributes
 
 *.json.error

--- a/docs/pr-summary-20.md
+++ b/docs/pr-summary-20.md
@@ -1,0 +1,45 @@
+## Summary
+
+Added the **Gitleaks Secrets Detection** GitHub Actions workflow at
+`.github/workflows/gitleaks.yml`. The workflow runs on every pull
+request, scans the PR diff for accidentally committed secrets, and
+fails the build if any are found. Third-party actions are pinned to
+40-character commit SHAs to guard against hijacked tags.
+
+Also repaired a malformed line in `.gitignore` (`!.github!.gitattributes`)
+that prevented any new file inside `.github/` from being added. The
+replacement (`!.github/` plus `!.github/**`) restores the intent of the
+original `!`-rules so workflow YAML files can be tracked.
+
+Closes #20.
+
+## Evidence
+
+This is a CI/workflow-only change — no UI or runtime behaviour is
+affected, so there is no screenshot. Verification performed:
+
+- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/gitleaks.yml'))"`
+  confirms the YAML is syntactically valid.
+- `git check-ignore -v .github/workflows/gitleaks.yml` returns exit 0
+  before the `.gitignore` fix (file ignored) and exit 1 after, proving
+  the negation now works.
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> CO[actions/checkout]
+    CO --> FB[Fetch base branch]
+    FB --> GL[gitleaks-action]
+    GL -->|secrets found| FAIL[Fail PR]
+    GL -->|clean| PASS[Pass PR]
+```
+
+## Test Plan
+
+- [x] `.github/workflows/gitleaks.yml` parses as valid YAML.
+- [x] Both `actions/checkout` and `gitleaks/gitleaks-action` are pinned
+      to 40-character commit SHAs (no floating tags).
+- [x] `permissions:` is scoped to `contents: read` only.
+- [x] `.gitignore` no longer blocks new files inside `.github/`.
+- [ ] On the first PR after merge, the `Gitleaks` check appears in the
+      PR's status list. Requires the `GITLEAKS_LICENSE` secret to be
+      configured at repo or org level for a full scan.


### PR DESCRIPTION
## Summary

Added the **Gitleaks Secrets Detection** GitHub Actions workflow at
`.github/workflows/gitleaks.yml`. The workflow runs on every pull
request, scans the PR diff for accidentally committed secrets, and
fails the build if any are found. Third-party actions are pinned to
40-character commit SHAs to guard against hijacked tags.

Also repaired a malformed line in `.gitignore` (`!.github!.gitattributes`)
that prevented any new file inside `.github/` from being added. The
replacement (`!.github/` plus `!.github/**`) restores the intent of the
original `!`-rules so workflow YAML files can be tracked.

Closes #20.

## Evidence

This is a CI/workflow-only change — no UI or runtime behaviour is
affected, so there is no screenshot. Verification performed:

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/gitleaks.yml'))"`
  confirms the YAML is syntactically valid.
- `git check-ignore -v .github/workflows/gitleaks.yml` returns exit 0
  before the `.gitignore` fix (file ignored) and exit 1 after, proving
  the negation now works.

```mermaid
flowchart LR
    PR[Pull Request] --> CO[actions/checkout]
    CO --> FB[Fetch base branch]
    FB --> GL[gitleaks-action]
    GL -->|secrets found| FAIL[Fail PR]
    GL -->|clean| PASS[Pass PR]
```

## Test Plan

- [x] `.github/workflows/gitleaks.yml` parses as valid YAML.
- [x] Both `actions/checkout` and `gitleaks/gitleaks-action` are pinned
      to 40-character commit SHAs (no floating tags).
- [x] `permissions:` is scoped to `contents: read` only.
- [x] `.gitignore` no longer blocks new files inside `.github/`.
- [ ] On the first PR after merge, the `Gitleaks` check appears in the
      PR's status list. Requires the `GITLEAKS_LICENSE` secret to be
      configured at repo or org level for a full scan.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-20 -->