### PR TITLE
Add Markdown Lint workflow (Issue #23)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,43 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "lts/*"
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+      - name: Run markdownlint-cli2
+        run: markdownlint-cli2
+      # Optional: mirror the local check-mermaid quality gate when Deno
+      # and the worker module are available in the repo (Issue #1683).
+      - name: Detect Deno worker module
+        id: detect-deno
+        run: |
+          if [ -f worker/deno/mod.ts ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      # denoland/setup-deno@v2
+      - if: steps.detect-deno.outputs.present == 'true'
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with:
+          deno-version: v2.x
+      - if: steps.detect-deno.outputs.present == 'true'
+        name: Validate Mermaid blocks
+        run: deno run --allow-read --allow-env=DEBUG,LOG_LEVEL,CONFIG_PATH,OUTPUT_JSON worker/deno/mod.ts check-mermaid

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ target/
 !.github/
 !.github/**
 !.gitattributes
+!.markdownlint-cli2.jsonc
 
 *.json.error
 *.json.error.*

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,49 @@
+// markdownlint-cli2 configuration (Issue #23).
+//
+// Rules are tuned to flag genuinely broken markdown while accepting the
+// stylistic choices already present in this repository. Tighten as we
+// progressively clean up existing documents.
+{
+  "config": {
+    "default": true,
+    // Long lines are common in narrative documentation and tables.
+    "MD013": false,
+    // The repo's existing markdown was authored without strict blank-line
+    // discipline around headings, fences, and lists. Disable until the
+    // documentation has been swept clean.
+    "MD012": false,
+    "MD022": false,
+    "MD031": false,
+    "MD032": false,
+    // Allow code blocks without an explicit language hint.
+    "MD040": false,
+    // Allow trailing whitespace and missing final newlines in existing files.
+    "MD009": false,
+    "MD047": false,
+    // Permit bare URLs — common in troubleshooting notes.
+    "MD034": false,
+    // The first line is not always a top-level heading in sub-documents.
+    "MD041": false,
+    // Inline HTML is occasionally used (e.g. <details>, <br>).
+    "MD033": false,
+    // Duplicate headings can appear in changelog-style documents.
+    "MD024": { "siblings_only": true },
+    // Existing docs use bold-only "summary" lines as visual sub-headers.
+    "MD036": false,
+    // Existing docs use compact-style tables without surrounding spaces.
+    "MD060": false,
+    // Trailing colons in headings are common in this repo's notes.
+    "MD026": false,
+    // Multiple H1s appear in docs/README.md where review comments are quoted.
+    "MD025": false
+  },
+  "globs": [
+    "**/*.md"
+  ],
+  "ignores": [
+    "node_modules",
+    "target",
+    ".coverage",
+    "docs/pr-summary-*.md"
+  ]
+}

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,8 @@
 {
   "imports": {
-    "@std/assert": "jsr:@std/assert@^1.0.13"
+    "@std/assert": "jsr:@std/assert@^1.0.13",
+    "@std/yaml": "jsr:@std/yaml@^1.0.5",
+    "@std/jsonc": "jsr:@std/jsonc@^1.0.1"
   },
   "exclude": [
     "docs/**/*",

--- a/deno.lock
+++ b/deno.lock
@@ -8,10 +8,13 @@
     "jsr:@std/fmt@~0.225.4": "0.225.6",
     "jsr:@std/http@0.224": "0.224.5",
     "jsr:@std/internal@^1.0.6": "1.0.8",
+    "jsr:@std/json@^1.0.2": "1.1.0",
+    "jsr:@std/jsonc@^1.0.1": "1.0.2",
     "jsr:@std/media-types@^1.0.0-rc.1": "1.1.0",
     "jsr:@std/net@~0.224.3": "0.224.5",
     "jsr:@std/path@1.0.0-rc.2": "1.0.0-rc.2",
-    "jsr:@std/streams@~0.224.5": "0.224.5"
+    "jsr:@std/streams@~0.224.5": "0.224.5",
+    "jsr:@std/yaml@^1.0.5": "1.1.0"
   },
   "jsr": {
     "@std/assert@1.0.13": {
@@ -48,6 +51,15 @@
     "@std/internal@1.0.8": {
       "integrity": "fc66e846d8d38a47cffd274d80d2ca3f0de71040f855783724bb6b87f60891f5"
     },
+    "@std/json@1.1.0": {
+      "integrity": "93330d3ed4054d6b1ffe54b075432c80a5f671be77277b978931e018014cb1cc"
+    },
+    "@std/jsonc@1.0.2": {
+      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
+      "dependencies": [
+        "jsr:@std/json"
+      ]
+    },
     "@std/media-types@1.1.0": {
       "integrity": "c9d093f0c05c3512932b330e3cc1fe1d627b301db33a4c2c2185c02471d6eaa4"
     },
@@ -59,6 +71,9 @@
     },
     "@std/streams@0.224.5": {
       "integrity": "bcde7818dd5460d474cdbd674b15f6638b9cd73cd64e52bd852fba2bd4d8ec91"
+    },
+    "@std/yaml@1.1.0": {
+      "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     }
   },
   "remote": {
@@ -96,6 +111,8 @@
     "https://deno.land/std@0.208.0/async/delay.ts": "a6142eb44cdd856b645086af2b811b1fcce08ec06bb7d50969e6a872ee9b8659",
     "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
     "https://deno.land/std@0.208.0/http/server.ts": "f3cde6672e631d3e00785743cfa96bfed275618c0352c5ae84abbe5a2e0e4afc",
+    "https://deno.land/std@0.208.0/json/common.ts": "ecd5e87d45b5f0df33238ed8b1746e1444da7f5c86ae53d0f0b04280f41a25bb",
+    "https://deno.land/std@0.208.0/jsonc/parse.ts": "6048912a52d1ee3876a89f57ae6885f3b675bf2708700ef8d3d72acf6ef3342e",
     "https://deno.land/std@0.208.0/path/_common/assert_path.ts": "061e4d093d4ba5aebceb2c4da3318bfe3289e868570e9d3a8e327d91c2958946",
     "https://deno.land/std@0.208.0/path/_common/basename.ts": "0d978ff818f339cd3b1d09dc914881f4d15617432ae519c1b8fdc09ff8d3789a",
     "https://deno.land/std@0.208.0/path/_common/common.ts": "9e4233b2eeb50f8b2ae10ecc2108f58583aea6fd3e8907827020282dc2b76143",
@@ -173,6 +190,38 @@
     "https://deno.land/std@0.208.0/path/windows/separator.ts": "ae21f27015f10510ed1ac4a0ba9c4c9c967cbdd9d9e776a3e4967553c397bd5d",
     "https://deno.land/std@0.208.0/path/windows/to_file_url.ts": "8e9ea9e1ff364aa06fa72999204229952d0a279dbb876b7b838b2b2fea55cce3",
     "https://deno.land/std@0.208.0/path/windows/to_namespaced_path.ts": "e0f4d4a5e77f28a5708c1a33ff24360f35637ba6d8f103d19661255ef7bfd50d",
+    "https://deno.land/std@0.208.0/yaml/_error.ts": "b59e2c76ce5a47b1b9fa0ff9f96c1dd92ea1e1b17ce4347ece5944a95c3c1a84",
+    "https://deno.land/std@0.208.0/yaml/_loader/loader.ts": "63ec7f0a265dbbabc54b25a4beefff7650e205160a2d75c7d8f8363b5f84851a",
+    "https://deno.land/std@0.208.0/yaml/_loader/loader_state.ts": "0841870b467169269d7c2dfa75cd288c319bc06f65edd9e42c29e5fced91c7a4",
+    "https://deno.land/std@0.208.0/yaml/_mark.ts": "dcd8585dee585e024475e9f3fe27d29740670fb64ebb970388094cad0fc11d5d",
+    "https://deno.land/std@0.208.0/yaml/_state.ts": "ef03d55ec235d48dcfbecc0ab3ade90bfae69a61094846e08003421c2cf5cfc6",
+    "https://deno.land/std@0.208.0/yaml/_type/binary.ts": "24d49614463a7339a8a16d894919c2ec18a10588ae360ec352093b60e2cc8b0d",
+    "https://deno.land/std@0.208.0/yaml/_type/bool.ts": "5bfa75da84343d45347b521ba4e5aeace9fe6f53447405290d53315a3fc20e66",
+    "https://deno.land/std@0.208.0/yaml/_type/float.ts": "056bd3cb9c5586238b20517511014fb24b0e36f98f9f6073e12da308b6b9808a",
+    "https://deno.land/std@0.208.0/yaml/_type/function.ts": "ff574fe84a750695302864e1c31b93f12d14ada4bde79a5f93197fc33ad17471",
+    "https://deno.land/std@0.208.0/yaml/_type/int.ts": "563ad074f0fa7aecf6b6c3d84135bcc95a8269dcc15de878de20ce868fd773fa",
+    "https://deno.land/std@0.208.0/yaml/_type/map.ts": "7b105e4ab03a361c61e7e335a0baf4d40f06460b13920e5af3fb2783a1464000",
+    "https://deno.land/std@0.208.0/yaml/_type/merge.ts": "8192bf3e4d637f32567917f48bb276043da9cf729cf594e5ec191f7cd229337e",
+    "https://deno.land/std@0.208.0/yaml/_type/mod.ts": "060e2b3d38725094b77ea3a3f05fc7e671fced8e67ca18e525be98c4aa8f4bbb",
+    "https://deno.land/std@0.208.0/yaml/_type/nil.ts": "606e8f0c44d73117c81abec822f89ef81e40f712258c74f186baa1af659b8887",
+    "https://deno.land/std@0.208.0/yaml/_type/omap.ts": "cfe59a294726f5cea705c39a61fd2b08199cf48f4ccd6b040cb550ec0f38d0a1",
+    "https://deno.land/std@0.208.0/yaml/_type/pairs.ts": "0032fdfe57558d21696a4f8cf5b5cfd1f698743177080affc18629685c905666",
+    "https://deno.land/std@0.208.0/yaml/_type/regexp.ts": "1ce118de15b2da43b4bd8e4395f42d448b731acf3bdaf7c888f40789f9a95f8b",
+    "https://deno.land/std@0.208.0/yaml/_type/seq.ts": "95333abeec8a7e4d967b8c8328b269e342a4bbdd2585395549b9c4f58c8533a2",
+    "https://deno.land/std@0.208.0/yaml/_type/set.ts": "f28ba44e632ef2a6eb580486fd47a460445eeddbdf1dbc739c3e62486f566092",
+    "https://deno.land/std@0.208.0/yaml/_type/str.ts": "a67a3c6e429d95041399e964015511779b1130ea5889fa257c48457bd3446e31",
+    "https://deno.land/std@0.208.0/yaml/_type/timestamp.ts": "706ea80a76a73e48efaeb400ace087da1f927647b53ad6f754f4e06d51af087f",
+    "https://deno.land/std@0.208.0/yaml/_type/undefined.ts": "94a316ca450597ccbc6750cbd79097ad0d5f3a019797eed3c841a040c29540ba",
+    "https://deno.land/std@0.208.0/yaml/_utils.ts": "26b311f0d42a7ce025060bd6320a68b50e52fd24a839581eb31734cd48e20393",
+    "https://deno.land/std@0.208.0/yaml/parse.ts": "1fbbda572bf3fff578b6482c0d8b85097a38de3176bf3ab2ca70c25fb0c960ef",
+    "https://deno.land/std@0.208.0/yaml/schema.ts": "96908b78dc50c340074b93fc1598d5e7e2fe59103f89ff81e5a49b2dedf77a67",
+    "https://deno.land/std@0.208.0/yaml/schema/core.ts": "fa406f18ceedc87a50e28bb90ec7a4c09eebb337f94ef17468349794fa828639",
+    "https://deno.land/std@0.208.0/yaml/schema/default.ts": "0047e80ae8a4a93293bc4c557ae8a546aabd46bb7165b9d9b940d57b4d88bde9",
+    "https://deno.land/std@0.208.0/yaml/schema/extended.ts": "0784416bf062d20a1626b53c03380e265b3e39b9409afb9f4cb7d659fd71e60d",
+    "https://deno.land/std@0.208.0/yaml/schema/failsafe.ts": "d219ab5febc43f770917d8ec37735a4b1ad671149846cbdcade767832b42b92b",
+    "https://deno.land/std@0.208.0/yaml/schema/json.ts": "5f41dd7c2f1ad545ef6238633ce9ee3d444dfc5a18101e1768bd5504bf90e5e5",
+    "https://deno.land/std@0.208.0/yaml/schema/mod.ts": "4472e827bab5025e92bc2eb2eeefa70ecbefc64b2799b765c69af84822efef32",
+    "https://deno.land/std@0.208.0/yaml/type.ts": "65553da3da3c029b6589c6e4903f0afbea6768be8fca61580711457151f2b30f",
     "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
     "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
     "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
@@ -209,7 +258,9 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@^1.0.13"
+      "jsr:@std/assert@^1.0.13",
+      "jsr:@std/jsonc@^1.0.1",
+      "jsr:@std/yaml@^1.0.5"
     ]
   }
 }

--- a/docs/pr-summary-23.md
+++ b/docs/pr-summary-23.md
@@ -1,0 +1,55 @@
+## Summary
+
+Added a Markdown Lint GitHub Actions workflow that runs `markdownlint-cli2`
+on every pull request and on pushes to `main`/`master`. The workflow is paired
+with a project-level `.markdownlint-cli2.jsonc` configuration tuned to flag
+genuinely broken markdown without churning on the stylistic choices already
+present in the repository's existing documents. Closes #23.
+
+## Evidence
+
+This is a CI-only change with no user interface. Verification was performed by:
+
+- Running `markdownlint-cli2` locally against the current tree — exits `0`
+  with `Summary: 0 error(s)` after the config tuning.
+- Running the new Deno test suite (`tests/markdown_lint_workflow_test.ts`)
+  — 8/8 passing, including a real invocation of the `markdownlint-cli2`
+  binary against the repository's markdown files.
+- The third-party actions referenced by the workflow are pinned to 40-character
+  commit SHAs (`actions/checkout@v4`, `actions/setup-node@v4`,
+  `denoland/setup-deno@v2`) in line with the project's supply-chain guidance.
+
+```mermaid
+flowchart LR
+    PR[Pull request] --> WF[Markdown Lint workflow]
+    WF --> CO[actions/checkout]
+    CO --> SN[actions/setup-node]
+    SN --> INST[npm i -g markdownlint-cli2]
+    INST --> RUN[markdownlint-cli2]
+    RUN --> CFG[.markdownlint-cli2.jsonc]
+    RUN --> DET{worker/deno/mod.ts?}
+    DET -- no --> DONE[Pass / Fail]
+    DET -- yes --> DENO[setup-deno + check-mermaid]
+    DENO --> DONE
+```
+
+## Test Plan
+
+- New: `tests/markdown_lint_workflow_test.ts` — asserts the workflow file
+  exists, parses as YAML, declares the expected triggers, defines the
+  `markdownlint` job on `ubuntu-latest`, installs and runs
+  `markdownlint-cli2`, pins every `uses:` action to a 40-character commit
+  SHA, ships a valid JSONC config, and that `markdownlint-cli2` exits `0`
+  against the repository's existing markdown files.
+- Run with `deno test --allow-read --allow-run tests/markdown_lint_workflow_test.ts`.
+- The repository-lint assertion gracefully skips when `markdownlint-cli2`
+  is not installed on the local machine, so it stays useful in CI without
+  blocking developers without the global npm package.
+
+## Notes
+
+- `.markdownlint-cli2.jsonc` is added to the `.gitignore` re-allow list so
+  the hidden config file is tracked (it is on the project's allowlist of
+  permitted hidden files).
+- `deno.json` gains JSR `@std/yaml` and `@std/jsonc` imports used by the
+  new test, avoiding the `no-import-prefix` Deno lint rule.

--- a/tests/markdown_lint_workflow_test.ts
+++ b/tests/markdown_lint_workflow_test.ts
@@ -1,0 +1,106 @@
+// Tests for the Markdown Lint GitHub Actions workflow (Issue #23).
+//
+// These tests verify the workflow file exists, parses as YAML, and contains
+// the required steps. They also verify a markdownlint-cli2 config is present
+// so the workflow passes against the existing markdown files in this repo.
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+import { parse as parseJsonc } from "@std/jsonc";
+
+const WORKFLOW_PATH = ".github/workflows/markdown-lint.yml";
+const CONFIG_PATH = ".markdownlint-cli2.jsonc";
+
+Deno.test("Markdown Lint workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("Markdown Lint workflow parses as valid YAML", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "Markdown Lint");
+});
+
+Deno.test("Markdown Lint workflow has correct triggers", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  // YAML "on" key sometimes parses to boolean true — accept either key.
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("pull_request" in on, "must trigger on pull_request");
+  assert("push" in on, "must trigger on push");
+});
+
+Deno.test("Markdown Lint workflow defines markdownlint job", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { jobs: Record<string, unknown> };
+  assert(doc.jobs, "workflow must have jobs");
+  assert(doc.jobs.markdownlint, "markdownlint job must exist");
+  const job = doc.jobs.markdownlint as { "runs-on": string; steps: unknown[] };
+  assertEquals(job["runs-on"], "ubuntu-latest");
+  assert(
+    Array.isArray(job.steps) && job.steps.length > 0,
+    "job must have steps",
+  );
+});
+
+Deno.test("Markdown Lint workflow installs markdownlint-cli2 and runs it", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  assertStringIncludes(text, "npm install -g markdownlint-cli2");
+  assertStringIncludes(text, "markdownlint-cli2");
+});
+
+Deno.test("Markdown Lint workflow pins actions to commit SHAs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  // Each `uses:` line in the workflow must reference a 40-char SHA, not a
+  // floating tag like @v4. This matches the supply-chain rule in the guide.
+  const usesLines = text.split("\n").filter((l) => /^\s*-\s*uses:/.test(l));
+  assert(usesLines.length > 0, "workflow must use at least one action");
+  for (const line of usesLines) {
+    assert(
+      /@[0-9a-f]{40}\s*$/.test(line.trim()),
+      `action not pinned to 40-char SHA: ${line.trim()}`,
+    );
+  }
+});
+
+Deno.test("markdownlint-cli2 config exists and parses as JSONC", async () => {
+  const text = await Deno.readTextFile(CONFIG_PATH);
+  const config = parseJsonc(text) as Record<string, unknown>;
+  assert(config, "config must parse to an object");
+  assert("config" in config, "must declare rule config");
+});
+
+Deno.test("markdownlint-cli2 passes against repository markdown files", async () => {
+  // The workflow runs `markdownlint-cli2` with no args, so it uses the
+  // globs declared in the config. This test asserts the same invocation
+  // returns exit code 0 — i.e. the lint passes against existing files.
+  const cmd = new Deno.Command("markdownlint-cli2", {
+    args: [],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  let result;
+  try {
+    result = await cmd.output();
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      console.warn(
+        "markdownlint-cli2 not installed locally — skipping repository lint check",
+      );
+      return;
+    }
+    throw err;
+  }
+  if (!result.success) {
+    const stdout = new TextDecoder().decode(result.stdout);
+    const stderr = new TextDecoder().decode(result.stderr);
+    throw new Error(
+      `markdownlint-cli2 failed:\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Added a Markdown Lint GitHub Actions workflow that runs `markdownlint-cli2`
on every pull request and on pushes to `main`/`master`. The workflow is paired
with a project-level `.markdownlint-cli2.jsonc` configuration tuned to flag
genuinely broken markdown without churning on the stylistic choices already
present in the repository's existing documents. Closes #23.

## Evidence

This is a CI-only change with no user interface. Verification was performed by:

- Running `markdownlint-cli2` locally against the current tree — exits `0`
  with `Summary: 0 error(s)` after the config tuning.
- Running the new Deno test suite (`tests/markdown_lint_workflow_test.ts`)
  — 8/8 passing, including a real invocation of the `markdownlint-cli2`
  binary against the repository's markdown files.
- The third-party actions referenced by the workflow are pinned to 40-character
  commit SHAs (`actions/checkout@v4`, `actions/setup-node@v4`,
  `denoland/setup-deno@v2`) in line with the project's supply-chain guidance.

```mermaid
flowchart LR
    PR[Pull request] --> WF[Markdown Lint workflow]
    WF --> CO[actions/checkout]
    CO --> SN[actions/setup-node]
    SN --> INST[npm i -g markdownlint-cli2]
    INST --> RUN[markdownlint-cli2]
    RUN --> CFG[.markdownlint-cli2.jsonc]
    RUN --> DET{worker/deno/mod.ts?}
    DET -- no --> DONE[Pass / Fail]
    DET -- yes --> DENO[setup-deno + check-mermaid]
    DENO --> DONE
```

## Test Plan

- New: `tests/markdown_lint_workflow_test.ts` — asserts the workflow file
  exists, parses as YAML, declares the expected triggers, defines the
  `markdownlint` job on `ubuntu-latest`, installs and runs
  `markdownlint-cli2`, pins every `uses:` action to a 40-character commit
  SHA, ships a valid JSONC config, and that `markdownlint-cli2` exits `0`
  against the repository's existing markdown files.
- Run with `deno test --allow-read --allow-run tests/markdown_lint_workflow_test.ts`.
- The repository-lint assertion gracefully skips when `markdownlint-cli2`
  is not installed on the local machine, so it stays useful in CI without
  blocking developers without the global npm package.

## Notes

- `.markdownlint-cli2.jsonc` is added to the `.gitignore` re-allow list so
  the hidden config file is tracked (it is on the project's allowlist of
  permitted hidden files).
- `deno.json` gains JSR `@std/yaml` and `@std/jsonc` imports used by the
  new test, avoiding the `no-import-prefix` Deno lint rule.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-23 -->