### PR TITLE
Add ShellCheck Lint workflow (Issue #27)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+name: ShellCheck
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # ludeeus/action-shellcheck pinned to commit SHA (Issue #27)
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca
+        with:
+          scandir: .
+          severity: warning

--- a/docs/pr-summary-27.md
+++ b/docs/pr-summary-27.md
@@ -1,0 +1,38 @@
+## Summary
+
+Added a ShellCheck Lint GitHub Actions workflow at `.github/workflows/shellcheck.yml`
+that runs on pull requests and pushes to `main`/`master`. The workflow scans every
+shell script in the repository at `warning` severity using
+[`ludeeus/action-shellcheck`](https://github.com/ludeeus/action-shellcheck).
+
+Both third-party actions are pinned to commit SHAs (not version tags) per the
+supply-chain guidelines.
+
+Also removed two unused variables (`SCRIPT_NAME`, `MAX_STALE_SECONDS`) from
+`run.sh` that triggered `SC2034` warnings — without this fix the new lint
+workflow would fail on first run.
+
+Closes #27.
+
+## Evidence
+
+This change is a backend/CI addition with no web interface. Validation performed:
+
+- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/shellcheck.yml'))"` &rarr; YAML parses.
+- `bash -n run.sh` &rarr; bash syntax OK after the cleanup.
+- `find . -name "*.sh" -not -path "./.git/*" -not -path "./target/*" | xargs shellcheck --severity=warning` &rarr; exit `0`, no findings across all six shell scripts (`process_date.sh`, `setup-hooks.sh`, `quality.sh`, `run.sh`, `run_annualized_tests.sh`, `helpers/server.sh`).
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> WF[ShellCheck workflow]
+    WF --> Scan[Scan *.sh at severity=warning]
+    Scan -->|clean| Pass[CI green]
+    Scan -->|warning| Fail[CI red]
+```
+
+## Test Plan
+
+- [x] Local ShellCheck pass on all six `*.sh` scripts at `severity=warning`.
+- [x] YAML syntax validated with `yaml.safe_load`.
+- [x] Bash syntax for the edited `run.sh` validated with `bash -n`.
+- [ ] First CI run on the PR exercises the new workflow end-to-end on GitHub-hosted runners.

--- a/run.sh
+++ b/run.sh
@@ -15,9 +15,6 @@
 # Configuration
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
-MAX_STALE_SECONDS=14400 # Four hours
-
 # Logging function
 log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1"


### PR DESCRIPTION
## Summary

Added a ShellCheck Lint GitHub Actions workflow at `.github/workflows/shellcheck.yml`
that runs on pull requests and pushes to `main`/`master`. The workflow scans every
shell script in the repository at `warning` severity using
[`ludeeus/action-shellcheck`](https://github.com/ludeeus/action-shellcheck).

Both third-party actions are pinned to commit SHAs (not version tags) per the
supply-chain guidelines.

Also removed two unused variables (`SCRIPT_NAME`, `MAX_STALE_SECONDS`) from
`run.sh` that triggered `SC2034` warnings — without this fix the new lint
workflow would fail on first run.

Closes #27.

## Evidence

This change is a backend/CI addition with no web interface. Validation performed:

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/shellcheck.yml'))"` &rarr; YAML parses.
- `bash -n run.sh` &rarr; bash syntax OK after the cleanup.
- `find . -name "*.sh" -not -path "./.git/*" -not -path "./target/*" | xargs shellcheck --severity=warning` &rarr; exit `0`, no findings across all six shell scripts (`process_date.sh`, `setup-hooks.sh`, `quality.sh`, `run.sh`, `run_annualized_tests.sh`, `helpers/server.sh`).

```mermaid
flowchart LR
    PR[Pull Request] --> WF[ShellCheck workflow]
    WF --> Scan[Scan *.sh at severity=warning]
    Scan -->|clean| Pass[CI green]
    Scan -->|warning| Fail[CI red]
```

## Test Plan

- [x] Local ShellCheck pass on all six `*.sh` scripts at `severity=warning`.
- [x] YAML syntax validated with `yaml.safe_load`.
- [x] Bash syntax for the edited `run.sh` validated with `bash -n`.
- [ ] First CI run on the PR exercises the new workflow end-to-end on GitHub-hosted runners.



---

🤖 Processed by: stservice<!-- vibe-worker-issue-27 -->