### PR TITLE
Extract shared projection module so TS tests exercise production code (#80)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3322,10 +3322,9 @@ class GRQValidator {
     }
 
     getDaysElapsed(scoreDate) {
-        const today = new Date();
-        const diffTime = Math.abs(today - scoreDate);
-        const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-        return diffDays;
+        // Delegate to the shared projection module (issue #80) so the browser
+        // and the Deno tests exercise identical maths.
+        return GRQProjection.getDaysElapsed(scoreDate, new Date());
     }
 
     // New method to calculate days elapsed based on actual market data availability
@@ -3381,20 +3380,20 @@ class GRQValidator {
         }
         const buyPrice = buyPriceObj.price;
 
-        // Calculate price return
-        const priceReturn = ((currentPrice - buyPrice) / buyPrice) *
-            100;
-
         // Add dividend return within 90 days
         const dividends = this.getDividendsWithin90Days(stock.stock);
         const totalDividends = dividends.reduce(
             (sum, div) => sum + div.amount,
             0,
         );
-        const dividendReturn = (totalDividends / buyPrice) * 100;
 
-        // Total return including dividends
-        return priceReturn + dividendReturn;
+        // Total return (price + dividends) via the shared projection module
+        // (issue #80) so production and tests share one implementation.
+        return GRQProjection.calculatePerformanceReturn(
+            buyPrice,
+            currentPrice,
+            totalDividends,
+        );
     }
 
     calculatePortfolioTargetPercentage() {
@@ -4418,94 +4417,21 @@ class GRQValidator {
         const projection = this.calculateHybridProjection(stock, scoreDate);
         if (!projection) return null;
 
-        const trendData = [];
-        const scoreDateTimestamp = scoreDate.getTime();
+        // The dampened-trend curve needs the regression line; the other
+        // methods derive their shape purely from the projection figures.
+        const trendLine = projection.projectionMethod === "dampened_trend"
+            ? this.calculateTrendLine(stock, scoreDate)
+            : null;
 
-        // Helper to get midnight date
-        const getDayDate = (base, day) => this.setDateToMidnight(new Date(base.getTime() + day * 24 * 60 * 60 * 1000));
+        // Delegate the weekly trend-shape generation to the shared projection
+        // module (issue #80) so production and the Deno tests share one
+        // implementation.
+        const trendData = GRQProjection.buildHybridProjectionData(
+            projection,
+            scoreDate,
+            trendLine,
+        );
 
-        if (projection.projectionMethod === "dampened_trend") {
-            const trendLine = this.calculateTrendLine(stock, scoreDate);
-            if (trendLine) {
-                const dampenFactor = projection.daysElapsed < 30 ? 0.3 : 0.5;
-                const dampenedSlope = trendLine.slope * dampenFactor;
-                // Generate weekly points up to 90 days, starting at zero
-                for (let day = 0; day <= 90; day += 7) {
-                    trendData.push({
-                        x: getDayDate(scoreDate, day),
-                        y: Math.max(dampenedSlope * day, -100)
-                    });
-                }
-                // Ensure we have exactly 90 days as the last point
-                const lastPoint = trendData[trendData.length - 1];
-                const lastPointDay = (lastPoint.x.getTime() - scoreDate.getTime()) / (24 * 60 * 60 * 1000);
-                if (lastPointDay !== 90) {
-                    trendData.push({
-                        x: getDayDate(scoreDate, 90),
-                        y: Math.max(dampenedSlope * 90, -100)
-                    });
-                }
-            }
-        } else if (projection.projectionMethod === "realistic_trajectory") {
-            // Realistic trajectory based on current performance rate
-            const current = projection.currentPerformance;
-            const daysElapsed = projection.daysElapsed;
-            const currentRate = current / daysElapsed; // % per day
-            
-            // Generate weekly points up to 90 days, starting at zero
-            for (let day = 0; day <= 90; day += 7) {
-                let predictedPerformance;
-                if (day <= daysElapsed) {
-                    // For days up to current, use linear interpolation
-                    predictedPerformance = (current / daysElapsed) * day;
-                } else {
-                    // For future days, use the projection
-                    predictedPerformance = projection.projected90DayPerformance * (day / 90);
-                }
-                
-                predictedPerformance = Math.max(Math.min(predictedPerformance, 200), -100);
-                trendData.push({
-                    x: getDayDate(scoreDate, day),
-                    y: predictedPerformance
-                });
-            }
-            
-            // Ensure we have exactly 90 days as the last point
-            const lastPoint = trendData[trendData.length - 1];
-            const lastPointDay = (lastPoint.x.getTime() - scoreDate.getTime()) / (24 * 60 * 60 * 1000);
-            if (lastPointDay !== 90) {
-                trendData.push({
-                    x: getDayDate(scoreDate, 90),
-                    y: projection.projected90DayPerformance
-                });
-            }
-        } else {
-            // Target-based or mean reversion - use the projection value from calculateHybridProjection
-            const projected90DayPerformance = projection.projected90DayPerformance;
-            
-            // Generate weekly points up to 90 days, starting at zero
-            for (let day = 0; day <= 90; day += 7) {
-                // Linear interpolation from zero to the projection
-                const progress = Math.min(day / 90, 1);
-                const predictedPerformance = projected90DayPerformance * progress;
-                
-                trendData.push({
-                    x: getDayDate(scoreDate, day),
-                    y: Math.max(Math.min(predictedPerformance, 200), -100)
-                });
-            }
-            
-            // Ensure we have exactly 90 days as the last point
-            const lastPoint = trendData[trendData.length - 1];
-            const lastPointDay = (lastPoint.x.getTime() - scoreDate.getTime()) / (24 * 60 * 60 * 1000);
-            if (lastPointDay !== 90) {
-                trendData.push({
-                    x: getDayDate(scoreDate, 90),
-                    y: projected90DayPerformance
-                });
-            }
-        }
-        
         return {
             data: trendData,
             projection: projection

--- a/docs/archive/pr-summaries/pr-summary-80.md
+++ b/docs/archive/pr-summaries/pr-summary-80.md
@@ -1,0 +1,79 @@
+## Summary
+
+The TypeScript suite reimplemented the dashboard's projection/scoring algorithms
+as test-local `Mock*` classes and asserted on the copy — tautologies that stayed
+green even if the production `GRQValidator` in `docs/app.js` drifted or broke. One
+test in `tests/trend_line_extension_test.ts` even **overrode**
+`calculateHybridProjectionData` inline and then asserted on the output of that very
+function; `tests/integration_test.ts` recomputed formulas inline and asserted on its
+own arithmetic (`20.0 ≈ 20.0`, `22.0`).
+
+This change applies resolution **(a)** from the issue (extract the maths into a
+module both `docs/app.js` and the tests import) for the core projection/scoring
+kernels, and resolution **(b)** (delete the named tautologies) for the inline
+method-override and inline-arithmetic steps:
+
+- **New shared module `docs/projection.js`** — a classic-script module published on
+  `globalThis` (mirroring `docs/escape.js`), with no module syntax, importable by
+  both the browser dashboard and the Deno tests. It exports `setDateToMidnight`,
+  `getDaysElapsed`, `calculatePerformanceReturn`, and `buildHybridProjectionData`.
+- **`GRQValidator` now delegates** `getDaysElapsed`, the performance-return maths in
+  `calculateStockPerformance`, and the hybrid trend-shape generation in
+  `calculateHybridProjectionData` to the shared module, so production and tests
+  exercise one implementation (no parallel copy to drift).
+- **`docs/index.html`** loads `projection.js` before `app.js`, next to `escape.js`.
+- **Tests rewritten to drive the real code** — the projection-data tests and the
+  integration performance step now import `docs/projection.js` and assert on the
+  shipped functions' observable output. A bug in the production trend-shape
+  generation now fails these tests.
+
+The remaining mock-validator test files (`realistic_projection_test.ts`,
+`chart_data_test.ts`, `basic_score_table_test.ts`, `buy_price_logic_test.ts`,
+`current_price_consistency_test.ts`, `hybrid_projection_tests.ts`,
+`judgement_hybrid_test.ts`, `portfolio_view_consistency_test.ts`,
+`schw_projection_test.ts`) depend on still-stateful logic (`getBuyPrice`,
+`calculateTrendLine`, `calculateHybridProjection`, the dilution variants) whose
+extraction touches DOM/market-data code paths that cannot be exercised headlessly.
+Converting them is larger and riskier than this scope, so it is tracked as
+follow-up issue **stSoftwareAU/GRQ-validation#100**.
+
+Closes #80.
+
+## Evidence
+
+This is a test-architecture / CLI change with no visual UI change, so no screenshot
+applies. The fix is verified by the rewritten tests, which now exercise the real
+shipped code path instead of a local mock:
+
+```mermaid
+flowchart LR
+    subgraph Before
+        T1[TS test] --> M[local Mock* copy]
+        A1[docs/app.js GRQValidator] -. never imported .-> T1
+    end
+    subgraph After
+        T2[TS test] --> P[docs/projection.js]
+        A2[docs/app.js GRQValidator] --> P
+    end
+```
+
+The shared module is the single source of truth: `GRQValidator` and the tests both
+call into `docs/projection.js`, so a regression in the production maths now breaks
+the suite.
+
+## Test Plan
+
+- **`tests/projection_module_test.ts`** (new) — 12 behavioural tests importing the
+  real `docs/projection.js`: `getDaysElapsed`, `calculatePerformanceReturn`
+  (happy/loss/invalid-buy-price), `setDateToMidnight` (no input mutation), and
+  `buildHybridProjectionData` for the `target_based`, `dampened_trend` (incl. no
+  trend line) and `realistic_trajectory` methods plus the -100% floor.
+- **`tests/trend_line_extension_test.ts`** — projection-data tests now call the real
+  `buildHybridProjectionData`; the inline `calculateHybridProjectionData` override
+  and the `Mock*` reimplementations were removed. The `calculateTrendLine`
+  regression test is retained (that function is extracted in #100).
+- **`tests/integration_test.ts`** — the performance step now calls the real
+  `calculatePerformanceReturn`; the `20.0 ≈ 20.0` tautology was removed.
+- Full Deno suite: `deno test --allow-read tests/*.ts` → **144 passed, 0 failed**.
+- `deno fmt`, `deno lint`, `deno check` all clean; `cargo check --all-targets` clean
+  (no Rust files changed).

--- a/docs/index.html
+++ b/docs/index.html
@@ -233,6 +233,9 @@
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
     <script src="escape.js"></script>
 
+    <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
+    <script src="projection.js"></script>
+
     <script>
         // Dynamically load app.js with version parameter
         const script = document.createElement('script');

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -1,0 +1,130 @@
+// Shared projection and scoring maths for the dashboard (issue #80).
+//
+// The dashboard's projection/scoring algorithms used to live only inside the
+// `GRQValidator` class in docs/app.js, where the TypeScript tests could not
+// reach them. The tests therefore reimplemented the algorithms as local
+// `Mock*` classes and asserted on the copy — tautologies that stayed green
+// even if app.js drifted or broke.
+//
+// These helpers extract the pure mathematical kernels so that BOTH the browser
+// dashboard (via `GRQValidator`) and the Deno tests exercise the exact same
+// code. The module mirrors docs/escape.js: it is loaded as a classic <script>
+// in docs/index.html and imported by the Deno tests, uses no module syntax,
+// and publishes its helpers on `globalThis`.
+
+// Set a date to local midnight (00:00:00.000). Returns a fresh Date so callers
+// never mutate the input.
+function setDateToMidnight(date) {
+    const d = new Date(date);
+    d.setHours(0, 0, 0, 0);
+    return d;
+}
+
+// Calendar days elapsed between a score date and a reference date (today).
+// `today` is passed in explicitly so the function is pure and deterministic.
+function getDaysElapsed(scoreDate, today) {
+    const diffTime = Math.abs(today.getTime() - scoreDate.getTime());
+    return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+}
+
+// Total percentage return = price return + dividend return, relative to the
+// buy price. Returns null when the buy price is missing or non-positive (the
+// same guard the dashboard applies before reporting a performance figure).
+function calculatePerformanceReturn(buyPrice, currentPrice, totalDividends) {
+    if (!buyPrice || buyPrice <= 0) {
+        return null;
+    }
+    const dividends = totalDividends || 0;
+    const priceReturn = ((currentPrice - buyPrice) / buyPrice) * 100;
+    const dividendReturn = (dividends / buyPrice) * 100;
+    return priceReturn + dividendReturn;
+}
+
+// Build the weekly trend-data series for a hybrid projection chart.
+//
+// `projection` is the result of GRQValidator.calculateHybridProjection (its
+// projectionMethod selects the curve shape); `scoreDate` anchors day 0; and
+// `trendLine` is the linear-regression result (only consulted for the
+// "dampened_trend" method, where it may be null). The series always starts at
+// day 0 and ends exactly at day 90, with weekly points in between. Returns an
+// array of `{ x: Date, y: number }` points.
+function buildHybridProjectionData(projection, scoreDate, trendLine) {
+    const trendData = [];
+
+    // Day offset from the score date, snapped to midnight to match chart axes.
+    const getDayDate = (base, day) =>
+        setDateToMidnight(
+            new Date(base.getTime() + day * 24 * 60 * 60 * 1000),
+        );
+
+    // Append the exact 90-day endpoint when the weekly loop stops short of it.
+    const ensureNinetyDayPoint = (yAt90) => {
+        const lastPoint = trendData[trendData.length - 1];
+        const lastPointDay = (lastPoint.x.getTime() - scoreDate.getTime()) /
+            (24 * 60 * 60 * 1000);
+        if (lastPointDay !== 90) {
+            trendData.push({ x: getDayDate(scoreDate, 90), y: yAt90 });
+        }
+    };
+
+    if (projection.projectionMethod === "dampened_trend") {
+        if (trendLine) {
+            const dampenFactor = projection.daysElapsed < 30 ? 0.3 : 0.5;
+            const dampenedSlope = trendLine.slope * dampenFactor;
+            for (let day = 0; day <= 90; day += 7) {
+                trendData.push({
+                    x: getDayDate(scoreDate, day),
+                    y: Math.max(dampenedSlope * day, -100),
+                });
+            }
+            ensureNinetyDayPoint(Math.max(dampenedSlope * 90, -100));
+        }
+    } else if (projection.projectionMethod === "realistic_trajectory") {
+        const current = projection.currentPerformance;
+        const daysElapsed = projection.daysElapsed;
+        for (let day = 0; day <= 90; day += 7) {
+            let predictedPerformance;
+            if (day <= daysElapsed) {
+                // Linear interpolation up to the current observation.
+                predictedPerformance = (current / daysElapsed) * day;
+            } else {
+                // Extrapolate toward the projected 90-day figure.
+                predictedPerformance = projection.projected90DayPerformance *
+                    (day / 90);
+            }
+            predictedPerformance = Math.max(
+                Math.min(predictedPerformance, 200),
+                -100,
+            );
+            trendData.push({
+                x: getDayDate(scoreDate, day),
+                y: predictedPerformance,
+            });
+        }
+        ensureNinetyDayPoint(projection.projected90DayPerformance);
+    } else {
+        // Target-based or mean-reversion: linear ramp from zero to the
+        // projected 90-day performance.
+        const projected90DayPerformance = projection.projected90DayPerformance;
+        for (let day = 0; day <= 90; day += 7) {
+            const progress = Math.min(day / 90, 1);
+            const predictedPerformance = projected90DayPerformance * progress;
+            trendData.push({
+                x: getDayDate(scoreDate, day),
+                y: Math.max(Math.min(predictedPerformance, 200), -100),
+            });
+        }
+        ensureNinetyDayPoint(projected90DayPerformance);
+    }
+
+    return trendData;
+}
+
+// Publish on globalThis so the browser dashboard (classic script) and the Deno
+// test importer can both reach the helpers, mirroring docs/escape.js.
+globalThis.GRQProjection = {
+    setDateToMidnight,
+    getDaysElapsed,
+    calculatePerformanceReturn,
+    buildHybridProjectionData,
+};

--- a/tests/integration_test.ts
+++ b/tests/integration_test.ts
@@ -1,4 +1,16 @@
-import { assertAlmostEquals, assertEquals } from "@std/assert";
+import { assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    calculatePerformanceReturn: (
+      buyPrice: number,
+      currentPrice: number,
+      totalDividends?: number,
+    ) => number | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
 
 // Integration test for 90-day portfolio calculations
 
@@ -20,18 +32,10 @@ Deno.test("Integration Tests", async (t) => {
     );
   });
 
-  await t.step("portfolio target logic", () => {
-    // Test that portfolio target is 20% for equal-weighted portfolio
-    const individualTarget = 20.0; // Each stock target
-    const portfolioTarget = 20.0; // Equal weighting means same target
-
-    assertAlmostEquals(
-      portfolioTarget,
-      individualTarget,
-      0.1,
-      "Portfolio target should equal individual target",
-    );
-  });
+  // NOTE (issue #80): the former "portfolio target logic" step asserted
+  // `20.0 ≈ 20.0` against two locally-declared constants — a tautology that
+  // verified no production code. It has been removed in favour of the
+  // real-function "performance calculation" step below.
 
   await t.step("dividend exclusion after 90 days", () => {
     // Test that dividends after 90 days are excluded
@@ -53,16 +57,19 @@ Deno.test("Integration Tests", async (t) => {
   });
 
   await t.step("performance calculation", () => {
-    // Mock performance calculation
+    // Drive the REAL shared performance maths (issue #80) rather than
+    // recomputing the formula inline and asserting on our own arithmetic.
     const buyPrice = 100.0;
-    const priceAt90Days = 120.0; // 20% gain
-    const dividends = 2.0; // $2 in dividends
+    const priceAt90Days = 120.0; // 20% price gain
+    const dividends = 2.0; // $2 in dividends -> +2%
 
-    const priceReturn = ((priceAt90Days - buyPrice) / buyPrice) * 100;
-    const dividendReturn = (dividends / buyPrice) * 100;
-    const totalReturn = priceReturn + dividendReturn;
+    const totalReturn = GRQProjection.calculatePerformanceReturn(
+      buyPrice,
+      priceAt90Days,
+      dividends,
+    );
 
-    assertAlmostEquals(totalReturn, 22.0, 0.1, "Total return should be 22.0%");
+    assertEquals(totalReturn, 22.0, "Total return should be 22.0%");
   });
 
   await t.step("chart data limitation", () => {

--- a/tests/projection_module_test.ts
+++ b/tests/projection_module_test.ts
@@ -1,0 +1,200 @@
+// Tests for the shared projection/scoring module (issue #80).
+//
+// These import the REAL shipped helpers from docs/projection.js — the same
+// code the dashboard's GRQValidator delegates to — and assert on their
+// observable output. They replace the former tautological tests that
+// reimplemented the algorithms as local mocks and asserted on the copy.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+interface ProjectionPoint {
+  x: Date;
+  y: number;
+}
+
+interface Projection {
+  projected90DayPerformance: number;
+  projectionMethod: string;
+  daysElapsed: number;
+  currentPerformance: number;
+}
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    setDateToMidnight: (date: Date) => Date;
+    getDaysElapsed: (scoreDate: Date, today: Date) => number;
+    calculatePerformanceReturn: (
+      buyPrice: number,
+      currentPrice: number,
+      totalDividends?: number,
+    ) => number | null;
+    buildHybridProjectionData: (
+      projection: Projection,
+      scoreDate: Date,
+      trendLine: { slope: number } | null,
+    ) => ProjectionPoint[];
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+Deno.test("projection.js publishes helpers on globalThis", () => {
+  assertEquals(typeof GRQProjection, "object");
+  assertEquals(typeof GRQProjection.getDaysElapsed, "function");
+  assertEquals(typeof GRQProjection.calculatePerformanceReturn, "function");
+  assertEquals(typeof GRQProjection.buildHybridProjectionData, "function");
+});
+
+Deno.test("setDateToMidnight zeroes the time and does not mutate input", () => {
+  const input = new Date("2025-01-15T13:45:30.500");
+  const result = GRQProjection.setDateToMidnight(input);
+  assertEquals(result.getHours(), 0);
+  assertEquals(result.getMinutes(), 0);
+  assertEquals(result.getSeconds(), 0);
+  assertEquals(result.getMilliseconds(), 0);
+  // The original Date is untouched.
+  assertEquals(input.getHours(), 13);
+});
+
+Deno.test("getDaysElapsed counts calendar days between dates", () => {
+  const scoreDate = new Date("2024-11-15");
+  const today = new Date("2025-02-13"); // exactly 90 days later
+  assertEquals(GRQProjection.getDaysElapsed(scoreDate, today), 90);
+});
+
+Deno.test("getDaysElapsed is symmetric (absolute difference)", () => {
+  const a = new Date("2025-01-01");
+  const b = new Date("2025-01-11");
+  assertEquals(GRQProjection.getDaysElapsed(a, b), 10);
+  assertEquals(GRQProjection.getDaysElapsed(b, a), 10);
+});
+
+Deno.test("calculatePerformanceReturn sums price and dividend returns", () => {
+  // $100 -> $120 is +20%; $2 of dividends adds another +2%.
+  const result = GRQProjection.calculatePerformanceReturn(100, 120, 2);
+  assert(result !== null);
+  assertEquals(result, 22);
+});
+
+Deno.test("calculatePerformanceReturn handles a price loss", () => {
+  // $100 -> $80 with no dividends is -20%.
+  assertEquals(GRQProjection.calculatePerformanceReturn(100, 80, 0), -20);
+});
+
+Deno.test("calculatePerformanceReturn returns null for an invalid buy price", () => {
+  assertEquals(GRQProjection.calculatePerformanceReturn(0, 120, 0), null);
+  assertEquals(GRQProjection.calculatePerformanceReturn(-5, 120, 0), null);
+});
+
+Deno.test("buildHybridProjectionData (target_based) ramps from zero to projection", () => {
+  const scoreDate = new Date("2025-01-01");
+  const projection: Projection = {
+    projected90DayPerformance: 30.0,
+    projectionMethod: "target_based",
+    daysElapsed: 60,
+    currentPerformance: 20.0,
+  };
+
+  const data = GRQProjection.buildHybridProjectionData(
+    projection,
+    scoreDate,
+    null,
+  );
+
+  // Starts at day 0 with zero performance.
+  const scoreMidnight = GRQProjection.setDateToMidnight(scoreDate).getTime();
+  const firstDay = (data[0].x.getTime() - scoreMidnight) /
+    (24 * 60 * 60 * 1000);
+  assertEquals(firstDay, 0);
+  assertEquals(data[0].y, 0);
+  assertEquals(data[0].x.getHours(), 0);
+
+  // Ends exactly at day 90 with the projected performance.
+  const last = data[data.length - 1];
+  const lastDay = (last.x.getTime() - scoreMidnight) / (24 * 60 * 60 * 1000);
+  assertEquals(lastDay, 90);
+  assertEquals(last.y, 30.0);
+});
+
+Deno.test("buildHybridProjectionData (dampened_trend) follows the trend slope", () => {
+  const scoreDate = new Date("2025-01-01");
+  const projection: Projection = {
+    projected90DayPerformance: 25.0,
+    projectionMethod: "dampened_trend",
+    daysElapsed: 30,
+    currentPerformance: 15.0,
+  };
+  // daysElapsed >= 30 -> dampen factor 0.5; slope 0.4 -> dampened 0.2.
+  const data = GRQProjection.buildHybridProjectionData(projection, scoreDate, {
+    slope: 0.4,
+  });
+
+  assertEquals(data[0].y, 0); // day 0 -> 0.2 * 0 = 0
+  const last = data[data.length - 1];
+  const scoreMidnight = GRQProjection.setDateToMidnight(scoreDate).getTime();
+  const lastDay = (last.x.getTime() - scoreMidnight) / (24 * 60 * 60 * 1000);
+  assertEquals(lastDay, 90);
+  assertEquals(last.y, 0.2 * 90); // 18.0
+});
+
+Deno.test("buildHybridProjectionData (dampened_trend) yields no points without a trend line", () => {
+  const scoreDate = new Date("2025-01-01");
+  const projection: Projection = {
+    projected90DayPerformance: 25.0,
+    projectionMethod: "dampened_trend",
+    daysElapsed: 30,
+    currentPerformance: 15.0,
+  };
+  const data = GRQProjection.buildHybridProjectionData(
+    projection,
+    scoreDate,
+    null,
+  );
+  assertEquals(data.length, 0);
+});
+
+Deno.test("buildHybridProjectionData (realistic_trajectory) interpolates then extrapolates", () => {
+  const scoreDate = new Date("2025-01-01");
+  const projection: Projection = {
+    projected90DayPerformance: 18.0,
+    projectionMethod: "realistic_trajectory",
+    daysElapsed: 28,
+    currentPerformance: 14.0, // 0.5% per day up to day 28
+  };
+  const data = GRQProjection.buildHybridProjectionData(
+    projection,
+    scoreDate,
+    null,
+  );
+
+  // Day 0 starts at zero.
+  assertEquals(data[0].y, 0);
+  // Day 14 (<= daysElapsed) interpolates: 14/28 * 14 = 7.
+  assertEquals(data[2].y, 7);
+  // Last point is exactly day 90 at the projected figure.
+  const last = data[data.length - 1];
+  const scoreMidnight = GRQProjection.setDateToMidnight(scoreDate).getTime();
+  const lastDay = (last.x.getTime() - scoreMidnight) / (24 * 60 * 60 * 1000);
+  assertEquals(lastDay, 90);
+  assertEquals(last.y, 18.0);
+});
+
+Deno.test("buildHybridProjectionData (dampened_trend) floors performance at -100", () => {
+  const scoreDate = new Date("2025-01-01");
+  const projection: Projection = {
+    projected90DayPerformance: -250.0,
+    projectionMethod: "dampened_trend",
+    daysElapsed: 90,
+    currentPerformance: -90.0,
+  };
+  // A steeply negative slope would project well below -100% without the floor.
+  const data = GRQProjection.buildHybridProjectionData(projection, scoreDate, {
+    slope: -5.0,
+  });
+  // Every dampened-trend point (weekly and the appended 90-day point) is
+  // clamped to the -100% floor.
+  for (const point of data) {
+    assert(point.y >= -100, `Point ${point.y} fell below the -100% floor`);
+  }
+  // The deeply negative tail is pinned exactly at the floor.
+  assertEquals(data[data.length - 1].y, -100);
+});

--- a/tests/trend_line_extension_test.ts
+++ b/tests/trend_line_extension_test.ts
@@ -1,213 +1,170 @@
+// Trend-line / hybrid-projection tests (issue #80).
+//
+// These used to reimplement GRQValidator.calculateHybridProjectionData as
+// local `Mock*` classes (and one test even overrode the method inline before
+// asserting on its own output — a pure tautology). They now import the REAL
+// shipped helper from docs/projection.js, the exact code the dashboard's
+// GRQValidator delegates to, and assert on its observable output. A bug in the
+// production trend-shape generation now fails these tests.
 import { assertEquals, assertExists } from "@std/assert";
+import "../docs/projection.js";
 
-// Helper to set date to midnight
-function setDateToMidnight(date: Date): Date {
-  const d = new Date(date);
-  d.setHours(0, 0, 0, 0);
-  return d;
+interface ProjectionPoint {
+  x: Date;
+  y: number;
 }
 
-// Mock implementation to test trend line extension
-class MockTrendLineExtension {
-  calculateHybridProjectionData(_stock: unknown, scoreDate: Date) {
-    const projection = {
-      projected90DayPerformance: 25.0,
-      projectionMethod: "dampened_trend",
-      confidence: 0.75,
-      daysElapsed: 30,
-      currentPerformance: 15.0,
-      targetPercentage: 30.0,
-    };
-
-    const trendData = [];
-    const scoreDateMidnight = setDateToMidnight(scoreDate);
-    const scoreDateTimestamp = scoreDateMidnight.getTime();
-    const getDayDate = (base: Date, day: number) =>
-      setDateToMidnight(new Date(base.getTime() + day * 24 * 60 * 60 * 1000));
-
-    // Simulate the dampened trend logic
-    const dampenedSlope = 0.3; // Mock slope
-
-    // Generate weekly points up to 90 days
-    const days = [];
-    for (let day = 0; day <= 90; day += 7) {
-      days.push(day);
-      const predictedPerformance = Math.max(dampenedSlope * day, -100);
-      trendData.push({
-        x: getDayDate(scoreDateMidnight, day),
-        y: predictedPerformance,
-      });
-    }
-
-    // Ensure we have exactly 90 days as the last point
-    const lastPoint = trendData[trendData.length - 1];
-    const lastPointDay = (lastPoint.x.getTime() - scoreDateTimestamp) /
-      (24 * 60 * 60 * 1000);
-
-    if (lastPointDay !== 90) {
-      // Add the exact 90-day point
-      const predictedPerformance90 = Math.max(dampenedSlope * 90, -100);
-      trendData.push({
-        x: getDayDate(scoreDateMidnight, 90),
-        y: predictedPerformance90,
-      });
-    }
-
-    return {
-      data: trendData,
-      projection: projection,
-    };
-  }
-
-  // Simulate a flat/negative trend with current far from target
-  calculateHybridProjectionDataFlat(_stock: unknown, scoreDate: Date) {
-    const projection = {
-      projected90DayPerformance: 5.0,
-      projectionMethod: "target_based",
-      confidence: 0.7,
-      daysElapsed: 90,
-      currentPerformance: -20.0,
-      targetPercentage: 40.0,
-    };
-    const trendData = [];
-    const scoreDateMidnight = setDateToMidnight(scoreDate);
-    const getDayDate = (base: Date, day: number) =>
-      setDateToMidnight(new Date(base.getTime() + day * 24 * 60 * 60 * 1000));
-    for (let day = 0; day <= 90; day += 7) {
-      // Linear interpolation, but should not just hit target if trend is flat/negative
-      const progress = Math.min(day / 90, 1);
-      // Simulate a capped/realistic projection
-      const predictedPerformance = -20.0 + (5.0 + 20.0) * progress;
-      trendData.push({
-        x: getDayDate(scoreDateMidnight, day),
-        y: predictedPerformance,
-      });
-    }
-    // Ensure 90-day point
-    const lastPoint = trendData[trendData.length - 1];
-    const lastPointDay = (lastPoint.x.getTime() - scoreDateMidnight.getTime()) /
-      (24 * 60 * 60 * 1000);
-    if (lastPointDay !== 90) {
-      trendData.push({
-        x: getDayDate(scoreDateMidnight, 90),
-        y: 5.0,
-      });
-    }
-    return {
-      data: trendData,
-      projection: projection,
-    };
-  }
+interface Projection {
+  projected90DayPerformance: number;
+  projectionMethod: string;
+  daysElapsed: number;
+  currentPerformance: number;
 }
 
-// Test the actual GRQValidator logic (DRY principle)
-Deno.test("Real GRQValidator - Trend Line Always Starts at Zero", () => {
-  // Create a minimal GRQValidator instance for testing
-  const validator = {
-    setDateToMidnight: function (date: Date): Date {
-      const d = new Date(date);
-      d.setHours(0, 0, 0, 0);
-      return d;
-    },
-    calculateHybridProjection: function (_stock: unknown, _scoreDate: Date) {
-      // Mock hybrid projection that returns realistic data
-      return {
-        projected90DayPerformance: 15.0,
-        projectionMethod: "target_based",
-        confidence: 0.7,
-        daysElapsed: 45,
-        currentPerformance: 8.0,
-        targetPercentage: 25.0,
-      };
-    },
-    calculateHybridProjectionData: function (stock: unknown, scoreDate: Date) {
-      const projection = this.calculateHybridProjection(stock, scoreDate);
-      if (!projection) return null;
-
-      const trendData = [];
-      const getDayDate = (base: Date, day: number) =>
-        this.setDateToMidnight(
-          new Date(base.getTime() + day * 24 * 60 * 60 * 1000),
-        );
-
-      // Target-based projection - should start at zero
-      const target = projection.targetPercentage || 0;
-      const current = projection.currentPerformance;
-
-      // Calculate realistic 90-day projection based on actual performance
-      let projected90DayPerformance;
-      if (current > 0) {
-        // If positive, project slight improvement (10% of remaining gap)
-        const gap = target - current;
-        projected90DayPerformance = current + (gap * 0.1);
-      } else {
-        // If negative, project slight recovery toward zero
-        projected90DayPerformance = current * 0.5; // Move halfway toward zero
-      }
-      projected90DayPerformance = Math.max(
-        Math.min(projected90DayPerformance, target),
-        -100,
-      );
-
-      // Update the projection object with the calculated value
-      projection.projected90DayPerformance = projected90DayPerformance;
-
-      // Generate weekly points up to 90 days, starting at zero
-      for (let day = 0; day <= 90; day += 7) {
-        const progress = Math.min(day / 90, 1);
-        const predictedPerformance = projected90DayPerformance * progress;
-        trendData.push({
-          x: getDayDate(scoreDate, day),
-          y: Math.max(Math.min(predictedPerformance, 200), -100),
-        });
-      }
-
-      // Ensure we have exactly 90 days as the last point
-      const lastPoint = trendData[trendData.length - 1];
-      const lastPointDay = (lastPoint.x.getTime() - scoreDate.getTime()) /
-        (24 * 60 * 60 * 1000);
-      if (lastPointDay !== 90) {
-        trendData.push({
-          x: getDayDate(scoreDate, 90),
-          y: projected90DayPerformance,
-        });
-      }
-
-      return {
-        data: trendData,
-        projection: projection,
-      };
-    },
+const g = globalThis as unknown as {
+  GRQProjection: {
+    setDateToMidnight: (date: Date) => Date;
+    buildHybridProjectionData: (
+      projection: Projection,
+      scoreDate: Date,
+      trendLine: { slope: number } | null,
+    ) => ProjectionPoint[];
   };
+};
+const GRQProjection = g.GRQProjection;
+const setDateToMidnight = GRQProjection.setDateToMidnight;
 
-  const stock = { stock: "TEST", target: 25.0 };
+// Days between the score date (midnight) and a projection point.
+function dayOffset(point: ProjectionPoint, scoreDate: Date): number {
+  const scoreMidnight = setDateToMidnight(scoreDate).getTime();
+  return (point.x.getTime() - scoreMidnight) / (24 * 60 * 60 * 1000);
+}
+
+Deno.test("Real buildHybridProjectionData - Trend Line Always Starts at Zero", () => {
+  const projection: Projection = {
+    projected90DayPerformance: 15.0,
+    projectionMethod: "target_based",
+    daysElapsed: 45,
+    currentPerformance: 8.0,
+  };
   const scoreDate = new Date("2025-01-01");
-  const scoreDateMidnight = setDateToMidnight(scoreDate);
 
-  const result = validator.calculateHybridProjectionData(stock, scoreDate);
+  const data = GRQProjection.buildHybridProjectionData(
+    projection,
+    scoreDate,
+    null,
+  );
 
-  assertExists(result);
-  assertExists(result.data);
-  assertEquals(result.data.length > 0, true);
+  assertExists(data);
+  assertEquals(data.length > 0, true);
 
-  // Check that the first point is at day 0 and starts at zero performance
-  const firstPoint = result.data[0];
-  const scoreDateTimestamp = scoreDateMidnight.getTime();
-  const firstPointDay = (firstPoint.x.getTime() - scoreDateTimestamp) /
-    (24 * 60 * 60 * 1000);
-  assertEquals(firstPointDay, 0);
+  // First point is day 0 at zero performance, snapped to midnight.
+  const firstPoint = data[0];
+  assertEquals(dayOffset(firstPoint, scoreDate), 0);
   assertEquals(firstPoint.x.getHours(), 0);
-  assertEquals(firstPoint.y, 0); // Should start at zero
+  assertEquals(firstPoint.y, 0);
 
-  // Check that the last point is exactly at 90 days
-  const lastPoint = result.data[result.data.length - 1];
-  const lastPointDay = (lastPoint.x.getTime() - scoreDateTimestamp) /
-    (24 * 60 * 60 * 1000);
-  assertEquals(lastPointDay, 90);
-  assertEquals(lastPoint.y, result.projection.projected90DayPerformance);
+  // Last point is exactly day 90 at the projected performance.
+  const lastPoint = data[data.length - 1];
+  assertEquals(dayOffset(lastPoint, scoreDate), 90);
+  assertEquals(lastPoint.y, projection.projected90DayPerformance);
 });
 
-// Test that trend line uses latest market data date instead of today's date
+Deno.test("Real buildHybridProjectionData - Ensures 90-Day Point at midnight", () => {
+  const projection: Projection = {
+    projected90DayPerformance: 25.0,
+    projectionMethod: "dampened_trend",
+    daysElapsed: 30,
+    currentPerformance: 15.0,
+  };
+  const scoreDate = new Date("2025-01-01");
+
+  const data = GRQProjection.buildHybridProjectionData(projection, scoreDate, {
+    slope: 0.3,
+  });
+
+  assertExists(data);
+  assertEquals(data.length > 0, true);
+
+  // Last point is exactly at day 90, snapped to midnight.
+  const lastPoint = data[data.length - 1];
+  assertEquals(dayOffset(lastPoint, scoreDate), 90);
+  assertEquals(lastPoint.x.getHours(), 0);
+  assertEquals(lastPoint.x.getMinutes(), 0);
+  assertEquals(lastPoint.x.getSeconds(), 0);
+
+  // First point is day 0; a dampened trend starts at zero.
+  const firstPoint = data[0];
+  assertEquals(dayOffset(firstPoint, scoreDate), 0);
+  assertEquals(firstPoint.x.getHours(), 0);
+  assertEquals(firstPoint.y, 0);
+
+  // Weekly intervals up to 90 days, plus a possible exact-90 endpoint.
+  const expectedMinPoints = Math.ceil(90 / 7) + 1;
+  assertEquals(data.length >= expectedMinPoints, true);
+});
+
+Deno.test("Real buildHybridProjectionData - Target-Based Method reaches the projection", () => {
+  // Target-based projection ramps linearly from zero to the projected 90-day
+  // performance. Driving the REAL function (not an inline override) proves the
+  // shipped code produces this curve.
+  const projection: Projection = {
+    projected90DayPerformance: 30.0,
+    projectionMethod: "target_based",
+    daysElapsed: 60,
+    currentPerformance: 20.0,
+  };
+  const scoreDate = new Date("2025-01-01");
+
+  const data = GRQProjection.buildHybridProjectionData(
+    projection,
+    scoreDate,
+    null,
+  );
+
+  assertExists(data);
+  assertEquals(data.length > 0, true);
+
+  // Last point is exactly at day 90 and equals the projected performance.
+  const lastPoint = data[data.length - 1];
+  assertEquals(dayOffset(lastPoint, scoreDate), 90);
+  assertEquals(lastPoint.x.getHours(), 0);
+  assertEquals(lastPoint.y, 30.0);
+});
+
+Deno.test("Real buildHybridProjectionData - Does Not Hit Target When Projection Is Lower", () => {
+  // When the realistic projection (5%) is well below the stock's target (40%),
+  // the curve must end at the projection, not at the target. The production
+  // function uses projected90DayPerformance, so it ends at 5%.
+  const projection: Projection = {
+    projected90DayPerformance: 5.0,
+    projectionMethod: "target_based",
+    daysElapsed: 90,
+    currentPerformance: -20.0,
+  };
+  const scoreDate = new Date("2025-05-15");
+
+  const data = GRQProjection.buildHybridProjectionData(
+    projection,
+    scoreDate,
+    null,
+  );
+
+  assertExists(data);
+  // The last point reflects the realistic projection (5.0), not the 40% target.
+  const lastPoint = data[data.length - 1];
+  assertEquals(lastPoint.y, 5.0);
+  // Target-based curves start at zero.
+  assertEquals(data[0].y, 0);
+});
+
+// Test that trend line uses latest market data date instead of today's date.
+//
+// This exercises the linear-regression shape of calculateTrendLine. The
+// regression maths still lives on GRQValidator (not yet extracted to the
+// shared module); the helper below mirrors it so the regression behaviour is
+// covered. Extracting calculateTrendLine into docs/projection.js is tracked as
+// follow-up work.
 Deno.test("Trend Line Uses Latest Market Data Date", () => {
   // Mock market data showing SCHW growth from April 15 to July 1
   const marketData: Record<
@@ -396,133 +353,6 @@ Deno.test("Trend Line Uses Latest Market Data Date", () => {
     true,
     `Projection should be <25%, got ${predicted90Day}%`,
   );
-
-  console.log(`90-day projection: ${predicted90Day.toFixed(1)}%`);
-  console.log(`July 1 performance: ${latestDataPoint.y.toFixed(1)}%`);
-  console.log(`Days since score date: ${daysSinceScore.toFixed(0)}`);
-});
-
-Deno.test("Trend Line Extension - Ensures 90-Day Point", () => {
-  const system = new MockTrendLineExtension();
-  const stock = { stock: "TEST" };
-  const scoreDate = new Date("2025-01-01");
-  const scoreDateMidnight = setDateToMidnight(scoreDate);
-
-  const result = system.calculateHybridProjectionData(stock, scoreDate);
-
-  assertExists(result);
-  assertExists(result.data);
-  assertEquals(result.data.length > 0, true);
-
-  // Check that the last point is exactly at 90 days
-  const lastPoint = result.data[result.data.length - 1];
-  const scoreDateTimestamp = scoreDateMidnight.getTime();
-  const lastPointDay = (lastPoint.x.getTime() - scoreDateTimestamp) /
-    (24 * 60 * 60 * 1000);
-
-  assertEquals(lastPointDay, 90);
-  assertEquals(lastPoint.x.getHours(), 0);
-  assertEquals(lastPoint.x.getMinutes(), 0);
-  assertEquals(lastPoint.x.getSeconds(), 0);
-
-  // Check that the first point is at day 0
-  const firstPoint = result.data[0];
-  const firstPointDay = (firstPoint.x.getTime() - scoreDateTimestamp) /
-    (24 * 60 * 60 * 1000);
-  assertEquals(firstPointDay, 0);
-  assertEquals(firstPoint.x.getHours(), 0);
-  // The trend line should always start at zero performance
-  assertEquals(firstPoint.y, 0);
-
-  // Check that we have reasonable number of points (weekly intervals + potential 90-day point)
-  const expectedMinPoints = Math.ceil(90 / 7) + 1; // Weekly points + potential 90-day point
-  assertEquals(result.data.length >= expectedMinPoints, true);
-});
-
-Deno.test("Trend Line Extension - Target-Based Method", () => {
-  const system = new MockTrendLineExtension();
-  const stock = { stock: "TEST" };
-  const scoreDate = new Date("2025-01-01");
-  const scoreDateMidnight = setDateToMidnight(scoreDate);
-
-  // Override to test target-based method
-  system.calculateHybridProjectionData = function (
-    _stock: unknown,
-    _scoreDate: Date,
-  ) {
-    const projection = {
-      projected90DayPerformance: 30.0,
-      projectionMethod: "target_based",
-      confidence: 0.7,
-      daysElapsed: 60,
-      currentPerformance: 20.0,
-      targetPercentage: 30.0,
-    };
-
-    const trendData = [];
-    const getDayDate = (base: Date, day: number) =>
-      setDateToMidnight(new Date(base.getTime() + day * 24 * 60 * 60 * 1000));
-    const target = 30.0;
-    const current = 20.0;
-
-    // Generate weekly points up to 90 days
-    for (let day = 0; day <= 90; day += 7) {
-      const progress = Math.min(day / 90, 1);
-      const predictedPerformance = current + (target - current) * progress;
-      trendData.push({
-        x: getDayDate(scoreDateMidnight, day),
-        y: predictedPerformance,
-      });
-    }
-    // Ensure we have exactly 90 days as the last point
-    const lastPoint = trendData[trendData.length - 1];
-    const lastPointDay = (lastPoint.x.getTime() - scoreDateMidnight.getTime()) /
-      (24 * 60 * 60 * 1000);
-    if (lastPointDay !== 90) {
-      // Add the exact 90-day point
-      const predictedPerformance90 = target; // At 90 days, we should reach the target
-      trendData.push({
-        x: getDayDate(scoreDateMidnight, 90),
-        y: predictedPerformance90,
-      });
-    }
-
-    return {
-      data: trendData,
-      projection: projection,
-    };
-  };
-
-  const result = system.calculateHybridProjectionData(stock, scoreDate);
-
-  assertExists(result);
-  assertExists(result.data);
-
-  // Check that the last point is exactly at 90 days
-  const lastPoint = result.data[result.data.length - 1];
-  const scoreDateTimestamp = scoreDateMidnight.getTime();
-  const lastPointDay = (lastPoint.x.getTime() - scoreDateTimestamp) /
-    (24 * 60 * 60 * 1000);
-
-  assertEquals(lastPointDay, 90);
-  assertEquals(lastPoint.x.getHours(), 0);
-
-  // Check that the last point value is the target (30.0)
-  assertEquals(lastPoint.y, 30.0);
-});
-
-Deno.test("Trend Line - Should Not Always Hit Target If Trend/Current Is Far Off", () => {
-  const system = new MockTrendLineExtension();
-  const stock = { stock: "AMX" };
-  const scoreDate = new Date("2025-05-15");
-  const result = system.calculateHybridProjectionDataFlat(stock, scoreDate);
-  assertExists(result);
-  assertExists(result.data);
-  // The last point should NOT be equal to the target (40.0), but rather the realistic projection (5.0)
-  const lastPoint = result.data[result.data.length - 1];
-  assertEquals(lastPoint.y, 5.0);
-  // The first point should be at zero
-  assertEquals(result.data[0].y, -20.0); // In this mock, current performance is -20%
 });
 
 console.log("All trend line extension tests passed! 🎉");


### PR DESCRIPTION
## Summary

The TypeScript suite reimplemented the dashboard's projection/scoring algorithms
as test-local `Mock*` classes and asserted on the copy — tautologies that stayed
green even if the production `GRQValidator` in `docs/app.js` drifted or broke. One
test in `tests/trend_line_extension_test.ts` even **overrode**
`calculateHybridProjectionData` inline and then asserted on the output of that very
function; `tests/integration_test.ts` recomputed formulas inline and asserted on its
own arithmetic (`20.0 ≈ 20.0`, `22.0`).

This change applies resolution **(a)** from the issue (extract the maths into a
module both `docs/app.js` and the tests import) for the core projection/scoring
kernels, and resolution **(b)** (delete the named tautologies) for the inline
method-override and inline-arithmetic steps:

- **New shared module `docs/projection.js`** — a classic-script module published on
  `globalThis` (mirroring `docs/escape.js`), with no module syntax, importable by
  both the browser dashboard and the Deno tests. It exports `setDateToMidnight`,
  `getDaysElapsed`, `calculatePerformanceReturn`, and `buildHybridProjectionData`.
- **`GRQValidator` now delegates** `getDaysElapsed`, the performance-return maths in
  `calculateStockPerformance`, and the hybrid trend-shape generation in
  `calculateHybridProjectionData` to the shared module, so production and tests
  exercise one implementation (no parallel copy to drift).
- **`docs/index.html`** loads `projection.js` before `app.js`, next to `escape.js`.
- **Tests rewritten to drive the real code** — the projection-data tests and the
  integration performance step now import `docs/projection.js` and assert on the
  shipped functions' observable output. A bug in the production trend-shape
  generation now fails these tests.

The remaining mock-validator test files (`realistic_projection_test.ts`,
`chart_data_test.ts`, `basic_score_table_test.ts`, `buy_price_logic_test.ts`,
`current_price_consistency_test.ts`, `hybrid_projection_tests.ts`,
`judgement_hybrid_test.ts`, `portfolio_view_consistency_test.ts`,
`schw_projection_test.ts`) depend on still-stateful logic (`getBuyPrice`,
`calculateTrendLine`, `calculateHybridProjection`, the dilution variants) whose
extraction touches DOM/market-data code paths that cannot be exercised headlessly.
Converting them is larger and riskier than this scope, so it is tracked as
follow-up issue **stSoftwareAU/GRQ-validation#100**.

Closes #80.

## Evidence

This is a test-architecture / CLI change with no visual UI change, so no screenshot
applies. The fix is verified by the rewritten tests, which now exercise the real
shipped code path instead of a local mock:

```mermaid
flowchart LR
    subgraph Before
        T1[TS test] --> M[local Mock* copy]
        A1[docs/app.js GRQValidator] -. never imported .-> T1
    end
    subgraph After
        T2[TS test] --> P[docs/projection.js]
        A2[docs/app.js GRQValidator] --> P
    end
```

The shared module is the single source of truth: `GRQValidator` and the tests both
call into `docs/projection.js`, so a regression in the production maths now breaks
the suite.

## Test Plan

- **`tests/projection_module_test.ts`** (new) — 12 behavioural tests importing the
  real `docs/projection.js`: `getDaysElapsed`, `calculatePerformanceReturn`
  (happy/loss/invalid-buy-price), `setDateToMidnight` (no input mutation), and
  `buildHybridProjectionData` for the `target_based`, `dampened_trend` (incl. no
  trend line) and `realistic_trajectory` methods plus the -100% floor.
- **`tests/trend_line_extension_test.ts`** — projection-data tests now call the real
  `buildHybridProjectionData`; the inline `calculateHybridProjectionData` override
  and the `Mock*` reimplementations were removed. The `calculateTrendLine`
  regression test is retained (that function is extracted in #100).
- **`tests/integration_test.ts`** — the performance step now calls the real
  `calculatePerformanceReturn`; the `20.0 ≈ 20.0` tautology was removed.
- Full Deno suite: `deno test --allow-read tests/*.ts` → **144 passed, 0 failed**.
- `deno fmt`, `deno lint`, `deno check` all clean; `cargo check --all-targets` clean
  (no Rust files changed).
