### PR TITLE
🟢 SCR-RUNBOOK: no SECURITY.md (no disclosure contact or emergency-bump procedure) (Issue #52)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+This repository (`grq-validation`) is a hybrid Rust + Deno project. This
+policy tells a reporter who to contact and gives the maintainers a rehearsed
+steer for cutting an emergency dependency bump if a transitive crate or JSR
+module is found to be compromised.
+
+## Reporting a vulnerability
+
+Please report any suspected vulnerability — including a compromised
+dependency — privately to **security@stsoftware.com.au**.
+
+- Do **not** open a public GitHub issue for a security report.
+- Include the affected component, the version, and how to reproduce or
+  observe the problem.
+- You will receive an acknowledgement, and we will keep you updated on the
+  remediation.
+
+You may also use GitHub's
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+to open a private advisory on this repository.
+
+## Emergency dependency-bump procedure
+
+When a malicious or vulnerable version of a dependency is disclosed, pin the
+known-safe version, refresh the lockfile, and re-run the tests before
+merging. Land the fix straight to the default branch as an out-of-band update.
+
+### Deno (JSR / `@std`) dependencies
+
+1. Pin the safe version in the `imports` map of `deno.json`.
+2. Refresh the cache and lockfile:
+
+   ```bash
+   deno cache --reload check_syntax.ts
+   deno outdated            # confirm the pinned version is in effect
+   ```
+
+3. Regenerate `deno.lock` (delete and re-resolve if needed) so the safe
+   version is locked.
+4. Verify before merging:
+
+   ```bash
+   deno test --allow-read tests/*.ts
+   ```
+
+### Rust (Cargo) dependencies
+
+1. Pin the safe version precisely:
+
+   ```bash
+   cargo update -p <crate> --precise <version>
+   ```
+
+2. Confirm the advisory is cleared and re-run the test suite:
+
+   ```bash
+   cargo audit
+   cargo test --all-targets --all-features
+   ```
+
+A few minutes of this rehearsed procedure is enough — the goal is that a
+reporter knows who to tell and the team has an agreed steer for the
+out-of-band update, not an exhaustive runbook.

--- a/docs/archive/pr-summaries/pr-summary-52.md
+++ b/docs/archive/pr-summaries/pr-summary-52.md
@@ -1,0 +1,58 @@
+# PR Summary — SCR-RUNBOOK: add SECURITY.md
+
+## Summary
+
+The repository had no `SECURITY.md`, so there was no published disclosure
+contact and no written emergency-bump procedure for responding to a
+compromised dependency of this Rust + Deno project. This PR adds a short
+root `SECURITY.md` that closes the SCR-RUNBOOK posture/readiness gap:
+
+- A disclosure contact — **security@stsoftware.com.au** — plus a pointer to
+  GitHub private vulnerability reporting.
+- A one-section emergency dependency-bump procedure naming the exact
+  commands for each toolchain:
+  - **Deno (JSR):** pin the safe version in `deno.json` `imports`, run
+    `deno cache --reload` / `deno outdated`, refresh `deno.lock`, and run
+    `deno test --allow-read tests/*.ts` before merging.
+  - **Rust (Cargo):** `cargo update -p <crate> --precise <version>`, then
+    `cargo audit` and `cargo test`.
+
+This is posture/readiness hygiene, not an active vulnerability.
+
+Closes #52.
+
+## Evidence
+
+Documentation/CLI change — no web interface to screenshot. Verified via the
+new Deno test suite and markdownlint:
+
+```text
+deno test --allow-read tests/security_md_test.ts
+ok | 4 passed | 0 failed
+
+deno test --allow-read tests/*.ts
+ok | 97 passed (57 steps) | 0 failed
+
+markdownlint-cli2 SECURITY.md
+Summary: 0 error(s)
+```
+
+```mermaid
+flowchart LR
+    A[Compromised dep disclosed] --> B[Report to security@stsoftware.com.au]
+    B --> C{Toolchain?}
+    C -->|Deno| D[Pin in deno.json -> refresh deno.lock -> deno test]
+    C -->|Rust| E[cargo update --precise -> cargo audit -> cargo test]
+    D --> F[Merge out-of-band bump]
+    E --> F
+```
+
+## Test Plan
+
+- Added `tests/security_md_test.ts` (TDD — written failing first, then made
+  to pass):
+  - `SECURITY.md exists at the repository root`
+  - `SECURITY.md publishes a disclosure contact`
+  - `SECURITY.md documents the Deno emergency-bump procedure`
+  - `SECURITY.md documents the Rust emergency-bump procedure`
+- Confirmed the full Deno suite (`tests/*.ts`) still passes (97 tests).

--- a/tests/security_md_test.ts
+++ b/tests/security_md_test.ts
@@ -1,0 +1,61 @@
+// Tests for SECURITY.md supply-chain readiness runbook (Issue #52).
+//
+// Verify the repository publishes a root SECURITY.md that names a
+// disclosure contact and documents an emergency dependency-bump
+// procedure for both the Deno (JSR) and Rust (Cargo) sides of this
+// hybrid project. This is the SCR-RUNBOOK posture/readiness gap: a
+// reporter must know who to tell, and the team must have a rehearsed
+// steer for an out-of-band update.
+
+import { assert } from "@std/assert";
+
+const SECURITY_PATH = "SECURITY.md";
+
+async function readSecurity(): Promise<string> {
+  return await Deno.readTextFile(SECURITY_PATH);
+}
+
+Deno.test("SECURITY.md exists at the repository root", async () => {
+  const stat = await Deno.stat(SECURITY_PATH);
+  assert(stat.isFile, `${SECURITY_PATH} should be a file`);
+});
+
+Deno.test("SECURITY.md publishes a disclosure contact", async () => {
+  const text = await readSecurity();
+  assert(
+    text.includes("security@stsoftware.com.au"),
+    "SECURITY.md must publish a disclosure contact email",
+  );
+});
+
+Deno.test("SECURITY.md documents the Deno emergency-bump procedure", async () => {
+  const text = await readSecurity();
+  assert(
+    text.includes("deno.json"),
+    "Deno procedure must reference pinning the safe version in deno.json",
+  );
+  assert(
+    text.includes("deno.lock"),
+    "Deno procedure must reference refreshing deno.lock",
+  );
+  assert(
+    /deno test/.test(text),
+    "Deno procedure must reference running deno test before merging",
+  );
+});
+
+Deno.test("SECURITY.md documents the Rust emergency-bump procedure", async () => {
+  const text = await readSecurity();
+  assert(
+    /cargo update -p/.test(text),
+    "Rust procedure must reference cargo update -p <crate> --precise",
+  );
+  assert(
+    /cargo audit/.test(text),
+    "Rust procedure must reference cargo audit",
+  );
+  assert(
+    /cargo test/.test(text),
+    "Rust procedure must reference running cargo test",
+  );
+});


### PR DESCRIPTION
# PR Summary — SCR-RUNBOOK: add SECURITY.md

## Summary

The repository had no `SECURITY.md`, so there was no published disclosure
contact and no written emergency-bump procedure for responding to a
compromised dependency of this Rust + Deno project. This PR adds a short
root `SECURITY.md` that closes the SCR-RUNBOOK posture/readiness gap:

- A disclosure contact — **security@stsoftware.com.au** — plus a pointer to
  GitHub private vulnerability reporting.
- A one-section emergency dependency-bump procedure naming the exact
  commands for each toolchain:
  - **Deno (JSR):** pin the safe version in `deno.json` `imports`, run
    `deno cache --reload` / `deno outdated`, refresh `deno.lock`, and run
    `deno test --allow-read tests/*.ts` before merging.
  - **Rust (Cargo):** `cargo update -p <crate> --precise <version>`, then
    `cargo audit` and `cargo test`.

This is posture/readiness hygiene, not an active vulnerability.

Closes #52.

## Evidence

Documentation/CLI change — no web interface to screenshot. Verified via the
new Deno test suite and markdownlint:

```text
deno test --allow-read tests/security_md_test.ts
ok | 4 passed | 0 failed

deno test --allow-read tests/*.ts
ok | 97 passed (57 steps) | 0 failed

markdownlint-cli2 SECURITY.md
Summary: 0 error(s)
```

```mermaid
flowchart LR
    A[Compromised dep disclosed] --> B[Report to security@stsoftware.com.au]
    B --> C{Toolchain?}
    C -->|Deno| D[Pin in deno.json -> refresh deno.lock -> deno test]
    C -->|Rust| E[cargo update --precise -> cargo audit -> cargo test]
    D --> F[Merge out-of-band bump]
    E --> F
```

## Test Plan

- Added `tests/security_md_test.ts` (TDD — written failing first, then made
  to pass):
  - `SECURITY.md exists at the repository root`
  - `SECURITY.md publishes a disclosure contact`
  - `SECURITY.md documents the Deno emergency-bump procedure`
  - `SECURITY.md documents the Rust emergency-bump procedure`
- Confirmed the full Deno suite (`tests/*.ts`) still passes (97 tests).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpwiccaa-f5679b`<!-- vibe-worker-issue-52 -->