### PR TITLE
Add Deno Lint and Format workflow (Issue #26)

### DIFF
--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -1,0 +1,37 @@
+name: Deno Quality
+
+on:
+  pull_request:
+    branches: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # denoland/setup-deno@v2.0.4
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with:
+          deno-version: v2.x
+      - name: Deno lint
+        run: deno lint
+      - name: Deno fmt check
+        run: deno fmt --check
+      - name: Deno type check
+        run: deno check tests/*.ts
+      # Run tests with coverage and upload to Codecov (Issue #1636).
+      # The codecov-action is a no-op when no test files are found.
+      - name: Run tests with coverage
+        run: deno test --allow-read --allow-env --coverage=cov_profile tests/*.ts
+      - name: Generate lcov report
+        run: deno coverage cov_profile --lcov --output=coverage.lcov
+      # codecov/codecov-action@v4
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
+        with:
+          files: coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/docs/pr-summary-26.md
+++ b/docs/pr-summary-26.md
@@ -1,0 +1,35 @@
+## Summary
+
+Add the **Deno Quality** GitHub Actions workflow at `.github/workflows/deno-quality.yml`. The workflow runs `deno lint`, `deno fmt --check`, `deno check`, and `deno test` with LCOV coverage uploaded to Codecov on every pull request. All third-party actions are pinned to 40-character commit SHAs per the supply-chain rule. Closes #26.
+
+The `deno check mod.ts` step from the issue template was adapted to `deno check tests/*.ts` because this repo has no `mod.ts`; the project's `deno.json` scopes Deno operations to `tests/**/*`, matching `quality.sh`.
+
+## Evidence
+
+CLI change — no UI to screenshot. Verified by:
+
+- Running `deno test --allow-read tests/deno_quality_workflow_test.ts` — all 6 tests pass.
+- Running `deno lint`, `deno fmt --check`, and `deno check` on the new test file — clean.
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> CO[checkout]
+    CO --> SD[setup-deno]
+    SD --> L[deno lint]
+    L --> F[deno fmt --check]
+    F --> C[deno check]
+    C --> T[deno test --coverage]
+    T --> CV[deno coverage --lcov]
+    CV --> UP[codecov-action]
+```
+
+## Test Plan
+
+- Added `tests/deno_quality_workflow_test.ts` covering:
+  - workflow file exists and parses as YAML
+  - `name` is `Deno Quality`
+  - `pull_request` trigger present
+  - top-level `contents: read` permission
+  - `quality` job runs `deno lint`, `deno fmt --check`, `deno check`, `deno test ... --coverage`, and `deno coverage ... --lcov`
+  - job uses `actions/checkout`, `denoland/setup-deno`, `codecov/codecov-action`
+  - every `uses:` is pinned to a 40-char commit SHA (supply-chain rule)

--- a/tests/deno_quality_workflow_test.ts
+++ b/tests/deno_quality_workflow_test.ts
@@ -1,0 +1,101 @@
+// Tests for the Deno Quality GitHub Actions workflow (Issue #26).
+//
+// Verify the workflow file exists, parses as YAML, declares a
+// pull_request trigger, defines a `quality` job that runs
+// `deno lint`, `deno fmt --check`, `deno check`, and `deno test`
+// with coverage uploaded to Codecov, and pins third-party actions
+// to 40-character commit SHAs to satisfy the supply-chain rule.
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/deno-quality.yml";
+
+Deno.test("Deno Quality workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("Deno Quality workflow parses as valid YAML", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "Deno Quality");
+});
+
+Deno.test("Deno Quality workflow triggers on pull_request", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  // YAML "on" key can parse to boolean true — accept either key.
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("pull_request" in on, "must trigger on pull_request");
+});
+
+Deno.test("Deno Quality workflow declares read permissions for contents", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { permissions?: Record<string, string> };
+  assert(doc.permissions, "workflow must declare top-level permissions");
+  assertEquals(doc.permissions.contents, "read");
+});
+
+Deno.test("Deno Quality workflow runs lint, fmt --check, check and test", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { jobs: Record<string, unknown> };
+  assert(doc.jobs, "workflow must have jobs");
+  assert(doc.jobs.quality, "quality job must exist");
+  const job = doc.jobs.quality as {
+    "runs-on": string;
+    steps: Array<
+      { run?: string; uses?: string; with?: Record<string, string> }
+    >;
+  };
+  assertEquals(job["runs-on"], "ubuntu-latest");
+  assert(Array.isArray(job.steps) && job.steps.length > 0, "job needs steps");
+
+  const runs = job.steps.map((s) => s.run ?? "").join("\n");
+  assert(/\bdeno\s+lint\b/.test(runs), "job must run `deno lint`");
+  assert(
+    /\bdeno\s+fmt\s+--check\b/.test(runs),
+    "job must run `deno fmt --check`",
+  );
+  assert(/\bdeno\s+check\b/.test(runs), "job must run `deno check`");
+  assert(
+    /\bdeno\s+test\b[^\n]*--coverage/.test(runs),
+    "job must run `deno test` with coverage",
+  );
+  assert(
+    /deno\s+coverage[^\n]*--lcov/.test(runs),
+    "job must export lcov coverage",
+  );
+
+  const uses = job.steps.map((s) => s.uses ?? "");
+  assert(
+    uses.some((u) => u.startsWith("actions/checkout@")),
+    "job must check out the repository",
+  );
+  assert(
+    uses.some((u) => u.startsWith("denoland/setup-deno@")),
+    "job must set up Deno",
+  );
+  assert(
+    uses.some((u) => u.startsWith("codecov/codecov-action@")),
+    "job must upload coverage to Codecov",
+  );
+});
+
+Deno.test("Deno Quality workflow pins actions to commit SHAs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a
+  // floating tag like @v2 or @v4.
+  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
+  assert(usesLines.length > 0, "workflow must use at least one action");
+  for (const line of usesLines) {
+    assert(
+      /@[0-9a-f]{40}\s*$/.test(line.trim()),
+      `action not pinned to 40-char SHA: ${line.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Add the **Deno Quality** GitHub Actions workflow at `.github/workflows/deno-quality.yml`. The workflow runs `deno lint`, `deno fmt --check`, `deno check`, and `deno test` with LCOV coverage uploaded to Codecov on every pull request. All third-party actions are pinned to 40-character commit SHAs per the supply-chain rule. Closes #26.

The `deno check mod.ts` step from the issue template was adapted to `deno check tests/*.ts` because this repo has no `mod.ts`; the project's `deno.json` scopes Deno operations to `tests/**/*`, matching `quality.sh`.

## Evidence

CLI change — no UI to screenshot. Verified by:

- Running `deno test --allow-read tests/deno_quality_workflow_test.ts` — all 6 tests pass.
- Running `deno lint`, `deno fmt --check`, and `deno check` on the new test file — clean.

```mermaid
flowchart LR
    PR[Pull Request] --> CO[checkout]
    CO --> SD[setup-deno]
    SD --> L[deno lint]
    L --> F[deno fmt --check]
    F --> C[deno check]
    C --> T[deno test --coverage]
    T --> CV[deno coverage --lcov]
    CV --> UP[codecov-action]
```

## Test Plan

- Added `tests/deno_quality_workflow_test.ts` covering:
  - workflow file exists and parses as YAML
  - `name` is `Deno Quality`
  - `pull_request` trigger present
  - top-level `contents: read` permission
  - `quality` job runs `deno lint`, `deno fmt --check`, `deno check`, `deno test ... --coverage`, and `deno coverage ... --lcov`
  - job uses `actions/checkout`, `denoland/setup-deno`, `codecov/codecov-action`
  - every `uses:` is pinned to a 40-char commit SHA (supply-chain rule)



---

🤖 Processed by: stservice<!-- vibe-worker-issue-26 -->