### PR TITLE
Convert remaining TS mock-validator tests to the shared projection module (#100)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3117,67 +3117,18 @@ class GRQValidator {
         const daysElapsed = this.getDaysElapsed(scoreDate);
         const targetPercentage = this.calculateTargetPercentage(stock, scoreDate);
 
-        // If we haven't reached 90 days yet, use hybrid projection
-        if (daysElapsed < 90) {
-            const hybridProjection = this.calculateHybridProjection(stock, scoreDate);
-            
-            if (hybridProjection && hybridProjection.confidence > 0.2) {
-                const predicted = hybridProjection.projected90DayPerformance;
-                const target = targetPercentage || 20; // Default to 20% if no target
-                const pctOfTarget = target === 0 ? 0 : predicted / target;
-                if (predicted < 0 || pctOfTarget < 0.2) {
-                    return `Declining (${predicted.toFixed(1)}%)`;
-                } else if (pctOfTarget >= 0.95) {
-                    return `On Track (${predicted.toFixed(1)}%)`;
-                } else if (pctOfTarget >= 0.2) {
-                    return `Below Target (${predicted.toFixed(1)}%)`;
-                } else {
-                    return `Declining (${predicted.toFixed(1)}%)`;
-                }
-            } else {
-                // Not enough data for reliable prediction - use current performance with context
-                const target = targetPercentage || 20; // Default to 20% if no target
-                const threshold = target * 0.8; // 80% of target
-                if (daysElapsed < 30) {
-                    // First 30 days - truly early
-                    if (performance > 0) {
-                        return `Early Days (+${performance.toFixed(1)}%)`;
-                    } else {
-                        return `Early Days (${performance.toFixed(1)}%)`;
-                    }
-                } else if (daysElapsed < 60) {
-                    // 30-60 days - mid period
-                    if (performance >= threshold) {
-                        return `On Track (${performance.toFixed(1)}%)`;
-                    } else if (performance > 0) {
-                        return `Below Target (${performance.toFixed(1)}%)`;
-                    } else {
-                        return `Declining (${performance.toFixed(1)}%)`;
-                    }
-                } else {
-                    // 60+ days - late period, should have good data
-                    if (performance >= threshold) {
-                        return `On Track (${performance.toFixed(1)}%)`;
-                    } else if (performance > 0) {
-                        return `Below Target (${performance.toFixed(1)}%)`;
-                    } else {
-                        return `Declining (${performance.toFixed(1)}%)`;
-                    }
-                }
-            }
-        } else {
-            // 90 days or more elapsed - use actual performance
-            const target = targetPercentage || 20; // Default to 20% if no target
-            const threshold = target * 0.8; // 80% of target
+        // Before day 90 the judgement leans on the hybrid projection; gather it
+        // so the shared kernel (issue #100) can apply the decision thresholds.
+        const projection = daysElapsed < 90
+            ? this.calculateHybridProjection(stock, scoreDate)
+            : null;
 
-            if (performance >= threshold) {
-                return "Hit Target";
-            } else if (performance > 0) {
-                return "Partial Success";
-            } else {
-                return "Missed Target";
-            }
-        }
+        return GRQProjection.computeJudgement({
+            performance,
+            daysElapsed,
+            targetPercentage,
+            projection,
+        });
     }
 
     getPerformanceClass(performance) {

--- a/docs/app.js
+++ b/docs/app.js
@@ -18,17 +18,9 @@ class GRQValidator {
 
     // Helper function to format currency values with thousand separators
     formatCurrency(value) {
-        if (value === null || value === undefined || isNaN(value)) {
-            return "N/A";
-        }
-        const money= new Intl.NumberFormat('en-US', {
-            style: 'currency',
-            currency: 'USD',
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2
-        }).format(value);
-
-        return money;
+        // Delegate to the shared projection module (issue #100) so the browser
+        // and the Deno tests format currency identically.
+        return GRQProjection.formatCurrency(value);
     }
 
     // Centralized method to get Bootstrap breakpoint
@@ -3092,12 +3084,11 @@ class GRQValidator {
     }
 
     getCurrentPrice(stockSymbol) {
-        const marketData = this.marketData[stockSymbol];
-        if (!marketData || marketData.length === 0) return "N/A";
-
-        // Use the latest market data (same as getWorking method)
-        const lastData = marketData[marketData.length - 1];
-        const currentPrice = (lastData.high + lastData.low) / 2; // Already post-split
+        // Latest-price maths lives in the shared projection module (issue #100).
+        const currentPrice = GRQProjection.currentPriceFromLatest(
+            this.marketData[stockSymbol],
+        );
+        if (currentPrice === null) return "N/A";
         return "$" + currentPrice.toFixed(2);
     }
 
@@ -3347,12 +3338,12 @@ class GRQValidator {
             }
         });
 
-        // Calculate days from score date to latest market data date
-        const diffTime = Math.abs(latestMarketDate - scoreDate);
-        const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-        
-        // Cap at 90 days for portfolio view consistency
-        return Math.min(diffDays, 90);
+        // Day-count maths (capped at 90) lives in the shared projection module
+        // (issue #100).
+        return GRQProjection.daysElapsedFromMarketData(
+            scoreDate,
+            latestMarketDate,
+        );
     }
 
     calculateStockPerformance(stock) {
@@ -3930,21 +3921,12 @@ class GRQValidator {
         stockSymbol,
         historicalDate,
     ) {
-        const marketData = this.marketData[stockSymbol];
-        if (!marketData) return 1.0;
-
-        // Find all splits that occurred after the historical date
-        let cumulativeSplit = 1.0;
-        for (const point of marketData) {
-            if (
-                point.date > historicalDate &&
-                point.splitCoefficient > 1.0
-            ) {
-                cumulativeSplit *= point.splitCoefficient;
-            }
-        }
-
-        return cumulativeSplit;
+        // Split-adjustment maths lives in the shared projection module
+        // (issue #100).
+        return GRQProjection.getSplitAdjustment(
+            this.marketData[stockSymbol],
+            historicalDate,
+        );
     }
 
     adjustHistoricalPriceToCurrent(
@@ -3952,48 +3934,20 @@ class GRQValidator {
         stockSymbol,
         historicalDate,
     ) {
-        const splitAdjustment = this
-            .getHistoricalToCurrentSplitAdjustment(
-                stockSymbol,
-                historicalDate,
-            );
-        const result = price / splitAdjustment;
-
-        return result;
+        return GRQProjection.adjustHistoricalPriceToCurrent(
+            price,
+            this.marketData[stockSymbol],
+            historicalDate,
+        );
     }
 
     getBuyPrice(stockSymbol, scoreDate) {
-        const marketData = this.marketData[stockSymbol];
-        if (!marketData) {
-            return null;
-        }
-
-        // Try to get the price on the exact score date or up to 5 days forward
-        for (let offset = 0; offset <= 5; offset++) {
-            const candidateDate = new Date(scoreDate.getTime());
-            candidateDate.setDate(candidateDate.getDate() + offset);
-            const candidateData = marketData.find((point) => {
-                const pointDate = new Date(
-                    point.date.getFullYear(),
-                    point.date.getMonth(),
-                    point.date.getDate(),
-                );
-                return pointDate.getTime() === candidateDate.getTime();
-            });
-            if (candidateData) {
-                const adjustedPrice = this.adjustHistoricalPriceToCurrent(
-                    (candidateData.high + candidateData.low) / 2,
-                    stockSymbol,
-                    scoreDate,
-                );
-                return {
-                    price: adjustedPrice,
-                    dateUsed: candidateDate
-                };
-            }
-        }
-        // No price found within 5 days
-        return null;
+        // Buy-price resolution (5-day forward search + split adjustment) lives
+        // in the shared projection module (issue #100).
+        return GRQProjection.getBuyPrice(
+            this.marketData[stockSymbol],
+            scoreDate,
+        );
     }
 
     createChart() {
@@ -4015,11 +3969,13 @@ class GRQValidator {
             stock.stock,
             scoreDate
         );
-        
-        if (buyPrice !== null && adjustedTarget !== null) {
-            return ((adjustedTarget - buyPrice.price) / buyPrice.price) * 100;
-        }
-        return null;
+
+        // Target-percentage maths lives in the shared projection module
+        // (issue #100).
+        return GRQProjection.calculateTargetPercentage(
+            buyPrice !== null ? buyPrice.price : null,
+            adjustedTarget,
+        );
     }
 
     // Centralized method to calculate stock performance with proper dilution handling
@@ -4113,38 +4069,13 @@ class GRQValidator {
             return null;
         }
 
-        // Calculate linear regression (y = mx + b)
-        const n = dataPoints.length;
-        const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
-        const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
-        const sumXY = dataPoints.reduce((sum, point) => sum + point.x * point.y, 0);
-        const sumXX = dataPoints.reduce((sum, point) => sum + point.x * point.x, 0);
+        // Linear-regression maths lives in the shared projection module
+        // (issue #100) so production and the Deno tests share one fit.
+        const trendLine = GRQProjection.computeTrendLine(dataPoints);
 
-        const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-        const intercept = (sumY - slope * sumX) / n;
+        console.log(`calculateTrendLine - ${stock.stock}: Slope: ${trendLine.slope.toFixed(4)}, Intercept: ${trendLine.intercept}, R²: ${trendLine.rSquared.toFixed(4)}, Predicted 90-day: ${trendLine.predicted90DayPerformance.toFixed(1)}%`);
 
-        // Force the trend line to start at zero on the score date
-        // Adjust the intercept so that when x=0 (score date), y=0
-        const adjustedIntercept = 0;
-        const adjustedSlope = slope;
-
-        // Predict performance at 90 days using the adjusted line
-        const predicted90DayPerformance = adjustedSlope * 90 + adjustedIntercept;
-
-        // Cap the prediction at -100% since you can't lose more than 100% of your investment
-        const cappedPredicted90DayPerformance = Math.max(predicted90DayPerformance, -100);
-
-        const rSquared = this.calculateRSquared(dataPoints, adjustedSlope, adjustedIntercept);
-        
-        console.log(`calculateTrendLine - ${stock.stock}: Slope: ${adjustedSlope.toFixed(4)}, Intercept: ${adjustedIntercept}, R²: ${rSquared.toFixed(4)}, Predicted 90-day: ${cappedPredicted90DayPerformance.toFixed(1)}% (original: ${predicted90DayPerformance.toFixed(1)}%)`);
-
-        return {
-            slope: adjustedSlope,
-            intercept: adjustedIntercept,
-            predicted90DayPerformance: cappedPredicted90DayPerformance,
-            dataPoints,
-            rSquared: rSquared
-        };
+        return trendLine;
     }
 
     // Calculate R-squared for trend line quality
@@ -4284,121 +4215,22 @@ class GRQValidator {
         
         console.log(`calculateHybridProjection - ${stock.stock}: Current performance: ${currentPerformance.toFixed(1)}%, Target: ${targetPercentage ? targetPercentage.toFixed(1) : 'N/A'}%`);
 
-        // Hybrid approach based on days elapsed
-        let projected90DayPerformance;
-        let projectionMethod;
-        let confidence;
+        // The dampened-trend horizons (under 60 days elapsed) need the
+        // regression line; the long-term trajectory derives its shape from the
+        // projection figures alone.
+        const trendLine = daysElapsed < 60
+            ? this.calculateTrendLine(stock, scoreDate)
+            : null;
 
-        if (daysElapsed < 30) {
-            // Short-term: Use dampened trend (reduce early volatility)
-            projectionMethod = "dampened_trend";
-            const trendLine = this.calculateTrendLine(stock, scoreDate);
-            
-            if (trendLine && trendLine.rSquared > 0.1) {
-                // Dampen the trend by 70% to account for mean reversion
-                const dampenedSlope = trendLine.slope * 0.3;
-                projected90DayPerformance = Math.max(dampenedSlope * 90, -100);
-                confidence = Math.min(trendLine.rSquared * 0.7, 0.8); // Reduce confidence for early projections
-                console.log(`calculateHybridProjection - ${stock.stock}: Using dampened trend (slope: ${trendLine.slope.toFixed(4)} → ${dampenedSlope.toFixed(4)})`);
-            } else {
-                // Fall back to realistic projection based on current performance
-                projectionMethod = "target_based";
-                if (targetPercentage !== null) {
-                    // Use current performance as base, project modest improvement if positive
-                    if (currentPerformance > 0) {
-                        // If currently positive, project slight improvement (10% of remaining gap)
-                        const gap = targetPercentage - currentPerformance;
-                        projected90DayPerformance = currentPerformance + (gap * 0.1);
-                    } else {
-                        // If currently negative, project slight recovery toward zero
-                        projected90DayPerformance = currentPerformance * 0.5; // Move halfway toward zero
-                    }
-                    // Cap at reasonable bounds
-                    projected90DayPerformance = Math.max(Math.min(projected90DayPerformance, targetPercentage), -100);
-                } else {
-                    projected90DayPerformance = -5; // Default to -5% if no target
-                }
-                confidence = 0.3; // Low confidence for early projections
-                console.log(`calculateHybridProjection - ${stock.stock}: Using realistic projection (insufficient trend data)`);
-            }
-        } else if (daysElapsed < 60) {
-            // Medium-term: Use dampened trend with higher confidence
-            projectionMethod = "dampened_trend";
-            const trendLine = this.calculateTrendLine(stock, scoreDate);
-            
-            if (trendLine && trendLine.rSquared > 0.05) {
-                // Dampen the trend by 50% for medium-term
-                const dampenedSlope = trendLine.slope * 0.5;
-                projected90DayPerformance = Math.max(dampenedSlope * 90, -100);
-                confidence = Math.min(trendLine.rSquared * 0.8, 0.9);
-                console.log(`calculateHybridProjection - ${stock.stock}: Using dampened trend (slope: ${trendLine.slope.toFixed(4)} → ${dampenedSlope.toFixed(4)})`);
-            } else {
-                // Fall back to realistic projection based on current performance
-                projectionMethod = "target_based";
-                if (targetPercentage !== null) {
-                    // Use current performance as base, project modest improvement if positive
-                    if (currentPerformance > 0) {
-                        // If currently positive, project slight improvement (15% of remaining gap)
-                        const gap = targetPercentage - currentPerformance;
-                        projected90DayPerformance = currentPerformance + (gap * 0.15);
-                    } else {
-                        // If currently negative, project slight recovery toward zero
-                        projected90DayPerformance = currentPerformance * 0.6; // Move 60% toward zero
-                    }
-                    // Cap at reasonable bounds
-                    projected90DayPerformance = Math.max(Math.min(projected90DayPerformance, targetPercentage), -100);
-                } else {
-                    projected90DayPerformance = -5; // Default to -5% if no target
-                }
-                confidence = 0.5;
-                console.log(`calculateHybridProjection - ${stock.stock}: Using realistic projection (insufficient trend data)`);
-            }
-        } else {
-            // Long-term: Use realistic projection based on current trajectory
-            projectionMethod = "realistic_trajectory";
-            
-            if (targetPercentage !== null) {
-                // Calculate what the current trajectory suggests for 90 days
-                const currentRate = currentPerformance / daysElapsed; // % per day
-                let trajectoryProjection = currentRate * 90;
-                
-                // If we're significantly behind target, be realistic about missing it
-                const targetThreshold = targetPercentage * 0.8; // 80% of target
-                const remainingDays = 90 - daysElapsed;
-                const remainingGap = targetPercentage - currentPerformance;
-                const requiredDailyRate = remainingGap / remainingDays;
-                
-                // If required rate is unrealistic (>2% per day), project missing target
-                if (requiredDailyRate > 2.0) {
-                    // Project based on current trajectory, but cap at a realistic maximum
-                    const realisticProjection = Math.min(trajectoryProjection, targetPercentage * 0.6);
-                    projected90DayPerformance = Math.max(realisticProjection, currentPerformance * 1.2); // At least some improvement
-                    confidence = 0.7; // High confidence we're missing target
-                    console.log(`calculateHybridProjection - ${stock.stock}: Projecting to miss target (required daily rate: ${requiredDailyRate.toFixed(2)}% is unrealistic)`);
-                } else {
-                    // If current performance is already above target, use trajectory projection
-                    if (currentPerformance > targetPercentage) {
-                        projected90DayPerformance = trajectoryProjection;
-                        confidence = 0.7;
-                        console.log(`calculateHybridProjection - ${stock.stock}: Current performance (${currentPerformance.toFixed(1)}%) already above target (${targetPercentage.toFixed(1)}%), using trajectory projection`);
-                    } else {
-                        // Still possible to hit target, but be conservative
-                        projected90DayPerformance = Math.min(trajectoryProjection, targetPercentage * 0.8);
-                        confidence = 0.6;
-                        console.log(`calculateHybridProjection - ${stock.stock}: Projecting conservative improvement toward target`);
-                    }
-                }
-            } else {
-                // Use mean reversion (move toward 0% performance)
-                const reversionRate = 0.4; // 40% reversion toward mean
-                projected90DayPerformance = currentPerformance * (1 - reversionRate);
-                confidence = 0.3;
-                console.log(`calculateHybridProjection - ${stock.stock}: Using mean reversion projection`);
-            }
-        }
-
-        // Ensure projection is within realistic bounds
-        projected90DayPerformance = Math.max(Math.min(projected90DayPerformance, 200), -100);
+        // The hybrid decision tree lives in the shared projection module
+        // (issue #100) so production and the Deno tests share one kernel.
+        const { projected90DayPerformance, projectionMethod, confidence } =
+            GRQProjection.computeHybridProjection({
+                daysElapsed,
+                currentPerformance,
+                targetPercentage,
+                trendLine,
+            });
 
         console.log(`calculateHybridProjection - ${stock.stock}: Final projection: ${projected90DayPerformance.toFixed(1)}% (method: ${projectionMethod}, confidence: ${confidence.toFixed(2)})`);
 

--- a/docs/archive/pr-summaries/pr-summary-100.md
+++ b/docs/archive/pr-summaries/pr-summary-100.md
@@ -1,0 +1,100 @@
+# Convert remaining TS mock-validator tests to the shared projection module
+
+## Summary
+
+Follow-up to #80. The nine remaining test files each defined their own `Mock*`
+validator and asserted on a **parallel reimplementation** of the dashboard's
+projection/scoring maths rather than on production code — tautologies that stay
+green even when `docs/app.js` drifts. Several of those copies had in fact already
+drifted from production (the judgement thresholds and the hybrid-projection
+fallbacks differed).
+
+This change extends `docs/projection.js` (the shared classic-script module
+published on `globalThis`, mirroring `docs/escape.js`) with the remaining pure
+kernels, rewires `GRQValidator` to delegate to them, and points every test at
+the real functions. The maths now has a single source of truth that both the
+browser dashboard and the Deno tests exercise. Behaviour is preserved — the
+fixture-based SCHW integration test still passes against the extracted kernels.
+
+Fixes #100.
+
+### New kernels in `docs/projection.js`
+
+- `formatCurrency` — USD formatting with `N/A` guard
+- `getSplitAdjustment` / `adjustHistoricalPriceToCurrent` — dilution maths
+- `getBuyPrice` — 5-day forward search + split adjustment
+- `currentPriceFromLatest` — latest-point midpoint
+- `calculateTargetPercentage` — target return vs buy price
+- `calculateRSquared` / `computeTrendLine` — linear regression through the origin
+- `daysElapsedFromMarketData` — capped day count
+- `computeHybridProjection` — the 90-day projection decision tree
+- `computeJudgement` — the performance → judgement string mapping
+
+`GRQValidator` methods (`getBuyPrice`, `calculateTrendLine`,
+`calculateHybridProjection`, `calculateJudgement`, `getCurrentPrice`,
+`calculateTargetPercentage`, the split-adjustment helpers, `formatCurrency`,
+`getDaysElapsedFromMarketData`) now gather their inputs (market data, dividends,
+buy price) and delegate the maths to these kernels.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    subgraph Browser
+      A[GRQValidator in app.js] -->|gathers market data,<br/>dividends, dates| K
+    end
+    subgraph Deno tests
+      T[*_test.ts] --> K
+    end
+    K[docs/projection.js kernels] -->|projection, judgement,<br/>buy price, trend line| A
+    K --> T
+```
+
+## Evidence
+
+Backend/maths change with no web UI to screenshot. Verified by the Deno test
+suite: all nine converted files now drive the real kernels, plus a new
+`tests/projection_kernels_test.ts` adds direct happy/error/edge coverage. The
+fixture-based `schw_projection_test.ts` passing against the extracted kernels is
+the key proof the extraction is faithful — its real Apr–Jul 2025 SCHW data still
+yields >15% current performance, >19% projection and R² > 0.3.
+
+```
+deno test --allow-read tests/*.ts
+ok | 137 passed (57 steps) | 0 failed
+```
+
+## Test Plan
+
+Converted to exercise the real shared kernels (no behaviour silently dropped;
+mock maths replaced, DOM/parse glue retained where out of `projection.js` scope):
+
+- `tests/realistic_projection_test.ts` → `computeHybridProjection`
+- `tests/judgement_hybrid_test.ts` → `computeHybridProjection` + `computeJudgement`
+- `tests/hybrid_projection_tests.ts` → `computeTrendLine` + `computeHybridProjection`
+- `tests/schw_projection_test.ts` (fixtures) → buy price, trend line, projection
+- `tests/buy_price_logic_test.ts` → `getBuyPrice`, split adjustment, target %
+- `tests/current_price_consistency_test.ts` → `currentPriceFromLatest`, `setDateToMidnight`
+- `tests/basic_score_table_test.ts` → `formatCurrency`
+- `tests/portfolio_view_consistency_test.ts` → buy price, trend line, day count
+- `tests/chart_data_test.ts` → performance return, price adjustment, target %
+
+Added:
+
+- `tests/projection_kernels_test.ts` — 23 direct unit tests covering every new
+  kernel across happy paths, error paths and edge cases (null inputs, <3 points,
+  -100 floor, [-100, 200] clamp, 90-day day-count cap, confidence gates).
+
+### Notes
+
+- Test market-data dates use local-midnight constructors so they match the
+  kernel's local-midnight date comparison regardless of the runner's timezone;
+  date assertions use local getters rather than `toISOString` (which shifts
+  across the date line in non-UTC offsets).
+- Drifted mock judgement/projection thresholds were corrected to match
+  production; affected assertions were re-derived from the real kernel output.
+
+### Deno regression avoided
+
+- Extended the existing Deno-native shared module and `deno test` suite; no Node
+  tooling, bundler, or `package.json` introduced.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -120,6 +120,268 @@ function buildHybridProjectionData(projection, scoreDate, trendLine) {
     return trendData;
 }
 
+// Format a numeric value as a USD currency string, mirroring the dashboard's
+// table rendering. Returns "N/A" for null/undefined/NaN so callers never show a
+// broken figure. Pure: no DOM or class state.
+function formatCurrency(value) {
+    if (value === null || value === undefined || isNaN(value)) {
+        return "N/A";
+    }
+    return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    }).format(value);
+}
+
+// Cumulative split adjustment from a historical date to "now". Walks the stock's
+// market data and multiplies every split (splitCoefficient > 1.0) recorded after
+// `historicalDate`. A missing series means no known splits, so the factor is 1.0.
+function getSplitAdjustment(marketData, historicalDate) {
+    if (!marketData) return 1.0;
+    let cumulativeSplit = 1.0;
+    for (const point of marketData) {
+        if (point.date > historicalDate && point.splitCoefficient > 1.0) {
+            cumulativeSplit *= point.splitCoefficient;
+        }
+    }
+    return cumulativeSplit;
+}
+
+// Restate a historical price in current (post-split) terms by dividing out the
+// cumulative split adjustment.
+function adjustHistoricalPriceToCurrent(price, marketData, historicalDate) {
+    return price / getSplitAdjustment(marketData, historicalDate);
+}
+
+// Resolve the buy price for a stock: the split-adjusted midpoint of the first
+// trading day on or within five days after the score date. Returns
+// `{ price, dateUsed }`, or null when no market data falls in that window.
+function getBuyPrice(marketData, scoreDate) {
+    if (!marketData) return null;
+
+    for (let offset = 0; offset <= 5; offset++) {
+        const candidateDate = new Date(scoreDate.getTime());
+        candidateDate.setDate(candidateDate.getDate() + offset);
+        const candidateData = marketData.find((point) => {
+            const pointDate = new Date(
+                point.date.getFullYear(),
+                point.date.getMonth(),
+                point.date.getDate(),
+            );
+            return pointDate.getTime() === candidateDate.getTime();
+        });
+        if (candidateData) {
+            const adjustedPrice = adjustHistoricalPriceToCurrent(
+                (candidateData.high + candidateData.low) / 2,
+                marketData,
+                scoreDate,
+            );
+            return { price: adjustedPrice, dateUsed: candidateDate };
+        }
+    }
+    return null;
+}
+
+// Latest observed price = midpoint of the most recent market-data point (already
+// post-split). Returns null when there is no data.
+function currentPriceFromLatest(marketData) {
+    if (!marketData || marketData.length === 0) return null;
+    const lastData = marketData[marketData.length - 1];
+    return (lastData.high + lastData.low) / 2;
+}
+
+// Target return as a percentage of the buy price. Returns null when either input
+// is missing, matching the dashboard's guard before reporting a target figure.
+function calculateTargetPercentage(buyPrice, adjustedTarget) {
+    if (buyPrice !== null && adjustedTarget !== null) {
+        return ((adjustedTarget - buyPrice) / buyPrice) * 100;
+    }
+    return null;
+}
+
+// Coefficient of determination (R²) for a linear fit y = slope·x + intercept over
+// the data points. Returns 0 when the data has no variance.
+function calculateRSquared(dataPoints, slope, intercept) {
+    const n = dataPoints.length;
+    const meanY = dataPoints.reduce((sum, point) => sum + point.y, 0) / n;
+
+    let ssRes = 0; // Sum of squared residuals.
+    let ssTot = 0; // Total sum of squares.
+    dataPoints.forEach((point) => {
+        const predicted = slope * point.x + intercept;
+        ssRes += Math.pow(point.y - predicted, 2);
+        ssTot += Math.pow(point.y - meanY, 2);
+    });
+
+    return ssTot > 0 ? 1 - (ssRes / ssTot) : 0;
+}
+
+// Linear-regression trend line over `{ x: daysSinceScore, y: totalReturn }`
+// points. The line is forced through the origin (intercept 0) so day 0 reads 0%,
+// the 90-day prediction is floored at -100%, and R² measures the fit. Returns
+// null when fewer than three points are available (too few for a meaningful fit).
+function computeTrendLine(dataPoints) {
+    if (!dataPoints || dataPoints.length < 3) {
+        return null;
+    }
+
+    const n = dataPoints.length;
+    const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
+    const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
+    const sumXY = dataPoints.reduce((sum, point) => sum + point.x * point.y, 0);
+    const sumXX = dataPoints.reduce((sum, point) => sum + point.x * point.x, 0);
+
+    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+
+    // Force the line through zero on the score date (x = 0 -> y = 0).
+    const adjustedIntercept = 0;
+    const adjustedSlope = slope;
+
+    const predicted90DayPerformance = adjustedSlope * 90 + adjustedIntercept;
+    // Cannot lose more than 100% of the investment.
+    const cappedPredicted90DayPerformance = Math.max(
+        predicted90DayPerformance,
+        -100,
+    );
+    const rSquared = calculateRSquared(
+        dataPoints,
+        adjustedSlope,
+        adjustedIntercept,
+    );
+
+    return {
+        slope: adjustedSlope,
+        intercept: adjustedIntercept,
+        predicted90DayPerformance: cappedPredicted90DayPerformance,
+        dataPoints,
+        rSquared,
+    };
+}
+
+// Days elapsed from the score date to the latest market-data date, capped at 90
+// (the validation window). Pure given the two dates.
+function daysElapsedFromMarketData(scoreDate, latestMarketDate) {
+    const diffTime = Math.abs(latestMarketDate - scoreDate);
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    return Math.min(diffDays, 90);
+}
+
+// The hybrid 90-day projection decision tree. Given the gathered inputs
+// (days elapsed, current performance, target percentage, and — for the short and
+// medium horizons — the regression trend line), it selects a projection method
+// and figure plus a confidence. This is the pure scoring kernel; the dashboard's
+// GRQValidator gathers the inputs (market data, buy price, dividends) and
+// delegates the maths here so production and tests share one implementation.
+function computeHybridProjection(
+    { daysElapsed, currentPerformance, targetPercentage, trendLine },
+) {
+    let projected90DayPerformance;
+    let projectionMethod;
+    let confidence;
+
+    if (daysElapsed < 30) {
+        // Short-term: dampened trend to temper early volatility.
+        projectionMethod = "dampened_trend";
+        if (trendLine && trendLine.rSquared > 0.1) {
+            const dampenedSlope = trendLine.slope * 0.3; // Dampen by 70%.
+            projected90DayPerformance = Math.max(dampenedSlope * 90, -100);
+            confidence = Math.min(trendLine.rSquared * 0.7, 0.8);
+        } else {
+            // Fall back to a target-anchored projection.
+            projectionMethod = "target_based";
+            if (targetPercentage !== null) {
+                if (currentPerformance > 0) {
+                    const gap = targetPercentage - currentPerformance;
+                    projected90DayPerformance = currentPerformance + gap * 0.1;
+                } else {
+                    projected90DayPerformance = currentPerformance * 0.5;
+                }
+                projected90DayPerformance = Math.max(
+                    Math.min(projected90DayPerformance, targetPercentage),
+                    -100,
+                );
+            } else {
+                projected90DayPerformance = -5;
+            }
+            confidence = 0.3;
+        }
+    } else if (daysElapsed < 60) {
+        // Medium-term: dampened trend with higher confidence.
+        projectionMethod = "dampened_trend";
+        if (trendLine && trendLine.rSquared > 0.05) {
+            const dampenedSlope = trendLine.slope * 0.5; // Dampen by 50%.
+            projected90DayPerformance = Math.max(dampenedSlope * 90, -100);
+            confidence = Math.min(trendLine.rSquared * 0.8, 0.9);
+        } else {
+            projectionMethod = "target_based";
+            if (targetPercentage !== null) {
+                if (currentPerformance > 0) {
+                    const gap = targetPercentage - currentPerformance;
+                    projected90DayPerformance = currentPerformance + gap * 0.15;
+                } else {
+                    projected90DayPerformance = currentPerformance * 0.6;
+                }
+                projected90DayPerformance = Math.max(
+                    Math.min(projected90DayPerformance, targetPercentage),
+                    -100,
+                );
+            } else {
+                projected90DayPerformance = -5;
+            }
+            confidence = 0.5;
+        }
+    } else {
+        // Long-term: extrapolate the current trajectory toward the target.
+        projectionMethod = "realistic_trajectory";
+        if (targetPercentage !== null) {
+            const currentRate = currentPerformance / daysElapsed; // % per day.
+            const trajectoryProjection = currentRate * 90;
+            const remainingDays = 90 - daysElapsed;
+            const remainingGap = targetPercentage - currentPerformance;
+            const requiredDailyRate = remainingGap / remainingDays;
+
+            if (requiredDailyRate > 2.0) {
+                // Catch-up rate is unrealistic: project a miss.
+                const realisticProjection = Math.min(
+                    trajectoryProjection,
+                    targetPercentage * 0.6,
+                );
+                projected90DayPerformance = Math.max(
+                    realisticProjection,
+                    currentPerformance * 1.2,
+                );
+                confidence = 0.7;
+            } else if (currentPerformance > targetPercentage) {
+                // Already above target: trust the trajectory.
+                projected90DayPerformance = trajectoryProjection;
+                confidence = 0.7;
+            } else {
+                // Target still reachable, but stay conservative.
+                projected90DayPerformance = Math.min(
+                    trajectoryProjection,
+                    targetPercentage * 0.8,
+                );
+                confidence = 0.6;
+            }
+        } else {
+            // No target: mean-revert toward 0% performance.
+            const reversionRate = 0.4;
+            projected90DayPerformance = currentPerformance * (1 - reversionRate);
+            confidence = 0.3;
+        }
+    }
+
+    // Keep the figure within realistic bounds.
+    projected90DayPerformance = Math.max(
+        Math.min(projected90DayPerformance, 200),
+        -100,
+    );
+
+    return { projected90DayPerformance, projectionMethod, confidence };
+}
+
 // Publish on globalThis so the browser dashboard (classic script) and the Deno
 // test importer can both reach the helpers, mirroring docs/escape.js.
 globalThis.GRQProjection = {
@@ -127,4 +389,14 @@ globalThis.GRQProjection = {
     getDaysElapsed,
     calculatePerformanceReturn,
     buildHybridProjectionData,
+    formatCurrency,
+    getSplitAdjustment,
+    adjustHistoricalPriceToCurrent,
+    getBuyPrice,
+    currentPriceFromLatest,
+    calculateTargetPercentage,
+    calculateRSquared,
+    computeTrendLine,
+    daysElapsedFromMarketData,
+    computeHybridProjection,
 };

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -382,6 +382,55 @@ function computeHybridProjection(
     return { projected90DayPerformance, projectionMethod, confidence };
 }
 
+// Map a stock's performance to a human-readable judgement string. Before day 90
+// it leans on the hybrid projection (when confident enough), otherwise on the
+// current performance against 80% of target; from day 90 it reports the realised
+// outcome. This is the pure scoring kernel the dashboard's GRQValidator gathers
+// inputs for and delegates to.
+function computeJudgement(
+    { performance, daysElapsed, targetPercentage, projection },
+) {
+    if (performance === null) return "Pending";
+
+    const target = targetPercentage || 20; // Default to 20% if no target.
+
+    if (daysElapsed < 90) {
+        if (projection && projection.confidence > 0.2) {
+            const predicted = projection.projected90DayPerformance;
+            const pctOfTarget = target === 0 ? 0 : predicted / target;
+            if (predicted < 0 || pctOfTarget < 0.2) {
+                return `Declining (${predicted.toFixed(1)}%)`;
+            } else if (pctOfTarget >= 0.95) {
+                return `On Track (${predicted.toFixed(1)}%)`;
+            } else if (pctOfTarget >= 0.2) {
+                return `Below Target (${predicted.toFixed(1)}%)`;
+            }
+            return `Declining (${predicted.toFixed(1)}%)`;
+        }
+
+        // Not enough data for a reliable projection: judge current performance.
+        const threshold = target * 0.8;
+        if (daysElapsed < 30) {
+            return performance > 0
+                ? `Early Days (+${performance.toFixed(1)}%)`
+                : `Early Days (${performance.toFixed(1)}%)`;
+        }
+        // 30-60 and 60+ days share the same thresholds.
+        if (performance >= threshold) {
+            return `On Track (${performance.toFixed(1)}%)`;
+        } else if (performance > 0) {
+            return `Below Target (${performance.toFixed(1)}%)`;
+        }
+        return `Declining (${performance.toFixed(1)}%)`;
+    }
+
+    // 90 days or more elapsed: report the realised outcome.
+    const threshold = target * 0.8;
+    if (performance >= threshold) return "Hit Target";
+    if (performance > 0) return "Partial Success";
+    return "Missed Target";
+}
+
 // Publish on globalThis so the browser dashboard (classic script) and the Deno
 // test importer can both reach the helpers, mirroring docs/escape.js.
 globalThis.GRQProjection = {
@@ -399,4 +448,5 @@ globalThis.GRQProjection = {
     computeTrendLine,
     daysElapsedFromMarketData,
     computeHybridProjection,
+    computeJudgement,
 };

--- a/tests/basic_score_table_test.ts
+++ b/tests/basic_score_table_test.ts
@@ -66,9 +66,19 @@ function updateBasicStockTable(scoreData: ScoreData[]): string {
       <td>${stock.score.toFixed(3)}</td>
       <td>${formatCurrency(stock.target)}</td>
       <td>${stock.exDividendDate || "N/A"}</td>
-      <td>${stock.dividendPerShare ? formatCurrency(stock.dividendPerShare) : "N/A"}</td>
-      <td>${stock.intrinsicValuePerShareBasic ? formatCurrency(stock.intrinsicValuePerShareBasic) : "N/A"}</td>
-      <td>${stock.intrinsicValuePerShareAdjusted ? formatCurrency(stock.intrinsicValuePerShareAdjusted) : "N/A"}</td>
+      <td>${
+      stock.dividendPerShare ? formatCurrency(stock.dividendPerShare) : "N/A"
+    }</td>
+      <td>${
+      stock.intrinsicValuePerShareBasic
+        ? formatCurrency(stock.intrinsicValuePerShareBasic)
+        : "N/A"
+    }</td>
+      <td>${
+      stock.intrinsicValuePerShareAdjusted
+        ? formatCurrency(stock.intrinsicValuePerShareAdjusted)
+        : "N/A"
+    }</td>
       <td>${stock.notes || ""}</td>
     `;
   });
@@ -76,7 +86,9 @@ function updateBasicStockTable(scoreData: ScoreData[]): string {
   const scoreDate = new Date("2025-02-14");
   const daysElapsed = 5;
   tableHTML += `
-    <td>Score Date: ${scoreDate.toISOString().split("T")[0]} (${daysElapsed} days ago)</td>
+    <td>Score Date: ${
+    scoreDate.toISOString().split("T")[0]
+  } (${daysElapsed} days ago)</td>
     <td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td>
   `;
 
@@ -91,15 +103,27 @@ Deno.test("Basic Score Table - No Market Data", async (t) => {
 
     assertEquals(tableHTML.includes("TEST1"), true, "Should include TEST1");
     assertEquals(tableHTML.includes("TEST2"), true, "Should include TEST2");
-    assertEquals(tableHTML.includes("0.850"), true, "Should include TEST1 score");
-    assertEquals(tableHTML.includes("0.720"), true, "Should include TEST2 score");
+    assertEquals(
+      tableHTML.includes("0.850"),
+      true,
+      "Should include TEST1 score",
+    );
+    assertEquals(
+      tableHTML.includes("0.720"),
+      true,
+      "Should include TEST2 score",
+    );
     assertEquals(tableHTML.includes("$18.50"), true, "Format TEST1 target");
     assertEquals(tableHTML.includes("$15.00"), true, "Format TEST2 target");
     assertEquals(tableHTML.includes("2025-03-15"), true, "Ex-dividend date");
     assertEquals(tableHTML.includes("$0.25"), true, "Format dividend");
     assertEquals(tableHTML.includes("N/A"), true, "N/A for missing dividend");
     assertEquals(tableHTML.includes("$20.00"), true, "Format basic intrinsic");
-    assertEquals(tableHTML.includes("$19.50"), true, "Format adjusted intrinsic");
+    assertEquals(
+      tableHTML.includes("$19.50"),
+      true,
+      "Format adjusted intrinsic",
+    );
     assertEquals(tableHTML.includes("Strong fundamentals"), true, "Notes");
     assertEquals(
       tableHTML.includes("Score Date: 2025-02-14 (5 days ago)"),

--- a/tests/basic_score_table_test.ts
+++ b/tests/basic_score_table_test.ts
@@ -1,4 +1,13 @@
+// Basic score-table rendering tests (issue #100).
+//
+// Currency formatting used to be reimplemented inside a `MockGRQValidator`. It
+// now comes from the REAL shared kernel `GRQProjection.formatCurrency` in
+// docs/projection.js (the same function the dashboard's GRQValidator.formatCurrency
+// delegates to), so the table's monetary cells can no longer drift from
+// production. The HTML row layout stays local test glue (dashboard UI, not
+// projection maths) but builds its currency cells with the real kernel.
 import { assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
 interface ScoreData {
   stock: string;
@@ -11,200 +20,87 @@ interface ScoreData {
   intrinsicValuePerShareAdjusted: number | null;
 }
 
-class MockGRQValidator {
-  scoreData: ScoreData[] = [];
-  marketData: Record<string, unknown[]> = {};
-  selectedFile = "test.tsv";
+const g = globalThis as unknown as {
+  GRQProjection: {
+    formatCurrency: (value: number | null | undefined) => string;
+  };
+};
+const formatCurrency = g.GRQProjection.formatCurrency;
 
-  setupBasicScoreData(): void {
-    this.scoreData = [
-      {
-        stock: "TEST1",
-        score: 0.85,
-        target: 18.5,
-        exDividendDate: "2025-03-15",
-        dividendPerShare: 0.25,
-        notes: "Strong fundamentals",
-        intrinsicValuePerShareBasic: 20.0,
-        intrinsicValuePerShareAdjusted: 19.5,
-      },
-      {
-        stock: "TEST2",
-        score: 0.72,
-        target: 15.0,
-        exDividendDate: null,
-        dividendPerShare: 0,
-        notes: "",
-        intrinsicValuePerShareBasic: null,
-        intrinsicValuePerShareAdjusted: null,
-      },
-    ];
-    // No market data
-    this.marketData = {};
-  }
+function setupBasicScoreData(): ScoreData[] {
+  return [
+    {
+      stock: "TEST1",
+      score: 0.85,
+      target: 18.5,
+      exDividendDate: "2025-03-15",
+      dividendPerShare: 0.25,
+      notes: "Strong fundamentals",
+      intrinsicValuePerShareBasic: 20.0,
+      intrinsicValuePerShareAdjusted: 19.5,
+    },
+    {
+      stock: "TEST2",
+      score: 0.72,
+      target: 15.0,
+      exDividendDate: null,
+      dividendPerShare: 0,
+      notes: "",
+      intrinsicValuePerShareBasic: null,
+      intrinsicValuePerShareAdjusted: null,
+    },
+  ];
+}
 
-  getScoreDate(): Date {
-    return new Date("2025-02-14");
-  }
+// Build the table HTML, formatting every monetary cell with the real kernel.
+function updateBasicStockTable(scoreData: ScoreData[]): string {
+  let tableHTML = `
+    <th>Stock</th><th>Score</th><th>90-Day Target</th>
+    <th>Ex-Dividend Date</th><th>Dividend Per Share</th>
+    <th>Intrinsic Value (Basic)</th><th>Intrinsic Value (Adjusted)</th><th>Notes</th>
+  `;
 
-  getDaysElapsed(): number {
-    return 5; // 5 days ago
-  }
-
-  formatCurrency(value: number | null | undefined): string {
-    if (value === null || value === undefined || isNaN(value)) {
-      return "N/A";
-    }
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(value);
-  }
-
-  updateBasicStockTable(): string {
-    // Simulate the table generation
-    let tableHTML = "";
-
-    // Table headers
+  scoreData.forEach((stock) => {
     tableHTML += `
-      <th>Stock</th>
-      <th>Score</th>
-      <th>90-Day Target</th>
-      <th>Ex-Dividend Date</th>
-      <th>Dividend Per Share</th>
-      <th>Intrinsic Value (Basic)</th>
-      <th>Intrinsic Value (Adjusted)</th>
-      <th>Notes</th>
+      <td>${stock.stock}</td>
+      <td>${stock.score.toFixed(3)}</td>
+      <td>${formatCurrency(stock.target)}</td>
+      <td>${stock.exDividendDate || "N/A"}</td>
+      <td>${stock.dividendPerShare ? formatCurrency(stock.dividendPerShare) : "N/A"}</td>
+      <td>${stock.intrinsicValuePerShareBasic ? formatCurrency(stock.intrinsicValuePerShareBasic) : "N/A"}</td>
+      <td>${stock.intrinsicValuePerShareAdjusted ? formatCurrency(stock.intrinsicValuePerShareAdjusted) : "N/A"}</td>
+      <td>${stock.notes || ""}</td>
     `;
+  });
 
-    // Stock rows
-    this.scoreData.forEach((stock) => {
-      tableHTML += `
-        <td>${stock.stock}</td>
-        <td>${stock.score.toFixed(3)}</td>
-        <td>${this.formatCurrency(stock.target)}</td>
-        <td>${stock.exDividendDate || "N/A"}</td>
-        <td>${
-        stock.dividendPerShare
-          ? this.formatCurrency(stock.dividendPerShare)
-          : "N/A"
-      }</td>
-        <td>${
-        stock.intrinsicValuePerShareBasic
-          ? this.formatCurrency(stock.intrinsicValuePerShareBasic)
-          : "N/A"
-      }</td>
-        <td>${
-        stock.intrinsicValuePerShareAdjusted
-          ? this.formatCurrency(stock.intrinsicValuePerShareAdjusted)
-          : "N/A"
-      }</td>
-        <td>${stock.notes || ""}</td>
-      `;
-    });
+  const scoreDate = new Date("2025-02-14");
+  const daysElapsed = 5;
+  tableHTML += `
+    <td>Score Date: ${scoreDate.toISOString().split("T")[0]} (${daysElapsed} days ago)</td>
+    <td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td><td>-</td>
+  `;
 
-    // Summary row
-    const scoreDate = this.getScoreDate();
-    const daysElapsed = this.getDaysElapsed();
-    tableHTML += `
-      <td>Score Date: ${
-      scoreDate.toISOString().split("T")[0]
-    } (${daysElapsed} days ago)</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-      <td>-</td>
-    `;
-
-    return tableHTML;
-  }
+  return tableHTML;
 }
 
 Deno.test("Basic Score Table - No Market Data", async (t) => {
-  const validator = new MockGRQValidator();
-  validator.setupBasicScoreData();
+  const scoreData = setupBasicScoreData();
 
   await t.step("should generate basic score table with all score data", () => {
-    const tableHTML = validator.updateBasicStockTable();
+    const tableHTML = updateBasicStockTable(scoreData);
 
-    // Check that all stocks are included
-    assertEquals(
-      tableHTML.includes("TEST1"),
-      true,
-      "Should include TEST1 stock",
-    );
-    assertEquals(
-      tableHTML.includes("TEST2"),
-      true,
-      "Should include TEST2 stock",
-    );
-
-    // Check that score data is formatted correctly
-    assertEquals(
-      tableHTML.includes("0.850"),
-      true,
-      "Should include TEST1 score",
-    );
-    assertEquals(
-      tableHTML.includes("0.720"),
-      true,
-      "Should include TEST2 score",
-    );
-
-    // Check that target prices are formatted as currency
-    assertEquals(
-      tableHTML.includes("$18.50"),
-      true,
-      "Should format TEST1 target as currency",
-    );
-    assertEquals(
-      tableHTML.includes("$15.00"),
-      true,
-      "Should format TEST2 target as currency",
-    );
-
-    // Check that dividend data is handled correctly
-    assertEquals(
-      tableHTML.includes("2025-03-15"),
-      true,
-      "Should include ex-dividend date",
-    );
-    assertEquals(
-      tableHTML.includes("$0.25"),
-      true,
-      "Should format dividend as currency",
-    );
-    assertEquals(
-      tableHTML.includes("N/A"),
-      true,
-      "Should show N/A for missing dividend data",
-    );
-
-    // Check that intrinsic values are handled correctly
-    assertEquals(
-      tableHTML.includes("$20.00"),
-      true,
-      "Should format basic intrinsic value",
-    );
-    assertEquals(
-      tableHTML.includes("$19.50"),
-      true,
-      "Should format adjusted intrinsic value",
-    );
-
-    // Check that notes are included
-    assertEquals(
-      tableHTML.includes("Strong fundamentals"),
-      true,
-      "Should include notes",
-    );
-
-    // Check that summary row is included
+    assertEquals(tableHTML.includes("TEST1"), true, "Should include TEST1");
+    assertEquals(tableHTML.includes("TEST2"), true, "Should include TEST2");
+    assertEquals(tableHTML.includes("0.850"), true, "Should include TEST1 score");
+    assertEquals(tableHTML.includes("0.720"), true, "Should include TEST2 score");
+    assertEquals(tableHTML.includes("$18.50"), true, "Format TEST1 target");
+    assertEquals(tableHTML.includes("$15.00"), true, "Format TEST2 target");
+    assertEquals(tableHTML.includes("2025-03-15"), true, "Ex-dividend date");
+    assertEquals(tableHTML.includes("$0.25"), true, "Format dividend");
+    assertEquals(tableHTML.includes("N/A"), true, "N/A for missing dividend");
+    assertEquals(tableHTML.includes("$20.00"), true, "Format basic intrinsic");
+    assertEquals(tableHTML.includes("$19.50"), true, "Format adjusted intrinsic");
+    assertEquals(tableHTML.includes("Strong fundamentals"), true, "Notes");
     assertEquals(
       tableHTML.includes("Score Date: 2025-02-14 (5 days ago)"),
       true,
@@ -213,8 +109,8 @@ Deno.test("Basic Score Table - No Market Data", async (t) => {
   });
 
   await t.step("should handle null/undefined values gracefully", () => {
-    // Add a stock with null values
-    validator.scoreData.push({
+    const withNulls = setupBasicScoreData();
+    withNulls.push({
       stock: "TEST3",
       score: 0.5,
       target: 10.0,
@@ -225,23 +121,9 @@ Deno.test("Basic Score Table - No Market Data", async (t) => {
       intrinsicValuePerShareAdjusted: null,
     });
 
-    const tableHTML = validator.updateBasicStockTable();
-
-    // Check that null values are handled
-    assertEquals(
-      tableHTML.includes("TEST3"),
-      true,
-      "Should include TEST3 stock",
-    );
-    assertEquals(
-      tableHTML.includes("N/A"),
-      true,
-      "Should show N/A for null values",
-    );
-    assertEquals(
-      tableHTML.includes("0.500"),
-      true,
-      "Should format score correctly",
-    );
+    const tableHTML = updateBasicStockTable(withNulls);
+    assertEquals(tableHTML.includes("TEST3"), true, "Should include TEST3");
+    assertEquals(tableHTML.includes("N/A"), true, "N/A for null values");
+    assertEquals(tableHTML.includes("0.500"), true, "Format score correctly");
   });
 });

--- a/tests/buy_price_logic_test.ts
+++ b/tests/buy_price_logic_test.ts
@@ -1,4 +1,18 @@
+// Buy-price / split-adjustment / target-percentage tests (issue #100).
+//
+// These used to drive a `MockGRQValidator` that copied getBuyPrice,
+// getHistoricalToCurrentSplitAdjustment, adjustHistoricalPriceToCurrent,
+// calculateTargetPercentage and the dilution performance maths. They now call
+// the REAL shared kernels in docs/projection.js (getBuyPrice, getSplitAdjustment,
+// adjustHistoricalPriceToCurrent, calculateTargetPercentage,
+// calculatePerformanceReturn) — the same code the dashboard's GRQValidator uses.
+//
+// Dates are built with local-midnight constructors so they match the kernel's
+// local-midnight date comparison regardless of the runner's timezone, and date
+// assertions use local getters (not toISOString, which would shift across the
+// date line in +/- UTC offsets).
 import { assertAlmostEquals, assertEquals, assertExists } from "@std/assert";
+import "../docs/projection.js";
 
 interface MarketDataPoint {
   date: Date;
@@ -9,262 +23,183 @@ interface MarketDataPoint {
   splitCoefficient: number;
 }
 
-interface Stock {
-  stock: string;
-  target: number;
+const g = globalThis as unknown as {
+  GRQProjection: {
+    getBuyPrice: (
+      marketData: MarketDataPoint[] | undefined,
+      scoreDate: Date,
+    ) => { price: number; dateUsed: Date } | null;
+    adjustHistoricalPriceToCurrent: (
+      price: number,
+      marketData: MarketDataPoint[] | undefined,
+      historicalDate: Date,
+    ) => number;
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+    calculatePerformanceReturn: (
+      buyPrice: number,
+      currentPrice: number,
+      totalDividends?: number,
+    ) => number | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+function targetPercentage(
+  marketData: MarketDataPoint[] | undefined,
+  scoreDate: Date,
+  target: number,
+): number | null {
+  const buyPrice = GRQProjection.getBuyPrice(marketData, scoreDate);
+  const adjustedTarget = GRQProjection.adjustHistoricalPriceToCurrent(
+    target,
+    marketData,
+    scoreDate,
+  );
+  return GRQProjection.calculateTargetPercentage(
+    buyPrice !== null ? buyPrice.price : null,
+    adjustedTarget,
+  );
 }
 
-class MockGRQValidator {
-  marketData: Record<string, MarketDataPoint[]> = {};
-  dividendData: Record<string, unknown[]> = {};
+// Mirror GRQValidator.calculateStockPerformanceWithDilution: last price within
+// 90 days vs the split-adjusted buy price (test data carries no dividends).
+function performanceWithDilution(
+  marketData: MarketDataPoint[] | undefined,
+  scoreDate: Date,
+): number | null {
+  if (!marketData || marketData.length === 0) return null;
+  const ninetyDayDate = new Date(scoreDate.getTime() + 90 * 24 * 60 * 60 * 1000);
+  const within90Days = marketData.filter((point) => point.date <= ninetyDayDate);
+  if (within90Days.length === 0) return null;
+  const lastData = within90Days[within90Days.length - 1];
+  const currentPrice = (lastData.high + lastData.low) / 2;
+  const buyPriceObj = GRQProjection.getBuyPrice(marketData, scoreDate);
+  if (buyPriceObj === null) return null;
+  return GRQProjection.calculatePerformanceReturn(
+    buyPriceObj.price,
+    currentPrice,
+    0,
+  );
+}
 
-  setupFebruary15Data(): void {
-    this.marketData = {
-      "NASDAQ:XP": [
-        {
-          date: new Date("2025-02-18"),
-          high: 15.18,
-          low: 14.72,
-          open: 14.72,
-          close: 15.02,
-          splitCoefficient: 1.0,
-        },
-        {
-          date: new Date("2025-02-19"),
-          high: 15.25,
-          low: 14.85,
-          open: 15.02,
-          close: 15.10,
-          splitCoefficient: 1.0,
-        },
-        {
-          date: new Date("2025-02-20"),
-          high: 15.30,
-          low: 14.90,
-          open: 15.10,
-          close: 15.20,
-          splitCoefficient: 1.0,
-        },
-      ],
-    };
-  }
-
-  getHistoricalToCurrentSplitAdjustment(
-    stockSymbol: string,
-    historicalDate: Date,
-  ): number {
-    const marketData = this.marketData[stockSymbol];
-    if (!marketData) return 1.0;
-    let cumulativeSplit = 1.0;
-    for (const point of marketData) {
-      if (point.date > historicalDate && point.splitCoefficient > 1.0) {
-        cumulativeSplit *= point.splitCoefficient;
-      }
-    }
-    return cumulativeSplit;
-  }
-
-  adjustHistoricalPriceToCurrent(
-    price: number,
-    stockSymbol: string,
-    historicalDate: Date,
-  ): number {
-    const splitAdjustment = this.getHistoricalToCurrentSplitAdjustment(
-      stockSymbol,
-      historicalDate,
-    );
-    return price / splitAdjustment;
-  }
-
-  getBuyPrice(
-    stockSymbol: string,
-    scoreDate: Date,
-  ): { price: number; dateUsed: Date } | null {
-    const marketData = this.marketData[stockSymbol];
-    if (!marketData) return null;
-    for (let offset = 0; offset <= 5; offset++) {
-      const candidateDate = new Date(scoreDate.getTime());
-      candidateDate.setDate(candidateDate.getDate() + offset);
-      const candidateData = marketData.find((point) => {
-        const pointDate = new Date(
-          point.date.getFullYear(),
-          point.date.getMonth(),
-          point.date.getDate(),
-        );
-        const candidateDateOnly = new Date(
-          candidateDate.getFullYear(),
-          candidateDate.getMonth(),
-          candidateDate.getDate(),
-        );
-        return pointDate.getTime() === candidateDateOnly.getTime();
-      });
-      if (candidateData) {
-        return {
-          price: this.adjustHistoricalPriceToCurrent(
-            (candidateData.high + candidateData.low) / 2,
-            stockSymbol,
-            scoreDate,
-          ),
-          dateUsed: candidateDate,
-        };
-      }
-    }
-    return null;
-  }
-
-  calculateTargetPercentage(stock: Stock, scoreDate: Date): number | null {
-    const buyPrice = this.getBuyPrice(stock.stock, scoreDate);
-    const adjustedTarget = this.adjustHistoricalPriceToCurrent(
-      stock.target,
-      stock.stock,
-      scoreDate,
-    );
-    if (buyPrice !== null && adjustedTarget !== null) {
-      return ((adjustedTarget - buyPrice.price) / buyPrice.price) * 100;
-    }
-    return null;
-  }
-
-  calculateStockPerformanceWithDilution(
-    stock: Stock,
-    scoreDate: Date,
-  ): number | null {
-    const marketData = this.marketData[stock.stock];
-    if (!marketData || marketData.length === 0) return null;
-    const ninetyDayDate = new Date(
-      scoreDate.getTime() + 90 * 24 * 60 * 60 * 1000,
-    );
-    const within90Days = marketData.filter((point) =>
-      point.date <= ninetyDayDate
-    );
-    if (within90Days.length === 0) return null;
-    const lastData = within90Days[within90Days.length - 1];
-    const currentPrice = (lastData.high + lastData.low) / 2;
-    const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-    if (buyPriceObj === null) return null;
-    const priceReturn =
-      ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-    const dividendReturn = 0; // No dividends in test data
-    return priceReturn + dividendReturn;
-  }
+function februaryData(): MarketDataPoint[] {
+  return [
+    {
+      date: new Date(2025, 1, 18),
+      high: 15.18,
+      low: 14.72,
+      open: 14.72,
+      close: 15.02,
+      splitCoefficient: 1.0,
+    },
+    {
+      date: new Date(2025, 1, 19),
+      high: 15.25,
+      low: 14.85,
+      open: 15.02,
+      close: 15.10,
+      splitCoefficient: 1.0,
+    },
+    {
+      date: new Date(2025, 1, 20),
+      high: 15.30,
+      low: 14.90,
+      open: 15.10,
+      close: 15.20,
+      splitCoefficient: 1.0,
+    },
+  ];
 }
 
 Deno.test("Buy Price Logic - February 15, 2025 Case", async (t) => {
-  const validator = new MockGRQValidator();
-  validator.setupFebruary15Data();
-  const scoreDate = new Date("2025-02-14");
-  const stock: Stock = { stock: "NASDAQ:XP", target: 18.5 };
+  const marketData = februaryData();
+  const scoreDate = new Date(2025, 1, 14);
 
   await t.step(
     "should find buy price on next available trading day (Feb 18)",
     () => {
-      const buyPrice = validator.getBuyPrice("NASDAQ:XP", scoreDate);
+      const buyPrice = GRQProjection.getBuyPrice(marketData, scoreDate);
       assertExists(buyPrice, "Buy price should not be null");
       assertEquals(
         buyPrice!.price,
         14.95,
         "Buy price should be (15.18 + 14.72) / 2 = 14.95",
       );
-      assertEquals(
-        buyPrice!.dateUsed.toISOString().split("T")[0],
-        "2025-02-18",
-        "Should use February 18, 2025",
-      );
+      assertEquals(buyPrice!.dateUsed.getFullYear(), 2025);
+      assertEquals(buyPrice!.dateUsed.getMonth(), 1, "February");
+      assertEquals(buyPrice!.dateUsed.getDate(), 18, "Should use February 18");
     },
   );
 
   await t.step("should calculate target percentage correctly", () => {
-    const targetPercentage = validator.calculateTargetPercentage(
-      stock,
-      scoreDate,
-    );
-    assertExists(targetPercentage, "Target percentage should not be null");
-    assertAlmostEquals(
-      targetPercentage!,
-      23.75,
-      0.01,
-      "Target percentage should be 23.75%",
-    );
+    const pct = targetPercentage(marketData, scoreDate, 18.5);
+    assertExists(pct, "Target percentage should not be null");
+    assertAlmostEquals(pct!, 23.75, 0.01, "Target percentage should be 23.75%");
   });
 
   await t.step("should calculate performance correctly", () => {
-    const performance = validator.calculateStockPerformanceWithDilution(
-      stock,
-      scoreDate,
-    );
+    const performance = performanceWithDilution(marketData, scoreDate);
     assertAlmostEquals(performance!, 1.0, 0.01, "Performance should be 1.00%");
   });
 });
 
 Deno.test("Buy Price Logic - Edge Cases", async (t) => {
-  const validator = new MockGRQValidator();
-
   await t.step("should return null for non-existent stock", () => {
-    const buyPrice = validator.getBuyPrice(
-      "NONEXISTENT",
-      new Date("2025-02-14"),
-    );
+    const buyPrice = GRQProjection.getBuyPrice(undefined, new Date(2025, 1, 14));
     assertEquals(buyPrice, null, "Should return null for non-existent stock");
   });
 
   await t.step("should return null when no market data", () => {
-    validator.marketData = {};
-    const buyPrice = validator.getBuyPrice("NASDAQ:XP", new Date("2025-02-14"));
+    const buyPrice = GRQProjection.getBuyPrice(undefined, new Date(2025, 1, 14));
     assertEquals(buyPrice, null, "Should return null when no market data");
   });
 
   await t.step("should handle exact date match", () => {
-    validator.setupFebruary15Data();
-    const buyPrice = validator.getBuyPrice("NASDAQ:XP", new Date("2025-02-18"));
-    assertExists(buyPrice, "Buy price should not be null");
-    assertEquals(
-      buyPrice!.dateUsed.toISOString().split("T")[0],
-      "2025-02-18",
-      "Should use exact date when available",
+    const buyPrice = GRQProjection.getBuyPrice(
+      februaryData(),
+      new Date(2025, 1, 18),
     );
+    assertExists(buyPrice, "Buy price should not be null");
+    assertEquals(buyPrice!.dateUsed.getDate(), 18, "Should use exact date");
   });
 });
 
 Deno.test("Buy Price Logic - Split Adjustments", async (t) => {
-  const validator = new MockGRQValidator();
-  validator.marketData = {
-    "NASDAQ:XP": [
-      {
-        date: new Date("2025-02-18"),
-        high: 30.36,
-        low: 29.44,
-        open: 29.44,
-        close: 30.04,
-        splitCoefficient: 1.0,
-      },
-      {
-        date: new Date("2025-02-20"),
-        high: 15.18,
-        low: 14.72,
-        open: 14.72,
-        close: 15.02,
-        splitCoefficient: 2.0,
-      },
-    ],
-  };
+  const marketData: MarketDataPoint[] = [
+    {
+      date: new Date(2025, 1, 18),
+      high: 30.36,
+      low: 29.44,
+      open: 29.44,
+      close: 30.04,
+      splitCoefficient: 1.0,
+    },
+    {
+      date: new Date(2025, 1, 20),
+      high: 15.18,
+      low: 14.72,
+      open: 14.72,
+      close: 15.02,
+      splitCoefficient: 2.0,
+    },
+  ];
 
   await t.step("should adjust buy price for splits", () => {
-    const buyPrice = validator.getBuyPrice("NASDAQ:XP", new Date("2025-02-18"));
+    const buyPrice = GRQProjection.getBuyPrice(marketData, new Date(2025, 1, 18));
     assertExists(buyPrice, "Buy price should not be null");
-    assertEquals(
-      buyPrice!.price,
-      14.95,
-      "Buy price should be adjusted for split",
-    );
+    // (30.36 + 29.44) / 2 = 29.90, divided by the 2:1 split = 14.95.
+    assertEquals(buyPrice!.price, 14.95, "Buy price should be split-adjusted");
   });
 });
 
 Deno.test("Buy Price Logic - 5 Day Forward Search", async (t) => {
-  const validator = new MockGRQValidator();
-  validator.marketData = {
-    "NASDAQ:XP": [
+  await t.step("should find price within 5 days", () => {
+    const marketData: MarketDataPoint[] = [
       {
-        date: new Date("2025-02-14"),
+        date: new Date(2025, 1, 14),
         high: 15.18,
         low: 14.72,
         open: 14.72,
@@ -272,78 +207,46 @@ Deno.test("Buy Price Logic - 5 Day Forward Search", async (t) => {
         splitCoefficient: 1.0,
       },
       {
-        date: new Date("2025-02-19"),
+        date: new Date(2025, 1, 19),
         high: 15.25,
         low: 14.85,
         open: 15.02,
         close: 15.10,
         splitCoefficient: 1.0,
       },
-    ],
-  };
-
-  await t.step("should find price within 5 days", () => {
-    const buyPrice = validator.getBuyPrice("NASDAQ:XP", new Date("2025-02-14"));
+    ];
+    const buyPrice = GRQProjection.getBuyPrice(marketData, new Date(2025, 1, 14));
     assertExists(buyPrice, "Buy price should not be null");
-    assertEquals(
-      buyPrice!.dateUsed.toISOString().split("T")[0],
-      "2025-02-14",
-      "Should find exact date when available",
-    );
+    assertEquals(buyPrice!.dateUsed.getDate(), 14, "Should find exact date");
   });
 
   await t.step("should return null if no price found within 5 days", () => {
-    validator.marketData = {
-      "NASDAQ:XP": [
-        {
-          date: new Date("2025-02-25"),
-          high: 15.18,
-          low: 14.72,
-          open: 14.72,
-          close: 15.02,
-          splitCoefficient: 1.0,
-        },
-      ],
-    };
-    const buyPrice = validator.getBuyPrice("NASDAQ:XP", new Date("2025-02-14"));
-    assertEquals(
-      buyPrice,
-      null,
-      "Should return null when no price found within 5 days",
-    );
+    const marketData: MarketDataPoint[] = [
+      {
+        date: new Date(2025, 1, 25),
+        high: 15.18,
+        low: 14.72,
+        open: 14.72,
+        close: 15.02,
+        splitCoefficient: 1.0,
+      },
+    ];
+    const buyPrice = GRQProjection.getBuyPrice(marketData, new Date(2025, 1, 14));
+    assertEquals(buyPrice, null, "Should return null beyond the 5-day window");
   });
 });
 
 Deno.test("Buy Price Logic - Null Safety", async (t) => {
-  const validator = new MockGRQValidator();
-
   await t.step(
     "should handle null buy price in target percentage calculation",
     () => {
-      const targetPercentage = validator.calculateTargetPercentage(
-        { stock: "NONEXISTENT", target: 18.5 },
-        new Date("2025-02-14"),
-      );
-      assertEquals(
-        targetPercentage,
-        null,
-        "Should return null when buy price is null",
-      );
+      const pct = targetPercentage(undefined, new Date(2025, 1, 14), 18.5);
+      assertEquals(pct, null, "Should return null when buy price is null");
     },
   );
 
-  await t.step(
-    "should handle null buy price in performance calculation",
-    () => {
-      const performance = validator.calculateStockPerformanceWithDilution(
-        { stock: "NONEXISTENT", target: 18.5 },
-        new Date("2025-02-14"),
-      );
-      assertEquals(
-        performance,
-        null,
-        "Should return null when buy price is null",
-      );
-    },
-  );
+  await t.step("should handle null buy price in performance calculation", () => {
+    const performance = performanceWithDilution(undefined, new Date(2025, 1, 14));
+    assertEquals(performance, null, "Should return null when buy price is null");
+  });
 });

--- a/tests/buy_price_logic_test.ts
+++ b/tests/buy_price_logic_test.ts
@@ -71,8 +71,12 @@ function performanceWithDilution(
   scoreDate: Date,
 ): number | null {
   if (!marketData || marketData.length === 0) return null;
-  const ninetyDayDate = new Date(scoreDate.getTime() + 90 * 24 * 60 * 60 * 1000);
-  const within90Days = marketData.filter((point) => point.date <= ninetyDayDate);
+  const ninetyDayDate = new Date(
+    scoreDate.getTime() + 90 * 24 * 60 * 60 * 1000,
+  );
+  const within90Days = marketData.filter((point) =>
+    point.date <= ninetyDayDate
+  );
   if (within90Days.length === 0) return null;
   const lastData = within90Days[within90Days.length - 1];
   const currentPrice = (lastData.high + lastData.low) / 2;
@@ -148,12 +152,18 @@ Deno.test("Buy Price Logic - February 15, 2025 Case", async (t) => {
 
 Deno.test("Buy Price Logic - Edge Cases", async (t) => {
   await t.step("should return null for non-existent stock", () => {
-    const buyPrice = GRQProjection.getBuyPrice(undefined, new Date(2025, 1, 14));
+    const buyPrice = GRQProjection.getBuyPrice(
+      undefined,
+      new Date(2025, 1, 14),
+    );
     assertEquals(buyPrice, null, "Should return null for non-existent stock");
   });
 
   await t.step("should return null when no market data", () => {
-    const buyPrice = GRQProjection.getBuyPrice(undefined, new Date(2025, 1, 14));
+    const buyPrice = GRQProjection.getBuyPrice(
+      undefined,
+      new Date(2025, 1, 14),
+    );
     assertEquals(buyPrice, null, "Should return null when no market data");
   });
 
@@ -188,7 +198,10 @@ Deno.test("Buy Price Logic - Split Adjustments", async (t) => {
   ];
 
   await t.step("should adjust buy price for splits", () => {
-    const buyPrice = GRQProjection.getBuyPrice(marketData, new Date(2025, 1, 18));
+    const buyPrice = GRQProjection.getBuyPrice(
+      marketData,
+      new Date(2025, 1, 18),
+    );
     assertExists(buyPrice, "Buy price should not be null");
     // (30.36 + 29.44) / 2 = 29.90, divided by the 2:1 split = 14.95.
     assertEquals(buyPrice!.price, 14.95, "Buy price should be split-adjusted");
@@ -215,7 +228,10 @@ Deno.test("Buy Price Logic - 5 Day Forward Search", async (t) => {
         splitCoefficient: 1.0,
       },
     ];
-    const buyPrice = GRQProjection.getBuyPrice(marketData, new Date(2025, 1, 14));
+    const buyPrice = GRQProjection.getBuyPrice(
+      marketData,
+      new Date(2025, 1, 14),
+    );
     assertExists(buyPrice, "Buy price should not be null");
     assertEquals(buyPrice!.dateUsed.getDate(), 14, "Should find exact date");
   });
@@ -231,7 +247,10 @@ Deno.test("Buy Price Logic - 5 Day Forward Search", async (t) => {
         splitCoefficient: 1.0,
       },
     ];
-    const buyPrice = GRQProjection.getBuyPrice(marketData, new Date(2025, 1, 14));
+    const buyPrice = GRQProjection.getBuyPrice(
+      marketData,
+      new Date(2025, 1, 14),
+    );
     assertEquals(buyPrice, null, "Should return null beyond the 5-day window");
   });
 });
@@ -245,8 +264,18 @@ Deno.test("Buy Price Logic - Null Safety", async (t) => {
     },
   );
 
-  await t.step("should handle null buy price in performance calculation", () => {
-    const performance = performanceWithDilution(undefined, new Date(2025, 1, 14));
-    assertEquals(performance, null, "Should return null when buy price is null");
-  });
+  await t.step(
+    "should handle null buy price in performance calculation",
+    () => {
+      const performance = performanceWithDilution(
+        undefined,
+        new Date(2025, 1, 14),
+      );
+      assertEquals(
+        performance,
+        null,
+        "Should return null when buy price is null",
+      );
+    },
+  );
 });

--- a/tests/chart_data_test.ts
+++ b/tests/chart_data_test.ts
@@ -1,6 +1,15 @@
+// Chart-data preparation tests (issue #100).
+//
+// The chart-dataset assembly is dashboard UI glue and stays local, but the maths
+// it used to reimplement inline — the per-point performance return, the
+// historical-price split adjustment and the target percentage — now come from
+// the REAL shared kernels in docs/projection.js (calculatePerformanceReturn,
+// adjustHistoricalPriceToCurrent, calculateTargetPercentage). getBuyPrice is
+// still reassigned per step to exercise how the chart reacts to null/zero/valid
+// buy prices.
 import { assertEquals, assertNotEquals } from "@std/assert";
+import "../docs/projection.js";
 
-// Define types for the mock validator
 interface MarketDataPoint {
   date: Date;
   high: number;
@@ -29,27 +38,40 @@ interface ChartDataPoint {
 interface Dataset {
   label: string;
   data: ChartDataPoint[];
-  borderColor?: string;
-  backgroundColor?: string;
-  borderWidth?: number;
-  fill?: boolean;
-  pointRadius?: number;
-  pointStyle?: string;
-  showLine?: boolean;
 }
 
-class MockGRQValidator {
+const g = globalThis as unknown as {
+  GRQProjection: {
+    calculatePerformanceReturn: (
+      buyPrice: number,
+      currentPrice: number,
+      totalDividends?: number,
+    ) => number | null;
+    adjustHistoricalPriceToCurrent: (
+      price: number,
+      marketData: MarketDataPoint[] | undefined,
+      historicalDate: Date,
+    ) => number;
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+const DAY = 24 * 60 * 60 * 1000;
+
+class ChartValidator {
   marketData: Record<string, MarketDataPoint[]> = {};
-  dividendData: Record<string, unknown[]> = {};
   scoreData: ScoreData[] = [];
-  selectedFile = "test.tsv";
   selectedStock: string | null = null;
 
   setupValidChartData(): void {
     this.marketData = {
       TEST: [
         {
-          date: new Date("2025-02-18"),
+          date: new Date(2025, 1, 18),
           high: 15.18,
           low: 14.72,
           open: 14.72,
@@ -57,7 +79,7 @@ class MockGRQValidator {
           splitCoefficient: 1.0,
         },
         {
-          date: new Date("2025-02-19"),
+          date: new Date(2025, 1, 19),
           high: 15.25,
           low: 14.85,
           open: 15.02,
@@ -66,7 +88,6 @@ class MockGRQValidator {
         },
       ],
     };
-
     this.scoreData = [
       {
         stock: "TEST",
@@ -82,276 +103,134 @@ class MockGRQValidator {
   }
 
   getScoreDate(): Date {
-    return new Date("2025-02-14");
+    return new Date(2025, 1, 14);
   }
 
-  getDaysElapsed(): number {
-    return 30;
-  }
-
-  getDaysElapsedFromMarketData(scoreDate: Date): number {
-    if (!this.marketData || Object.keys(this.marketData).length === 0) {
-      return this.getDaysElapsed();
-    }
-    let latestMarketDate = scoreDate;
-    this.scoreData.forEach((stock) => {
-      const marketData = this.marketData[stock.stock];
-      if (marketData && marketData.length > 0) {
-        const stockLatestDate = marketData[marketData.length - 1].date;
-        if (stockLatestDate > latestMarketDate) {
-          latestMarketDate = stockLatestDate;
-        }
-      }
-    });
-    const diffTime = Math.abs(latestMarketDate.getTime() - scoreDate.getTime());
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    return Math.min(diffDays, 90);
-  }
-
+  // Default to the real kernel; tests reassign this to probe null/zero cases.
   getBuyPrice(
     _stockSymbol: string,
     _scoreDate: Date,
   ): { price: number; dateUsed: Date } | null {
-    return { price: 15.0, dateUsed: new Date("2025-02-18") };
-  }
-
-  adjustHistoricalPriceToCurrent(
-    price: number,
-    _stockSymbol: string,
-    _historicalDate: Date,
-  ): number {
-    return price;
-  }
-
-  calculateTargetPercentage(_stock: ScoreData, _scoreDate: Date): number {
-    return 20.0;
-  }
-
-  calculatePortfolioTargetPercentage(): number {
-    return 20.0;
+    return { price: 15.0, dateUsed: new Date(2025, 1, 18) };
   }
 
   calculatePortfolioData(): ChartDataPoint[] {
     return [
-      { x: new Date("2025-02-18"), y: 5.0 },
-      { x: new Date("2025-02-19"), y: 6.0 },
+      { x: new Date(2025, 1, 18), y: 5.0 },
+      { x: new Date(2025, 1, 19), y: 6.0 },
     ];
   }
 
   calculateCostOfCapitalData(): ChartDataPoint[] {
     return [
-      { x: new Date("2025-02-18"), y: 2.0 },
-      { x: new Date("2025-02-19"), y: 2.5 },
+      { x: new Date(2025, 1, 18), y: 2.0 },
+      { x: new Date(2025, 1, 19), y: 2.5 },
     ];
-  }
-
-  calculateTrendLine(_stock: ScoreData, _scoreDate: Date): null {
-    return null;
   }
 
   prepareChartData(): { datasets: Dataset[] } {
     const datasets: Dataset[] = [];
     const scoreDate = this.getScoreDate();
-    const ninetyDayDate = new Date(
-      scoreDate.getTime() + 90 * 24 * 60 * 60 * 1000,
-    );
+    const ninetyDayDate = new Date(scoreDate.getTime() + 90 * DAY);
 
     if (this.selectedStock) {
-      // Single stock view
       const stock = this.scoreData.find((s) => s.stock === this.selectedStock);
-      if (stock) {
-        const marketData = this.marketData[stock.stock];
-        if (marketData && marketData.length > 0) {
-          const targetPercentage = this.calculateTargetPercentage(
-            stock,
-            scoreDate,
-          );
-          const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-
-          if (!buyPriceObj || !buyPriceObj.price || buyPriceObj.price <= 0) {
-            // Don't add any performance datasets if no valid buy price
-            // Only add cost of capital line later
-          } else {
-            const buyPrice = buyPriceObj.price;
-            const before90Days: ChartDataPoint[] = [];
-
-            marketData.forEach((point) => {
-              const adjustedPrice = this.adjustHistoricalPriceToCurrent(
-                (point.high + point.low) / 2,
-                stock.stock,
-                point.date,
-              );
-              const yValue = ((adjustedPrice - buyPrice) / buyPrice) * 100;
-              if (isNaN(yValue) || yValue === null) return; // skip invalid
-
-              const dataPoint: ChartDataPoint = {
+      const marketData = stock ? this.marketData[stock.stock] : undefined;
+      if (stock && marketData && marketData.length > 0) {
+        const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
+        if (buyPriceObj && buyPriceObj.price > 0) {
+          const buyPrice = buyPriceObj.price;
+          const before90Days: ChartDataPoint[] = [];
+          marketData.forEach((point) => {
+            const adjustedPrice = GRQProjection.adjustHistoricalPriceToCurrent(
+              (point.high + point.low) / 2,
+              marketData,
+              point.date,
+            );
+            const yValue = GRQProjection.calculatePerformanceReturn(
+              buyPrice,
+              adjustedPrice,
+              0,
+            );
+            if (yValue === null || isNaN(yValue)) return;
+            if (point.date <= ninetyDayDate) {
+              before90Days.push({
                 x: new Date(point.date.getTime()),
                 y: yValue,
-              };
+              });
+            }
+          });
 
-              if (point.date <= ninetyDayDate) {
-                before90Days.push(dataPoint);
-              }
+          const clean = before90Days.filter((p) =>
+            typeof p.y === "number" && !isNaN(p.y)
+          );
+          if (clean.length > 0) {
+            datasets.push({ label: "Performance", data: clean });
+          }
+
+          const targetPercentage = GRQProjection.calculateTargetPercentage(
+            buyPrice,
+            stock.target,
+          );
+          if (targetPercentage !== null) {
+            datasets.push({
+              label: "Target",
+              data: [{ x: ninetyDayDate, y: targetPercentage }],
             });
-
-            // Filter out any invalid y values
-            const cleanBefore90 = before90Days.filter((p) =>
-              typeof p.y === "number" && !isNaN(p.y)
-            );
-
-            if (cleanBefore90.length > 0) {
-              datasets.push({
-                label: "Performance",
-                data: cleanBefore90,
-                borderColor: "rgba(102, 126, 234, 1)",
-                backgroundColor: "rgba(102, 126, 234, 0.1)",
-                borderWidth: 3,
-                fill: false,
-                pointRadius: 3,
-              });
-            }
-
-            // Add target dot only if we have valid buy price
-            if (targetPercentage !== null) {
-              datasets.push({
-                label: "Target",
-                data: [
-                  {
-                    x: ninetyDayDate,
-                    y: targetPercentage,
-                  },
-                ],
-                borderColor: "rgba(255, 193, 7, 1)",
-                backgroundColor: "rgba(255, 193, 7, 1)",
-                borderWidth: 0,
-                fill: false,
-                pointRadius: 8,
-                pointStyle: "circle",
-                showLine: false,
-              });
-            }
           }
         }
       }
     } else {
-      // Portfolio view
-      let hasValidBuyPrice = false;
-      for (const stock of this.scoreData) {
+      const hasValidBuyPrice = this.scoreData.some((stock) => {
         const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-        if (buyPriceObj && buyPriceObj.price > 0) {
-          hasValidBuyPrice = true;
-          break;
-        }
-      }
+        return buyPriceObj !== null && buyPriceObj.price > 0;
+      });
       if (hasValidBuyPrice) {
-        const portfolioData = this.calculatePortfolioData();
-        const before90Days: ChartDataPoint[] = [];
-        portfolioData.forEach((point) => {
-          if (point.x <= ninetyDayDate) {
-            before90Days.push(point);
-          }
-        });
-        const cleanBefore90 = before90Days.filter((p) =>
-          typeof p.y === "number" && !isNaN(p.y)
-        );
-        if (cleanBefore90.length > 0) {
-          datasets.push({
-            label: "Performance",
-            data: cleanBefore90,
-            borderColor: "rgba(102, 126, 234, 1)",
-            backgroundColor: "rgba(102, 126, 234, 0.1)",
-            borderWidth: 3,
-            fill: false,
-            pointRadius: 3,
-          });
-        }
-        const portfolioTarget = this.calculatePortfolioTargetPercentage();
-        if (portfolioTarget !== null) {
-          datasets.push({
-            label: "Target",
-            data: [
-              {
-                x: ninetyDayDate,
-                y: portfolioTarget,
-              },
-            ],
-            borderColor: "rgba(255, 193, 7, 1)",
-            backgroundColor: "rgba(255, 193, 7, 1)",
-            borderWidth: 0,
-            fill: false,
-            pointRadius: 8,
-            pointStyle: "circle",
-            showLine: false,
-          });
+        const clean = this.calculatePortfolioData()
+          .filter((p) =>
+            p.x <= ninetyDayDate && typeof p.y === "number" && !isNaN(p.y)
+          );
+        if (clean.length > 0) {
+          datasets.push({ label: "Performance", data: clean });
         }
       }
     }
-    // Add cost of capital line
+
     const costOfCapitalData = this.calculateCostOfCapitalData();
     if (costOfCapitalData.length > 0) {
-      datasets.push({
-        label: "Cost of Capital",
-        data: costOfCapitalData,
-        borderColor: "rgba(108, 117, 125, 0.8)",
-        backgroundColor: "rgba(108, 117, 125, 0.1)",
-        borderWidth: 2,
-        fill: false,
-        pointRadius: 0,
-      });
+      datasets.push({ label: "Cost of Capital", data: costOfCapitalData });
     }
     return { datasets };
   }
 }
 
 Deno.test("Chart Data Preparation - Invalid Y Values", async (t) => {
-  const validator = new MockGRQValidator();
+  const validator = new ChartValidator();
   validator.setupValidChartData();
 
   await t.step("should handle null buy price gracefully", () => {
-    // Simulate missing buy price
     validator.getBuyPrice = () => null;
     const chartData = validator.prepareChartData();
-
-    // Should return empty datasets when no buy price
-    assertEquals(
-      chartData.datasets.length,
-      1,
-      "Should only have cost of capital line",
-    );
-    assertEquals(
-      chartData.datasets[0].label,
-      "Cost of Capital",
-      "Should have cost of capital line",
-    );
+    assertEquals(chartData.datasets.length, 1, "Only cost of capital line");
+    assertEquals(chartData.datasets[0].label, "Cost of Capital");
   });
 
   await t.step("should handle zero buy price gracefully", () => {
-    // Simulate zero buy price
-    validator.getBuyPrice = () => ({ price: 0, dateUsed: new Date() });
+    validator.getBuyPrice = () => ({
+      price: 0,
+      dateUsed: new Date(2025, 1, 18),
+    });
     const chartData = validator.prepareChartData();
-
-    // Should return empty datasets when buy price is zero
-    assertEquals(
-      chartData.datasets.length,
-      1,
-      "Should only have cost of capital line",
-    );
-    assertEquals(
-      chartData.datasets[0].label,
-      "Cost of Capital",
-      "Should have cost of capital line",
-    );
+    assertEquals(chartData.datasets.length, 1, "Only cost of capital line");
+    assertEquals(chartData.datasets[0].label, "Cost of Capital");
   });
 
   await t.step("should filter out invalid y values", () => {
-    // Restore valid buy price
     validator.getBuyPrice = () => ({
       price: 15.0,
-      dateUsed: new Date("2025-02-18"),
+      dateUsed: new Date(2025, 1, 18),
     });
     const chartData = validator.prepareChartData();
-
-    // Check that all data points have valid y values
     chartData.datasets.forEach((dataset) => {
       dataset.data.forEach((point) => {
         assertEquals(typeof point.y, "number", "Y value should be a number");
@@ -366,27 +245,14 @@ Deno.test("Market Index Data Clearing", async (t) => {
   await t.step(
     "should clear market index data when switching score dates",
     () => {
-      // This test verifies the logic that marketIndexData should be set to null
-      // when loadScoreFile() is called to prevent stale SP500/NASDAQ/Russell 2000 data display
-
-      // Simulate the behavior: when switching dates, marketIndexData should be null
-      let marketIndexData: {
-        sp500: string;
-        nasdaq: string;
-        russell2000: string;
-      } | null = {
-        sp500: "old data",
-        nasdaq: "old data",
-        russell2000: "old data",
-      };
-
-      // Simulate switching score dates (loadScoreFile logic)
-      marketIndexData = null;
-
+      let marketIndexData:
+        | { sp500: string; nasdaq: string; russell2000: string }
+        | null = { sp500: "old", nasdaq: "old", russell2000: "old" };
+      marketIndexData = null; // loadScoreFile() clears stale index data.
       assertEquals(
         marketIndexData,
         null,
-        "Market index data should be cleared when switching dates",
+        "Index data cleared when switching dates",
       );
     },
   );
@@ -394,27 +260,15 @@ Deno.test("Market Index Data Clearing", async (t) => {
   await t.step(
     "should show portfolio data only when market index data is null",
     () => {
-      // This test verifies that when marketIndexData is null,
-      // the chart should only show portfolio data (no SP500/NASDAQ lines)
-
       const marketIndexData = null;
-      const hasMarketIndexData = marketIndexData !== null;
-
       assertEquals(
-        hasMarketIndexData,
+        marketIndexData !== null,
         false,
-        "Should not have market index data initially",
+        "No market index data initially",
       );
-
-      // When marketIndexData is null, chart should only show portfolio data
-      const expectedChartLines = ["Portfolio", "Target", "Cost of Capital"];
-      const actualChartLines = ["Portfolio", "Target", "Cost of Capital"]; // No SP500/NASDAQ
-
-      assertEquals(
-        actualChartLines.length,
-        expectedChartLines.length,
-        "Chart should only show portfolio data when market index data is null",
-      );
+      const expected = ["Portfolio", "Target", "Cost of Capital"];
+      const actual = ["Portfolio", "Target", "Cost of Capital"];
+      assertEquals(actual.length, expected.length, "Only portfolio data shown");
     },
   );
 });

--- a/tests/current_price_consistency_test.ts
+++ b/tests/current_price_consistency_test.ts
@@ -1,4 +1,14 @@
+// Current-price consistency tests (issue #100).
+//
+// The "current price" maths — the midpoint of the latest market-data point —
+// used to be reimplemented inside a `MockGRQValidator`. It now comes from the
+// REAL shared kernel `GRQProjection.currentPriceFromLatest` in docs/projection.js
+// (the same function the dashboard's GRQValidator.getCurrentPrice delegates to),
+// so the current-price figure and its "working" explanation can no longer drift
+// from production. The filename parsing and the working-string layout remain
+// local test glue (they are dashboard UI plumbing, not projection maths).
 import { assert, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
 interface MarketDataPoint {
   date: Date;
@@ -9,226 +19,128 @@ interface MarketDataPoint {
   splitCoefficient: number;
 }
 
-interface StockData {
-  stock: string;
-  score: number;
-  target: number;
-  exDividendDate: string | null;
-  dividendPerShare: number;
-  notes: string;
-  intrinsicValuePerShareBasic: number | null;
-  intrinsicValuePerShareAdjusted: number | null;
+const g = globalThis as unknown as {
+  GRQProjection: {
+    currentPriceFromLatest: (marketData: MarketDataPoint[]) => number | null;
+    setDateToMidnight: (date: Date) => Date;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+const MARKET: Record<string, MarketDataPoint[]> = {
+  "NYSE:SCHW": [
+    {
+      date: new Date(2025, 3, 15),
+      high: 78.12,
+      low: 77.03,
+      open: 77.55,
+      close: 77.19,
+      splitCoefficient: 1.0,
+    },
+    {
+      date: new Date(2025, 6, 1),
+      high: 91.6772,
+      low: 90.14,
+      open: 90.92,
+      close: 91.17,
+      splitCoefficient: 1.0,
+    },
+  ],
+};
+
+// Real kernel drives the figure; only the "$x.xx" formatting is local.
+function getCurrentPrice(stockSymbol: string): string {
+  const price = GRQProjection.currentPriceFromLatest(MARKET[stockSymbol]);
+  return price === null ? "N/A" : "$" + price.toFixed(2);
 }
 
-class MockGRQValidator {
-  marketData: Record<string, MarketDataPoint[]> = {};
-  scoreData: StockData[] = [];
-  selectedFile = "2025/April/15.tsv";
+function getCurrentPriceForTable(stockSymbol: string): string | null {
+  const currentPrice = getCurrentPrice(stockSymbol);
+  return currentPrice === "N/A" ? null : currentPrice;
+}
 
-  constructor() {
-    this.setupTestData();
+function getScoreDate(scoreFile: string): Date {
+  const [year, month, dayPart] = scoreFile.split("/");
+  const day = dayPart.split(".")[0];
+  const monthMap: Record<string, number> = {
+    January: 0,
+    February: 1,
+    March: 2,
+    April: 3,
+    May: 4,
+    June: 5,
+    July: 6,
+    August: 7,
+    September: 8,
+    October: 9,
+    November: 10,
+    December: 11,
+  };
+  return new Date(parseInt(year), monthMap[month], parseInt(day));
+}
+
+function getWorking(field: string, stockSymbol: string): string {
+  if (field !== "current-price") return "Not a current-price field";
+
+  const scoreDate = getScoreDate("2025/April/15.tsv");
+  const header = `Stock: ${stockSymbol} | Field: ${field} | Score Date: ${
+    scoreDate.toISOString().split("T")[0]
+  }\n\n`;
+
+  const marketData = MARKET[stockSymbol];
+  const price = GRQProjection.currentPriceFromLatest(marketData);
+  if (price === null) {
+    return header + "Current Price working:\nNo market data available";
   }
-
-  setupTestData(): void {
-    this.scoreData = [
-      {
-        stock: "NYSE:SCHW",
-        score: 0.977,
-        target: 78.12,
-        exDividendDate: null,
-        dividendPerShare: 0.0,
-        notes: "",
-        intrinsicValuePerShareBasic: null,
-        intrinsicValuePerShareAdjusted: null,
-      },
-    ];
-
-    // Real SCHW data from the CSV file
-    this.marketData["NYSE:SCHW"] = [
-      {
-        date: new Date("2025-04-15"),
-        high: 78.12,
-        low: 77.03,
-        open: 77.55,
-        close: 77.19,
-        splitCoefficient: 1.0,
-      },
-      {
-        date: new Date("2025-07-01"),
-        high: 91.6772,
-        low: 90.14,
-        open: 90.92,
-        close: 91.17,
-        splitCoefficient: 1.0,
-      },
-    ];
-  }
-
-  setDateToMidnight(date: Date): Date {
-    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  }
-
-  getScoreDate(scoreFile: string): Date {
-    const parts = scoreFile.split("/");
-    const month = parts[1];
-    const day = parts[2].split(".")[0];
-    const year = parts[0];
-
-    const monthMap: Record<string, number> = {
-      January: 0,
-      February: 1,
-      March: 2,
-      April: 3,
-      May: 4,
-      June: 5,
-      July: 6,
-      August: 7,
-      September: 8,
-      October: 9,
-      November: 10,
-      December: 11,
-    };
-
-    return new Date(parseInt(year), monthMap[month], parseInt(day));
-  }
-
-  getCurrentPrice(stockSymbol: string): string {
-    const marketData = this.marketData[stockSymbol];
-    if (!marketData || marketData.length === 0) {
-      return "N/A";
-    }
-
-    // Use the latest market data (same as getWorking method)
-    const lastData = marketData[marketData.length - 1];
-    const currentPrice = (lastData.high + lastData.low) / 2; // Already post-split
-    return "$" + currentPrice.toFixed(2);
-  }
-
-  getWorking(
-    field: string,
-    stockSymbol: string,
-    _scoreData: StockData[],
-  ): string {
-    if (field !== "current-price") {
-      return "Not a current-price field";
-    }
-
-    const scoreDate = this.getScoreDate(this.selectedFile);
-    const header = `Stock: ${stockSymbol} | Field: ${field} | Score Date: ${
-      scoreDate.toISOString().split("T")[0]
-    }\n\n`;
-
-    const marketData = this.marketData[stockSymbol];
-    if (!marketData || marketData.length === 0) {
-      return header + "Current Price working:\nNo market data available";
-    }
-    const lastData = marketData[marketData.length - 1];
-    const currentPrice = (lastData.high + lastData.low) / 2; // Already post-split
-    return (
-      header +
-      `Current Price working:\n= (High + Low) / 2 from latest market data\n= ($${
-        lastData.high.toFixed(2)
-      } + $${lastData.low.toFixed(2)}) / 2\n= $${currentPrice.toFixed(2)}`
-    );
-  }
-
-  // Mock method for table display
-  getCurrentPriceForTable(stockSymbol: string): string | null {
-    const currentPrice = this.getCurrentPrice(stockSymbol);
-    return currentPrice === "N/A" ? null : currentPrice;
-  }
+  const lastData = marketData[marketData.length - 1];
+  return (
+    header +
+    `Current Price working:\n= (High + Low) / 2 from latest market data\n= ($${
+      lastData.high.toFixed(2)
+    } + $${lastData.low.toFixed(2)}) / 2\n= $${price.toFixed(2)}`
+  );
 }
 
 Deno.test("Current Price Consistency Tests", async (t) => {
-  const validator = new MockGRQValidator();
-
   await t.step("current price and working logic match for SCHW", () => {
-    const currentPrice = validator.getCurrentPrice("NYSE:SCHW");
-    const working = validator.getWorking(
-      "current-price",
-      "NYSE:SCHW",
-      validator.scoreData,
-    );
-    const tableValue = validator.getCurrentPriceForTable("NYSE:SCHW");
+    const currentPrice = getCurrentPrice("NYSE:SCHW");
+    const working = getWorking("current-price", "NYSE:SCHW");
+    const tableValue = getCurrentPriceForTable("NYSE:SCHW");
 
-    // Expected: (91.6772 + 90.14) / 2 = 90.91
+    // Expected: (91.6772 + 90.14) / 2 = 90.91 (to 2 dp).
     const expectedPrice = "$90.91";
 
     assertEquals(currentPrice, expectedPrice, "Current price should be $90.91");
-    assert(
-      working.includes(expectedPrice),
-      "Working logic should include $90.91",
-    );
-    assertEquals(
-      tableValue,
-      expectedPrice,
-      "Table value should match current price",
-    );
+    assert(working.includes(expectedPrice), "Working should include $90.91");
+    assertEquals(tableValue, expectedPrice, "Table value should match price");
 
-    // Extract the calculated value from working logic
     const workingMatch = working.match(/= \$(\d+\.\d+)$/m);
     assert(workingMatch, "Should be able to extract value from working logic");
-    const workingValue = "$" + workingMatch[1];
-    assertEquals(
-      workingValue,
-      expectedPrice,
-      "Working logic value should match expected",
-    );
-    assertEquals(
-      currentPrice,
-      workingValue,
-      "Current price and working logic should match",
-    );
+    assertEquals("$" + workingMatch![1], currentPrice, "Working matches price");
   });
 
   await t.step("handles missing market data correctly", () => {
-    const currentPrice = validator.getCurrentPrice("NYSE:INVALID");
-    const working = validator.getWorking(
-      "current-price",
-      "NYSE:INVALID",
-      validator.scoreData,
-    );
-    const tableValue = validator.getCurrentPriceForTable("NYSE:INVALID");
+    const currentPrice = getCurrentPrice("NYSE:INVALID");
+    const working = getWorking("current-price", "NYSE:INVALID");
+    const tableValue = getCurrentPriceForTable("NYSE:INVALID");
 
     assertEquals(currentPrice, "N/A", "Should return N/A for missing stock");
     assert(
       working.includes("No market data available"),
       "Working should indicate no data",
     );
-    assertEquals(
-      tableValue,
-      null,
-      "Table value should be null for missing stock",
-    );
+    assertEquals(tableValue, null, "Table value should be null for missing");
   });
 
   await t.step("calculates correct current price from latest data", () => {
-    const marketData = validator.marketData["NYSE:SCHW"];
-    assert(
-      marketData && marketData.length > 0,
-      "Should have market data for SCHW",
-    );
-
+    const marketData = MARKET["NYSE:SCHW"];
     const latestData = marketData[marketData.length - 1];
-    const expectedCalculation = (latestData.high + latestData.low) / 2;
-    const expectedPrice = "$" + expectedCalculation.toFixed(2);
-
-    const currentPrice = validator.getCurrentPrice("NYSE:SCHW");
-    assertEquals(
-      currentPrice,
-      expectedPrice,
-      "Should calculate from latest data",
-    );
+    const expectedPrice = "$" + ((latestData.high + latestData.low) / 2).toFixed(2);
+    assertEquals(getCurrentPrice("NYSE:SCHW"), expectedPrice, "From latest data");
   });
 
   await t.step("working logic shows correct calculation steps", () => {
-    const working = validator.getWorking(
-      "current-price",
-      "NYSE:SCHW",
-      validator.scoreData,
-    );
-
-    // Should show the calculation steps
+    const working = getWorking("current-price", "NYSE:SCHW");
     assert(
       working.includes("= (High + Low) / 2 from latest market data"),
       "Should show formula",
@@ -241,12 +153,17 @@ Deno.test("Current Price Consistency Tests", async (t) => {
   });
 
   await t.step("score date is correctly parsed", () => {
-    const scoreDate = validator.getScoreDate("2025/April/15.tsv");
-    const expectedDate = new Date(2025, 3, 15); // April is month 3 (0-indexed)
-    assertEquals(
-      scoreDate.getTime(),
-      expectedDate.getTime(),
-      "Score date should be parsed correctly",
+    const scoreDate = getScoreDate("2025/April/15.tsv");
+    const expectedDate = new Date(2025, 3, 15); // April is month 3 (0-indexed).
+    assertEquals(scoreDate.getTime(), expectedDate.getTime(), "Parsed date");
+  });
+
+  await t.step("setDateToMidnight zeroes the time component", () => {
+    const midnight = GRQProjection.setDateToMidnight(
+      new Date("2025-04-15T13:45:30"),
     );
+    assertEquals(midnight.getHours(), 0);
+    assertEquals(midnight.getMinutes(), 0);
+    assertEquals(midnight.getSeconds(), 0);
   });
 });

--- a/tests/current_price_consistency_test.ts
+++ b/tests/current_price_consistency_test.ts
@@ -135,8 +135,13 @@ Deno.test("Current Price Consistency Tests", async (t) => {
   await t.step("calculates correct current price from latest data", () => {
     const marketData = MARKET["NYSE:SCHW"];
     const latestData = marketData[marketData.length - 1];
-    const expectedPrice = "$" + ((latestData.high + latestData.low) / 2).toFixed(2);
-    assertEquals(getCurrentPrice("NYSE:SCHW"), expectedPrice, "From latest data");
+    const expectedPrice = "$" +
+      ((latestData.high + latestData.low) / 2).toFixed(2);
+    assertEquals(
+      getCurrentPrice("NYSE:SCHW"),
+      expectedPrice,
+      "From latest data",
+    );
   });
 
   await t.step("working logic shows correct calculation steps", () => {

--- a/tests/hybrid_projection_tests.ts
+++ b/tests/hybrid_projection_tests.ts
@@ -1,6 +1,15 @@
-import { assertEquals, assertExists } from "@std/assert";
+// Hybrid-projection tests (issue #100).
+//
+// These used to drive a `MockHybridProjectionSystem` that reimplemented buy
+// price, performance, the trend-line regression and the whole projection
+// decision tree, then asserted on that copy. They now build market data and
+// delegate every piece of maths to the REAL shared kernels in
+// docs/projection.js (getBuyPrice, currentPriceFromLatest,
+// calculatePerformanceReturn, calculateTargetPercentage, computeTrendLine,
+// computeHybridProjection) — the same code the dashboard's GRQValidator uses.
+import { assert, assertEquals, assertExists } from "@std/assert";
+import "../docs/projection.js";
 
-// Mock data structures to match the JavaScript implementation
 interface MarketDataPoint {
   date: Date;
   high: number;
@@ -9,547 +18,211 @@ interface MarketDataPoint {
   close: number;
   splitCoefficient: number;
 }
-type TrendLine = {
-  slope: number;
-  intercept: number;
-  rSquared: number;
-  dataPoints: { x: number; y: number }[];
-};
-interface StockData {
-  stock: string;
-  score: number;
-  target: number;
-  exDividendDate: string | null;
-  dividendPerShare: number;
-  notes: string;
-  intrinsicValuePerShareBasic: number | null;
-  intrinsicValuePerShareAdjusted: number | null;
-}
 
 interface DividendData {
   exDivDate: Date;
   amount: number;
 }
 
-interface HybridProjection {
+interface Projection {
   projected90DayPerformance: number;
   projectionMethod: string;
   confidence: number;
-  daysElapsed: number;
-  currentPerformance: number;
-  targetPercentage: number | null;
 }
 
-// Mock implementation of the hybrid projection system
-class MockHybridProjectionSystem {
-  private marketData: Record<string, MarketDataPoint[]> = {};
-  private dividendData: Record<string, DividendData[]> = {};
-
-  constructor() {
-    // Initialize with test data
-    this.setupTestData();
-  }
-
-  private setupTestData() {
-    const baseDate = new Date("2025-01-01");
-
-    // Stock with strong upward trend
-    this.marketData["STRONG_UP"] = [];
-    for (let i = 0; i < 30; i++) {
-      const date = new Date(baseDate.getTime() + i * 24 * 60 * 60 * 1000);
-      const basePrice = 100 + i * 2; // Strong upward trend
-      this.marketData["STRONG_UP"].push({
-        date,
-        high: basePrice + 1,
-        low: basePrice - 1,
-        open: basePrice,
-        close: basePrice,
-        splitCoefficient: 1.0,
-      });
-    }
-
-    // Stock with downward trend
-    this.marketData["STRONG_DOWN"] = [];
-    for (let i = 0; i < 30; i++) {
-      const date = new Date(baseDate.getTime() + i * 24 * 60 * 60 * 1000);
-      const basePrice = 100 - i * 1.5; // Downward trend
-      this.marketData["STRONG_DOWN"].push({
-        date,
-        high: basePrice + 1,
-        low: basePrice - 1,
-        open: basePrice,
-        close: basePrice,
-        splitCoefficient: 1.0,
-      });
-    }
-
-    // Stock with volatile data (low R-squared)
-    this.marketData["VOLATILE"] = [];
-    for (let i = 0; i < 30; i++) {
-      const date = new Date(baseDate.getTime() + i * 24 * 60 * 60 * 1000);
-      const basePrice = 100 + Math.sin(i * 0.5) * 50 + Math.random() * 20; // Very volatile pattern
-      this.marketData["VOLATILE"].push({
-        date,
-        high: basePrice + 1,
-        low: basePrice - 1,
-        open: basePrice,
-        close: basePrice,
-        splitCoefficient: 1.0,
-      });
-    }
-
-    // Stock with insufficient data - only 1 data point
-    this.marketData["INSUFFICIENT"] = [
-      {
-        date: baseDate,
-        high: 100,
-        low: 98,
-        open: 99,
-        close: 99,
-        splitCoefficient: 1.0,
-      },
-    ];
-
-    // Add dividend data
-    this.dividendData["STRONG_UP"] = [
-      { exDivDate: new Date("2025-01-15"), amount: 1.0 },
-      { exDivDate: new Date("2025-02-15"), amount: 1.0 },
-    ];
-  }
-
-  private getBuyPrice(
-    stockSymbol: string,
-    scoreDate: Date,
-  ): { price: number; dateUsed: Date } | null {
-    const marketData = this.marketData[stockSymbol];
-    if (!marketData || marketData.length === 0) return null;
-
-    // Find price on or after score date
-    for (let offset = 0; offset <= 5; offset++) {
-      const candidateDate = new Date(
-        scoreDate.getTime() + offset * 24 * 60 * 60 * 1000,
-      );
-      const candidateData = marketData.find((point) =>
-        point.date.getTime() === candidateDate.getTime()
-      );
-      if (candidateData) {
-        return {
-          price: (candidateData.high + candidateData.low) / 2,
-          dateUsed: candidateDate,
-        };
-      }
-    }
-    return null;
-  }
-
-  private calculateCurrentPerformance(
-    stock: StockData,
-    scoreDate: Date,
-  ): number | null {
-    const marketData = this.marketData[stock.stock];
-    if (!marketData || marketData.length === 0) return null;
-
-    const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-    if (!buyPriceObj) return null;
-
-    // For insufficient data test, return null
-    if (stock.stock === "INSUFFICIENT") return null;
-
-    const lastData = marketData[marketData.length - 1];
-    const currentPrice = (lastData.high + lastData.low) / 2;
-    const priceReturn =
-      ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-
-    // Add dividend return
-    const dividends = this.dividendData[stock.stock] || [];
-    const totalDividends = dividends.reduce((sum, div) => sum + div.amount, 0);
-    const dividendReturn = (totalDividends / buyPriceObj.price) * 100;
-
-    return priceReturn + dividendReturn;
-  }
-
-  private calculateTargetPercentage(
-    stock: StockData,
-    scoreDate: Date,
-  ): number | null {
-    const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-    if (!buyPriceObj) return null;
-    return ((stock.target - buyPriceObj.price) / buyPriceObj.price) * 100;
-  }
-
-  private calculateTrendLine(
-    stock: StockData,
-    scoreDate: Date,
-  ): TrendLine | null {
-    const marketData = this.marketData[stock.stock];
-    if (!marketData || marketData.length < 3) return null;
-
-    const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-    if (!buyPriceObj) return null;
-
-    // Calculate data points for regression
-    const dataPoints: { x: number; y: number }[] = [];
-    marketData.forEach((point) => {
-      if (point.date >= scoreDate) {
-        const daysSinceScore = (point.date.getTime() - scoreDate.getTime()) /
-          (1000 * 60 * 60 * 24);
-        const currentPrice = (point.high + point.low) / 2;
-        const priceReturn =
-          ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-
-        // Add dividends up to this point
-        const dividends = this.dividendData[stock.stock] || [];
-        const dividendsUpToDate = dividends.filter((d) =>
-          d.exDivDate <= point.date
-        );
-        const totalDividends = dividendsUpToDate.reduce(
-          (sum, div) => sum + div.amount,
-          0,
-        );
-        const dividendReturn = (totalDividends / buyPriceObj.price) * 100;
-
-        dataPoints.push({
-          x: daysSinceScore,
-          y: priceReturn + dividendReturn,
-        });
-      }
-    });
-
-    if (dataPoints.length < 3) return null;
-
-    // Calculate linear regression
-    const n = dataPoints.length;
-    const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
-    const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
-    const sumXY = dataPoints.reduce((sum, point) => sum + point.x * point.y, 0);
-    const sumXX = dataPoints.reduce((sum, point) => sum + point.x * point.x, 0);
-
-    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-    const intercept = 0; // Force through origin
-
-    // Calculate R-squared
-    const meanY = sumY / n;
-    let ssRes = 0;
-    let ssTot = 0;
-    dataPoints.forEach((point) => {
-      const predicted = slope * point.x + intercept;
-      ssRes += Math.pow(point.y - predicted, 2);
-      ssTot += Math.pow(point.y - meanY, 2);
-    });
-    const rSquared = ssTot > 0 ? 1 - (ssRes / ssTot) : 0;
-
-    return { slope, intercept, rSquared, dataPoints };
-  }
-
-  calculateHybridProjection(
-    stock: StockData,
-    scoreDate: Date,
-  ): HybridProjection | null {
-    const marketData = this.marketData[stock.stock];
-    if (!marketData || marketData.length === 0) return null;
-
-    const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-    if (!buyPriceObj) return null;
-
-    const currentPerformance = this.calculateCurrentPerformance(
-      stock,
-      scoreDate,
-    );
-    if (currentPerformance === null) return null;
-
-    const targetPercentage = this.calculateTargetPercentage(stock, scoreDate);
-    // Use a fixed date for testing - 15 days after score date
-    const testDate = new Date(scoreDate.getTime() + 15 * 24 * 60 * 60 * 1000);
-    const daysElapsed = Math.floor(
-      (testDate.getTime() - scoreDate.getTime()) / (1000 * 60 * 60 * 24),
-    );
-
-    let projected90DayPerformance: number;
-    let projectionMethod: string;
-    let confidence: number;
-
-    if (daysElapsed < 30) {
-      // Short-term: Use dampened trend
-      projectionMethod = "dampened_trend";
-      const trendLine = this.calculateTrendLine(stock, scoreDate);
-
-      if (trendLine && trendLine.rSquared > 0.1) {
-        const dampenedSlope = trendLine.slope * 0.3;
-        projected90DayPerformance = Math.max(dampenedSlope * 90, -100);
-        confidence = Math.min(trendLine.rSquared * 0.7, 0.8);
-      } else {
-        projectionMethod = "target_based";
-        projected90DayPerformance = targetPercentage || -5;
-        confidence = 0.3;
-      }
-    } else if (daysElapsed < 60) {
-      // Medium-term: Use dampened trend with higher confidence
-      projectionMethod = "dampened_trend";
-      const trendLine = this.calculateTrendLine(stock, scoreDate);
-
-      if (trendLine && trendLine.rSquared > 0.05) {
-        const dampenedSlope = trendLine.slope * 0.5;
-        projected90DayPerformance = Math.max(dampenedSlope * 90, -100);
-        confidence = Math.min(trendLine.rSquared * 0.8, 0.9);
-      } else {
-        projectionMethod = "target_based";
-        projected90DayPerformance = targetPercentage || -5;
-        confidence = 0.5;
-      }
-    } else {
-      // Long-term: Use realistic projection based on current trajectory
-      projectionMethod = "realistic_trajectory";
-
-      if (targetPercentage !== null) {
-        // Calculate what the current trajectory suggests for 90 days
-        const currentRate = currentPerformance / daysElapsed; // % per day
-        const trajectoryProjection = currentRate * 90;
-
-        // If we're significantly behind target, be realistic about missing it
-        const remainingDays = 90 - daysElapsed;
-        const remainingGap = targetPercentage - currentPerformance;
-        const requiredDailyRate = remainingGap / remainingDays;
-
-        // If required rate is unrealistic (>2% per day), project missing target
-        if (requiredDailyRate > 2.0) {
-          // Project based on current trajectory, but cap at a realistic maximum
-          const realisticProjection = Math.min(
-            trajectoryProjection,
-            targetPercentage * 0.6,
-          );
-          projected90DayPerformance = Math.max(
-            realisticProjection,
-            currentPerformance * 1.2,
-          ); // At least some improvement
-          confidence = 0.7; // High confidence we're missing target
-        } else {
-          // Still possible to hit target, but be conservative
-          projected90DayPerformance = Math.min(
-            trajectoryProjection,
-            targetPercentage * 0.8,
-          );
-          confidence = 0.6;
-        }
-      } else {
-        // Use mean reversion (move toward 0% performance)
-        const reversionRate = 0.4; // 40% reversion toward mean
-        projected90DayPerformance = currentPerformance * (1 - reversionRate);
-        confidence = 0.3;
-      }
-    }
-
-    projected90DayPerformance = Math.max(
-      Math.min(projected90DayPerformance, 200),
-      -100,
-    );
-
-    return {
-      projected90DayPerformance,
-      projectionMethod,
-      confidence,
-      daysElapsed,
-      currentPerformance,
-      targetPercentage,
-    };
-  }
-}
-
-// Test cases
-Deno.test("Hybrid Projection - Strong Upward Trend (Early Days)", () => {
-  const system = new MockHybridProjectionSystem();
-  const stock: StockData = {
-    stock: "STRONG_UP",
-    score: 0.8,
-    target: 120,
-    exDividendDate: null,
-    dividendPerShare: 0,
-    notes: "",
-    intrinsicValuePerShareBasic: null,
-    intrinsicValuePerShareAdjusted: null,
+const g = globalThis as unknown as {
+  GRQProjection: {
+    getBuyPrice: (
+      marketData: MarketDataPoint[],
+      scoreDate: Date,
+    ) => { price: number; dateUsed: Date } | null;
+    currentPriceFromLatest: (marketData: MarketDataPoint[]) => number | null;
+    calculatePerformanceReturn: (
+      buyPrice: number,
+      currentPrice: number,
+      totalDividends?: number,
+    ) => number | null;
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+    computeTrendLine: (
+      dataPoints: { x: number; y: number }[],
+    ) => { slope: number; rSquared: number } | null;
+    computeHybridProjection: (inputs: {
+      daysElapsed: number;
+      currentPerformance: number;
+      targetPercentage: number | null;
+      trendLine: { slope: number; rSquared: number } | null;
+    }) => Projection;
   };
-  const scoreDate = new Date("2025-01-01");
+};
+const GRQProjection = g.GRQProjection;
 
-  const projection = system.calculateHybridProjection(stock, scoreDate);
+const DAY = 24 * 60 * 60 * 1000;
+const SCORE_DATE = new Date(2025, 0, 1); // Local midnight so buy-price dates match.
 
-  assertExists(projection);
+// Build a 30-point series from a price function of the day index.
+function series(priceAt: (i: number) => number): MarketDataPoint[] {
+  const points: MarketDataPoint[] = [];
+  for (let i = 0; i < 30; i++) {
+    const basePrice = priceAt(i);
+    points.push({
+      date: new Date(2025, 0, 1 + i),
+      high: basePrice + 1,
+      low: basePrice - 1,
+      open: basePrice,
+      close: basePrice,
+      splitCoefficient: 1.0,
+    });
+  }
+  return points;
+}
+
+const MARKET: Record<string, MarketDataPoint[]> = {
+  STRONG_UP: series((i) => 100 + i * 2), // Strong linear uptrend.
+  STRONG_DOWN: series((i) => 100 - i * 1.5), // Linear downtrend.
+  // Deterministic oscillation with no net trend -> very low R² fit.
+  VOLATILE: series((i) => (i % 2 === 0 ? 125 : 75)),
+  INSUFFICIENT: [
+    {
+      date: SCORE_DATE,
+      high: 100,
+      low: 98,
+      open: 99,
+      close: 99,
+      splitCoefficient: 1.0,
+    },
+  ],
+};
+
+const DIVIDENDS: Record<string, DividendData[]> = {
+  STRONG_UP: [
+    { exDivDate: new Date(2025, 0, 15), amount: 1.0 },
+    { exDivDate: new Date(2025, 1, 15), amount: 1.0 },
+  ],
+};
+
+// Collect `{ x: daysSinceScore, y: totalReturn }` points the way the dashboard
+// does before handing them to the regression kernel. This is data plumbing; the
+// regression and projection maths come from the shared kernels.
+function trendDataPoints(
+  marketData: MarketDataPoint[],
+  buyPrice: number,
+  dividends: DividendData[],
+): { x: number; y: number }[] {
+  const points: { x: number; y: number }[] = [];
+  for (const point of marketData) {
+    if (point.date < SCORE_DATE) continue;
+    const daysSinceScore = (point.date.getTime() - SCORE_DATE.getTime()) / DAY;
+    const currentPrice = (point.high + point.low) / 2;
+    const priceReturn = ((currentPrice - buyPrice) / buyPrice) * 100;
+    const totalDividends = dividends
+      .filter((d) => d.exDivDate <= point.date)
+      .reduce((sum, d) => sum + d.amount, 0);
+    const dividendReturn = (totalDividends / buyPrice) * 100;
+    points.push({ x: daysSinceScore, y: priceReturn + dividendReturn });
+  }
+  return points;
+}
+
+// Drive the real kernels for a stock at a fixed 15-day (early) horizon.
+function projectStock(symbol: string, target: number) {
+  const marketData = MARKET[symbol];
+  const dividends = DIVIDENDS[symbol] || [];
+  const buyObj = GRQProjection.getBuyPrice(marketData, SCORE_DATE);
+  assertExists(buyObj);
+  const buyPrice = buyObj.price;
+
+  const currentPrice = GRQProjection.currentPriceFromLatest(marketData);
+  assert(currentPrice !== null);
+  const totalDividends = dividends.reduce((sum, d) => sum + d.amount, 0);
+  const currentPerformance = GRQProjection.calculatePerformanceReturn(
+    buyPrice,
+    currentPrice,
+    totalDividends,
+  );
+  assert(currentPerformance !== null);
+
+  const targetPercentage = GRQProjection.calculateTargetPercentage(
+    buyPrice,
+    target,
+  );
+  const trendLine = GRQProjection.computeTrendLine(
+    trendDataPoints(marketData, buyPrice, dividends),
+  );
+
+  const projection = GRQProjection.computeHybridProjection({
+    daysElapsed: 15, // Early-days horizon (< 30).
+    currentPerformance,
+    targetPercentage,
+    trendLine,
+  });
+
+  return { projection, trendLine, currentPerformance, targetPercentage };
+}
+
+Deno.test("Hybrid Projection - Strong Upward Trend (Early Days)", () => {
+  const { projection } = projectStock("STRONG_UP", 120);
   assertEquals(projection.projectionMethod, "dampened_trend");
-  assertEquals(projection.confidence > 0.2, true);
-  assertEquals(projection.projected90DayPerformance > 0, true);
-  assertEquals(projection.projected90DayPerformance <= 200, true);
-  assertEquals(projection.projected90DayPerformance >= -100, true);
+  assert(projection.confidence > 0.2);
+  assert(projection.projected90DayPerformance > 0);
+  assert(projection.projected90DayPerformance <= 200);
+  assert(projection.projected90DayPerformance >= -100);
 });
 
 Deno.test("Hybrid Projection - Strong Downward Trend (Early Days)", () => {
-  const system = new MockHybridProjectionSystem();
-  const stock: StockData = {
-    stock: "STRONG_DOWN",
-    score: 0.3,
-    target: 80,
-    exDividendDate: null,
-    dividendPerShare: 0,
-    notes: "",
-    intrinsicValuePerShareBasic: null,
-    intrinsicValuePerShareAdjusted: null,
-  };
-  const scoreDate = new Date("2025-01-01");
-
-  const projection = system.calculateHybridProjection(stock, scoreDate);
-
-  assertExists(projection);
+  const { projection } = projectStock("STRONG_DOWN", 80);
   assertEquals(projection.projectionMethod, "dampened_trend");
-  assertEquals(projection.confidence > 0.2, true);
-  assertEquals(projection.projected90DayPerformance < 0, true);
-  assertEquals(projection.projected90DayPerformance >= -100, true);
+  assert(projection.confidence > 0.2);
+  assert(projection.projected90DayPerformance < 0);
+  assert(projection.projected90DayPerformance >= -100);
 });
 
 Deno.test("Hybrid Projection - Volatile Data (Low Confidence)", () => {
-  const system = new MockHybridProjectionSystem();
-  const stock: StockData = {
-    stock: "VOLATILE",
-    score: 0.5,
-    target: 110,
-    exDividendDate: null,
-    dividendPerShare: 0,
-    notes: "",
-    intrinsicValuePerShareBasic: null,
-    intrinsicValuePerShareAdjusted: null,
-  };
-  const scoreDate = new Date("2025-01-01");
-
-  const projection = system.calculateHybridProjection(stock, scoreDate);
-
-  assertExists(projection);
-  // Should fall back to target-based due to low R-squared
+  const { projection } = projectStock("VOLATILE", 110);
+  // Low R² fit -> fall back to the target-based method with low confidence.
   assertEquals(projection.projectionMethod, "target_based");
-  assertEquals(projection.confidence <= 0.5, true);
+  assert(projection.confidence <= 0.5);
 });
 
 Deno.test("Hybrid Projection - Insufficient Data", () => {
-  const system = new MockHybridProjectionSystem();
-  const stock: StockData = {
-    stock: "INSUFFICIENT",
-    score: 0.6,
-    target: 105,
-    exDividendDate: null,
-    dividendPerShare: 0,
-    notes: "",
-    intrinsicValuePerShareBasic: null,
-    intrinsicValuePerShareAdjusted: null,
-  };
-  const scoreDate = new Date("2025-01-01");
-
-  const projection = system.calculateHybridProjection(stock, scoreDate);
-
-  // Should return null due to insufficient data
-  assertEquals(projection, null);
+  // A single market-data point cannot support a regression: the real trend-line
+  // kernel returns null (the genuine insufficient-data signal).
+  const buyObj = GRQProjection.getBuyPrice(MARKET.INSUFFICIENT, SCORE_DATE);
+  assertExists(buyObj);
+  const trendLine = GRQProjection.computeTrendLine(
+    trendDataPoints(MARKET.INSUFFICIENT, buyObj.price, []),
+  );
+  assertEquals(trendLine, null);
 });
 
 Deno.test("Hybrid Projection - Target-Based Fallback", () => {
-  const system = new MockHybridProjectionSystem();
-  const stock: StockData = {
-    stock: "STRONG_UP",
-    score: 0.8,
-    target: 150, // High target
-    exDividendDate: null,
-    dividendPerShare: 0,
-    notes: "",
-    intrinsicValuePerShareBasic: null,
-    intrinsicValuePerShareAdjusted: null,
-  };
-  const scoreDate = new Date("2025-01-01");
-
-  const projection = system.calculateHybridProjection(stock, scoreDate);
-
-  assertExists(projection);
-  // Should use target-based if trend is unreliable
-  assertEquals(projection.targetPercentage !== null, true);
-  assertEquals(projection.projected90DayPerformance > 0, true);
+  const { projection, targetPercentage } = projectStock("VOLATILE", 150);
+  assert(targetPercentage !== null);
+  assertEquals(projection.projectionMethod, "target_based");
 });
 
 Deno.test("Hybrid Projection - Bounds Checking", () => {
-  const system = new MockHybridProjectionSystem();
-  const stock: StockData = {
-    stock: "STRONG_UP",
-    score: 0.8,
-    target: 300, // Extremely high target
-    exDividendDate: null,
-    dividendPerShare: 0,
-    notes: "",
-    intrinsicValuePerShareBasic: null,
-    intrinsicValuePerShareAdjusted: null,
-  };
-  const scoreDate = new Date("2025-01-01");
-
-  const projection = system.calculateHybridProjection(stock, scoreDate);
-
-  assertExists(projection);
-  // Should be capped at 200%
-  assertEquals(projection.projected90DayPerformance <= 200, true);
-  assertEquals(projection.projected90DayPerformance >= -100, true);
+  const { projection } = projectStock("STRONG_UP", 300);
+  assert(projection.projected90DayPerformance <= 200);
+  assert(projection.projected90DayPerformance >= -100);
 });
 
 Deno.test("Hybrid Projection - Confidence Levels", () => {
-  const system = new MockHybridProjectionSystem();
-  const stock: StockData = {
-    stock: "STRONG_UP",
-    score: 0.8,
-    target: 120,
-    exDividendDate: null,
-    dividendPerShare: 0,
-    notes: "",
-    intrinsicValuePerShareBasic: null,
-    intrinsicValuePerShareAdjusted: null,
-  };
-  const scoreDate = new Date("2025-01-01");
-
-  const projection = system.calculateHybridProjection(stock, scoreDate);
-
-  assertExists(projection);
-  assertEquals(projection.confidence >= 0, true);
-  assertEquals(projection.confidence <= 1, true);
+  const { projection } = projectStock("STRONG_UP", 120);
+  assert(projection.confidence >= 0);
+  assert(projection.confidence <= 1);
 });
 
 Deno.test("Hybrid Projection - Method Selection Logic", () => {
-  const system = new MockHybridProjectionSystem();
-  const stock: StockData = {
-    stock: "STRONG_UP",
-    score: 0.8,
-    target: 120,
-    exDividendDate: null,
-    dividendPerShare: 0,
-    notes: "",
-    intrinsicValuePerShareBasic: null,
-    intrinsicValuePerShareAdjusted: null,
-  };
-  const scoreDate = new Date("2025-01-01");
-
-  const projection = system.calculateHybridProjection(stock, scoreDate);
-
-  assertExists(projection);
-  // Should be one of the valid methods
+  const { projection } = projectStock("STRONG_UP", 120);
   const validMethods = ["dampened_trend", "target_based"];
-  assertEquals(validMethods.includes(projection.projectionMethod), true);
+  assert(validMethods.includes(projection.projectionMethod));
 });
 
 Deno.test("Hybrid Projection - Dividend Integration", () => {
-  const system = new MockHybridProjectionSystem();
-  const stock: StockData = {
-    stock: "STRONG_UP",
-    score: 0.8,
-    target: 120,
-    exDividendDate: "2025-01-15",
-    dividendPerShare: 1.0,
-    notes: "",
-    intrinsicValuePerShareBasic: null,
-    intrinsicValuePerShareAdjusted: null,
-  };
-  const scoreDate = new Date("2025-01-01");
-
-  const projection = system.calculateHybridProjection(stock, scoreDate);
-
-  assertExists(projection);
-  // Current performance should include dividends
-  assertEquals(projection.currentPerformance > 0, true);
+  const { currentPerformance } = projectStock("STRONG_UP", 120);
+  // STRONG_UP pays two dividends, so current performance includes them.
+  assert(currentPerformance > 0);
 });
-
-console.log("All hybrid projection tests passed! 🎉");

--- a/tests/judgement_hybrid_test.ts
+++ b/tests/judgement_hybrid_test.ts
@@ -1,198 +1,125 @@
-import { assertEquals, assertExists } from "@std/assert";
+// Judgement-from-hybrid-projection tests (issue #100).
+//
+// These used to drive a `MockJudgementSystem` that hardcoded projections per
+// stock and reimplemented the judgement thresholds (which had drifted from
+// production). They now exercise the REAL shared kernels
+// `GRQProjection.computeHybridProjection` and `GRQProjection.computeJudgement`
+// from docs/projection.js — the same functions the dashboard's GRQValidator
+// delegates to.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
-// Define proper types instead of 'any'
-interface StockData {
-  stock: string;
-  targetPercentage?: number;
-}
-
-interface HybridProjection {
+interface Projection {
   projected90DayPerformance: number;
   projectionMethod: string;
   confidence: number;
-  daysElapsed: number;
-  currentPerformance: number;
-  targetPercentage: number | null;
 }
 
-// Mock the hybrid projection system for testing judgements
-class MockJudgementSystem {
-  calculateHybridProjection(
-    stock: StockData,
-    _scoreDate: Date,
-  ): HybridProjection | null {
-    // Mock different scenarios
-    if (stock.stock === "STRONG_UP") {
-      return {
-        projected90DayPerformance: 45.2,
-        projectionMethod: "dampened_trend",
-        confidence: 0.75,
-        daysElapsed: 30,
-        currentPerformance: 25.0,
-        targetPercentage: 60.0,
-      };
-    } else if (stock.stock === "STRONG_DOWN") {
-      return {
-        projected90DayPerformance: -57.3,
-        projectionMethod: "dampened_trend",
-        confidence: 0.68,
-        daysElapsed: 45,
-        currentPerformance: -35.0,
-        targetPercentage: 20.0,
-      };
-    } else if (stock.stock === "LOW_CONFIDENCE") {
-      return {
-        projected90DayPerformance: 15.0,
-        projectionMethod: "target_based",
-        confidence: 0.15, // Below threshold
-        daysElapsed: 20,
-        currentPerformance: 8.0,
-        targetPercentage: 25.0,
-      };
-    }
-    return null;
-  }
+const g = globalThis as unknown as {
+  GRQProjection: {
+    computeHybridProjection: (inputs: {
+      daysElapsed: number;
+      currentPerformance: number;
+      targetPercentage: number | null;
+      trendLine: { slope: number; rSquared: number } | null;
+    }) => Projection;
+    computeJudgement: (inputs: {
+      performance: number | null;
+      daysElapsed: number;
+      targetPercentage: number | null;
+      projection: Projection | null;
+    }) => string;
+    computeTrendLine: (
+      dataPoints: { x: number; y: number }[],
+    ) => { slope: number; intercept: number } | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
 
-  calculateTargetPercentage(stock: StockData, _scoreDate: Date): number {
-    return stock.targetPercentage || 20.0;
-  }
+Deno.test("Judgement with Hybrid Projection - Strong Upward (Below Target)", () => {
+  // 30 days elapsed, confident upward trend that still lands below 95% of target.
+  const projection = GRQProjection.computeHybridProjection({
+    daysElapsed: 30,
+    currentPerformance: 25.0,
+    targetPercentage: 60.0,
+    trendLine: { slope: 1.0, rSquared: 0.5 }, // dampened 0.5 -> 45% at day 90.
+  });
+  assertEquals(projection.projectionMethod, "dampened_trend");
+  assertEquals(projection.projected90DayPerformance, 45.0);
 
-  getDaysElapsed(_scoreDate: Date): number {
-    // Mock 30 days elapsed
-    return 30;
-  }
-
-  calculateJudgement(stock: StockData, performance: number | null): string {
-    if (performance === null) return "Pending";
-
-    const scoreDate = new Date("2025-01-01");
-    const daysElapsed = this.getDaysElapsed(scoreDate);
-    const targetPercentage = this.calculateTargetPercentage(stock, scoreDate);
-
-    // If we haven't reached 90 days yet, use hybrid projection
-    if (daysElapsed < 90) {
-      const hybridProjection = this.calculateHybridProjection(stock, scoreDate);
-
-      if (hybridProjection && hybridProjection.confidence > 0.2) {
-        const predicted = hybridProjection.projected90DayPerformance;
-        const target = targetPercentage || 20; // Default to 20% if no target
-
-        if (predicted >= target * 0.8) {
-          return `On Track (${predicted.toFixed(1)}%)`;
-        } else if (predicted > 0) {
-          return `Below Target (${predicted.toFixed(1)}%)`;
-        } else {
-          return `Declining (${predicted.toFixed(1)}%)`;
-        }
-      } else {
-        // Fall back to current performance logic
-        const target = targetPercentage || 20;
-        const threshold = target * 0.8;
-
-        if (daysElapsed < 30) {
-          if (performance > 0) {
-            return `Early Days (+${performance.toFixed(1)}%)`;
-          } else {
-            return `Early Days (${performance.toFixed(1)}%)`;
-          }
-        } else if (daysElapsed < 60) {
-          if (performance >= threshold) {
-            return `On Track (${performance.toFixed(1)}%)`;
-          } else if (performance > 0) {
-            return `Below Target (${performance.toFixed(1)}%)`;
-          } else {
-            return `Declining (${performance.toFixed(1)}%)`;
-          }
-        } else {
-          if (performance >= threshold) {
-            return `On Track (${performance.toFixed(1)}%)`;
-          } else if (performance > 0) {
-            return `Below Target (${performance.toFixed(1)}%)`;
-          } else {
-            return `Declining (${performance.toFixed(1)}%)`;
-          }
-        }
-      }
-    } else {
-      // 90 days or more elapsed - use actual performance
-      const target = targetPercentage || 20;
-      const threshold = target * 0.8;
-
-      if (performance >= threshold) {
-        return "Hit Target";
-      } else if (performance > 0) {
-        return "Partial Success";
-      } else {
-        return "Missed Target";
-      }
-    }
-  }
-}
-
-// Test cases
-Deno.test("Judgement with Hybrid Projection - Strong Upward", () => {
-  const system = new MockJudgementSystem();
-  const stock: StockData = { stock: "STRONG_UP", targetPercentage: 60.0 };
-  const performance = 25.0;
-
-  const judgement = system.calculateJudgement(stock, performance);
-
-  console.log("Strong Upward judgement:", judgement);
-  assertExists(judgement);
-  // 45.2% is less than 80% of 60% target (48%), so it should be "Below Target"
-  assertEquals(judgement.includes("Below Target"), true);
-  assertEquals(judgement.includes("45.2%"), true); // Should use hybrid projection
+  const judgement = GRQProjection.computeJudgement({
+    performance: 25.0,
+    daysElapsed: 30,
+    targetPercentage: 60.0,
+    projection,
+  });
+  // 45 / 60 = 0.75 of target -> Below Target, reporting the projection.
+  assert(judgement.includes("Below Target"), judgement);
+  assert(judgement.includes("45.0%"), judgement);
 });
 
-Deno.test("Judgement with Hybrid Projection - Strong Downward", () => {
-  const system = new MockJudgementSystem();
-  const stock: StockData = { stock: "STRONG_DOWN", targetPercentage: 20.0 };
-  const performance = -35.0;
+Deno.test("Judgement with Hybrid Projection - Strong Downward (Declining)", () => {
+  const projection = GRQProjection.computeHybridProjection({
+    daysElapsed: 45,
+    currentPerformance: -35.0,
+    targetPercentage: 20.0,
+    trendLine: { slope: -1.2733333, rSquared: 0.5 }, // dampened -> negative.
+  });
+  assert(projection.projected90DayPerformance < 0);
 
-  const judgement = system.calculateJudgement(stock, performance);
-
-  assertExists(judgement);
-  assertEquals(judgement.includes("Declining"), true);
-  assertEquals(judgement.includes("-57.3%"), true); // Should use hybrid projection, not -100%
+  const judgement = GRQProjection.computeJudgement({
+    performance: -35.0,
+    daysElapsed: 45,
+    targetPercentage: 20.0,
+    projection,
+  });
+  // Negative projection -> Declining, reporting the projection (not -100%).
+  assert(judgement.includes("Declining"), judgement);
+  assert(
+    judgement.includes(projection.projected90DayPerformance.toFixed(1)),
+    judgement,
+  );
 });
 
 Deno.test("Judgement with Low Confidence - Falls Back to Current Performance", () => {
-  const system = new MockJudgementSystem();
-  const stock: StockData = { stock: "LOW_CONFIDENCE", targetPercentage: 25.0 };
-  const performance = 8.0;
+  // Confidence below the 0.2 threshold -> the judgement ignores the projection
+  // and judges current performance instead.
+  const projection = GRQProjection.computeHybridProjection({
+    daysElapsed: 30,
+    currentPerformance: 8.0,
+    targetPercentage: 25.0,
+    trendLine: { slope: 0.5, rSquared: 0.2 }, // confidence 0.16 (< 0.2).
+  });
+  assert(projection.confidence < 0.2, `confidence ${projection.confidence}`);
 
-  const judgement = system.calculateJudgement(stock, performance);
-
-  console.log("Low Confidence judgement:", judgement);
-  assertExists(judgement);
-  // Should fall back to current performance since confidence is too low
-  // With 30 days elapsed, it should be in the 30-60 day range, not "Early Days"
-  assertEquals(judgement.includes("Below Target"), true);
-  assertEquals(judgement.includes("8.0%"), true);
+  const judgement = GRQProjection.computeJudgement({
+    performance: 8.0,
+    daysElapsed: 30,
+    targetPercentage: 25.0,
+    projection,
+  });
+  // 30 days, 8% < 80% of 25% target -> Below Target on current performance.
+  assert(judgement.includes("Below Target"), judgement);
+  assert(judgement.includes("8.0%"), judgement);
 });
 
 Deno.test("Judgement with Null Performance", () => {
-  const system = new MockJudgementSystem();
-  const stock: StockData = { stock: "TEST", targetPercentage: 20.0 };
-  const performance: number | null = null;
-
-  const judgement = system.calculateJudgement(stock, performance);
-
+  const judgement = GRQProjection.computeJudgement({
+    performance: null,
+    daysElapsed: 30,
+    targetPercentage: 20.0,
+    projection: null,
+  });
   assertEquals(judgement, "Pending");
 });
 
 Deno.test("Trend Line Always Starts at Zero", () => {
-  const system = new MockJudgementSystem();
-  const stock: StockData = { stock: "STRONG_UP", targetPercentage: 60.0 };
-  const scoreDate = new Date("2025-01-01");
-
-  const hybridProjection = system.calculateHybridProjection(stock, scoreDate);
-
-  assertExists(hybridProjection);
-  // The trend line should always start at zero performance on the score date
-  // This is a fundamental requirement - no performance has occurred yet
-  assertEquals(hybridProjection.daysElapsed >= 0, true);
-  assertEquals(hybridProjection.currentPerformance >= 0, true); // Current performance should be positive for STRONG_UP
+  // The production trend line is forced through the origin so day 0 reads 0%.
+  const trendLine = GRQProjection.computeTrendLine([
+    { x: 0, y: 0 },
+    { x: 10, y: 12 },
+    { x: 20, y: 26 },
+  ]);
+  assert(trendLine !== null);
+  assertEquals(trendLine.intercept, 0, "Trend line must start at zero");
 });
-
-console.log("All judgement hybrid tests passed! 🎉");

--- a/tests/portfolio_view_consistency_test.ts
+++ b/tests/portfolio_view_consistency_test.ts
@@ -1,6 +1,15 @@
+// Portfolio-view consistency tests (issue #100).
+//
+// These used to drive a `MockGRQValidator` that copied getBuyPrice, the
+// target-percentage formula, the market-data day count, the portfolio trend-line
+// regression and R². The portfolio maths now comes from the REAL shared kernels
+// in docs/projection.js (getBuyPrice, calculatePerformanceReturn,
+// calculateTargetPercentage, daysElapsedFromMarketData, computeTrendLine). The
+// portfolio-series and chart-dataset assembly stay local glue (dashboard UI),
+// but build their figures with the kernels so they cannot drift from production.
 import { assertEquals, assertExists } from "@std/assert";
+import "../docs/projection.js";
 
-// Define proper types for the test data
 interface StockData {
   stock: string;
   score: number;
@@ -21,27 +30,38 @@ interface MarketDataPoint {
   splitCoefficient: number;
 }
 
-interface DividendData {
-  exDivDate: Date;
-  amount: number;
-}
+const DAY = 1000 * 60 * 60 * 24;
 
-interface TrendLineResult {
-  slope: number;
-  intercept: number;
-  predicted90DayPerformance: number;
-  dataPoints: Array<{ x: number; y: number }>;
-  rSquared: number;
-}
+const g = globalThis as unknown as {
+  GRQProjection: {
+    getBuyPrice: (
+      marketData: MarketDataPoint[] | undefined,
+      scoreDate: Date,
+    ) => { price: number; dateUsed: Date } | null;
+    calculatePerformanceReturn: (
+      buyPrice: number,
+      currentPrice: number,
+      totalDividends?: number,
+    ) => number | null;
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+    daysElapsedFromMarketData: (
+      scoreDate: Date,
+      latestMarketDate: Date,
+    ) => number;
+    computeTrendLine: (
+      dataPoints: { x: number; y: number }[],
+    ) => { slope: number; intercept: number; rSquared: number } | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
 
-// Mock the GRQValidator class for testing
-class MockGRQValidator {
+class PortfolioValidator {
   scoreData: StockData[] = [];
   marketData: Record<string, MarketDataPoint[]> = {};
-  dividendData: Record<string, DividendData[]> = {};
-  selectedFile = "2025/February/18.tsv";
   selectedStock: string | null = null;
-  costOfCapital = 10;
 
   setupTestData(): void {
     this.scoreData = [
@@ -70,7 +90,7 @@ class MockGRQValidator {
     this.marketData = {
       "NASDAQ:XP": [
         {
-          date: new Date(2025, 1, 18), // Feb 18 — local time, matches getScoreDate()
+          date: new Date(2025, 1, 18),
           high: 15.18,
           low: 14.72,
           open: 14.72,
@@ -78,7 +98,7 @@ class MockGRQValidator {
           splitCoefficient: 1.0,
         },
         {
-          date: new Date(2025, 1, 19), // Feb 19
+          date: new Date(2025, 1, 19),
           high: 15.25,
           low: 14.85,
           open: 15.02,
@@ -86,7 +106,7 @@ class MockGRQValidator {
           splitCoefficient: 1.0,
         },
         {
-          date: new Date(2025, 1, 20), // Feb 20
+          date: new Date(2025, 1, 20),
           high: 15.30,
           low: 14.90,
           open: 15.10,
@@ -96,7 +116,7 @@ class MockGRQValidator {
       ],
       "NYSE:AAPL": [
         {
-          date: new Date(2025, 1, 18), // Feb 18
+          date: new Date(2025, 1, 18),
           high: 180.50,
           low: 179.20,
           open: 179.20,
@@ -104,21 +124,12 @@ class MockGRQValidator {
           splitCoefficient: 1.0,
         },
         {
-          date: new Date(2025, 1, 19), // Feb 19
+          date: new Date(2025, 1, 19),
           high: 181.00,
           low: 179.80,
           open: 180.00,
           close: 180.50,
           splitCoefficient: 1.0,
-        },
-      ],
-    };
-
-    this.dividendData = {
-      "NYSE:AAPL": [
-        {
-          exDivDate: new Date(2025, 2, 15), // Mar 15 — local time
-          amount: 0.25,
         },
       ],
     };
@@ -135,122 +146,76 @@ class MockGRQValidator {
   }
 
   getDaysElapsed(scoreDate: Date): number {
-    const today = new Date();
-    const diffTime = Math.abs(today.getTime() - scoreDate.getTime());
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    return diffDays;
+    const diffTime = Math.abs(new Date().getTime() - scoreDate.getTime());
+    return Math.ceil(diffTime / DAY);
   }
 
   getDaysElapsedFromMarketData(scoreDate: Date): number {
     if (!this.marketData || Object.keys(this.marketData).length === 0) {
-      // Fall back to calendar days if no market data
-      return this.getDaysElapsed(scoreDate);
+      return this.getDaysElapsed(scoreDate); // Calendar fallback.
     }
-
-    // Find the latest market data date across all stocks
+    // Find the latest market-data date across the portfolio (data plumbing)...
     let latestMarketDate = scoreDate;
-
     this.scoreData.forEach((stock) => {
-      const marketData = this.marketData[stock.stock];
-      if (marketData && marketData.length > 0) {
-        const stockLatestDate = marketData[marketData.length - 1].date;
-        if (stockLatestDate > latestMarketDate) {
-          latestMarketDate = stockLatestDate;
-        }
+      const md = this.marketData[stock.stock];
+      if (md && md.length > 0) {
+        const last = md[md.length - 1].date;
+        if (last > latestMarketDate) latestMarketDate = last;
       }
     });
-
-    // Calculate days from score date to latest market data date
-    const diffTime = Math.abs(latestMarketDate.getTime() - scoreDate.getTime());
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-
-    // Cap at 90 days for portfolio view consistency
-    return Math.min(diffDays, 90);
-  }
-
-  getBuyPrice(
-    stockSymbol: string,
-    scoreDate: Date,
-  ): { price: number; dateUsed: Date } | null {
-    const marketData = this.marketData[stockSymbol];
-    if (!marketData) return null;
-
-    for (let offset = 0; offset <= 5; offset++) {
-      const candidateDate = new Date(scoreDate.getTime());
-      candidateDate.setDate(candidateDate.getDate() + offset);
-      const candidateData = marketData.find((point) => {
-        const pointDate = new Date(
-          point.date.getFullYear(),
-          point.date.getMonth(),
-          point.date.getDate(),
-        );
-        return pointDate.getTime() === candidateDate.getTime();
-      });
-      if (candidateData) {
-        return {
-          price: (candidateData.high + candidateData.low) / 2,
-          dateUsed: candidateDate,
-        };
-      }
-    }
-    return null;
+    // ...then delegate the capped day count to the kernel.
+    return GRQProjection.daysElapsedFromMarketData(scoreDate, latestMarketDate);
   }
 
   calculateTargetPercentage(stock: StockData, scoreDate: Date): number | null {
-    const buyPrice = this.getBuyPrice(stock.stock, scoreDate);
-    if (buyPrice !== null) {
-      return ((stock.target - buyPrice.price) / buyPrice.price) * 100;
-    }
-    return null;
+    const buyPrice = GRQProjection.getBuyPrice(
+      this.marketData[stock.stock],
+      scoreDate,
+    );
+    return GRQProjection.calculateTargetPercentage(
+      buyPrice ? buyPrice.price : null,
+      stock.target,
+    );
   }
 
   calculatePortfolioData(): Array<{ x: Date; y: number }> {
-    const scoreDate = this.getScoreDate(this.selectedFile);
+    const scoreDate = this.getScoreDate("2025/February/18.tsv");
     const portfolioData: Array<{ x: Date; y: number }> = [];
 
     const allDates = new Set<number>();
     this.scoreData.forEach((stock) => {
-      const marketData = this.marketData[stock.stock];
-      if (marketData) {
-        marketData.forEach((point) => {
-          allDates.add(point.date.getTime());
-        });
-      }
+      this.marketData[stock.stock]?.forEach((point) =>
+        allDates.add(point.date.getTime())
+      );
     });
-
     allDates.add(scoreDate.getTime());
-    const sortedDates = Array.from(allDates).sort((a, b) => a - b);
 
-    sortedDates.forEach((timestamp) => {
-      const date = new Date(timestamp);
+    Array.from(allDates).sort((a, b) => a - b).forEach((timestamp) => {
       let totalPerformance = 0;
       let validStocks = 0;
-
       this.scoreData.forEach((stock) => {
-        const marketData = this.marketData[stock.stock];
-        if (marketData) {
-          const dataPoint = marketData.find(
-            (point) => point.date.getTime() === timestamp,
-          );
-
-          const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-          if (!buyPriceObj) return;
-
-          if (dataPoint) {
-            const currentPrice = (dataPoint.high + dataPoint.low) / 2;
-            const priceReturn =
-              ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-            totalPerformance += priceReturn;
-            validStocks++;
-          } else if (timestamp === scoreDate.getTime()) {
-            validStocks++;
-          }
+        const md = this.marketData[stock.stock];
+        if (!md) return;
+        const buyPriceObj = GRQProjection.getBuyPrice(md, scoreDate);
+        if (!buyPriceObj) return;
+        const dataPoint = md.find((point) =>
+          point.date.getTime() === timestamp
+        );
+        if (dataPoint) {
+          const currentPrice = (dataPoint.high + dataPoint.low) / 2;
+          totalPerformance += GRQProjection.calculatePerformanceReturn(
+            buyPriceObj.price,
+            currentPrice,
+            0,
+          )!;
+          validStocks++;
+        } else if (timestamp === scoreDate.getTime()) {
+          validStocks++;
         }
       });
-
       if (validStocks > 0) {
         portfolioData.push({
-          x: new Date(date.getTime()),
+          x: new Date(timestamp),
           y: totalPerformance / validStocks,
         });
       }
@@ -259,64 +224,13 @@ class MockGRQValidator {
     return portfolioData;
   }
 
-  calculatePortfolioTrendLine(): TrendLineResult | null {
-    const scoreDate = this.getScoreDate(this.selectedFile);
-    const portfolioData = this.calculatePortfolioData();
-    const dataPoints: Array<{ x: number; y: number }> = [];
-
-    portfolioData.forEach((point) => {
-      const daysSinceScore = (point.x.getTime() - scoreDate.getTime()) /
-        (1000 * 60 * 60 * 24);
-      dataPoints.push({
-        x: daysSinceScore,
-        y: point.y,
-      });
-    });
-
-    if (dataPoints.length < 3) {
-      return null;
-    }
-
-    // Calculate linear regression
-    const n = dataPoints.length;
-    const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
-    const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
-    const sumXY = dataPoints.reduce((sum, point) => sum + point.x * point.y, 0);
-    const sumXX = dataPoints.reduce((sum, point) => sum + point.x * point.x, 0);
-
-    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-    const intercept = 0; // Force to start at zero
-
-    const predicted90DayPerformance = Math.max(slope * 90 + intercept, -100);
-    const rSquared = this.calculateRSquared(dataPoints, slope, intercept);
-
-    return {
-      slope,
-      intercept,
-      predicted90DayPerformance,
-      dataPoints,
-      rSquared,
-    };
-  }
-
-  calculateRSquared(
-    dataPoints: Array<{ x: number; y: number }>,
-    slope: number,
-    intercept: number,
-  ): number {
-    const n = dataPoints.length;
-    const meanY = dataPoints.reduce((sum, point) => sum + point.y, 0) / n;
-
-    let ssRes = 0; // Sum of squared residuals
-    let ssTot = 0; // Total sum of squares
-
-    dataPoints.forEach((point) => {
-      const predicted = slope * point.x + intercept;
-      ssRes += Math.pow(point.y - predicted, 2);
-      ssTot += Math.pow(point.y - meanY, 2);
-    });
-
-    return ssTot > 0 ? 1 - (ssRes / ssTot) : 0;
+  calculatePortfolioTrendLine() {
+    const scoreDate = this.getScoreDate("2025/February/18.tsv");
+    const dataPoints = this.calculatePortfolioData().map((point) => ({
+      x: (point.x.getTime() - scoreDate.getTime()) / DAY,
+      y: point.y,
+    }));
+    return GRQProjection.computeTrendLine(dataPoints);
   }
 
   prepareChartData(): {
@@ -325,57 +239,35 @@ class MockGRQValidator {
     const datasets: Array<
       { label: string; data: Array<{ x: Date; y: number }> }
     > = [];
-    const scoreDate = this.getScoreDate(this.selectedFile);
+    const scoreDate = this.getScoreDate("2025/February/18.tsv");
     const marketDataDaysElapsed = this.getDaysElapsedFromMarketData(scoreDate);
 
-    if (!this.selectedStock) {
-      // Portfolio view
-      const portfolioData = this.calculatePortfolioData();
-      if (portfolioData.length > 0) {
-        datasets.push({
-          label: "Performance",
-          data: portfolioData,
-        });
-      }
+    if (this.selectedStock) return { datasets };
 
-      // Add trend line if less than 90 days
-      if (marketDataDaysElapsed < 90) {
-        const portfolioTrendLine = this.calculatePortfolioTrendLine();
-        if (portfolioTrendLine) {
-          const trendData: Array<{ x: Date; y: number }> = [];
-          for (let day = 0; day <= 90; day += 7) {
-            const predictedPerformance = Math.max(
-              portfolioTrendLine.slope * day + portfolioTrendLine.intercept,
-              -100,
-            );
-            trendData.push({
-              x: new Date(scoreDate.getTime() + (day * 24 * 60 * 60 * 1000)),
-              y: predictedPerformance,
-            });
-          }
+    const portfolioData = this.calculatePortfolioData();
+    if (portfolioData.length > 0) {
+      datasets.push({ label: "Performance", data: portfolioData });
+    }
 
-          const daysElapsed = marketDataDaysElapsed;
-          const rSquared = portfolioTrendLine.rSquared;
-
-          // Adjust confidence threshold based on days elapsed
-          let confidenceThreshold = 0.05;
-          if (daysElapsed >= 80) {
-            confidenceThreshold = 0.001; // Extremely lenient for very late-stage predictions (80+ days)
-          } else if (daysElapsed >= 60) {
-            confidenceThreshold = 0.01;
-          } else if (daysElapsed >= 30) {
-            confidenceThreshold = 0.03;
-          }
-
-          const label = rSquared >= confidenceThreshold
-            ? "Portfolio Trend Prediction"
-            : "Portfolio Trend (Low Confidence)";
-
-          datasets.push({
-            label,
-            data: trendData,
+    if (marketDataDaysElapsed < 90) {
+      const trendLine = this.calculatePortfolioTrendLine();
+      if (trendLine) {
+        const trendData: Array<{ x: Date; y: number }> = [];
+        for (let day = 0; day <= 90; day += 7) {
+          trendData.push({
+            x: new Date(scoreDate.getTime() + day * DAY),
+            y: Math.max(trendLine.slope * day + trendLine.intercept, -100),
           });
         }
+        let confidenceThreshold = 0.05;
+        if (marketDataDaysElapsed >= 80) confidenceThreshold = 0.001;
+        else if (marketDataDaysElapsed >= 60) confidenceThreshold = 0.01;
+        else if (marketDataDaysElapsed >= 30) confidenceThreshold = 0.03;
+
+        const label = trendLine.rSquared >= confidenceThreshold
+          ? "Portfolio Trend Prediction"
+          : "Portfolio Trend (Low Confidence)";
+        datasets.push({ label, data: trendData });
       }
     }
 
@@ -383,9 +275,8 @@ class MockGRQValidator {
   }
 }
 
-// Test cases
 Deno.test("Portfolio View Consistency", async (t) => {
-  const validator = new MockGRQValidator();
+  const validator = new PortfolioValidator();
   validator.setupTestData();
 
   await t.step(
@@ -393,19 +284,17 @@ Deno.test("Portfolio View Consistency", async (t) => {
     () => {
       const scoreDate = validator.getScoreDate("2025/February/18.tsv");
 
-      // Test with limited market data (test data only goes to Feb 20)
-      const marketDataDays = validator.getDaysElapsedFromMarketData(scoreDate);
       assertEquals(
-        marketDataDays,
+        validator.getDaysElapsedFromMarketData(scoreDate),
         2,
         "Should return actual days from market data when less than 90",
       );
 
-      // Test with extended market data (Jun 18 = 120 days from Feb 18, well beyond 90)
+      // Extended market data (Jun 18 = 120 days) caps at 90.
       validator.marketData = {
         "NASDAQ:XP": [
           {
-            date: new Date(2025, 1, 18), // Feb 18 — local time
+            date: new Date(2025, 1, 18),
             high: 15.18,
             low: 14.72,
             open: 14.72,
@@ -413,7 +302,7 @@ Deno.test("Portfolio View Consistency", async (t) => {
             splitCoefficient: 1.0,
           },
           {
-            date: new Date(2025, 5, 18), // Jun 18 — 120 days from Feb 18
+            date: new Date(2025, 5, 18),
             high: 16.00,
             low: 15.50,
             open: 15.50,
@@ -422,42 +311,32 @@ Deno.test("Portfolio View Consistency", async (t) => {
           },
         ],
       };
-
-      const extendedDays = validator.getDaysElapsedFromMarketData(scoreDate);
       assertEquals(
-        extendedDays,
+        validator.getDaysElapsedFromMarketData(scoreDate),
         90,
         "Should cap at 90 days when market data extends beyond 90 days",
       );
 
-      // Test with no market data (fallback to calendar days)
       validator.marketData = {};
-      const fallbackDays = validator.getDaysElapsedFromMarketData(scoreDate);
       assertExists(
-        fallbackDays,
-        "Should fallback to calendar days when no market data",
+        validator.getDaysElapsedFromMarketData(scoreDate),
+        "Should fall back to calendar days when no market data",
       );
     },
   );
 
   await t.step("should use market data days for portfolio view", () => {
-    // Reset to test data
     validator.setupTestData();
-
-    // Test portfolio view with limited market data (should show trend line)
     const chartData = validator.prepareChartData();
-
-    // Should have performance data
     const performanceDataset = chartData.datasets.find((d) =>
       d.label === "Performance"
     );
     assertExists(performanceDataset, "Should have performance dataset");
 
-    // Test with extended market data (should not show trend line)
     validator.marketData = {
       "NASDAQ:XP": [
         {
-          date: new Date(2025, 1, 18), // Feb 18 — local time
+          date: new Date(2025, 1, 18),
           high: 15.18,
           low: 14.72,
           open: 14.72,
@@ -465,7 +344,7 @@ Deno.test("Portfolio View Consistency", async (t) => {
           splitCoefficient: 1.0,
         },
         {
-          date: new Date(2025, 5, 18), // Jun 18 — 120 days from Feb 18
+          date: new Date(2025, 5, 18),
           high: 16.00,
           low: 15.50,
           open: 15.50,
@@ -474,15 +353,10 @@ Deno.test("Portfolio View Consistency", async (t) => {
         },
       ],
     };
-
     const extendedChartData = validator.prepareChartData();
-
-    // Note: trend line generation depends on R-squared threshold, so we just check the logic
-    console.log(
-      "Extended market data chart datasets:",
-      extendedChartData.datasets.map((d) => d.label),
+    assertExists(
+      extendedChartData.datasets,
+      "Extended chart data should exist",
     );
   });
 });
-
-console.log("All portfolio view consistency tests passed! 🎉");

--- a/tests/projection_kernels_test.ts
+++ b/tests/projection_kernels_test.ts
@@ -1,0 +1,345 @@
+// Behavioural tests for the projection/scoring kernels added in issue #100.
+//
+// These import the REAL shipped helpers from docs/projection.js — the same code
+// the dashboard's GRQValidator delegates to — and assert on their observable
+// output across happy paths, error paths and edge cases.
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+interface MarketDataPoint {
+  date: Date;
+  high: number;
+  low: number;
+  open: number;
+  close: number;
+  splitCoefficient: number;
+}
+
+interface Projection {
+  projected90DayPerformance: number;
+  projectionMethod: string;
+  confidence: number;
+}
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    formatCurrency: (value: number | null | undefined) => string;
+    getSplitAdjustment: (
+      marketData: MarketDataPoint[] | undefined,
+      historicalDate: Date,
+    ) => number;
+    adjustHistoricalPriceToCurrent: (
+      price: number,
+      marketData: MarketDataPoint[] | undefined,
+      historicalDate: Date,
+    ) => number;
+    getBuyPrice: (
+      marketData: MarketDataPoint[] | undefined,
+      scoreDate: Date,
+    ) => { price: number; dateUsed: Date } | null;
+    currentPriceFromLatest: (marketData: MarketDataPoint[]) => number | null;
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+    calculateRSquared: (
+      dataPoints: { x: number; y: number }[],
+      slope: number,
+      intercept: number,
+    ) => number;
+    computeTrendLine: (
+      dataPoints: { x: number; y: number }[],
+    ) => {
+      slope: number;
+      intercept: number;
+      predicted90DayPerformance: number;
+      rSquared: number;
+    } | null;
+    daysElapsedFromMarketData: (
+      scoreDate: Date,
+      latestMarketDate: Date,
+    ) => number;
+    computeHybridProjection: (inputs: {
+      daysElapsed: number;
+      currentPerformance: number;
+      targetPercentage: number | null;
+      trendLine: { slope: number; rSquared: number } | null;
+    }) => Projection;
+    computeJudgement: (inputs: {
+      performance: number | null;
+      daysElapsed: number;
+      targetPercentage: number | null;
+      projection: Projection | null;
+    }) => string;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+function makePoint(
+  date: Date,
+  high: number,
+  low: number,
+  split = 1.0,
+): MarketDataPoint {
+  return { date, high, low, open: low, close: high, splitCoefficient: split };
+}
+
+// --- formatCurrency ---------------------------------------------------------
+
+Deno.test("formatCurrency renders USD with two decimals", () => {
+  assertEquals(GRQProjection.formatCurrency(18.5), "$18.50");
+  assertEquals(GRQProjection.formatCurrency(0), "$0.00");
+});
+
+Deno.test("formatCurrency returns N/A for missing or non-numeric values", () => {
+  assertEquals(GRQProjection.formatCurrency(null), "N/A");
+  assertEquals(GRQProjection.formatCurrency(undefined), "N/A");
+  assertEquals(GRQProjection.formatCurrency(NaN), "N/A");
+});
+
+// --- split adjustment -------------------------------------------------------
+
+Deno.test("getSplitAdjustment multiplies splits after the historical date", () => {
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 50, 49, 2.0), // 2:1 split after day 1.
+  ];
+  assertEquals(GRQProjection.getSplitAdjustment(md, new Date(2025, 0, 1)), 2.0);
+  // A split on/before the date does not count.
+  assertEquals(
+    GRQProjection.getSplitAdjustment(md, new Date(2025, 0, 10)),
+    1.0,
+  );
+});
+
+Deno.test("getSplitAdjustment defaults to 1.0 without market data", () => {
+  assertEquals(GRQProjection.getSplitAdjustment(undefined, new Date()), 1.0);
+});
+
+Deno.test("adjustHistoricalPriceToCurrent divides out the split", () => {
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 50, 49, 2.0),
+  ];
+  assertEquals(
+    GRQProjection.adjustHistoricalPriceToCurrent(30, md, new Date(2025, 0, 1)),
+    15,
+  );
+});
+
+// --- getBuyPrice ------------------------------------------------------------
+
+Deno.test("getBuyPrice finds the next trading day within five days", () => {
+  const md = [makePoint(new Date(2025, 1, 18), 15.18, 14.72)];
+  const buy = GRQProjection.getBuyPrice(md, new Date(2025, 1, 14));
+  assert(buy !== null);
+  assertEquals(buy!.price, 14.95);
+  assertEquals(buy!.dateUsed.getDate(), 18);
+});
+
+Deno.test("getBuyPrice returns null beyond the five-day window or with no data", () => {
+  const md = [makePoint(new Date(2025, 1, 25), 15.18, 14.72)];
+  assertEquals(GRQProjection.getBuyPrice(md, new Date(2025, 1, 14)), null);
+  assertEquals(
+    GRQProjection.getBuyPrice(undefined, new Date(2025, 1, 14)),
+    null,
+  );
+});
+
+// --- currentPriceFromLatest -------------------------------------------------
+
+Deno.test("currentPriceFromLatest returns the midpoint of the last point", () => {
+  const md = [
+    makePoint(new Date(2025, 0, 1), 10, 9),
+    makePoint(new Date(2025, 0, 2), 12, 10),
+  ];
+  assertEquals(GRQProjection.currentPriceFromLatest(md), 11);
+  assertEquals(GRQProjection.currentPriceFromLatest([]), null);
+});
+
+// --- calculateTargetPercentage ----------------------------------------------
+
+Deno.test("calculateTargetPercentage returns the return vs the buy price", () => {
+  assertAlmostEquals(
+    GRQProjection.calculateTargetPercentage(14.95, 18.5)!,
+    23.75,
+    0.01,
+  );
+});
+
+Deno.test("calculateTargetPercentage returns null when an input is missing", () => {
+  assertEquals(GRQProjection.calculateTargetPercentage(null, 18.5), null);
+  assertEquals(GRQProjection.calculateTargetPercentage(14.95, null), null);
+});
+
+// --- computeTrendLine -------------------------------------------------------
+
+Deno.test("computeTrendLine fits a line through the origin with R²", () => {
+  const trend = GRQProjection.computeTrendLine([
+    { x: 0, y: 0 },
+    { x: 10, y: 10 },
+    { x: 20, y: 20 },
+  ]);
+  assert(trend !== null);
+  assertEquals(trend!.intercept, 0);
+  assertAlmostEquals(trend!.slope, 1, 1e-9);
+  assertAlmostEquals(trend!.predicted90DayPerformance, 90, 1e-9);
+  assertAlmostEquals(trend!.rSquared, 1, 1e-9);
+});
+
+Deno.test("computeTrendLine returns null for fewer than three points", () => {
+  assertEquals(GRQProjection.computeTrendLine([{ x: 0, y: 0 }]), null);
+  assertEquals(GRQProjection.computeTrendLine([]), null);
+});
+
+Deno.test("computeTrendLine floors the 90-day prediction at -100", () => {
+  const trend = GRQProjection.computeTrendLine([
+    { x: 0, y: 0 },
+    { x: 10, y: -50 },
+    { x: 20, y: -100 },
+  ]);
+  assert(trend !== null);
+  assertEquals(trend!.predicted90DayPerformance, -100);
+});
+
+// --- calculateRSquared ------------------------------------------------------
+
+Deno.test("calculateRSquared is 1 for a perfect fit and 0 for no variance", () => {
+  const perfect = GRQProjection.calculateRSquared(
+    [{ x: 0, y: 0 }, { x: 1, y: 2 }, { x: 2, y: 4 }],
+    2,
+    0,
+  );
+  assertAlmostEquals(perfect, 1, 1e-9);
+  const flat = GRQProjection.calculateRSquared(
+    [{ x: 0, y: 5 }, { x: 1, y: 5 }],
+    0,
+    5,
+  );
+  assertEquals(flat, 0);
+});
+
+// --- daysElapsedFromMarketData ----------------------------------------------
+
+Deno.test("daysElapsedFromMarketData counts days and caps at 90", () => {
+  const score = new Date(2025, 1, 18);
+  assertEquals(
+    GRQProjection.daysElapsedFromMarketData(score, new Date(2025, 1, 20)),
+    2,
+  );
+  assertEquals(
+    GRQProjection.daysElapsedFromMarketData(score, new Date(2025, 5, 18)),
+    90,
+  );
+});
+
+// --- computeHybridProjection ------------------------------------------------
+
+Deno.test("computeHybridProjection uses the dampened trend early when confident", () => {
+  const p = GRQProjection.computeHybridProjection({
+    daysElapsed: 15,
+    currentPerformance: 10,
+    targetPercentage: 30,
+    trendLine: { slope: 1.0, rSquared: 0.5 },
+  });
+  assertEquals(p.projectionMethod, "dampened_trend");
+  assertEquals(p.projected90DayPerformance, 27); // 1.0 * 0.3 * 90.
+});
+
+Deno.test("computeHybridProjection falls back to target-based with a weak trend", () => {
+  const p = GRQProjection.computeHybridProjection({
+    daysElapsed: 15,
+    currentPerformance: 10,
+    targetPercentage: 30,
+    trendLine: { slope: 1.0, rSquared: 0.01 }, // Below the 0.1 threshold.
+  });
+  assertEquals(p.projectionMethod, "target_based");
+  assertEquals(p.confidence, 0.3);
+});
+
+Deno.test("computeHybridProjection uses the realistic trajectory after 60 days", () => {
+  const p = GRQProjection.computeHybridProjection({
+    daysElapsed: 80,
+    currentPerformance: 1,
+    targetPercentage: 50,
+    trendLine: null,
+  });
+  assertEquals(p.projectionMethod, "realistic_trajectory");
+  assertEquals(p.confidence, 0.7); // Required catch-up rate is unrealistic.
+});
+
+Deno.test("computeHybridProjection clamps the projection to [-100, 200]", () => {
+  const high = GRQProjection.computeHybridProjection({
+    daysElapsed: 15,
+    currentPerformance: 10,
+    targetPercentage: 30,
+    trendLine: { slope: 100, rSquared: 0.9 },
+  });
+  assertEquals(high.projected90DayPerformance, 200);
+});
+
+// --- computeJudgement -------------------------------------------------------
+
+Deno.test("computeJudgement returns Pending for null performance", () => {
+  assertEquals(
+    GRQProjection.computeJudgement({
+      performance: null,
+      daysElapsed: 30,
+      targetPercentage: 20,
+      projection: null,
+    }),
+    "Pending",
+  );
+});
+
+Deno.test("computeJudgement reports the projection when confident", () => {
+  const judgement = GRQProjection.computeJudgement({
+    performance: 10,
+    daysElapsed: 30,
+    targetPercentage: 60,
+    projection: {
+      projected90DayPerformance: 45,
+      projectionMethod: "dampened_trend",
+      confidence: 0.5,
+    },
+  });
+  // 45 / 60 = 0.75 of target -> Below Target.
+  assert(judgement.startsWith("Below Target"));
+  assert(judgement.includes("45.0%"));
+});
+
+Deno.test("computeJudgement falls back to current performance when not confident", () => {
+  const judgement = GRQProjection.computeJudgement({
+    performance: 8,
+    daysElapsed: 30,
+    targetPercentage: 25,
+    projection: {
+      projected90DayPerformance: 20,
+      projectionMethod: "target_based",
+      confidence: 0.1, // Below the 0.2 confidence gate.
+    },
+  });
+  assert(judgement.startsWith("Below Target"));
+  assert(judgement.includes("8.0%"));
+});
+
+Deno.test("computeJudgement reports the realised outcome from day 90", () => {
+  assertEquals(
+    GRQProjection.computeJudgement({
+      performance: 25,
+      daysElapsed: 90,
+      targetPercentage: 20,
+      projection: null,
+    }),
+    "Hit Target",
+  );
+  assertEquals(
+    GRQProjection.computeJudgement({
+      performance: -5,
+      daysElapsed: 90,
+      targetPercentage: 20,
+      projection: null,
+    }),
+    "Missed Target",
+  );
+});

--- a/tests/realistic_projection_test.ts
+++ b/tests/realistic_projection_test.ts
@@ -1,332 +1,139 @@
-import { assertEquals } from "@std/assert";
+// Realistic-trajectory projection tests (issue #100).
+//
+// These used to drive a `MockGRQValidator` that reimplemented (and forced) the
+// long-term projection branch, so they asserted on a copy of the maths rather
+// than the shipped code. They now exercise the REAL shared kernel
+// `GRQProjection.computeHybridProjection` from docs/projection.js — the same
+// function the dashboard's GRQValidator delegates to — for the long-term
+// (>= 60 days elapsed) "realistic_trajectory" horizon.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
-interface ScoreData {
-  stock: string;
-  score: number;
-  target: number;
-  exDividendDate: string | null;
-  dividendPerShare: number;
-  notes: string;
-  intrinsicValuePerShareBasic: number | null;
-  intrinsicValuePerShareAdjusted: number | null;
+interface Projection {
+  projected90DayPerformance: number;
+  projectionMethod: string;
+  confidence: number;
 }
 
-interface MarketDataPoint {
-  date: Date;
-  high: number;
-  low: number;
-  open: number;
-  close: number;
-  splitCoefficient: number;
-}
-
-class MockGRQValidator {
-  marketData: Record<string, MarketDataPoint[]> = {};
-  dividendData: Record<string, unknown[]> = {};
-  scoreData: ScoreData[] = [];
-  selectedFile = "test.tsv";
-  selectedStock: string | null = null;
-
-  setupBehindTargetScenario(): void {
-    // Setup a scenario where stock is significantly behind target
-    // Current performance: 2% at 49 days, target: 50.8%
-    this.marketData = {
-      "NYSE:SEM": [
-        {
-          date: new Date("2025-05-14"), // Score date
-          high: 100.0,
-          low: 100.0,
-          open: 100.0,
-          close: 100.0,
-          splitCoefficient: 1.0,
-        },
-        {
-          date: new Date("2025-07-02"), // 49 days later
-          high: 102.0,
-          low: 102.0,
-          open: 102.0,
-          close: 102.0,
-          splitCoefficient: 1.0,
-        },
-      ],
-    };
-
-    this.scoreData = [
-      {
-        stock: "NYSE:SEM",
-        score: 0.8,
-        target: 150.8, // Target price that gives 50.8% return
-        exDividendDate: null,
-        dividendPerShare: 0,
-        notes: "",
-        intrinsicValuePerShareBasic: null,
-        intrinsicValuePerShareAdjusted: null,
-      },
-    ];
-  }
-
-  getScoreDate(): Date {
-    return new Date("2025-05-14");
-  }
-
-  getDaysElapsed(): number {
-    return 49; // 49 days elapsed
-  }
-
-  getBuyPrice(
-    _stockSymbol: string,
-    _scoreDate: Date,
-  ): { price: number; dateUsed: Date } | null {
-    return { price: 100.0, dateUsed: new Date("2025-05-14") };
-  }
-
-  calculateStockPerformance(_stock: ScoreData): number {
-    return 2.0; // 2% performance
-  }
-
-  calculateTargetPercentage(_stock: ScoreData, _scoreDate: Date): number {
-    return 50.8; // 50.8% target
-  }
-
-  calculateTrendLine(_stock: ScoreData, _scoreDate: Date): null {
-    return null; // No trend line available
-  }
-
-  calculateHybridProjection(stock: ScoreData, scoreDate: Date) {
-    const daysElapsed = this.getDaysElapsed();
-    const currentPerformance = this.calculateStockPerformance(stock);
-    const targetPercentage = this.calculateTargetPercentage(stock, scoreDate);
-
-    // Long-term: Use realistic projection based on current trajectory
-    const projectionMethod = "realistic_trajectory";
-
-    if (targetPercentage !== null) {
-      // Calculate what the current trajectory suggests for 90 days
-      const currentRate = currentPerformance / daysElapsed; // % per day
-      const trajectoryProjection = currentRate * 90;
-
-      // If we're significantly behind target, be realistic about missing it
-      const remainingDays = 90 - daysElapsed;
-      const remainingGap = targetPercentage - currentPerformance;
-      const requiredDailyRate = remainingGap / remainingDays;
-
-      let projected90DayPerformance: number;
-      let confidence: number;
-
-      // If required rate is unrealistic (>2% per day), project missing target
-      if (requiredDailyRate > 2.0) {
-        // Project based on current trajectory, but cap at a realistic maximum
-        const realisticProjection = Math.min(
-          trajectoryProjection,
-          targetPercentage * 0.6,
-        );
-        projected90DayPerformance = Math.max(
-          realisticProjection,
-          currentPerformance * 1.2,
-        ); // At least some improvement
-        confidence = 0.7; // High confidence we're missing target
-      } else {
-        // Still possible to hit target, but be conservative
-        projected90DayPerformance = Math.min(
-          trajectoryProjection,
-          targetPercentage * 0.8,
-        );
-        confidence = 0.6;
-      }
-
-      return {
-        projected90DayPerformance,
-        projectionMethod,
-        confidence,
-        daysElapsed,
-        currentPerformance,
-        targetPercentage,
-      };
-    }
-
-    return null;
-  }
-}
+const g = globalThis as unknown as {
+  GRQProjection: {
+    computeHybridProjection: (inputs: {
+      daysElapsed: number;
+      currentPerformance: number;
+      targetPercentage: number | null;
+      trendLine: { slope: number; rSquared: number } | null;
+    }) => Projection;
+  };
+};
+const GRQProjection = g.GRQProjection;
 
 Deno.test("Realistic Projection - Behind Target Scenario", async (t) => {
-  const validator = new MockGRQValidator();
-  validator.setupBehindTargetScenario();
+  const target = 50.8;
 
   await t.step(
-    "should project realistic performance when significantly behind target",
+    "projects a conservative figure when behind but catch-up is still feasible",
     () => {
-      const stock = validator.scoreData[0];
-      const scoreDate = validator.getScoreDate();
-      const projection = validator.calculateHybridProjection(stock, scoreDate);
+      // 65 days elapsed, 2% current performance: the required daily catch-up
+      // rate (48.8% / 25 days = 1.95%) is below the 2%/day "unrealistic"
+      // threshold, so the kernel uses the conservative trajectory branch.
+      const projection = GRQProjection.computeHybridProjection({
+        daysElapsed: 65,
+        currentPerformance: 2.0,
+        targetPercentage: target,
+        trendLine: null,
+      });
 
-      // Verify projection exists
-      assertEquals(projection !== null, true, "Should generate projection");
-      if (!projection) return;
-
-      // Verify projection method
       assertEquals(
         projection.projectionMethod,
         "realistic_trajectory",
-        "Should use realistic trajectory method",
+        "Should use the long-term realistic trajectory method",
       );
 
-      // Verify input values
-      assertEquals(projection.daysElapsed, 49, "Should have 49 days elapsed");
+      // Conservative branch: min(trajectory, target * 0.8).
+      const trajectory = (2.0 / 65) * 90;
+      const expected = Math.min(trajectory, target * 0.8);
       assertEquals(
-        projection.currentPerformance,
-        2.0,
-        "Should have 2% current performance",
+        projection.projected90DayPerformance,
+        expected,
+        "Should project the conservative trajectory figure",
       );
-      assertEquals(
-        projection.targetPercentage,
-        50.8,
-        "Should have 50.8% target",
+      assert(
+        projection.projected90DayPerformance < target,
+        "Projection should be less than the target",
       );
-
-      // Calculate expected values
-      const currentRate = 2.0 / 49; // 0.0408% per day
-      const trajectoryProjection = currentRate * 90; // 3.67%
-      const remainingDays = 90 - 49; // 41 days
-      const remainingGap = 50.8 - 2.0; // 48.8%
-      const _requiredDailyRate = remainingGap / remainingDays; // 1.19% per day
-
-      // Since required daily rate (1.19%) is not > 2.0%, it should use conservative projection
-      const _expectedProjection = Math.min(trajectoryProjection, 50.8 * 0.8); // min(3.67%, 40.64%) = 3.67%
-
-      // Verify projection is realistic (much lower than target)
-      assertEquals(
-        projection.projected90DayPerformance < 50.8,
-        true,
-        "Projection should be less than target",
-      );
-      assertEquals(
+      assert(
         projection.projected90DayPerformance > 2.0,
-        true,
-        "Projection should be higher than current performance",
+        "Projection should exceed current performance",
       );
-      assertEquals(
+      assert(
         projection.projected90DayPerformance < 10.0,
-        true,
         "Projection should be realistic (< 10%)",
       );
-
-      // Verify confidence
-      assertEquals(
-        projection.confidence,
-        0.6,
-        "Should have moderate confidence",
-      );
+      assertEquals(projection.confidence, 0.6, "Should have moderate confidence");
     },
   );
 
-  await t.step("should handle extremely behind target scenario", () => {
-    // Modify to create an even worse scenario
-    const stock = validator.scoreData[0];
-    const scoreDate = validator.getScoreDate();
+  await t.step("handles an extremely behind-target scenario", () => {
+    // 60 days elapsed, 1% performance: still feasible (required 1.66%/day),
+    // conservative branch.
+    const projection = GRQProjection.computeHybridProjection({
+      daysElapsed: 60,
+      currentPerformance: 1.0,
+      targetPercentage: target,
+      trendLine: null,
+    });
 
-    // Mock even worse performance: 1% at 60 days with 50% target
-    const originalCalculateStockPerformance =
-      validator.calculateStockPerformance;
-    validator.calculateStockPerformance = () => 1.0; // 1% performance
-    validator.getDaysElapsed = () => 60; // 60 days elapsed
-
-    const projection = validator.calculateHybridProjection(stock, scoreDate);
-
-    // Restore original methods
-    validator.calculateStockPerformance = originalCalculateStockPerformance;
-    validator.getDaysElapsed = () => 49;
-
-    assertEquals(projection !== null, true, "Should generate projection");
-    if (!projection) return;
-
-    // Calculate expected values for this scenario
-    const currentRate = 1.0 / 60; // 0.0167% per day
-    const trajectoryProjection = currentRate * 90; // 1.5%
-    const remainingDays = 90 - 60; // 30 days
-    const remainingGap = 50.8 - 1.0; // 49.8%
-    const _requiredDailyRate = remainingGap / remainingDays; // 1.66% per day
-
-    // Since required daily rate (1.66%) is not > 2.0%, it should use conservative projection
-    const _expectedProjection = Math.min(trajectoryProjection, 50.8 * 0.8); // min(1.5%, 40.64%) = 1.5%
-
-    // Verify projection is very low
-    assertEquals(
+    const trajectory = (1.0 / 60) * 90;
+    const expected = Math.min(trajectory, target * 0.8);
+    assertEquals(projection.projected90DayPerformance, expected);
+    assert(
       projection.projected90DayPerformance < 5.0,
-      true,
       "Projection should be very low (< 5%)",
     );
-    assertEquals(
+    assert(
       projection.projected90DayPerformance > 1.0,
-      true,
-      "Projection should be higher than current performance",
+      "Projection should exceed current performance",
     );
   });
 
-  await t.step("should handle unrealistic catch-up scenario", () => {
-    // Modify to create a scenario where required daily rate > 2%
-    const stock = validator.scoreData[0];
-    const scoreDate = validator.getScoreDate();
+  await t.step("handles an unrealistic catch-up scenario", () => {
+    // 80 days elapsed, 1% performance: required daily rate (49.8% / 10 days =
+    // 4.98%) exceeds 2%/day, so the kernel projects a miss with high confidence.
+    const projection = GRQProjection.computeHybridProjection({
+      daysElapsed: 80,
+      currentPerformance: 1.0,
+      targetPercentage: target,
+      trendLine: null,
+    });
 
-    // Mock scenario: 1% at 80 days with 50% target (requires 2.45% per day)
-    const originalCalculateStockPerformance =
-      validator.calculateStockPerformance;
-    const originalGetDaysElapsed = validator.getDaysElapsed;
-    validator.calculateStockPerformance = () => 1.0; // 1% performance
-    validator.getDaysElapsed = () => 80; // 80 days elapsed
-
-    const projection = validator.calculateHybridProjection(stock, scoreDate);
-
-    // Restore original methods
-    validator.calculateStockPerformance = originalCalculateStockPerformance;
-    validator.getDaysElapsed = originalGetDaysElapsed;
-
-    assertEquals(projection !== null, true, "Should generate projection");
-    if (!projection) return;
-
-    // Calculate expected values for this scenario
-    const currentRate = 1.0 / 80; // 0.0125% per day
-    const trajectoryProjection = currentRate * 90; // 1.125%
-    const remainingDays = 90 - 80; // 10 days
-    const remainingGap = 50.8 - 1.0; // 49.8%
-    const _requiredDailyRate = remainingGap / remainingDays; // 4.98% per day
-
-    // Since required daily rate (4.98%) > 2.0%, it should use realistic projection
-    const realisticProjection = Math.min(trajectoryProjection, 50.8 * 0.6); // min(1.125%, 30.48%) = 1.125%
-    const expectedProjection = Math.max(realisticProjection, 1.0 * 1.2); // max(1.125%, 1.2) = 1.2
-
-    // Verify projection is realistic and confidence is high
+    const trajectory = (1.0 / 80) * 90;
+    const realisticProjection = Math.min(trajectory, target * 0.6);
+    const expected = Math.max(realisticProjection, 1.0 * 1.2);
     assertEquals(
       projection.projected90DayPerformance,
-      expectedProjection,
-      "Should use realistic projection",
+      expected,
+      "Should use the floored realistic projection",
     );
     assertEquals(
       projection.confidence,
       0.7,
-      "Should have high confidence for unrealistic catch-up",
+      "Should have high confidence for an unrealistic catch-up",
     );
   });
 
   await t.step(
-    "should return 'Declining' judgement for far behind target scenario",
+    "yields a 'Declining' judgement for the far-behind-target scenario",
     () => {
-      // Simulate the judgement logic
-      const stock = validator.scoreData[0];
-      const scoreDate = validator.getScoreDate();
-      const projection = validator.calculateHybridProjection(stock, scoreDate);
-      if (!projection) throw new Error("No projection");
+      const projection = GRQProjection.computeHybridProjection({
+        daysElapsed: 65,
+        currentPerformance: 2.0,
+        targetPercentage: target,
+        trendLine: null,
+      });
+
       const predicted = projection.projected90DayPerformance;
-      const target = projection.targetPercentage || 20;
-      const pctOfTarget = target === 0 ? 0 : predicted / target;
-      console.log(
-        "DEBUG: predicted=",
-        predicted,
-        "target=",
-        target,
-        "pctOfTarget=",
-        pctOfTarget,
-      );
-      let judgement;
+      const pctOfTarget = predicted / target;
+      let judgement: string;
       if (predicted < 0 || pctOfTarget < 0.2) {
         judgement = `Declining (${predicted.toFixed(1)}%)`;
       } else if (pctOfTarget >= 0.95) {
@@ -336,10 +143,11 @@ Deno.test("Realistic Projection - Behind Target Scenario", async (t) => {
       } else {
         judgement = `Declining (${predicted.toFixed(1)}%)`;
       }
-      // Should be 'Declining' for this scenario
-      if (!judgement.startsWith("Declining")) {
-        throw new Error("Judgement should be 'Declining' for this scenario");
-      }
+
+      assert(
+        judgement.startsWith("Declining"),
+        "Judgement should be 'Declining' for this scenario",
+      );
     },
   );
 });

--- a/tests/realistic_projection_test.ts
+++ b/tests/realistic_projection_test.ts
@@ -69,7 +69,11 @@ Deno.test("Realistic Projection - Behind Target Scenario", async (t) => {
         projection.projected90DayPerformance < 10.0,
         "Projection should be realistic (< 10%)",
       );
-      assertEquals(projection.confidence, 0.6, "Should have moderate confidence");
+      assertEquals(
+        projection.confidence,
+        0.6,
+        "Should have moderate confidence",
+      );
     },
   );
 

--- a/tests/schw_projection_test.ts
+++ b/tests/schw_projection_test.ts
@@ -77,7 +77,11 @@ const g = globalThis as unknown as {
       currentPerformance: number;
       targetPercentage: number | null;
       trendLine: { slope: number; rSquared: number } | null;
-    }) => { projected90DayPerformance: number; projectionMethod: string; confidence: number };
+    }) => {
+      projected90DayPerformance: number;
+      projectionMethod: string;
+      confidence: number;
+    };
   };
 };
 const GRQProjection = g.GRQProjection;
@@ -107,7 +111,9 @@ class TestGRQValidator {
         dividendPerShare: values[4] ? parseFloat(values[4]) : 0,
         notes: values[5] || "",
         intrinsicValuePerShareBasic: values[6] ? parseFloat(values[6]) : null,
-        intrinsicValuePerShareAdjusted: values[7] ? parseFloat(values[7]) : null,
+        intrinsicValuePerShareAdjusted: values[7]
+          ? parseFloat(values[7])
+          : null,
       };
     });
   }
@@ -207,7 +213,8 @@ class TestGRQValidator {
     const dataPoints: { x: number; y: number }[] = [];
     marketData.forEach((point) => {
       if (point.date >= scoreDate && point.date <= trendEndDate) {
-        const daysSinceScore = (point.date.getTime() - scoreDate.getTime()) / DAY;
+        const daysSinceScore = (point.date.getTime() - scoreDate.getTime()) /
+          DAY;
         const currentPrice = (point.high + point.low) / 2;
         const priceReturn =
           ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
@@ -285,7 +292,9 @@ Deno.test("NYSE:SCHW Projection Test - Using Real App Functions", async (t) => {
     assert(currentPerformance !== null, "Should have current performance");
     assert(
       currentPerformance! > 15,
-      `Current performance should be > 15%, got ${currentPerformance?.toFixed(1)}%`,
+      `Current performance should be > 15%, got ${
+        currentPerformance?.toFixed(1)
+      }%`,
     );
   });
 
@@ -294,11 +303,15 @@ Deno.test("NYSE:SCHW Projection Test - Using Real App Functions", async (t) => {
     assert(projection, "Should have projection");
     assert(
       projection!.projected90DayPerformance > 17,
-      `Projection should be > 17%, got ${projection!.projected90DayPerformance.toFixed(1)}%`,
+      `Projection should be > 17%, got ${
+        projection!.projected90DayPerformance.toFixed(1)
+      }%`,
     );
     assert(
       projection!.projected90DayPerformance > 19,
-      `Projection should be > 19%, got ${projection!.projected90DayPerformance.toFixed(1)}%`,
+      `Projection should be > 19%, got ${
+        projection!.projected90DayPerformance.toFixed(1)
+      }%`,
     );
   });
 

--- a/tests/schw_projection_test.ts
+++ b/tests/schw_projection_test.ts
@@ -1,8 +1,19 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write
 
+// NYSE:SCHW fixture-based projection test (issue #100).
+//
+// This is the most integration-like test: it loads a frozen snapshot of SCHW
+// score/market/dividend fixtures and checks current performance, the 90-day
+// hybrid projection and the trend-line fit. It used to reimplement getBuyPrice,
+// performance, the regression and the whole projection tree inside a
+// `TestGRQValidator`. It now loads the same fixtures but delegates every piece
+// of maths to the REAL shared kernels in docs/projection.js (getBuyPrice,
+// currentPriceFromLatest, calculatePerformanceReturn, computeTrendLine,
+// calculateTargetPercentage, computeHybridProjection) — the same code the
+// dashboard's GRQValidator uses.
 import { assert } from "@std/assert";
+import "../docs/projection.js";
 
-// TypeScript interfaces for type safety
 interface StockData {
   stock: string;
   score: number;
@@ -20,7 +31,7 @@ interface MarketDataPoint {
   low: number;
   open: number;
   close: number;
-  split_coefficient: number;
+  splitCoefficient: number;
 }
 
 interface DividendDataPoint {
@@ -28,20 +39,7 @@ interface DividendDataPoint {
   amount: number;
 }
 
-interface DataPoint {
-  x: number;
-  y: number;
-}
-
-interface TrendLineResult {
-  slope: number;
-  intercept: number;
-  predicted90DayPerformance: number;
-  dataPoints: DataPoint[];
-  rSquared: number;
-}
-
-interface HybridProjectionResult {
+interface Projection {
   projected90DayPerformance: number;
   projectionMethod: string;
   confidence: number;
@@ -50,15 +48,48 @@ interface HybridProjectionResult {
   targetPercentage: number | null;
 }
 
-// Import the actual app.js functions by creating a minimal version for testing
+const g = globalThis as unknown as {
+  GRQProjection: {
+    getBuyPrice: (
+      marketData: MarketDataPoint[] | undefined,
+      scoreDate: Date,
+    ) => { price: number; dateUsed: Date } | null;
+    currentPriceFromLatest: (marketData: MarketDataPoint[]) => number | null;
+    calculatePerformanceReturn: (
+      buyPrice: number,
+      currentPrice: number,
+      totalDividends?: number,
+    ) => number | null;
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+    computeTrendLine: (
+      dataPoints: { x: number; y: number }[],
+    ) => {
+      slope: number;
+      intercept: number;
+      predicted90DayPerformance: number;
+      rSquared: number;
+    } | null;
+    computeHybridProjection: (inputs: {
+      daysElapsed: number;
+      currentPerformance: number;
+      targetPercentage: number | null;
+      trendLine: { slope: number; rSquared: number } | null;
+    }) => { projected90DayPerformance: number; projectionMethod: string; confidence: number };
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+const DAY = 1000 * 60 * 60 * 24;
+
 class TestGRQValidator {
   scoreData: StockData[] = [];
   marketData: Record<string, MarketDataPoint[]> = {};
   dividendData: Record<string, DividendDataPoint[]> = {};
   selectedFile = "2025/April/15.tsv";
-  costOfCapital = 0.15;
 
-  // Optional path overrides — used by fixture-based tests for determinism.
   scorePath = "docs/scores/2025/April/15.tsv";
   marketDataPath = "docs/scores/2025/April/15.csv";
   dividendDataPath = "docs/scores/2025/April/15-dividends.csv";
@@ -66,7 +97,6 @@ class TestGRQValidator {
   async loadScoreData() {
     const text = await Deno.readTextFile(this.scorePath);
     const lines = text.trim().split("\n");
-
     this.scoreData = lines.slice(1).map((line) => {
       const values = line.split("\t");
       return {
@@ -77,9 +107,7 @@ class TestGRQValidator {
         dividendPerShare: values[4] ? parseFloat(values[4]) : 0,
         notes: values[5] || "",
         intrinsicValuePerShareBasic: values[6] ? parseFloat(values[6]) : null,
-        intrinsicValuePerShareAdjusted: values[7]
-          ? parseFloat(values[7])
-          : null,
+        intrinsicValuePerShareAdjusted: values[7] ? parseFloat(values[7]) : null,
       };
     });
   }
@@ -87,609 +115,203 @@ class TestGRQValidator {
   async loadMarketData() {
     const text = await Deno.readTextFile(this.marketDataPath);
     const lines = text.trim().split("\n");
-
-    // Parse CSV data
-    const marketDataByStock: Record<string, MarketDataPoint[]> = {};
-
+    const byStock: Record<string, MarketDataPoint[]> = {};
     lines.slice(1).forEach((line) => {
       const values = line.split(",");
       const ticker = values[1];
-      const date = new Date(values[0]);
-      const high = parseFloat(values[2]);
-      const low = parseFloat(values[3]);
-      const open = parseFloat(values[4]);
-      const close = parseFloat(values[5]);
-      const split_coefficient = parseFloat(values[6]);
-
-      if (!marketDataByStock[ticker]) {
-        marketDataByStock[ticker] = [];
-      }
-
-      marketDataByStock[ticker].push({
-        date,
-        high,
-        low,
-        open,
-        close,
-        split_coefficient,
+      (byStock[ticker] ||= []).push({
+        date: new Date(values[0]),
+        high: parseFloat(values[2]),
+        low: parseFloat(values[3]),
+        open: parseFloat(values[4]),
+        close: parseFloat(values[5]),
+        splitCoefficient: parseFloat(values[6]),
       });
     });
-
-    this.marketData = marketDataByStock;
+    this.marketData = byStock;
   }
 
   async loadDividendData() {
     const text = await Deno.readTextFile(this.dividendDataPath);
     const lines = text.trim().split("\n");
-
-    const dividendDataByStock: Record<string, DividendDataPoint[]> = {};
-
+    const byStock: Record<string, DividendDataPoint[]> = {};
     lines.slice(1).forEach((line) => {
-      if (line.trim()) {
-        const values = line.split(",");
-        const date = new Date(values[0]);
-        const symbol = values[1];
-        const amount = parseFloat(values[2]);
-
-        if (!dividendDataByStock[symbol]) {
-          dividendDataByStock[symbol] = [];
-        }
-
-        dividendDataByStock[symbol].push({
-          exDivDate: date,
-          amount,
-        });
-      }
+      if (!line.trim()) return;
+      const values = line.split(",");
+      (byStock[values[1]] ||= []).push({
+        exDivDate: new Date(values[0]),
+        amount: parseFloat(values[2]),
+      });
     });
-
-    this.dividendData = dividendDataByStock;
+    this.dividendData = byStock;
   }
 
   getScoreDate(scoreFile: string): Date {
     const match = scoreFile.match(/(\d{4})\/(\w+)\/(\d+)\.tsv/);
     if (!match) return new Date();
-
     const [, year, month, day] = match;
     const monthMap: Record<string, number> = {
-      "January": 0,
-      "February": 1,
-      "March": 2,
-      "April": 3,
-      "May": 4,
-      "June": 5,
-      "July": 6,
-      "August": 7,
-      "September": 8,
-      "October": 9,
-      "November": 10,
-      "December": 11,
+      January: 0,
+      February: 1,
+      March: 2,
+      April: 3,
+      May: 4,
+      June: 5,
+      July: 6,
+      August: 7,
+      September: 8,
+      October: 9,
+      November: 10,
+      December: 11,
     };
-
     return new Date(parseInt(year), monthMap[month], parseInt(day));
-  }
-
-  getBuyPrice(
-    stockSymbol: string,
-    scoreDate: Date,
-  ): { price: number; dateUsed: Date } | null {
-    const marketData = this.marketData[stockSymbol];
-    if (!marketData) return null;
-
-    // Find the price on the score date or next available day
-    for (let i = 0; i <= 5; i++) {
-      const targetDate = new Date(
-        scoreDate.getTime() + i * 24 * 60 * 60 * 1000,
-      );
-      const scoreData = marketData.find((point: MarketDataPoint) => {
-        const pointDate = new Date(
-          point.date.getFullYear(),
-          point.date.getMonth(),
-          point.date.getDate(),
-        );
-        const targetDateOnly = new Date(
-          targetDate.getFullYear(),
-          targetDate.getMonth(),
-          targetDate.getDate(),
-        );
-        return pointDate.getTime() === targetDateOnly.getTime();
-      });
-
-      if (scoreData) {
-        const price = (scoreData.high + scoreData.low) / 2;
-        return { price, dateUsed: scoreData.date };
-      }
-    }
-
-    return null;
-  }
-
-  getCurrentPrice(stockSymbol: string): string {
-    const marketData = this.marketData[stockSymbol];
-    if (!marketData || marketData.length === 0) return "N/A";
-
-    const lastData = marketData[marketData.length - 1];
-    const currentPrice = (lastData.high + lastData.low) / 2;
-    return "$" + currentPrice.toFixed(2);
   }
 
   getDividendsWithin90Days(stockSymbol: string): DividendDataPoint[] {
     const dividends = this.dividendData[stockSymbol] || [];
     const scoreDate = this.getScoreDate(this.selectedFile);
-    const ninetyDayDate = new Date(
-      scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
-    );
-
-    return dividends.filter((div: DividendDataPoint) =>
-      div.exDivDate <= ninetyDayDate
-    );
+    const ninetyDayDate = new Date(scoreDate.getTime() + 90 * DAY);
+    return dividends.filter((div) => div.exDivDate <= ninetyDayDate);
   }
 
+  // Current performance via the real performance-return kernel.
   calculateStockPerformance(stock: StockData): number | null {
     const scoreDate = this.getScoreDate(this.selectedFile);
-    const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-    if (!buyPriceObj) return null;
-
-    const buyPrice = buyPriceObj.price;
-    const currentPriceStr = this.getCurrentPrice(stock.stock);
-    if (currentPriceStr === "N/A") return null;
-
-    const currentPrice = parseFloat(currentPriceStr.slice(1));
-    const dividends = this.getDividendsWithin90Days(stock.stock);
-    const totalDividends = dividends.reduce(
-      (sum: number, div: DividendDataPoint) => sum + div.amount,
-      0,
+    const buyPriceObj = GRQProjection.getBuyPrice(
+      this.marketData[stock.stock],
+      scoreDate,
     );
-
-    const totalReturn = (currentPrice - buyPrice + totalDividends) / buyPrice;
-    return totalReturn * 100;
+    if (!buyPriceObj) return null;
+    const currentPrice = GRQProjection.currentPriceFromLatest(
+      this.marketData[stock.stock],
+    );
+    if (currentPrice === null) return null;
+    const totalDividends = this.getDividendsWithin90Days(stock.stock)
+      .reduce((sum, div) => sum + div.amount, 0);
+    return GRQProjection.calculatePerformanceReturn(
+      buyPriceObj.price,
+      currentPrice,
+      totalDividends,
+    );
   }
 
-  calculateTrendLine(
-    stock: StockData,
-    scoreDate: Date,
-    endDate?: Date,
-  ): TrendLineResult | null {
+  // Collect regression points (data plumbing) then delegate to the kernel.
+  calculateTrendLine(stock: StockData, scoreDate: Date) {
     const marketData = this.marketData[stock.stock];
     if (!marketData || marketData.length === 0) return null;
-
-    const scoreDateTimestamp = scoreDate.getTime();
-    const trendEndDate = endDate ||
-      (marketData && marketData.length > 0
-        ? marketData[marketData.length - 1].date
-        : new Date());
-
-    const dataPoints: DataPoint[] = [];
-    const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-
+    const buyPriceObj = GRQProjection.getBuyPrice(marketData, scoreDate);
     if (!buyPriceObj || buyPriceObj.price <= 0) return null;
+    const trendEndDate = marketData[marketData.length - 1].date;
+    const dividends = this.getDividendsWithin90Days(stock.stock);
 
-    marketData.forEach((point: MarketDataPoint) => {
+    const dataPoints: { x: number; y: number }[] = [];
+    marketData.forEach((point) => {
       if (point.date >= scoreDate && point.date <= trendEndDate) {
-        const daysSinceScore = (point.date.getTime() - scoreDateTimestamp) /
-          (1000 * 60 * 60 * 24);
+        const daysSinceScore = (point.date.getTime() - scoreDate.getTime()) / DAY;
         const currentPrice = (point.high + point.low) / 2;
-
         const priceReturn =
           ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-        const dividends = this.getDividendsWithin90Days(stock.stock);
-        const dividendsUpToDate = dividends.filter((d: DividendDataPoint) =>
-          d.exDivDate <= point.date
-        );
-        const totalDividends = dividendsUpToDate.reduce(
-          (sum: number, div: DividendDataPoint) => sum + div.amount,
-          0,
-        );
+        const totalDividends = dividends
+          .filter((d) => d.exDivDate <= point.date)
+          .reduce((sum, div) => sum + div.amount, 0);
         const dividendReturn = (totalDividends / buyPriceObj.price) * 100;
-        const totalReturn = priceReturn + dividendReturn;
-
-        dataPoints.push({
-          x: daysSinceScore,
-          y: totalReturn,
-        });
+        dataPoints.push({ x: daysSinceScore, y: priceReturn + dividendReturn });
       }
     });
 
-    if (dataPoints.length < 3) return null;
-
-    const n = dataPoints.length;
-    const sumX = dataPoints.reduce(
-      (sum: number, point: DataPoint) => sum + point.x,
-      0,
-    );
-    const sumY = dataPoints.reduce(
-      (sum: number, point: DataPoint) => sum + point.y,
-      0,
-    );
-    const sumXY = dataPoints.reduce(
-      (sum: number, point: DataPoint) => sum + point.x * point.y,
-      0,
-    );
-    const sumXX = dataPoints.reduce(
-      (sum: number, point: DataPoint) => sum + point.x * point.x,
-      0,
-    );
-
-    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-    const _intercept = (sumY - slope * sumX) / n;
-
-    const adjustedIntercept = 0;
-    const adjustedSlope = slope;
-
-    const predicted90DayPerformance = adjustedSlope * 90 + adjustedIntercept;
-    const cappedPredicted90DayPerformance = Math.max(
-      predicted90DayPerformance,
-      -100,
-    );
-
-    const rSquared = this.calculateRSquared(
-      dataPoints,
-      adjustedSlope,
-      adjustedIntercept,
-    );
-
-    return {
-      slope: adjustedSlope,
-      intercept: adjustedIntercept,
-      predicted90DayPerformance: cappedPredicted90DayPerformance,
-      dataPoints,
-      rSquared: rSquared,
-    };
-  }
-
-  calculateRSquared(
-    dataPoints: DataPoint[],
-    slope: number,
-    intercept: number,
-  ): number {
-    const n = dataPoints.length;
-    const meanY =
-      dataPoints.reduce((sum: number, point: DataPoint) => sum + point.y, 0) /
-      n;
-
-    let ssRes = 0;
-    let ssTot = 0;
-
-    dataPoints.forEach((point: DataPoint) => {
-      const predicted = slope * point.x + intercept;
-      ssRes += Math.pow(point.y - predicted, 2);
-      ssTot += Math.pow(point.y - meanY, 2);
-    });
-
-    return ssTot > 0 ? 1 - (ssRes / ssTot) : 0;
+    return GRQProjection.computeTrendLine(dataPoints);
   }
 
   calculateTargetPercentage(stock: StockData, scoreDate: Date): number | null {
-    const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-    if (!buyPriceObj || buyPriceObj.price <= 0) return null;
-
-    const targetPrice = stock.target;
-    const targetReturn =
-      ((targetPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-    return targetReturn;
+    const buyPriceObj = GRQProjection.getBuyPrice(
+      this.marketData[stock.stock],
+      scoreDate,
+    );
+    return GRQProjection.calculateTargetPercentage(
+      buyPriceObj ? buyPriceObj.price : null,
+      stock.target,
+    );
   }
 
-  // This is the actual function from app.js that we want to test
+  // Gather inputs the way GRQValidator does, then delegate the decision tree.
   calculateHybridProjection(
     stock: StockData,
     scoreDate: Date,
-  ): HybridProjectionResult | null {
+  ): Projection | null {
     const marketData = this.marketData[stock.stock];
-    if (!marketData || marketData.length === 0) {
-      console.log(
-        `calculateHybridProjection - ${stock.stock}: No market data available`,
-      );
-      return null;
-    }
-
-    const scoreDateTimestamp = scoreDate.getTime();
-    // Use the latest market data date instead of today's date
-    const latestMarketDate = marketData && marketData.length > 0
-      ? marketData[marketData.length - 1].date
-      : new Date();
+    if (!marketData || marketData.length === 0) return null;
+    const latestMarketDate = marketData[marketData.length - 1].date;
     const daysElapsed = Math.floor(
-      (latestMarketDate.getTime() - scoreDateTimestamp) / (1000 * 60 * 60 * 24),
+      (latestMarketDate.getTime() - scoreDate.getTime()) / DAY,
     );
 
-    console.log(
-      `calculateHybridProjection - ${stock.stock}: Days elapsed: ${daysElapsed} (using latest market data date: ${
-        latestMarketDate.toISOString().split("T")[0]
-      })`,
-    );
-
-    // Get buy price
-    const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-    if (!buyPriceObj || buyPriceObj.price <= 0) {
-      console.log(
-        `calculateHybridProjection - ${stock.stock}: No valid buy price`,
-      );
-      return null;
-    }
-
-    // Calculate current performance
+    const buyPriceObj = GRQProjection.getBuyPrice(marketData, scoreDate);
+    if (!buyPriceObj || buyPriceObj.price <= 0) return null;
     const currentPerformance = this.calculateStockPerformance(stock);
-    if (currentPerformance === null) {
-      console.log(
-        `calculateHybridProjection - ${stock.stock}: Cannot calculate current performance`,
-      );
-      return null;
-    }
-
-    // Get target percentage
+    if (currentPerformance === null) return null;
     const targetPercentage = this.calculateTargetPercentage(stock, scoreDate);
+    const trendLine = daysElapsed < 60
+      ? this.calculateTrendLine(stock, scoreDate)
+      : null;
 
-    console.log(
-      `calculateHybridProjection - ${stock.stock}: Current performance: ${
-        currentPerformance.toFixed(1)
-      }%, Target: ${targetPercentage ? targetPercentage.toFixed(1) : "N/A"}%`,
-    );
-
-    // Hybrid approach based on days elapsed
-    let projected90DayPerformance;
-    let projectionMethod;
-    let confidence;
-
-    if (daysElapsed < 30) {
-      // Short-term: Use dampened trend (reduce early volatility)
-      projectionMethod = "dampened_trend";
-      const trendLine = this.calculateTrendLine(stock, scoreDate);
-
-      if (trendLine && trendLine.rSquared > 0.1) {
-        // Dampen the trend by 70% to account for mean reversion
-        const dampenedSlope = trendLine.slope * 0.3;
-        projected90DayPerformance = Math.max(dampenedSlope * 90, -100);
-        confidence = Math.min(trendLine.rSquared * 0.7, 0.8); // Reduce confidence for early projections
-        console.log(
-          `calculateHybridProjection - ${stock.stock}: Using dampened trend (slope: ${
-            trendLine.slope.toFixed(4)
-          } → ${dampenedSlope.toFixed(4)})`,
-        );
-      } else {
-        // Fall back to realistic projection based on current performance
-        projectionMethod = "target_based";
-        if (targetPercentage !== null) {
-          // Use current performance as base, project modest improvement if positive
-          if (currentPerformance > 0) {
-            // If currently positive, project slight improvement (10% of remaining gap)
-            const gap = targetPercentage - currentPerformance;
-            projected90DayPerformance = currentPerformance + (gap * 0.1);
-          } else {
-            // If currently negative, project slight recovery toward zero
-            projected90DayPerformance = currentPerformance * 0.5; // Move halfway toward zero
-          }
-          // Cap at reasonable bounds
-          projected90DayPerformance = Math.max(
-            Math.min(projected90DayPerformance, targetPercentage),
-            -100,
-          );
-        } else {
-          projected90DayPerformance = -5; // Default to -5% if no target
-        }
-        confidence = 0.3; // Low confidence for early projections
-        console.log(
-          `calculateHybridProjection - ${stock.stock}: Using realistic projection (insufficient trend data)`,
-        );
-      }
-    } else if (daysElapsed < 60) {
-      // Medium-term: Use dampened trend with higher confidence
-      projectionMethod = "dampened_trend";
-      const trendLine = this.calculateTrendLine(stock, scoreDate);
-
-      if (trendLine && trendLine.rSquared > 0.05) {
-        // Dampen the trend by 50% for medium-term
-        const dampenedSlope = trendLine.slope * 0.5;
-        projected90DayPerformance = Math.max(dampenedSlope * 90, -100);
-        confidence = Math.min(trendLine.rSquared * 0.8, 0.9);
-        console.log(
-          `calculateHybridProjection - ${stock.stock}: Using dampened trend (slope: ${
-            trendLine.slope.toFixed(4)
-          } → ${dampenedSlope.toFixed(4)})`,
-        );
-      } else {
-        // Fall back to realistic projection based on current performance
-        projectionMethod = "target_based";
-        if (targetPercentage !== null) {
-          // Use current performance as base, project modest improvement if positive
-          if (currentPerformance > 0) {
-            // If currently positive, project slight improvement (15% of remaining gap)
-            const gap = targetPercentage - currentPerformance;
-            projected90DayPerformance = currentPerformance + (gap * 0.15);
-          } else {
-            // If currently negative, project slight recovery toward zero
-            projected90DayPerformance = currentPerformance * 0.6; // Move 60% toward zero
-          }
-          // Cap at reasonable bounds
-          projected90DayPerformance = Math.max(
-            Math.min(projected90DayPerformance, targetPercentage),
-            -100,
-          );
-        } else {
-          projected90DayPerformance = -5; // Default to -5% if no target
-        }
-        confidence = 0.5;
-        console.log(
-          `calculateHybridProjection - ${stock.stock}: Using realistic projection (insufficient trend data)`,
-        );
-      }
-    } else {
-      // Long-term: Use realistic projection based on current trajectory
-      projectionMethod = "realistic_trajectory";
-
-      if (targetPercentage !== null) {
-        // Calculate what the current trajectory suggests for 90 days
-        const currentRate = currentPerformance / daysElapsed; // % per day
-        const trajectoryProjection = currentRate * 90;
-
-        // If we're significantly behind target, be realistic about missing it
-        const _targetThreshold = targetPercentage * 0.8; // 80% of target
-        const remainingDays = 90 - daysElapsed;
-        const remainingGap = targetPercentage - currentPerformance;
-        const requiredDailyRate = remainingGap / remainingDays;
-
-        // If required rate is unrealistic (>2% per day), project missing target
-        if (requiredDailyRate > 2.0) {
-          // Project based on current trajectory, but cap at a realistic maximum
-          const realisticProjection = Math.min(
-            trajectoryProjection,
-            targetPercentage * 0.6,
-          );
-          projected90DayPerformance = Math.max(
-            realisticProjection,
-            currentPerformance * 1.2,
-          ); // At least some improvement
-          confidence = 0.7; // High confidence we're missing target
-          console.log(
-            `calculateHybridProjection - ${stock.stock}: Projecting to miss target (required daily rate: ${
-              requiredDailyRate.toFixed(2)
-            }% is unrealistic)`,
-          );
-        } else {
-          // If current performance is already above target, use trajectory projection
-          if (currentPerformance > targetPercentage) {
-            projected90DayPerformance = trajectoryProjection;
-            confidence = 0.7;
-            console.log(
-              `calculateHybridProjection - ${stock.stock}: Current performance (${
-                currentPerformance.toFixed(1)
-              }%) already above target (${
-                targetPercentage.toFixed(1)
-              }%), using trajectory projection`,
-            );
-          } else {
-            // Still possible to hit target, but be conservative
-            projected90DayPerformance = Math.min(
-              trajectoryProjection,
-              targetPercentage * 0.8,
-            );
-            confidence = 0.6;
-            console.log(
-              `calculateHybridProjection - ${stock.stock}: Projecting conservative improvement toward target`,
-            );
-          }
-        }
-      } else {
-        // Use mean reversion (move toward 0% performance)
-        const reversionRate = 0.4; // 40% reversion toward mean
-        projected90DayPerformance = currentPerformance * (1 - reversionRate);
-        confidence = 0.3;
-        console.log(
-          `calculateHybridProjection - ${stock.stock}: Using mean reversion projection`,
-        );
-      }
-    }
-
-    // Ensure projection is within realistic bounds
-    projected90DayPerformance = Math.max(
-      Math.min(projected90DayPerformance, 200),
-      -100,
-    );
-
-    console.log(
-      `calculateHybridProjection - ${stock.stock}: Final projection: ${
-        projected90DayPerformance.toFixed(1)
-      }% (method: ${projectionMethod}, confidence: ${confidence.toFixed(2)})`,
-    );
-
-    return {
-      projected90DayPerformance,
-      projectionMethod,
-      confidence,
+    const projection = GRQProjection.computeHybridProjection({
       daysElapsed,
       currentPerformance,
       targetPercentage,
-    };
+      trendLine,
+    });
+    return { ...projection, daysElapsed, currentPerformance, targetPercentage };
   }
 }
 
 Deno.test("NYSE:SCHW Projection Test - Using Real App Functions", async (t) => {
-  // Use a fixed snapshot of market data so assertions are deterministic
-  // regardless of how many rows the live CSV accumulates over time.
-  // Snapshot covers Apr 15 – Jul 1 2025 (≈77 calendar days / 53 trading days).
+  // Frozen snapshot covering Apr 15 – Jul 1 2025 (~77 calendar days) so the
+  // assertions stay deterministic as the live CSV grows.
   const validator = new TestGRQValidator();
   validator.scorePath = "tests/fixtures/schw_april_2025_scores.tsv";
   validator.marketDataPath = "tests/fixtures/schw_april_2025_snapshot.csv";
   validator.dividendDataPath = "tests/fixtures/schw_april_2025_dividends.csv";
 
-  // Load the fixture data files
   await validator.loadScoreData();
   await validator.loadMarketData();
   await validator.loadDividendData();
 
   const scoreDate = validator.getScoreDate("2025/April/15.tsv");
-  const stock = validator.scoreData.find((s: StockData) =>
-    s.stock === "NYSE:SCHW"
-  );
-
+  const stock = validator.scoreData.find((s) => s.stock === "NYSE:SCHW");
   assert(stock, "NYSE:SCHW should be found in score data");
 
-  await t.step(
-    "should calculate correct current performance using app functions",
-    () => {
-      const currentPerformance = validator.calculateStockPerformance(stock);
-      assert(currentPerformance !== null, "Should have current performance");
+  await t.step("should calculate correct current performance", () => {
+    const currentPerformance = validator.calculateStockPerformance(stock!);
+    assert(currentPerformance !== null, "Should have current performance");
+    assert(
+      currentPerformance! > 15,
+      `Current performance should be > 15%, got ${currentPerformance?.toFixed(1)}%`,
+    );
+  });
 
-      console.log(`Current performance: ${currentPerformance?.toFixed(1)}%`);
+  await t.step("should calculate correct 90-day projection", () => {
+    const projection = validator.calculateHybridProjection(stock!, scoreDate);
+    assert(projection, "Should have projection");
+    assert(
+      projection!.projected90DayPerformance > 17,
+      `Projection should be > 17%, got ${projection!.projected90DayPerformance.toFixed(1)}%`,
+    );
+    assert(
+      projection!.projected90DayPerformance > 19,
+      `Projection should be > 19%, got ${projection!.projected90DayPerformance.toFixed(1)}%`,
+    );
+  });
 
-      // Current performance should be around 17-20% based on the data
-      assert(
-        currentPerformance! > 15,
-        `Current performance should be > 15%, got ${
-          currentPerformance?.toFixed(1)
-        }%`,
-      );
-    },
-  );
-
-  await t.step(
-    "should calculate correct 90-day projection using app functions",
-    () => {
-      const projection = validator.calculateHybridProjection(stock, scoreDate);
-      assert(projection, "Should have projection");
-
-      console.log(
-        `Projected 90-day performance: ${
-          projection.projected90DayPerformance.toFixed(1)
-        }%`,
-      );
-      console.log(`Confidence: ${projection.confidence.toFixed(3)}`);
-      console.log(`Method: ${projection.projectionMethod}`);
-
-      // The projection should be well over 17% based on the strong upward trend
-      assert(
-        projection.projected90DayPerformance > 17,
-        `Projection should be > 17%, got ${
-          projection.projected90DayPerformance.toFixed(1)
-        }%`,
-      );
-
-      // Should be closer to 20% or higher given the strong performance
-      assert(
-        projection.projected90DayPerformance > 19,
-        `Projection should be > 19%, got ${
-          projection.projected90DayPerformance.toFixed(1)
-        }%`,
-      );
-    },
-  );
-
-  await t.step("should have strong trend line fit using app functions", () => {
-    const trendLine = validator.calculateTrendLine(stock, scoreDate);
-
+  await t.step("should have strong trend line fit", () => {
+    const trendLine = validator.calculateTrendLine(stock!, scoreDate);
     assert(trendLine, "Should have trend line");
-    console.log(`Trend line R-squared: ${trendLine.rSquared.toFixed(3)}`);
-    console.log(
-      `Trend line slope: ${trendLine.slope.toFixed(4)} (price change per day)`,
-    );
-
-    // Should have good fit given the consistent upward trend
     assert(
-      trendLine.rSquared > 0.3,
-      `R-squared should be > 0.3, got ${trendLine.rSquared.toFixed(3)}`,
+      trendLine!.rSquared > 0.3,
+      `R-squared should be > 0.3, got ${trendLine!.rSquared.toFixed(3)}`,
     );
-
-    // Slope should be positive (upward trend)
     assert(
-      trendLine.slope > 0,
-      `Slope should be positive, got ${trendLine.slope.toFixed(4)}`,
+      trendLine!.slope > 0,
+      `Slope should be positive, got ${trendLine!.slope.toFixed(4)}`,
     );
   });
 });


### PR DESCRIPTION
# Convert remaining TS mock-validator tests to the shared projection module

## Summary

Follow-up to #80. The nine remaining test files each defined their own `Mock*`
validator and asserted on a **parallel reimplementation** of the dashboard's
projection/scoring maths rather than on production code — tautologies that stay
green even when `docs/app.js` drifts. Several of those copies had in fact already
drifted from production (the judgement thresholds and the hybrid-projection
fallbacks differed).

This change extends `docs/projection.js` (the shared classic-script module
published on `globalThis`, mirroring `docs/escape.js`) with the remaining pure
kernels, rewires `GRQValidator` to delegate to them, and points every test at
the real functions. The maths now has a single source of truth that both the
browser dashboard and the Deno tests exercise. Behaviour is preserved — the
fixture-based SCHW integration test still passes against the extracted kernels.

Fixes #100.

### New kernels in `docs/projection.js`

- `formatCurrency` — USD formatting with `N/A` guard
- `getSplitAdjustment` / `adjustHistoricalPriceToCurrent` — dilution maths
- `getBuyPrice` — 5-day forward search + split adjustment
- `currentPriceFromLatest` — latest-point midpoint
- `calculateTargetPercentage` — target return vs buy price
- `calculateRSquared` / `computeTrendLine` — linear regression through the origin
- `daysElapsedFromMarketData` — capped day count
- `computeHybridProjection` — the 90-day projection decision tree
- `computeJudgement` — the performance → judgement string mapping

`GRQValidator` methods (`getBuyPrice`, `calculateTrendLine`,
`calculateHybridProjection`, `calculateJudgement`, `getCurrentPrice`,
`calculateTargetPercentage`, the split-adjustment helpers, `formatCurrency`,
`getDaysElapsedFromMarketData`) now gather their inputs (market data, dividends,
buy price) and delegate the maths to these kernels.

### Data flow

```mermaid
flowchart LR
    subgraph Browser
      A[GRQValidator in app.js] -->|gathers market data,<br/>dividends, dates| K
    end
    subgraph Deno tests
      T[*_test.ts] --> K
    end
    K[docs/projection.js kernels] -->|projection, judgement,<br/>buy price, trend line| A
    K --> T
```

## Evidence

Backend/maths change with no web UI to screenshot. Verified by the Deno test
suite: all nine converted files now drive the real kernels, plus a new
`tests/projection_kernels_test.ts` adds direct happy/error/edge coverage. The
fixture-based `schw_projection_test.ts` passing against the extracted kernels is
the key proof the extraction is faithful — its real Apr–Jul 2025 SCHW data still
yields >15% current performance, >19% projection and R² > 0.3.

```
deno test --allow-read tests/*.ts
ok | 137 passed (57 steps) | 0 failed
```

## Test Plan

Converted to exercise the real shared kernels (no behaviour silently dropped;
mock maths replaced, DOM/parse glue retained where out of `projection.js` scope):

- `tests/realistic_projection_test.ts` → `computeHybridProjection`
- `tests/judgement_hybrid_test.ts` → `computeHybridProjection` + `computeJudgement`
- `tests/hybrid_projection_tests.ts` → `computeTrendLine` + `computeHybridProjection`
- `tests/schw_projection_test.ts` (fixtures) → buy price, trend line, projection
- `tests/buy_price_logic_test.ts` → `getBuyPrice`, split adjustment, target %
- `tests/current_price_consistency_test.ts` → `currentPriceFromLatest`, `setDateToMidnight`
- `tests/basic_score_table_test.ts` → `formatCurrency`
- `tests/portfolio_view_consistency_test.ts` → buy price, trend line, day count
- `tests/chart_data_test.ts` → performance return, price adjustment, target %

Added:

- `tests/projection_kernels_test.ts` — 23 direct unit tests covering every new
  kernel across happy paths, error paths and edge cases (null inputs, <3 points,
  -100 floor, [-100, 200] clamp, 90-day day-count cap, confidence gates).

### Notes

- Test market-data dates use local-midnight constructors so they match the
  kernel's local-midnight date comparison regardless of the runner's timezone;
  date assertions use local getters rather than `toISOString` (which shifts
  across the date line in non-UTC offsets).
- Drifted mock judgement/projection thresholds were corrected to match
  production; affected assertions were re-derived from the real kernel output.

### Deno regression avoided

- Extended the existing Deno-native shared module and `deno test` suite; no Node
  tooling, bundler, or `package.json` introduced.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq58grwt-311649`<!-- vibe-worker-issue-100 -->