### PR TITLE
Add Deno Dependency Updates workflow (Issue #25)

### DIFF
--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -1,0 +1,34 @@
+name: Deno Dependency Updates
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  outdated:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # denoland/setup-deno@v2.0.4
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with:
+          deno-version: v2.x
+      - name: Run deno outdated --update --latest
+        run: deno outdated --update --latest
+      # peter-evans/create-pull-request@v7.0.11
+      - uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
+        with:
+          # Org-level PAT (Issue #1636); falls back to GITHUB_TOKEN when
+          # the secret is unset. Using the PAT ensures downstream PR
+          # workflows fire on the resulting pull request.
+          token: ${{ secrets.ACTIONS_PUSH || secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update Deno dependencies"
+          title: "chore: update Deno dependencies"
+          branch: chore/deno-outdated
+          body: "Automated Deno dependency update via `deno outdated --update --latest`."

--- a/docs/pr-summary-25.md
+++ b/docs/pr-summary-25.md
@@ -1,0 +1,42 @@
+# Add Deno Dependency Updates workflow
+
+## Summary
+
+Added `.github/workflows/deno-outdated.yml`, a new GitHub Actions workflow that runs `deno outdated --update --latest` on a weekly schedule (Mondays at 06:00 UTC) and opens a pull request with the bumped dependencies. The workflow also supports manual dispatch. Third-party actions are pinned to 40-character commit SHAs to satisfy the project's supply-chain rule. Closes #25.
+
+## Evidence
+
+This change is purely a GitHub Actions workflow file plus its unit tests — there is no UI to screenshot and no runtime performance to benchmark. Verification is via the new Deno test suite, which parses the YAML and asserts the workflow's shape.
+
+```mermaid
+flowchart LR
+    A[Weekly cron / manual dispatch] --> B[Checkout repo]
+    B --> C[Setup Deno v2.x]
+    C --> D[deno outdated --update --latest]
+    D --> E[create-pull-request]
+    E --> F[chore/deno-outdated PR]
+```
+
+Test results for the new workflow (6/6 passing):
+
+```text
+running 6 tests from ./tests/deno_outdated_workflow_test.ts
+Deno Outdated workflow file exists ... ok
+Deno Outdated workflow parses as valid YAML ... ok
+Deno Outdated workflow has schedule and workflow_dispatch triggers ... ok
+Deno Outdated workflow declares write permissions for PR creation ... ok
+Deno Outdated workflow runs deno outdated and creates a PR ... ok
+Deno Outdated workflow pins actions to commit SHAs ... ok
+ok | 6 passed | 0 failed
+```
+
+Pre-existing failures in `markdown_lint_workflow_test.ts` and `schw_projection_test.ts` exist on `main` and are out of scope for this issue.
+
+## Test Plan
+
+- `tests/deno_outdated_workflow_test.ts` — six new tests verifying:
+  - the workflow file exists and parses as valid YAML;
+  - the `on` block declares both a `schedule` (with a non-empty cron) and a `workflow_dispatch` trigger;
+  - top-level `permissions` grant `contents: write` and `pull-requests: write` so `create-pull-request` can open a PR;
+  - the `outdated` job runs on `ubuntu-latest`, executes `deno outdated --update --latest`, and uses `actions/checkout`, `denoland/setup-deno`, and `peter-evans/create-pull-request`;
+  - every `uses:` line pins its action to a 40-character commit SHA (supply-chain rule).

--- a/tests/deno_outdated_workflow_test.ts
+++ b/tests/deno_outdated_workflow_test.ts
@@ -1,0 +1,102 @@
+// Tests for the Deno Dependency Updates GitHub Actions workflow (Issue #25).
+//
+// Verify the workflow file exists, parses as YAML, declares the expected
+// triggers (weekly schedule + workflow_dispatch), defines an `outdated`
+// job that runs `deno outdated --update --latest` and opens a PR, and
+// pins third-party actions to 40-character commit SHAs to satisfy the
+// supply-chain rule.
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/deno-outdated.yml";
+
+Deno.test("Deno Outdated workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("Deno Outdated workflow parses as valid YAML", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "Deno Dependency Updates");
+});
+
+Deno.test("Deno Outdated workflow has schedule and workflow_dispatch triggers", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  // YAML "on" key can parse to boolean true — accept either key.
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("schedule" in on, "must trigger on a schedule");
+  assert("workflow_dispatch" in on, "must support manual dispatch");
+  const schedule = on.schedule as Array<{ cron: string }>;
+  assert(
+    Array.isArray(schedule) && schedule.length > 0,
+    "schedule must list at least one cron entry",
+  );
+  assert(
+    schedule.some((s) => typeof s.cron === "string" && s.cron.length > 0),
+    "schedule entry must declare a non-empty cron expression",
+  );
+});
+
+Deno.test("Deno Outdated workflow declares write permissions for PR creation", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { permissions?: Record<string, string> };
+  assert(doc.permissions, "workflow must declare top-level permissions");
+  assertEquals(doc.permissions.contents, "write");
+  assertEquals(doc.permissions["pull-requests"], "write");
+});
+
+Deno.test("Deno Outdated workflow runs deno outdated and creates a PR", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { jobs: Record<string, unknown> };
+  assert(doc.jobs, "workflow must have jobs");
+  assert(doc.jobs.outdated, "outdated job must exist");
+  const job = doc.jobs.outdated as {
+    "runs-on": string;
+    steps: Array<
+      { run?: string; uses?: string; with?: Record<string, string> }
+    >;
+  };
+  assertEquals(job["runs-on"], "ubuntu-latest");
+  assert(Array.isArray(job.steps) && job.steps.length > 0, "job needs steps");
+
+  const runs = job.steps.map((s) => s.run ?? "").join("\n");
+  assert(
+    /deno\s+outdated\s+--update\s+--latest/.test(runs),
+    "job must run `deno outdated --update --latest`",
+  );
+
+  const uses = job.steps.map((s) => s.uses ?? "");
+  assert(
+    uses.some((u) => u.startsWith("actions/checkout@")),
+    "job must check out the repository",
+  );
+  assert(
+    uses.some((u) => u.startsWith("denoland/setup-deno@")),
+    "job must set up Deno",
+  );
+  assert(
+    uses.some((u) => u.startsWith("peter-evans/create-pull-request@")),
+    "job must use create-pull-request to open a PR",
+  );
+});
+
+Deno.test("Deno Outdated workflow pins actions to commit SHAs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a
+  // floating tag like @v2 or @v7.
+  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
+  assert(usesLines.length > 0, "workflow must use at least one action");
+  for (const line of usesLines) {
+    assert(
+      /@[0-9a-f]{40}\s*$/.test(line.trim()),
+      `action not pinned to 40-char SHA: ${line.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
# Add Deno Dependency Updates workflow

## Summary

Added `.github/workflows/deno-outdated.yml`, a new GitHub Actions workflow that runs `deno outdated --update --latest` on a weekly schedule (Mondays at 06:00 UTC) and opens a pull request with the bumped dependencies. The workflow also supports manual dispatch. Third-party actions are pinned to 40-character commit SHAs to satisfy the project's supply-chain rule. Closes #25.

## Evidence

This change is purely a GitHub Actions workflow file plus its unit tests — there is no UI to screenshot and no runtime performance to benchmark. Verification is via the new Deno test suite, which parses the YAML and asserts the workflow's shape.

```mermaid
flowchart LR
    A[Weekly cron / manual dispatch] --> B[Checkout repo]
    B --> C[Setup Deno v2.x]
    C --> D[deno outdated --update --latest]
    D --> E[create-pull-request]
    E --> F[chore/deno-outdated PR]
```

Test results for the new workflow (6/6 passing):

```text
running 6 tests from ./tests/deno_outdated_workflow_test.ts
Deno Outdated workflow file exists ... ok
Deno Outdated workflow parses as valid YAML ... ok
Deno Outdated workflow has schedule and workflow_dispatch triggers ... ok
Deno Outdated workflow declares write permissions for PR creation ... ok
Deno Outdated workflow runs deno outdated and creates a PR ... ok
Deno Outdated workflow pins actions to commit SHAs ... ok
ok | 6 passed | 0 failed
```

Pre-existing failures in `markdown_lint_workflow_test.ts` and `schw_projection_test.ts` exist on `main` and are out of scope for this issue.

## Test Plan

- `tests/deno_outdated_workflow_test.ts` — six new tests verifying:
  - the workflow file exists and parses as valid YAML;
  - the `on` block declares both a `schedule` (with a non-empty cron) and a `workflow_dispatch` trigger;
  - top-level `permissions` grant `contents: write` and `pull-requests: write` so `create-pull-request` can open a PR;
  - the `outdated` job runs on `ubuntu-latest`, executes `deno outdated --update --latest`, and uses `actions/checkout`, `denoland/setup-deno`, and `peter-evans/create-pull-request`;
  - every `uses:` line pins its action to a 40-character commit SHA (supply-chain rule).



---

🤖 Processed by: stservice<!-- vibe-worker-issue-25 -->