### PR TITLE
Pin GitHub Actions to commit SHAs in ci.yml and dependency-review.yml (Issue #65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
       docs-changed: ${{ steps.filter.outputs.docs }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      # actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 0  # Fetch full history for proper diffs
         
@@ -65,15 +66,18 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      # actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      # dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       with:
         components: rustfmt, clippy
         
     - name: Cache dependencies
-      uses: actions/cache@v4
+      # actions/cache@v4.3.0
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: |
           ~/.cargo/registry
@@ -105,7 +109,8 @@ jobs:
       continue-on-error: true
       
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      # codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
       with:
         file: ./coverage/cobertura.xml
         flags: unittests
@@ -121,10 +126,12 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      # actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      # dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         
     # Check bash script syntax
     - name: Check Bash Script Syntax
@@ -134,7 +141,8 @@ jobs:
         echo "All bash scripts have valid syntax"
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      # actions/cache@v4.3.0
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: |
           ~/.cargo/registry
@@ -170,7 +178,8 @@ jobs:
         fi
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      # actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: grq-validation-release
         path: |
@@ -189,16 +198,20 @@ jobs:
       id-token: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      # actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       
     - name: Setup Pages
-      uses: actions/configure-pages@v4
+      # actions/configure-pages@v4.0.0
+      uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d
       
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      # actions/upload-pages-artifact@v3.0.1
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
       with:
         path: ./docs
       
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4 
+      # actions/deploy-pages@v4.0.5
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,5 +11,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      # actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/dependency-review-action@v4.9.0
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48

--- a/docs/archive/pr-summaries/pr-summary-65.md
+++ b/docs/archive/pr-summaries/pr-summary-65.md
@@ -1,0 +1,72 @@
+# PR Summary — Pin unpinned third-party GitHub Actions (Issue #65)
+
+## Summary
+
+`.github/workflows/ci.yml` and `.github/workflows/dependency-review.yml` pinned
+their GitHub Actions to mutable tags/branches (`@stable`, `@v4`, `@v3`) instead
+of 40-character commit SHAs. A mutable ref can be repointed at malicious code by
+a compromised upstream account, which would then execute in CI with the
+workflow token — most acutely the `dtolnay/rust-toolchain@stable` *branch* and
+`codecov/codecov-action@v4` (codecov was the subject of a 2021 supply-chain
+compromise). Every other workflow in the repo already pins to SHAs, so this was
+a regression from the established convention.
+
+This PR pins every action in both files to a full commit SHA with a
+`# owner/action@version` comment above the `uses:` line — matching the exact
+convention used by `deno-quality.yml`, `cargo-audit.yml`, `gitleaks.yml`, etc.
+Reused the SHAs already trusted in the repo for `actions/checkout` (v4.2.2),
+`dtolnay/rust-toolchain` (stable) and `codecov/codecov-action` (v4); resolved
+fresh SHAs for the remaining first-party actions via the GitHub tags API.
+
+Closes #65.
+
+### Actions pinned
+
+| Action | Version comment | SHA |
+| --- | --- | --- |
+| actions/checkout | v4.2.2 | `11bd71901bbe5b1630ceea73d27597364c9af683` |
+| dtolnay/rust-toolchain | stable | `29eef336d9b2848a0b548edc03f92a220660cdb8` |
+| actions/cache | v4.3.0 | `0057852bfaa89a56745cba8c7296529d2fc39830` |
+| codecov/codecov-action | v4 | `b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238` |
+| actions/upload-artifact | v4.6.2 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
+| actions/configure-pages | v4.0.0 | `1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d` |
+| actions/upload-pages-artifact | v3.0.1 | `56afc609e74202658d3ffba0e8f6dda462b719fa` |
+| actions/deploy-pages | v4.0.5 | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` |
+| actions/dependency-review-action | v4.9.0 | `2031cfc080254a8a887f58cffee85186f0e49e48` |
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via new
+Deno tests that read and assert on the actual workflow YAML.
+
+```mermaid
+flowchart LR
+    A["uses: dtolnay/rust-toolchain@stable<br/>(mutable branch)"] -->|pin| B["# dtolnay/rust-toolchain@stable<br/>uses: ...@29eef336…<br/>(immutable SHA)"]
+    A -.->|attacker repoints ref| C["malicious code runs<br/>in CI with token"]
+    B -.->|SHA cannot be repointed| D["only audited code runs"]
+```
+
+Test run:
+
+```
+ok | 9 passed | 0 failed   # ci_workflow_test.ts + dependency_review_workflow_test.ts
+ok | 112 passed | 0 failed # full Deno suite
+```
+
+## Test Plan
+
+Added (TDD — written failing first, then made to pass):
+
+- `tests/ci_workflow_test.ts`
+  - file exists and parses as valid YAML
+  - every `uses:` is pinned to a 40-char commit SHA
+  - no `uses:` line references the mutable `dtolnay/rust-toolchain@stable` branch
+  - each pinned action carries a `# owner/action@version` comment above it
+- `tests/dependency_review_workflow_test.ts`
+  - file exists and parses as valid YAML
+  - every `uses:` is pinned to a 40-char commit SHA
+  - each pinned action carries a version comment above it
+
+The SHA-pinning assertions failed against the unpinned workflows and pass after
+the fix. `deno fmt`, `deno lint`, and `deno check` are clean; the full Deno test
+suite (112 tests) passes.

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -1,0 +1,60 @@
+// Tests for the CI/CD Pipeline GitHub Actions workflow (Issue #65).
+//
+// Supply-chain hardening: every third-party (and first-party) action used
+// in ci.yml must be pinned to a 40-character commit SHA rather than a
+// mutable tag/branch (e.g. @stable, @v4). A moving ref can be repointed at
+// malicious code by a compromised upstream account and would then run in CI
+// with the workflow token. These tests enforce SHA pinning and basic
+// structural sanity.
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/ci.yml";
+
+Deno.test("CI workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("CI workflow parses as valid YAML", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "CI/CD Pipeline");
+});
+
+Deno.test("CI workflow pins every action to a 40-char commit SHA", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
+  assert(usesLines.length > 0, "workflow must use at least one action");
+  for (const line of usesLines) {
+    assert(
+      /@[0-9a-f]{40}\s*$/.test(line.trim()),
+      `action not pinned to 40-char SHA: ${line.trim()}`,
+    );
+  }
+});
+
+Deno.test("CI workflow no longer references the mutable rust-toolchain stable branch", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
+  // The branch ref must not appear on a `uses:` line (a trailing version
+  // comment above the line documenting `@stable` is fine).
+  assert(
+    !usesLines.some((l) => /dtolnay\/rust-toolchain@stable\b/.test(l)),
+    "dtolnay/rust-toolchain must be pinned to a SHA, not @stable",
+  );
+});
+
+Deno.test("CI workflow carries a version comment above each pinned action", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*-?\s*uses:/.test(lines[i])) continue;
+    const prev = (lines[i - 1] ?? "").trim();
+    assert(
+      /^#\s*\S+\/\S+@\S+/.test(prev),
+      `missing version comment above: ${lines[i].trim()}`,
+    );
+  }
+});

--- a/tests/dependency_review_workflow_test.ts
+++ b/tests/dependency_review_workflow_test.ts
@@ -1,0 +1,46 @@
+// Tests for the Dependency Review GitHub Actions workflow (Issue #65).
+//
+// Supply-chain hardening: actions in dependency-review.yml must be pinned to
+// 40-character commit SHAs rather than mutable tags (e.g. @v4), matching the
+// convention already used by the repo's other workflows.
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/dependency-review.yml";
+
+Deno.test("Dependency Review workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("Dependency Review workflow parses as valid YAML", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "Dependency Review");
+});
+
+Deno.test("Dependency Review workflow pins every action to a 40-char commit SHA", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
+  assert(usesLines.length > 0, "workflow must use at least one action");
+  for (const line of usesLines) {
+    assert(
+      /@[0-9a-f]{40}\s*$/.test(line.trim()),
+      `action not pinned to 40-char SHA: ${line.trim()}`,
+    );
+  }
+});
+
+Deno.test("Dependency Review workflow carries a version comment above each pinned action", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*-?\s*uses:/.test(lines[i])) continue;
+    const prev = (lines[i - 1] ?? "").trim();
+    assert(
+      /^#\s*\S+\/\S+@\S+/.test(prev),
+      `missing version comment above: ${lines[i].trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
# PR Summary — Pin unpinned third-party GitHub Actions (Issue #65)

## Summary

`.github/workflows/ci.yml` and `.github/workflows/dependency-review.yml` pinned
their GitHub Actions to mutable tags/branches (`@stable`, `@v4`, `@v3`) instead
of 40-character commit SHAs. A mutable ref can be repointed at malicious code by
a compromised upstream account, which would then execute in CI with the
workflow token — most acutely the `dtolnay/rust-toolchain@stable` *branch* and
`codecov/codecov-action@v4` (codecov was the subject of a 2021 supply-chain
compromise). Every other workflow in the repo already pins to SHAs, so this was
a regression from the established convention.

This PR pins every action in both files to a full commit SHA with a
`# owner/action@version` comment above the `uses:` line — matching the exact
convention used by `deno-quality.yml`, `cargo-audit.yml`, `gitleaks.yml`, etc.
Reused the SHAs already trusted in the repo for `actions/checkout` (v4.2.2),
`dtolnay/rust-toolchain` (stable) and `codecov/codecov-action` (v4); resolved
fresh SHAs for the remaining first-party actions via the GitHub tags API.

Closes #65.

### Actions pinned

| Action | Version comment | SHA |
| --- | --- | --- |
| actions/checkout | v4.2.2 | `11bd71901bbe5b1630ceea73d27597364c9af683` |
| dtolnay/rust-toolchain | stable | `29eef336d9b2848a0b548edc03f92a220660cdb8` |
| actions/cache | v4.3.0 | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| codecov/codecov-action | v4 | `b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238` |
| actions/upload-artifact | v4.6.2 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| actions/configure-pages | v4.0.0 | `1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d` |
| actions/upload-pages-artifact | v3.0.1 | `56afc609e74202658d3ffba0e8f6dda462b719fa` |
| actions/deploy-pages | v4.0.5 | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` |
| actions/dependency-review-action | v4.9.0 | `2031cfc080254a8a887f58cffee85186f0e49e48` |

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via new
Deno tests that read and assert on the actual workflow YAML.

```mermaid
flowchart LR
    A["uses: dtolnay/rust-toolchain@stable<br/>(mutable branch)"] -->|pin| B["# dtolnay/rust-toolchain@stable<br/>uses: ...@29eef336…<br/>(immutable SHA)"]
    A -.->|attacker repoints ref| C["malicious code runs<br/>in CI with token"]
    B -.->|SHA cannot be repointed| D["only audited code runs"]
```

Test run:

```
ok | 9 passed | 0 failed   # ci_workflow_test.ts + dependency_review_workflow_test.ts
ok | 112 passed | 0 failed # full Deno suite
```

## Test Plan

Added (TDD — written failing first, then made to pass):

- `tests/ci_workflow_test.ts`
  - file exists and parses as valid YAML
  - every `uses:` is pinned to a 40-char commit SHA
  - no `uses:` line references the mutable `dtolnay/rust-toolchain@stable` branch
  - each pinned action carries a `# owner/action@version` comment above it
- `tests/dependency_review_workflow_test.ts`
  - file exists and parses as valid YAML
  - every `uses:` is pinned to a 40-char commit SHA
  - each pinned action carries a version comment above it

The SHA-pinning assertions failed against the unpinned workflows and pass after
the fix. `deno fmt`, `deno lint`, and `deno check` are clean; the full Deno test
suite (112 tests) passes.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mpxnd3cz-0ecd89`<!-- vibe-worker-issue-65 -->