### PR TITLE
Consume grq_validation library crate from the binary (Issue #94)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-94.md
+++ b/docs/archive/pr-summaries/pr-summary-94.md
@@ -1,0 +1,70 @@
+# Binary now consumes the `grq_validation` library crate
+
+## Summary
+
+The binary (`src/main.rs`) re-declared `pub mod models;` and `pub mod utils;`,
+compiling its own private copy of both modules even though the package already
+exposes them through the `grq_validation` library crate (`src/lib.rs`,
+`[lib] name = "grq_validation"`). The whole library was therefore compiled
+twice, and — more importantly — the binary did **not** consume the same crate
+the integration tests exercise (`tests/dividend_tests.rs` and
+`tests/market_data_tests.rs` import `grq_validation::utils::…`). The two copies
+could drift, so behaviour verified by tests was not guaranteed to match the
+behaviour shipped by the binary. The duplication was also why several `pub`
+items carried `#[allow(dead_code)]`: functions reached only through the
+library/tests looked "dead" to the binary crate.
+
+This PR makes the binary depend on the library crate:
+
+- Dropped `pub mod models;` and `pub mod utils;` from `main.rs`.
+- Changed `use utils::…` to `use grq_validation::utils::…` and rewrote every
+  remaining `utils::…` path as `grq_validation::utils::…`.
+- Removed the now-redundant `#[allow(dead_code)]` attributes from `src/utils.rs`
+  (9 occurrences) and `src/models.rs` (1 occurrence). Pub items in the library
+  crate are public API and are no longer flagged as dead code.
+
+The binary and the integration tests now share a single compiled copy of the
+modules.
+
+Closes #94.
+
+## Evidence
+
+This is a backend/CLI structural change with no web interface to screenshot.
+Verification was done via the build, linter and test suite:
+
+- `cargo build` — compiles cleanly.
+- `cargo clippy --all-targets --all-features -- -D warnings` — passes with zero
+  warnings, confirming no `dead_code` warnings resurfaced after removing the
+  `#[allow(dead_code)]` attributes.
+- `cargo test --all-targets --all-features` — 25 unit tests + 2 integration
+  tests pass.
+- `./quality.sh < /dev/null` — completed successfully (Rust + Deno checks).
+
+```mermaid
+flowchart LR
+    subgraph Before
+        B1[main.rs<br/>pub mod models<br/>pub mod utils] -.inlined copy.-> M1[models/utils]
+        L1[lib grq_validation] --> M2[models/utils]
+        T1[integration tests] --> L1
+    end
+    subgraph After
+        B2[main.rs] --> L2[lib grq_validation]
+        T2[integration tests] --> L2
+        L2 --> M3[single models/utils copy]
+    end
+```
+
+## Test Plan
+
+No behavioural change was introduced, so the existing test suite is the
+regression guard — and it is the right one here: the integration tests
+(`tests/dividend_tests.rs`, `tests/market_data_tests.rs`) import the binary's
+functions via `grq_validation::utils::…`, which is exactly the crate path the
+binary now consumes. After this change the binary and the tests exercise the
+same compiled code.
+
+- `cargo test --all-targets --all-features` — all 27 tests pass (25 unit, 2
+  integration).
+- `cargo clippy --all-targets --all-features -- -D warnings` — confirms the
+  removed `#[allow(dead_code)]` attributes are no longer needed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,12 @@
 use anyhow::{anyhow, Result};
 use chrono::{NaiveDate, Utc};
 use clap::Parser;
-use log::info;
-use std::path::Path;
-use utils::{
+use grq_validation::utils::{
     create_dividend_csv_for_score_file, create_market_data_long_csv_for_score_file,
     extract_ticker_codes_from_score_file, read_index_json,
 };
-
-pub mod models;
-pub mod utils;
+use log::info;
+use std::path::Path;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -96,7 +93,10 @@ fn main() -> Result<()> {
 
         if days_since_score >= 90 {
             // Use regular performance calculation
-            match utils::calculate_portfolio_performance(&score_file_path, score_file_date) {
+            match grq_validation::utils::calculate_portfolio_performance(
+                &score_file_path,
+                score_file_date,
+            ) {
                 Ok(performance) => {
                     println!("\n=== {date} Performance Results ===");
                     println!("Score Date: {}", performance.score_date);
@@ -121,7 +121,7 @@ fn main() -> Result<()> {
                     }
 
                     // Update the index.json with this performance data
-                    let mut index_data = utils::read_index_json(&args.docs_path)?;
+                    let mut index_data = grq_validation::utils::read_index_json(&args.docs_path)?;
                     for score_entry in &mut index_data.scores {
                         if score_entry.date == date {
                             score_entry.performance_90_day = Some(performance.performance_90_day);
@@ -145,13 +145,13 @@ fn main() -> Result<()> {
             }
         } else {
             // Use hybrid projection for dates less than 90 days old
-            match utils::read_tsv_score_file(&score_file_path) {
+            match grq_validation::utils::read_tsv_score_file(&score_file_path) {
                 Ok(stock_records) => {
-                    match utils::read_market_data_from_csv(&utils::derive_csv_output_path(
-                        &score_file_path,
-                    )) {
+                    match grq_validation::utils::read_market_data_from_csv(
+                        &grq_validation::utils::derive_csv_output_path(&score_file_path),
+                    ) {
                         Ok(market_data_csv) => {
-                            match utils::calculate_hybrid_projection(
+                            match grq_validation::utils::calculate_hybrid_projection(
                                 &stock_records,
                                 score_file_date,
                                 &market_data_csv,
@@ -183,7 +183,8 @@ fn main() -> Result<()> {
                                     }
 
                                     // Update the index.json with this projection data
-                                    let mut index_data = utils::read_index_json(&args.docs_path)?;
+                                    let mut index_data =
+                                        grq_validation::utils::read_index_json(&args.docs_path)?;
                                     for score_entry in &mut index_data.scores {
                                         if score_entry.date == date {
                                             score_entry.performance_90_day =
@@ -232,7 +233,7 @@ fn main() -> Result<()> {
     // Calculate performance for all score files that are at least 90 days old
     if args.calculate_performance {
         info!("Calculating performance metrics for all score files...");
-        match utils::update_index_with_performance(&args.docs_path) {
+        match grq_validation::utils::update_index_with_performance(&args.docs_path) {
             Ok(_) => {
                 info!("Successfully updated index.json with performance metrics");
             }
@@ -323,7 +324,10 @@ fn main() -> Result<()> {
 
                 // Calculate performance for this score file immediately after creating CSVs
                 info!("Calculating performance for {}", score_entry.date);
-                match utils::calculate_portfolio_performance(&score_file_path, &score_entry.date) {
+                match grq_validation::utils::calculate_portfolio_performance(
+                    &score_file_path,
+                    &score_entry.date,
+                ) {
                     Ok(performance) => {
                         info!(
                             "Performance for {}: {:.2}% (90-day), {:.2}% (annualized)",
@@ -333,7 +337,8 @@ fn main() -> Result<()> {
                         );
 
                         // Update the index.json with this performance data
-                        let mut index_data = utils::read_index_json(&args.docs_path)?;
+                        let mut index_data =
+                            grq_validation::utils::read_index_json(&args.docs_path)?;
                         for score_entry_update in &mut index_data.scores {
                             if score_entry_update.date == score_entry.date {
                                 score_entry_update.performance_90_day =

--- a/src/models.rs
+++ b/src/models.rs
@@ -103,7 +103,6 @@ pub struct StockRecord {
 }
 
 impl StockRecord {
-    #[allow(dead_code)]
     pub fn new(stock: String, score: f64, target: f64) -> Self {
         Self {
             stock,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,6 @@ use std::path::Path;
 pub const MARKET_DATA_BASE_PATH: &str = "../GRQ-shareprices2025Q1";
 pub const DIVIDEND_DATA_BASE_PATH: &str = "../GRQ-dividends";
 
-#[allow(dead_code)]
 pub fn validate_stock_symbol(symbol: &str) -> bool {
     // Basic validation for stock symbols
     if symbol.is_empty() || symbol.len() > 30 {
@@ -22,7 +21,6 @@ pub fn validate_stock_symbol(symbol: &str) -> bool {
         .all(|c| c.is_alphanumeric() || c == '.' || c == ':')
 }
 
-#[allow(dead_code)]
 pub fn calculate_average_score(scores: &[f64]) -> f64 {
     if scores.is_empty() {
         return 0.0;
@@ -31,7 +29,6 @@ pub fn calculate_average_score(scores: &[f64]) -> f64 {
     scores.iter().sum::<f64>() / scores.len() as f64
 }
 
-#[allow(dead_code)]
 pub fn read_index_json(docs_path: &str) -> Result<IndexData> {
     use std::fs;
     use std::path::Path;
@@ -57,7 +54,6 @@ pub fn read_index_json(docs_path: &str) -> Result<IndexData> {
     Ok(index_data)
 }
 
-#[allow(dead_code)]
 pub fn extract_ticker_from_symbol(symbol: &str) -> Option<String> {
     // Extract ticker from "NYSE:SEM" -> "SEM"
     symbol
@@ -65,13 +61,11 @@ pub fn extract_ticker_from_symbol(symbol: &str) -> Option<String> {
         .map(|colon_pos| symbol[colon_pos + 1..].to_string())
 }
 
-#[allow(dead_code)]
 pub fn get_market_data_path(ticker: &str) -> String {
     let first_letter = ticker.chars().next().unwrap_or('X').to_uppercase();
     format!("{MARKET_DATA_BASE_PATH}/data/{first_letter}/{ticker}.json")
 }
 
-#[allow(dead_code)]
 pub fn read_tsv_score_file(file_path: &str) -> Result<Vec<StockRecord>> {
     use csv::ReaderBuilder;
     use std::fs::File;
@@ -92,7 +86,6 @@ pub fn read_tsv_score_file(file_path: &str) -> Result<Vec<StockRecord>> {
     Ok(stock_records)
 }
 
-#[allow(dead_code)]
 pub fn extract_ticker_codes_from_score_file(file_path: &str) -> Result<Vec<String>> {
     let stock_records = read_tsv_score_file(file_path)?;
     let ticker_codes: Vec<String> = stock_records
@@ -103,7 +96,6 @@ pub fn extract_ticker_codes_from_score_file(file_path: &str) -> Result<Vec<Strin
     Ok(ticker_codes)
 }
 
-#[allow(dead_code)]
 pub fn extract_symbol_from_ticker(ticker: &str) -> String {
     let symbol = match ticker.rsplit_once(':') {
         Some((_, symbol)) => symbol.to_string(),
@@ -157,7 +149,6 @@ pub fn read_market_data_from_csv(
     Ok(market_data)
 }
 
-#[allow(dead_code)]
 pub fn filter_market_data_by_date_range(
     market_data: &MarketData,
     start_date: &str,


### PR DESCRIPTION
# Binary now consumes the `grq_validation` library crate

## Summary

The binary (`src/main.rs`) re-declared `pub mod models;` and `pub mod utils;`,
compiling its own private copy of both modules even though the package already
exposes them through the `grq_validation` library crate (`src/lib.rs`,
`[lib] name = "grq_validation"`). The whole library was therefore compiled
twice, and — more importantly — the binary did **not** consume the same crate
the integration tests exercise (`tests/dividend_tests.rs` and
`tests/market_data_tests.rs` import `grq_validation::utils::…`). The two copies
could drift, so behaviour verified by tests was not guaranteed to match the
behaviour shipped by the binary. The duplication was also why several `pub`
items carried `#[allow(dead_code)]`: functions reached only through the
library/tests looked "dead" to the binary crate.

This PR makes the binary depend on the library crate:

- Dropped `pub mod models;` and `pub mod utils;` from `main.rs`.
- Changed `use utils::…` to `use grq_validation::utils::…` and rewrote every
  remaining `utils::…` path as `grq_validation::utils::…`.
- Removed the now-redundant `#[allow(dead_code)]` attributes from `src/utils.rs`
  (9 occurrences) and `src/models.rs` (1 occurrence). Pub items in the library
  crate are public API and are no longer flagged as dead code.

The binary and the integration tests now share a single compiled copy of the
modules.

Closes #94.

## Evidence

This is a backend/CLI structural change with no web interface to screenshot.
Verification was done via the build, linter and test suite:

- `cargo build` — compiles cleanly.
- `cargo clippy --all-targets --all-features -- -D warnings` — passes with zero
  warnings, confirming no `dead_code` warnings resurfaced after removing the
  `#[allow(dead_code)]` attributes.
- `cargo test --all-targets --all-features` — 25 unit tests + 2 integration
  tests pass.
- `./quality.sh < /dev/null` — completed successfully (Rust + Deno checks).

```mermaid
flowchart LR
    subgraph Before
        B1[main.rs<br/>pub mod models<br/>pub mod utils] -.inlined copy.-> M1[models/utils]
        L1[lib grq_validation] --> M2[models/utils]
        T1[integration tests] --> L1
    end
    subgraph After
        B2[main.rs] --> L2[lib grq_validation]
        T2[integration tests] --> L2
        L2 --> M3[single models/utils copy]
    end
```

## Test Plan

No behavioural change was introduced, so the existing test suite is the
regression guard — and it is the right one here: the integration tests
(`tests/dividend_tests.rs`, `tests/market_data_tests.rs`) import the binary's
functions via `grq_validation::utils::…`, which is exactly the crate path the
binary now consumes. After this change the binary and the tests exercise the
same compiled code.

- `cargo test --all-targets --all-features` — all 27 tests pass (25 unit, 2
  integration).
- `cargo clippy --all-targets --all-features -- -D warnings` — confirms the
  removed `#[allow(dead_code)]` attributes are no longer needed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq5ntcbr-4e3c0a`<!-- vibe-worker-issue-94 -->