### PR TITLE
Add deno audit vulnerability scanning to CI (Issue #59)

### DIFF
--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -3,6 +3,9 @@ name: Deno Quality
 on:
   pull_request:
     branches: ["*"]
+  schedule:
+    # Weekly audit so a JSR/@std compromise is caught even with no open PR.
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read
@@ -23,6 +26,10 @@ jobs:
         run: deno fmt --check
       - name: Deno type check
         run: deno check tests/*.ts
+      # Scan the resolved JSR/@std dependency graph against the advisory
+      # database — the Deno-side counterpart to `cargo audit` (Issue #59).
+      - name: Deno audit
+        run: deno audit
       # Run tests with coverage and upload to Codecov (Issue #1636).
       # The codecov-action is a no-op when no test files are found.
       - name: Run tests with coverage

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ dependency hygiene.
 3. **Deno Outdated** (`deno-outdated.yml`) — checks for outdated JSR/npm
    imports used by the TypeScript dashboard tests.
 4. **Deno Quality** (`deno-quality.yml`) — runs `deno fmt`, `deno lint`,
-   `deno check`, and `deno test` against `tests/`.
+   `deno check`, `deno audit`, and `deno test` against `tests/` on every
+   pull request and on a weekly schedule. `deno audit` scans the resolved
+   JSR/`@std` dependency graph for known vulnerabilities — the Deno-side
+   counterpart to `cargo audit`.
 5. **Dependency Review** (`dependency-review.yml`) — reviews dependency
    changes on pull requests for known vulnerabilities and licence issues.
 6. **Gitleaks** (`gitleaks.yml`) — scans the repository for accidentally

--- a/docs/archive/pr-summaries/pr-summary-59.md
+++ b/docs/archive/pr-summaries/pr-summary-59.md
@@ -1,0 +1,60 @@
+# SCR-VULN-SCAN: Add Deno/JSR vulnerability scanning to CI
+
+## Summary
+
+The Rust dependency surface was audited in CI (`cargo audit`), but the
+Deno/JSR surface (`@std/assert`, `@std/yaml`, `@std/jsonc`) had no
+vulnerability scanner — a compromised JSR/`@std` release would pass
+through CI undetected. This wires `deno audit` into the existing
+**Deno Quality** workflow so the resolved JSR dependency graph is checked
+against the advisory database, mirroring `cargo audit` on the Rust side.
+
+Changes:
+
+- `.github/workflows/deno-quality.yml` — added a `Deno audit` step
+  (`deno audit`) after the type-check step, and added a weekly `schedule`
+  trigger (`cron: "0 6 * * 1"`, matching `cargo-audit.yml`) so a JSR
+  compromise is caught even when no pull request is open.
+- `README.md` — documented the new `deno audit` step and weekly schedule
+  under the Deno Quality workflow entry.
+- `tests/deno_quality_workflow_test.ts` — added regression tests.
+
+Closes #59.
+
+## Evidence
+
+This is a CI/workflow change with no web interface to screenshot.
+Verification was done via the test suite and by confirming `deno audit`
+runs cleanly against the current lockfile:
+
+```text
+$ deno audit
+No known vulnerabilities found
+```
+
+```mermaid
+flowchart LR
+    PR[Pull request / weekly cron] --> Q[Deno Quality job]
+    Q --> L[deno lint]
+    Q --> F[deno fmt --check]
+    Q --> C[deno check]
+    Q --> A[deno audit  ← new]
+    Q --> T[deno test + coverage]
+    A -->|advisory DB| V{Vulnerable JSR dep?}
+    V -->|yes| Fail[CI fails]
+    V -->|no| Pass[CI passes]
+```
+
+## Test Plan
+
+Added to `tests/deno_quality_workflow_test.ts` (both fail against the
+unmodified workflow, pass after the change):
+
+- `Deno Quality workflow runs deno audit (SCR-VULN-SCAN, Issue #59)` —
+  asserts the `quality` job runs `deno audit`.
+- `Deno Quality workflow triggers on a weekly schedule (Issue #59)` —
+  asserts the workflow declares a non-empty `schedule` cron trigger.
+
+Existing Deno Quality workflow tests (file exists, valid YAML,
+pull_request trigger, read-only permissions, lint/fmt/check/test steps,
+SHA-pinned actions) continue to pass. Full Deno suite: `103 passed`.

--- a/tests/deno_quality_workflow_test.ts
+++ b/tests/deno_quality_workflow_test.ts
@@ -86,6 +86,43 @@ Deno.test("Deno Quality workflow runs lint, fmt --check, check and test", async 
   );
 });
 
+Deno.test("Deno Quality workflow runs deno audit (SCR-VULN-SCAN, Issue #59)", async () => {
+  // The Deno/JSR dependency surface must be scanned for known
+  // vulnerabilities in CI, mirroring `cargo audit` on the Rust side.
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { jobs: Record<string, unknown> };
+  const job = doc.jobs.quality as {
+    steps: Array<{ run?: string }>;
+  };
+  const runs = job.steps.map((s) => s.run ?? "").join("\n");
+  assert(
+    /\bdeno\s+audit\b/.test(runs),
+    "quality job must run `deno audit` to scan JSR dependencies",
+  );
+});
+
+Deno.test("Deno Quality workflow triggers on a weekly schedule (Issue #59)", async () => {
+  // The audit should also run on the existing weekly cron so a JSR
+  // compromise is caught even without an open pull request.
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("schedule" in on, "must trigger on a schedule");
+  const schedule = on.schedule as Array<{ cron: string }>;
+  assert(
+    Array.isArray(schedule) && schedule.length > 0,
+    "schedule must list at least one cron entry",
+  );
+  assert(
+    schedule.some((s) => typeof s.cron === "string" && s.cron.length > 0),
+    "schedule entry must declare a non-empty cron expression",
+  );
+});
+
 Deno.test("Deno Quality workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a


### PR DESCRIPTION
# SCR-VULN-SCAN: Add Deno/JSR vulnerability scanning to CI

## Summary

The Rust dependency surface was audited in CI (`cargo audit`), but the
Deno/JSR surface (`@std/assert`, `@std/yaml`, `@std/jsonc`) had no
vulnerability scanner — a compromised JSR/`@std` release would pass
through CI undetected. This wires `deno audit` into the existing
**Deno Quality** workflow so the resolved JSR dependency graph is checked
against the advisory database, mirroring `cargo audit` on the Rust side.

Changes:

- `.github/workflows/deno-quality.yml` — added a `Deno audit` step
  (`deno audit`) after the type-check step, and added a weekly `schedule`
  trigger (`cron: "0 6 * * 1"`, matching `cargo-audit.yml`) so a JSR
  compromise is caught even when no pull request is open.
- `README.md` — documented the new `deno audit` step and weekly schedule
  under the Deno Quality workflow entry.
- `tests/deno_quality_workflow_test.ts` — added regression tests.

Closes #59.

## Evidence

This is a CI/workflow change with no web interface to screenshot.
Verification was done via the test suite and by confirming `deno audit`
runs cleanly against the current lockfile:

```text
$ deno audit
No known vulnerabilities found
```

```mermaid
flowchart LR
    PR[Pull request / weekly cron] --> Q[Deno Quality job]
    Q --> L[deno lint]
    Q --> F[deno fmt --check]
    Q --> C[deno check]
    Q --> A[deno audit  ← new]
    Q --> T[deno test + coverage]
    A -->|advisory DB| V{Vulnerable JSR dep?}
    V -->|yes| Fail[CI fails]
    V -->|no| Pass[CI passes]
```

## Test Plan

Added to `tests/deno_quality_workflow_test.ts` (both fail against the
unmodified workflow, pass after the change):

- `Deno Quality workflow runs deno audit (SCR-VULN-SCAN, Issue #59)` —
  asserts the `quality` job runs `deno audit`.
- `Deno Quality workflow triggers on a weekly schedule (Issue #59)` —
  asserts the workflow declares a non-empty `schedule` cron trigger.

Existing Deno Quality workflow tests (file exists, valid YAML,
pull_request trigger, read-only permissions, lint/fmt/check/test steps,
SHA-pinned actions) continue to pass. Full Deno suite: `103 passed`.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpx2l4hm-fb566e`<!-- vibe-worker-issue-59 -->