### PR TITLE
Add Semgrep SAST Scanning workflow (Issue #21)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,32 @@
+name: Semgrep
+
+# Static analysis security testing (SAST) via Semgrep (Issue #21).
+#
+# Runs the Semgrep `p/default` ruleset on every pull request. The job
+# runs inside the official `semgrep/semgrep` container so the CLI is
+# pre-installed. SEMGREP_APP_TOKEN, when present as a repo/org secret,
+# uploads findings to Semgrep AppSec Platform; without it the scan still
+# runs locally and fails the build on findings.
+#
+# Third-party actions are pinned to 40-character commit SHAs to satisfy
+# the supply-chain rule (Issue #1756 / dep-bump guidelines).
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      # actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Run Semgrep CI
+        run: semgrep ci --config p/default
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/docs/pr-summary-21.md
+++ b/docs/pr-summary-21.md
@@ -1,0 +1,47 @@
+## Summary
+
+Added the Semgrep SAST Scanning GitHub Actions workflow at
+`.github/workflows/semgrep.yml`. The workflow runs `semgrep ci --config
+p/default` inside the official `semgrep/semgrep` container on every
+pull request, surfacing static-analysis findings before merge. Closes
+#21.
+
+Supply-chain hardening per the repo's existing pattern (gitleaks,
+cargo-audit): `actions/checkout` is pinned to a 40-character commit
+SHA rather than a floating tag. `SEMGREP_APP_TOKEN` is passed through
+from repo/org secrets so findings can also be uploaded to Semgrep
+AppSec Platform when configured; when the secret is absent the scan
+still runs locally and fails the build on findings.
+
+## Evidence
+
+Backend/CI-only change — no UI to screenshot. Evidence is the new
+test suite plus the workflow file itself.
+
+```mermaid
+flowchart LR
+    A[Pull request opened] --> B[Semgrep workflow]
+    B --> C[Checkout repo]
+    C --> D[semgrep ci --config p/default]
+    D --> E{Findings?}
+    E -->|yes| F[Fail PR check]
+    E -->|no| G[Pass PR check]
+    D --> H[Upload to AppSec Platform<br/>if SEMGREP_APP_TOKEN set]
+```
+
+## Test Plan
+
+- Added `tests/semgrep_workflow_test.ts` with six TDD tests that
+  verify the new workflow file:
+  - exists at `.github/workflows/semgrep.yml`;
+  - parses as valid YAML with `name: Semgrep`;
+  - triggers on `pull_request`;
+  - declares top-level read-only `contents` permission;
+  - defines a `semgrep` job that runs in the `semgrep/semgrep`
+    container and invokes `semgrep ci`;
+  - pins every `uses:` reference to a 40-character commit SHA.
+- All 6 new tests pass under `deno test --allow-read
+  tests/semgrep_workflow_test.ts`.
+- The 2 pre-existing failures (`schw_projection_test`,
+  `markdown_lint_workflow_test`) are unrelated to this change and were
+  confirmed present on `main` before this branch.

--- a/tests/semgrep_workflow_test.ts
+++ b/tests/semgrep_workflow_test.ts
@@ -1,0 +1,80 @@
+// Tests for the Semgrep SAST GitHub Actions workflow (Issue #21).
+//
+// Verify the workflow file exists, parses as YAML, declares the expected
+// pull_request trigger, declares read-only contents permission, defines a
+// `semgrep` job that runs in the semgrep/semgrep container and invokes
+// `semgrep ci`, and pins third-party actions to 40-character commit SHAs
+// to satisfy the supply-chain rule.
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/semgrep.yml";
+
+Deno.test("Semgrep workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("Semgrep workflow parses as valid YAML with expected name", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "Semgrep");
+});
+
+Deno.test("Semgrep workflow triggers on pull_request", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  // YAML "on" key sometimes parses to boolean true — accept either key.
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("pull_request" in on, "must trigger on pull_request");
+});
+
+Deno.test("Semgrep workflow declares read-only contents permission", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { permissions?: Record<string, string> };
+  assert(doc.permissions, "workflow must declare top-level permissions");
+  assertEquals(doc.permissions.contents, "read");
+});
+
+Deno.test("Semgrep workflow defines semgrep job that runs `semgrep ci`", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { jobs: Record<string, unknown> };
+  assert(doc.jobs, "workflow must declare jobs");
+  assert(doc.jobs.semgrep, "semgrep job must exist");
+  const job = doc.jobs.semgrep as {
+    "runs-on": string;
+    container?: { image?: string } | string;
+    steps: Array<{ run?: string; uses?: string }>;
+  };
+  assertEquals(job["runs-on"], "ubuntu-latest");
+  const containerImage = typeof job.container === "string"
+    ? job.container
+    : job.container?.image;
+  assert(
+    typeof containerImage === "string" &&
+      containerImage.startsWith("semgrep/semgrep"),
+    "job must run in the semgrep/semgrep container",
+  );
+  assert(Array.isArray(job.steps) && job.steps.length > 0, "job needs steps");
+  const runs = job.steps.map((s) => s.run ?? "").join("\n");
+  assert(/semgrep\s+ci/.test(runs), "semgrep job must run `semgrep ci`");
+});
+
+Deno.test("Semgrep workflow pins actions to commit SHAs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a
+  // floating tag like @stable or @v4.
+  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
+  assert(usesLines.length > 0, "workflow must use at least one action");
+  for (const line of usesLines) {
+    assert(
+      /@[0-9a-f]{40}\s*$/.test(line.trim()),
+      `action not pinned to 40-char SHA: ${line.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Added the Semgrep SAST Scanning GitHub Actions workflow at
`.github/workflows/semgrep.yml`. The workflow runs `semgrep ci --config
p/default` inside the official `semgrep/semgrep` container on every
pull request, surfacing static-analysis findings before merge. Closes
#21.

Supply-chain hardening per the repo's existing pattern (gitleaks,
cargo-audit): `actions/checkout` is pinned to a 40-character commit
SHA rather than a floating tag. `SEMGREP_APP_TOKEN` is passed through
from repo/org secrets so findings can also be uploaded to Semgrep
AppSec Platform when configured; when the secret is absent the scan
still runs locally and fails the build on findings.

## Evidence

Backend/CI-only change — no UI to screenshot. Evidence is the new
test suite plus the workflow file itself.

```mermaid
flowchart LR
    A[Pull request opened] --> B[Semgrep workflow]
    B --> C[Checkout repo]
    C --> D[semgrep ci --config p/default]
    D --> E{Findings?}
    E -->|yes| F[Fail PR check]
    E -->|no| G[Pass PR check]
    D --> H[Upload to AppSec Platform<br/>if SEMGREP_APP_TOKEN set]
```

## Test Plan

- Added `tests/semgrep_workflow_test.ts` with six TDD tests that
  verify the new workflow file:
  - exists at `.github/workflows/semgrep.yml`;
  - parses as valid YAML with `name: Semgrep`;
  - triggers on `pull_request`;
  - declares top-level read-only `contents` permission;
  - defines a `semgrep` job that runs in the `semgrep/semgrep`
    container and invokes `semgrep ci`;
  - pins every `uses:` reference to a 40-character commit SHA.
- All 6 new tests pass under `deno test --allow-read
  tests/semgrep_workflow_test.ts`.
- The 2 pre-existing failures (`schw_projection_test`,
  `markdown_lint_workflow_test`) are unrelated to this change and were
  confirmed present on `main` before this branch.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-21 -->