### PR TITLE
Fix path traversal via encoded `..` in helpers/server.ts (#62)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/path": "jsr:@std/path@^1.0.8",
     "@std/yaml": "jsr:@std/yaml@^1.1.1",
     "@std/jsonc": "jsr:@std/jsonc@^1.0.2"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -8,11 +8,13 @@
     "jsr:@std/fmt@~0.225.4": "0.225.6",
     "jsr:@std/http@0.224": "0.224.5",
     "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/json@^1.0.2": "1.1.0",
     "jsr:@std/jsonc@^1.0.2": "1.0.2",
     "jsr:@std/media-types@^1.0.0-rc.1": "1.1.0",
     "jsr:@std/net@~0.224.3": "0.224.5",
     "jsr:@std/path@1.0.0-rc.2": "1.0.0-rc.2",
+    "jsr:@std/path@^1.0.8": "1.1.5",
     "jsr:@std/streams@~0.224.5": "0.224.5",
     "jsr:@std/yaml@^1.1.1": "1.1.1"
   },
@@ -20,7 +22,7 @@
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/async@1.0.12": {
@@ -44,12 +46,15 @@
         "jsr:@std/fmt",
         "jsr:@std/media-types",
         "jsr:@std/net",
-        "jsr:@std/path",
+        "jsr:@std/path@1.0.0-rc.2",
         "jsr:@std/streams"
       ]
     },
     "@std/internal@1.0.13": {
       "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     },
     "@std/json@1.1.0": {
       "integrity": "93330d3ed4054d6b1ffe54b075432c80a5f671be77277b978931e018014cb1cc"
@@ -68,6 +73,12 @@
     },
     "@std/path@1.0.0-rc.2": {
       "integrity": "39f20d37a44d1867abac8d91c169359ea6e942237a45a99ee1e091b32b921c7d"
+    },
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
     },
     "@std/streams@0.224.5": {
       "integrity": "bcde7818dd5460d474cdbd674b15f6638b9cd73cd64e52bd852fba2bd4d8ec91"
@@ -260,6 +271,7 @@
     "dependencies": [
       "jsr:@std/assert@^1.0.19",
       "jsr:@std/jsonc@^1.0.2",
+      "jsr:@std/path@^1.0.8",
       "jsr:@std/yaml@^1.1.1"
     ]
   }

--- a/docs/archive/pr-summaries/pr-summary-62.md
+++ b/docs/archive/pr-summaries/pr-summary-62.md
@@ -1,0 +1,70 @@
+# Fix path traversal via encoded `..` in helpers/server.ts
+
+## Summary
+
+The static test server (`helpers/server.ts`) percent-decoded the request
+path *after* URL parsing and joined it onto the docs root with no containment
+check. The `URL` parser collapses literal `../` but leaves percent-encoded
+dots (`%2e%2e%2f`) intact, so `decodeURIComponent` turned them back into `../`
+and `join("docs", "../../etc/passwd")` escaped the docs root — letting any
+client reachable on the network read arbitrary files (the server runs with
+`--allow-read`).
+
+This change hardens `getFilePath` and binds the server to loopback only.
+**Closes #62.**
+
+### What changed
+- **Decode once, then reject traversal segments.** After decoding, any path
+  whose segments include `..` is rejected outright.
+- **Defence in depth — containment check.** The resolved absolute path is
+  compared against the resolved docs root with `resolve` + `relative`; anything
+  that resolves outside (`..`-prefixed or absolute) is rejected.
+- **Malformed escapes rejected.** A lone `%` (which makes `decodeURIComponent`
+  throw) is caught and rejected instead of 500-ing.
+- `getFilePath` now returns `string | null`; `handleRequest` responds **403
+  Forbidden** for a `null` result.
+- **Bind to `127.0.0.1`** instead of all interfaces — this is a local test
+  server, not a public host.
+- Server startup is guarded by `import.meta.main` and `getFilePath` /
+  `handleRequest` are exported, so the logic is unit-testable without binding a
+  socket.
+- Added `@std/path` to `deno.json` imports for the test's bare specifier.
+
+### Request flow
+
+```mermaid
+flowchart TD
+    A[Request path] --> B[decode once]
+    B -->|throws| R[403 Forbidden]
+    B --> C{contains '..' segment?}
+    C -->|yes| R
+    C -->|no| D[resolve under docs root]
+    D --> E{stays within docs root?}
+    E -->|no| R
+    E -->|yes| F[stat / read file -> 200/404]
+```
+
+## Evidence
+
+Backend/CLI change — no web UI to screenshot. Verified via unit tests that
+call the real `getFilePath` with the issue's exploit payloads:
+
+```
+ok | 10 passed | 0 failed (102ms)
+```
+
+The new test `getFilePath - rejects encoded ../ traversal to /etc/passwd`
+reproduces the issue trigger (`GET /%2e%2e/%2e%2e/%2e%2e/etc/passwd`) and now
+returns `null` (→ 403) instead of resolving outside the docs root. Full deno
+suite: `113 passed | 0 failed`.
+
+## Test Plan
+
+Added `tests/server_path_traversal_test.ts`:
+- **Happy path** — root, explicit `index.html`, nested asset, and `docs/`-prefixed
+  paths all resolve inside the docs root.
+- **Error path** — encoded `../` to `/etc/passwd`, literal `../`, traversal
+  behind a `docs/` prefix, mixed encoded/literal traversal, and malformed
+  percent-encoding are all rejected (`null`).
+- **Edge case** — a filename merely containing dots (`my..file.txt`) is still
+  served.

--- a/helpers/server.ts
+++ b/helpers/server.ts
@@ -10,11 +10,20 @@
  * Default port is 8000 if not specified.
  */
 
-import { join } from "https://deno.land/std@0.208.0/path/mod.ts";
+import {
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "https://deno.land/std@0.208.0/path/mod.ts";
 
 const DEFAULT_PORT = 8000;
 const DOCS_DIR = "docs";
+// Resolve the docs root once so every request can be checked for containment.
+const DOCS_ROOT = resolve(DOCS_DIR);
 const port = parseInt(Deno.args[0] ?? "") || DEFAULT_PORT;
+// Bind to loopback only — this is a local test server, not a public host.
+const HOSTNAME = "127.0.0.1";
 const DEBUG = true;
 
 const MIME_TYPES: Record<string, string> = {
@@ -40,8 +49,21 @@ function getMimeType(filename: string) {
   return MIME_TYPES[ext] ?? "application/octet-stream";
 }
 
-function getFilePath(url: string) {
-  let path = decodeURIComponent(url.substring(1));
+/**
+ * Resolve a request path to an absolute file path inside {@link DOCS_ROOT}.
+ *
+ * Returns `null` when the request is malformed or would escape the docs root,
+ * so the caller can respond with a 403 instead of serving an arbitrary file.
+ */
+export function getFilePath(url: string): string | null {
+  // Decode exactly once. A malformed escape (e.g. a lone "%") throws — reject it.
+  let path: string;
+  try {
+    path = decodeURIComponent(url.substring(1));
+  } catch {
+    if (DEBUG) console.log(`🚫 Rejected malformed URL: "${url}"`);
+    return null;
+  }
 
   if (DEBUG) {
     console.log(`🔍 Requested URL: "${url}"`);
@@ -55,14 +77,30 @@ function getFilePath(url: string) {
     path = path.substring(5) || "index.html";
   }
 
-  const fullPath = join(DOCS_DIR, path);
+  // Reject any decoded path that still contains a parent-directory segment.
+  if (path.split(/[/\\]/).some((segment) => segment === "..")) {
+    if (DEBUG) console.log(`🚫 Rejected traversal segment in: "${path}"`);
+    return null;
+  }
+
+  const fullPath = resolve(join(DOCS_ROOT, path));
+
+  // Defence in depth: confirm the resolved path stays within the docs root.
+  const rel = relative(DOCS_ROOT, fullPath);
+  if (
+    rel === ".." || rel.startsWith(`..${"/"}`) || rel.startsWith("..\\") ||
+    isAbsolute(rel)
+  ) {
+    if (DEBUG) console.log(`🚫 Rejected out-of-root path: "${fullPath}"`);
+    return null;
+  }
 
   if (DEBUG) console.log(`🎯 Final file path: "${fullPath}"`);
 
   return fullPath;
 }
 
-async function handleRequest(request: Request): Promise<Response> {
+export async function handleRequest(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const filePath = getFilePath(url.pathname);
 
@@ -70,6 +108,11 @@ async function handleRequest(request: Request): Promise<Response> {
     console.log(
       `\n📥 ${new Date().toISOString()} - ${request.method} ${url.pathname}`,
     );
+  }
+
+  if (filePath === null) {
+    if (DEBUG) console.log(`⛔ 403 - Forbidden: ${url.pathname}`);
+    return new Response("Forbidden", { status: 403 });
   }
 
   try {
@@ -111,16 +154,18 @@ async function handleRequest(request: Request): Promise<Response> {
   }
 }
 
-console.log(`🚀 Starting test server on http://localhost:${port}`);
-console.log(`📁 Serving files from: ${DOCS_DIR}`);
-console.log(`🌐 Available URLs:`);
-console.log(`   • http://localhost:${port}/ (main dashboard)`);
-console.log(`   • http://localhost:${port}/docs/ (same as root)`);
-console.log(`   • http://localhost:${port}/index.html (explicit index)`);
-console.log(`   • http://localhost:${port}/scores/ (data files)`);
-console.log(`⏹️  Press Ctrl+C to stop the server`);
-console.log(`🔍 Debug logging is ${DEBUG ? "ENABLED" : "DISABLED"}`);
-console.log("");
+if (import.meta.main) {
+  console.log(`🚀 Starting test server on http://${HOSTNAME}:${port}`);
+  console.log(`📁 Serving files from: ${DOCS_DIR}`);
+  console.log(`🌐 Available URLs:`);
+  console.log(`   • http://${HOSTNAME}:${port}/ (main dashboard)`);
+  console.log(`   • http://${HOSTNAME}:${port}/docs/ (same as root)`);
+  console.log(`   • http://${HOSTNAME}:${port}/index.html (explicit index)`);
+  console.log(`   • http://${HOSTNAME}:${port}/scores/ (data files)`);
+  console.log(`⏹️  Press Ctrl+C to stop the server`);
+  console.log(`🔍 Debug logging is ${DEBUG ? "ENABLED" : "DISABLED"}`);
+  console.log("");
 
-// new native API (no external import required)
-Deno.serve({ port }, handleRequest);
+  // new native API (no external import required)
+  Deno.serve({ port, hostname: HOSTNAME }, handleRequest);
+}

--- a/tests/server_path_traversal_test.ts
+++ b/tests/server_path_traversal_test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for path-traversal containment in the static test server.
+ *
+ * Regression coverage for issue #62: a request path was percent-decoded after
+ * URL parsing and joined onto the docs root with no `..` containment check, so
+ * `GET /%2e%2e/%2e%2e/etc/passwd` could read files outside `docs/`.
+ */
+
+import { assertEquals } from "@std/assert";
+import { resolve } from "@std/path";
+import { getFilePath } from "../helpers/server.ts";
+
+const DOCS_ROOT = resolve("docs");
+
+// Happy path — ordinary requests resolve to a file inside the docs root.
+Deno.test("getFilePath - root maps to index.html inside docs", () => {
+  assertEquals(getFilePath("/"), resolve(DOCS_ROOT, "index.html"));
+});
+
+Deno.test("getFilePath - explicit index.html stays in docs", () => {
+  assertEquals(getFilePath("/index.html"), resolve(DOCS_ROOT, "index.html"));
+});
+
+Deno.test("getFilePath - nested asset stays in docs", () => {
+  assertEquals(
+    getFilePath("/scores/data.json"),
+    resolve(DOCS_ROOT, "scores/data.json"),
+  );
+});
+
+Deno.test("getFilePath - docs/ prefix is stripped to a contained path", () => {
+  assertEquals(
+    getFilePath("/docs/styles.css"),
+    resolve(DOCS_ROOT, "styles.css"),
+  );
+});
+
+// Error path — percent-encoded traversal must be rejected (the issue trigger).
+Deno.test("getFilePath - rejects encoded ../ traversal to /etc/passwd", () => {
+  assertEquals(getFilePath("/%2e%2e/%2e%2e/%2e%2e/etc/passwd"), null);
+});
+
+Deno.test("getFilePath - rejects literal ../ traversal", () => {
+  assertEquals(getFilePath("/../../etc/passwd"), null);
+});
+
+Deno.test("getFilePath - rejects traversal hidden behind docs/ prefix", () => {
+  assertEquals(getFilePath("/docs/../../etc/passwd"), null);
+});
+
+Deno.test("getFilePath - rejects mixed encoded/literal traversal", () => {
+  assertEquals(getFilePath("/%2e%2e/../etc/passwd"), null);
+});
+
+Deno.test("getFilePath - rejects malformed percent-encoding", () => {
+  // A lone "%" makes decodeURIComponent throw; the request must be rejected.
+  assertEquals(getFilePath("/%"), null);
+});
+
+// Edge case — a filename that merely contains dots is fine.
+Deno.test("getFilePath - allows dotted filenames that are not traversal", () => {
+  assertEquals(
+    getFilePath("/my..file.txt"),
+    resolve(DOCS_ROOT, "my..file.txt"),
+  );
+});


### PR DESCRIPTION
# Fix path traversal via encoded `..` in helpers/server.ts

## Summary

The static test server (`helpers/server.ts`) percent-decoded the request
path *after* URL parsing and joined it onto the docs root with no containment
check. The `URL` parser collapses literal `../` but leaves percent-encoded
dots (`%2e%2e%2f`) intact, so `decodeURIComponent` turned them back into `../`
and `join("docs", "../../etc/passwd")` escaped the docs root — letting any
client reachable on the network read arbitrary files (the server runs with
`--allow-read`).

This change hardens `getFilePath` and binds the server to loopback only.
**Closes #62.**

### What changed
- **Decode once, then reject traversal segments.** After decoding, any path
  whose segments include `..` is rejected outright.
- **Defence in depth — containment check.** The resolved absolute path is
  compared against the resolved docs root with `resolve` + `relative`; anything
  that resolves outside (`..`-prefixed or absolute) is rejected.
- **Malformed escapes rejected.** A lone `%` (which makes `decodeURIComponent`
  throw) is caught and rejected instead of 500-ing.
- `getFilePath` now returns `string | null`; `handleRequest` responds **403
  Forbidden** for a `null` result.
- **Bind to `127.0.0.1`** instead of all interfaces — this is a local test
  server, not a public host.
- Server startup is guarded by `import.meta.main` and `getFilePath` /
  `handleRequest` are exported, so the logic is unit-testable without binding a
  socket.
- Added `@std/path` to `deno.json` imports for the test's bare specifier.

### Request flow

```mermaid
flowchart TD
    A[Request path] --> B[decode once]
    B -->|throws| R[403 Forbidden]
    B --> C{contains '..' segment?}
    C -->|yes| R
    C -->|no| D[resolve under docs root]
    D --> E{stays within docs root?}
    E -->|no| R
    E -->|yes| F[stat / read file -> 200/404]
```

## Evidence

Backend/CLI change — no web UI to screenshot. Verified via unit tests that
call the real `getFilePath` with the issue's exploit payloads:

```
ok | 10 passed | 0 failed (102ms)
```

The new test `getFilePath - rejects encoded ../ traversal to /etc/passwd`
reproduces the issue trigger (`GET /%2e%2e/%2e%2e/%2e%2e/etc/passwd`) and now
returns `null` (→ 403) instead of resolving outside the docs root. Full deno
suite: `113 passed | 0 failed`.

## Test Plan

Added `tests/server_path_traversal_test.ts`:
- **Happy path** — root, explicit `index.html`, nested asset, and `docs/`-prefixed
  paths all resolve inside the docs root.
- **Error path** — encoded `../` to `/etc/passwd`, literal `../`, traversal
  behind a `docs/` prefix, mixed encoded/literal traversal, and malformed
  percent-encoding are all rejected (`null`).
- **Edge case** — a filename merely containing dots (`my..file.txt`) is still
  served.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mpxkxs33-a682de`<!-- vibe-worker-issue-62 -->