### PR TITLE
Add release-age quarantine to Deno auto-update (Issue #64)

### DIFF
--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -20,7 +20,13 @@ jobs:
         with:
           deno-version: v2.x
       - name: Run deno outdated --update --latest
-        run: deno outdated --update --latest
+        # Supply-chain quarantine (Issue #64): --minimum-dependency-age=P1D
+        # holds back any external dependency published less than 24h ago, so
+        # a freshly-hijacked release cannot land in the auto-opened PR within
+        # the same weekly window. Internal jsr:@stsoftware/* and
+        # npm:@stsoftware/* deps are excluded (0h) via deno.json so they still
+        # update immediately. The flag honours deno.json's minimumDependencyAge.
+        run: deno outdated --update --latest --minimum-dependency-age=P1D
       # peter-evans/create-pull-request@v7.0.11
       - uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:

--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,8 @@
 {
+  "minimumDependencyAge": {
+    "age": "P1D",
+    "exclude": ["jsr:@stsoftware/*", "npm:@stsoftware/*"]
+  },
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/path": "jsr:@std/path@^1.1.5",

--- a/docs/archive/pr-summaries/pr-summary-64.md
+++ b/docs/archive/pr-summaries/pr-summary-64.md
@@ -1,0 +1,76 @@
+# Add release-age quarantine to Deno auto-update
+
+## Summary
+
+`deno-outdated.yml` ran `deno outdated --update --latest` weekly with **no
+release-age gate**, so a freshly-published (and possibly hijacked) external
+JSR/`@std` dependency could land in the auto-opened `chore/deno-outdated` PR
+within the same weekly window — the exact exposure `VIBE_BUMP_QUARANTINE_HOURS`
+(default 24h) is meant to close.
+
+This change gates external dependency upgrades behind a 24h (`P1D`) quarantine
+using Deno's native `--minimum-dependency-age` support, and records the same
+floor in `deno.json` so the CLI honours it everywhere. Internal
+`stSoftwareAU/*` deps are excluded (0h) so they still update immediately, per
+the dependency-bump policy. Closes #64.
+
+### Changes
+
+- **`.github/workflows/deno-outdated.yml`** — the update step now runs
+  `deno outdated --update --latest --minimum-dependency-age=P1D`.
+- **`deno.json`** — declares a canonical `minimumDependencyAge` block:
+
+  ```json
+  "minimumDependencyAge": {
+    "age": "P1D",
+    "exclude": ["jsr:@stsoftware/*", "npm:@stsoftware/*"]
+  }
+  ```
+
+  `age: "P1D"` is the ISO-8601  24h external floor; the `exclude` globs give
+  internal `stSoftwareAU` Deno deps a 0h quarantine.
+
+### Scope note
+
+The crates.io ecosystem is **not** auto-bumped by this workflow (it has no
+scheduled auto-update path), so it is out of scope here. Gating crates.io
+updates would require its own mechanism and is left for a separate change.
+
+## Deno regression avoided
+
+Used Deno's native `--minimum-dependency-age` flag and the `deno.json`
+`minimumDependencyAge` config rather than introducing Renovate/Dependabot
+(Node-style tooling) into this Deno repo.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the
+test suite and the local quality gate:
+
+```mermaid
+flowchart LR
+    A[Weekly cron / dispatch] --> B[deno outdated --update --latest]
+    B --> C{published < 24h ago?}
+    C -- external --> D[held back: quarantined]
+    C -- "internal @stsoftware/*" --> E[update now: 0h]
+    C -- ">= 24h old" --> E
+    E --> F[create-pull-request: chore/deno-outdated]
+```
+
+- `deno test --allow-read tests/deno_outdated_workflow_test.ts` — 8 passed.
+- `deno test --allow-read tests/*.ts` — 162 passed.
+- `./quality.sh` — passes cleanly (cargo + Deno lint/check/test).
+- Confirmed `deno 2.8.2` accepts both the `--minimum-dependency-age` flag and
+  the `minimumDependencyAge` config (`deno check` reports no error).
+
+## Test Plan
+
+Added two tests to `tests/deno_outdated_workflow_test.ts` (both fail against
+the unfixed code, pass after the fix):
+
+- *Deno Outdated workflow gates updates behind a release-age quarantine
+  (Issue #64)* — asserts the update step passes `--minimum-dependency-age`
+  with a window of at least 24h (`P1D` or `>= 1440` minutes).
+- *deno.json declares a minimumDependencyAge quarantine with internal
+  exclusions (Issue #64)* — asserts `minimumDependencyAge.age == "P1D"` and
+  that `jsr:@stsoftware/*` and `npm:@stsoftware/*` are excluded.

--- a/tests/deno_outdated_workflow_test.ts
+++ b/tests/deno_outdated_workflow_test.ts
@@ -87,6 +87,59 @@ Deno.test("Deno Outdated workflow runs deno outdated and creates a PR", async ()
   );
 });
 
+Deno.test("Deno Outdated workflow gates updates behind a release-age quarantine (Issue #64)", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { jobs: Record<string, unknown> };
+  const job = doc.jobs.outdated as {
+    steps: Array<{ run?: string }>;
+  };
+  const runs = job.steps.map((s) => s.run ?? "").join("\n");
+
+  // Supply-chain quarantine: the update step must pass
+  // --minimum-dependency-age so a freshly-published (possibly hijacked)
+  // external dependency is held back rather than auto-bumped.
+  const match = runs.match(/--minimum-dependency-age[=\s]+(\S+)/);
+  assert(
+    match,
+    "deno outdated must pass --minimum-dependency-age to quarantine new releases",
+  );
+
+  // The quarantine window must be at least 24h (P1D). Accept the ISO-8601
+  // one-day duration or an explicit minutes value >= 1440.
+  const value = match![1];
+  const isOneDayOrMore = value === "P1D" ||
+    (/^\d+$/.test(value) && Number(value) >= 1440);
+  assert(
+    isOneDayOrMore,
+    `quarantine window must be at least 24h (P1D); got '${value}'`,
+  );
+});
+
+Deno.test("deno.json declares a minimumDependencyAge quarantine with internal exclusions (Issue #64)", async () => {
+  const text = await Deno.readTextFile("deno.json");
+  const { parse: parseJsonc } = await import("@std/jsonc");
+  const config = parseJsonc(text) as {
+    minimumDependencyAge?: { age?: string; exclude?: string[] };
+  };
+  const mda = config.minimumDependencyAge;
+  assert(mda, "deno.json must declare minimumDependencyAge");
+  assertEquals(mda.age, "P1D", "external quarantine floor must be 24h (P1D)");
+  assert(
+    Array.isArray(mda.exclude),
+    "minimumDependencyAge.exclude must be a list",
+  );
+  // Internal stSoftwareAU deps bypass the quarantine (0h) so they update
+  // immediately, per the dependency-bump policy.
+  assert(
+    mda.exclude!.includes("jsr:@stsoftware/*"),
+    "internal jsr:@stsoftware/* deps must be excluded from the quarantine",
+  );
+  assert(
+    mda.exclude!.includes("npm:@stsoftware/*"),
+    "internal npm:@stsoftware/* deps must be excluded from the quarantine",
+  );
+});
+
 Deno.test("Deno Outdated workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a


### PR DESCRIPTION
# Add release-age quarantine to Deno auto-update

## Summary

`deno-outdated.yml` ran `deno outdated --update --latest` weekly with **no
release-age gate**, so a freshly-published (and possibly hijacked) external
JSR/`@std` dependency could land in the auto-opened `chore/deno-outdated` PR
within the same weekly window — the exact exposure `VIBE_BUMP_QUARANTINE_HOURS`
(default 24h) is meant to close.

This change gates external dependency upgrades behind a 24h (`P1D`) quarantine
using Deno's native `--minimum-dependency-age` support, and records the same
floor in `deno.json` so the CLI honours it everywhere. Internal
`stSoftwareAU/*` deps are excluded (0h) so they still update immediately, per
the dependency-bump policy. Closes #64.

### Changes

- **`.github/workflows/deno-outdated.yml`** — the update step now runs
  `deno outdated --update --latest --minimum-dependency-age=P1D`.
- **`deno.json`** — declares a canonical `minimumDependencyAge` block:

  ```json
  "minimumDependencyAge": {
    "age": "P1D",
    "exclude": ["jsr:@stsoftware/*", "npm:@stsoftware/*"]
  }
  ```

  `age: "P1D"` is the ISO-8601  24h external floor; the `exclude` globs give
  internal `stSoftwareAU` Deno deps a 0h quarantine.

### Scope note

The crates.io ecosystem is **not** auto-bumped by this workflow (it has no
scheduled auto-update path), so it is out of scope here. Gating crates.io
updates would require its own mechanism and is left for a separate change.

## Deno regression avoided

Used Deno's native `--minimum-dependency-age` flag and the `deno.json`
`minimumDependencyAge` config rather than introducing Renovate/Dependabot
(Node-style tooling) into this Deno repo.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the
test suite and the local quality gate:

```mermaid
flowchart LR
    A[Weekly cron / dispatch] --> B[deno outdated --update --latest]
    B --> C{published < 24h ago?}
    C -- external --> D[held back: quarantined]
    C -- "internal @stsoftware/*" --> E[update now: 0h]
    C -- ">= 24h old" --> E
    E --> F[create-pull-request: chore/deno-outdated]
```

- `deno test --allow-read tests/deno_outdated_workflow_test.ts` — 8 passed.
- `deno test --allow-read tests/*.ts` — 162 passed.
- `./quality.sh` — passes cleanly (cargo + Deno lint/check/test).
- Confirmed `deno 2.8.2` accepts both the `--minimum-dependency-age` flag and
  the `minimumDependencyAge` config (`deno check` reports no error).

## Test Plan

Added two tests to `tests/deno_outdated_workflow_test.ts` (both fail against
the unfixed code, pass after the fix):

- *Deno Outdated workflow gates updates behind a release-age quarantine
  (Issue #64)* — asserts the update step passes `--minimum-dependency-age`
  with a window of at least 24h (`P1D` or `>= 1440` minutes).
- *deno.json declares a minimumDependencyAge quarantine with internal
  exclusions (Issue #64)* — asserts `minimumDependencyAge.age == "P1D"` and
  that `jsr:@stsoftware/*` and `npm:@stsoftware/*` are excluded.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq8f2tmr-63b4e8`<!-- vibe-worker-issue-64 -->