### PR TITLE
chore: update Deno dependencies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
   "imports": {
-    "@std/assert": "jsr:@std/assert@^1.0.13",
-    "@std/yaml": "jsr:@std/yaml@^1.0.5",
-    "@std/jsonc": "jsr:@std/jsonc@^1.0.1"
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/yaml": "jsr:@std/yaml@^1.1.0",
+    "@std/jsonc": "jsr:@std/jsonc@^1.0.2"
   },
   "exclude": [
     "docs/**/*",

--- a/deno.lock
+++ b/deno.lock
@@ -1,24 +1,23 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@^1.0.13": "1.0.13",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@^1.0.0-rc.1": "1.0.12",
     "jsr:@std/cli@~0.224.7": "0.224.7",
     "jsr:@std/encoding@1.0.0-rc.2": "1.0.0-rc.2",
     "jsr:@std/fmt@~0.225.4": "0.225.6",
     "jsr:@std/http@0.224": "0.224.5",
-    "jsr:@std/internal@^1.0.6": "1.0.8",
-    "jsr:@std/json@^1.0.2": "1.1.0",
-    "jsr:@std/jsonc@^1.0.1": "1.0.2",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/jsonc@^1.0.2": "1.0.2",
     "jsr:@std/media-types@^1.0.0-rc.1": "1.1.0",
     "jsr:@std/net@~0.224.3": "0.224.5",
     "jsr:@std/path@1.0.0-rc.2": "1.0.0-rc.2",
     "jsr:@std/streams@~0.224.5": "0.224.5",
-    "jsr:@std/yaml@^1.0.5": "1.1.0"
+    "jsr:@std/yaml@^1.1.0": "1.1.0"
   },
   "jsr": {
-    "@std/assert@1.0.13": {
-      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal"
       ]
@@ -48,17 +47,11 @@
         "jsr:@std/streams"
       ]
     },
-    "@std/internal@1.0.8": {
-      "integrity": "fc66e846d8d38a47cffd274d80d2ca3f0de71040f855783724bb6b87f60891f5"
-    },
-    "@std/json@1.1.0": {
-      "integrity": "93330d3ed4054d6b1ffe54b075432c80a5f671be77277b978931e018014cb1cc"
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
     },
     "@std/jsonc@1.0.2": {
-      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
-      "dependencies": [
-        "jsr:@std/json"
-      ]
+      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7"
     },
     "@std/media-types@1.1.0": {
       "integrity": "c9d093f0c05c3512932b330e3cc1fe1d627b301db33a4c2c2185c02471d6eaa4"
@@ -258,9 +251,9 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@^1.0.13",
-      "jsr:@std/jsonc@^1.0.1",
-      "jsr:@std/yaml@^1.0.5"
+      "jsr:@std/assert@^1.0.19",
+      "jsr:@std/jsonc@^1.0.2",
+      "jsr:@std/yaml@^1.1.0"
     ]
   }
 }


### PR DESCRIPTION
Automated Deno dependency update via `deno outdated --update --latest`.