### PR TITLE
Set timeout-minutes on every workflow job (Issue #71)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   check-changes:
     name: Check for Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       rust-changed: ${{ steps.filter.outputs.rust }}
       docs-changed: ${{ steps.filter.outputs.docs }}
@@ -61,6 +62,7 @@ jobs:
   test:
     name: Test and Quality Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: check-changes
     if: needs.check-changes.outputs.rust-changed == 'true'
     
@@ -121,6 +123,7 @@ jobs:
   build:
     name: Build Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [check-changes, test]
     if: needs.check-changes.outputs.rust-changed == 'true' && (needs.test.result == 'success' || needs.test.result == 'skipped')
     
@@ -189,6 +192,7 @@ jobs:
   deploy-pages:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: check-changes
     if: |
       github.ref == 'refs/heads/main' && 

--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   outdated:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   semgrep:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: semgrep/semgrep
     steps:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/docs/archive/pr-summaries/pr-summary-71.md
+++ b/docs/archive/pr-summaries/pr-summary-71.md
@@ -1,0 +1,65 @@
+# Set `timeout-minutes` on every workflow job
+
+## Summary
+
+No job in any repository workflow declared `timeout-minutes:`, so each fell
+back to GitHub's 360-minute (6-hour) default. A wedged step — a flaky network
+install, a stuck `deno test`, or a runaway build — could hold a runner for up
+to six hours, blocking the queue and burning minutes.
+
+This change adds an explicit, work-sized `timeout-minutes:` to all 12 jobs
+across the 9 workflows, bounding each job's worst case. Heavier Rust
+build/test jobs get 30 minutes; lint/audit/security jobs get 10–15. Closes #71.
+
+| Workflow | Job | timeout-minutes |
+| --- | --- | --- |
+| `ci.yml` | `check-changes` | 10 |
+| `ci.yml` | `test` | 30 |
+| `ci.yml` | `build` | 30 |
+| `ci.yml` | `deploy-pages` | 15 |
+| `deno-quality.yml` | `quality` | 15 |
+| `cargo-audit.yml` | `audit` | 15 |
+| `deno-outdated.yml` | `outdated` | 15 |
+| `dependency-review.yml` | `dependency-review` | 10 |
+| `gitleaks.yml` | `gitleaks` | 10 |
+| `markdown-lint.yml` | `markdownlint` | 10 |
+| `semgrep.yml` | `semgrep` | 15 |
+| `shellcheck.yml` | `shellcheck` | 10 |
+
+## Evidence
+
+This is a CI configuration change with no web interface to screenshot.
+Correctness is verified by a new Deno test suite that parses every workflow
+YAML and asserts each job declares a positive `timeout-minutes` below the
+360-minute GitHub default.
+
+```mermaid
+flowchart LR
+    A[Step hangs] --> B{timeout-minutes set?}
+    B -- No --> C[Runner held up to 360 min]
+    B -- Yes --> D[Job killed at bound<br/>10–30 min]
+```
+
+Test run (TDD — failed before the fix, passes after):
+
+```
+running 3 tests from ./tests/workflow_timeout_test.ts
+at least one workflow file is present ... ok
+every job declares a timeout-minutes ... ok
+every timeout-minutes is a sane positive bound below the GitHub default ... ok
+ok | 3 passed | 0 failed
+```
+
+Full Deno suite: `165 passed | 0 failed`.
+
+## Test Plan
+
+- Added `tests/workflow_timeout_test.ts`:
+  - `at least one workflow file is present` — guards against the suite
+    silently passing on an empty directory.
+  - `every job declares a timeout-minutes` — parses each workflow and
+    asserts every job sets a numeric `timeout-minutes`.
+  - `every timeout-minutes is a sane positive bound below the GitHub default`
+    — asserts each value is a positive integer below 360.
+- Verified the new tests fail against the unmodified workflows and pass after
+  adding the timeouts.

--- a/tests/workflow_timeout_test.ts
+++ b/tests/workflow_timeout_test.ts
@@ -1,0 +1,83 @@
+// Tests that every job in every GitHub Actions workflow declares an explicit
+// `timeout-minutes:` (Issue #71).
+//
+// Without a per-job timeout, a wedged step falls back to GitHub's 360-minute
+// (6-hour) default, holding a runner hostage and burning minutes. Each job
+// must bound its worst case with a sensible, positive timeout.
+
+import { assert } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOWS_DIR = ".github/workflows";
+
+// GitHub's implicit default when timeout-minutes is omitted.
+const GITHUB_DEFAULT_TIMEOUT = 360;
+
+interface Job {
+  "timeout-minutes"?: number;
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function listWorkflowFiles(): Promise<string[]> {
+  const files: string[] = [];
+  for await (const entry of Deno.readDir(WORKFLOWS_DIR)) {
+    if (
+      entry.isFile &&
+      (entry.name.endsWith(".yml") || entry.name.endsWith(".yaml"))
+    ) {
+      files.push(`${WORKFLOWS_DIR}/${entry.name}`);
+    }
+  }
+  return files.sort();
+}
+
+async function loadJobs(path: string): Promise<Record<string, Job>> {
+  const text = await Deno.readTextFile(path);
+  const doc = parseYaml(text) as Workflow;
+  return doc.jobs ?? {};
+}
+
+Deno.test("at least one workflow file is present", async () => {
+  const files = await listWorkflowFiles();
+  assert(files.length > 0, "expected workflow files under .github/workflows");
+});
+
+Deno.test("every job declares a timeout-minutes", async () => {
+  const files = await listWorkflowFiles();
+  for (const file of files) {
+    const jobs = await loadJobs(file);
+    assert(
+      Object.keys(jobs).length > 0,
+      `${file} must declare at least one job`,
+    );
+    for (const [name, job] of Object.entries(jobs)) {
+      assert(
+        typeof job["timeout-minutes"] === "number",
+        `${file}: job '${name}' must declare timeout-minutes`,
+      );
+    }
+  }
+});
+
+Deno.test("every timeout-minutes is a sane positive bound below the GitHub default", async () => {
+  const files = await listWorkflowFiles();
+  for (const file of files) {
+    const jobs = await loadJobs(file);
+    for (const [name, job] of Object.entries(jobs)) {
+      const timeout = job["timeout-minutes"];
+      assert(
+        typeof timeout === "number" &&
+          Number.isInteger(timeout) &&
+          timeout > 0,
+        `${file}: job '${name}' timeout-minutes must be a positive integer`,
+      );
+      assert(
+        (timeout as number) < GITHUB_DEFAULT_TIMEOUT,
+        `${file}: job '${name}' timeout-minutes (${timeout}) must be below the ${GITHUB_DEFAULT_TIMEOUT}-minute GitHub default`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
# Set `timeout-minutes` on every workflow job

## Summary

No job in any repository workflow declared `timeout-minutes:`, so each fell
back to GitHub's 360-minute (6-hour) default. A wedged step — a flaky network
install, a stuck `deno test`, or a runaway build — could hold a runner for up
to six hours, blocking the queue and burning minutes.

This change adds an explicit, work-sized `timeout-minutes:` to all 12 jobs
across the 9 workflows, bounding each job's worst case. Heavier Rust
build/test jobs get 30 minutes; lint/audit/security jobs get 10–15. Closes #71.

| Workflow | Job | timeout-minutes |
| --- | --- | --- |
| `ci.yml` | `check-changes` | 10 |
| `ci.yml` | `test` | 30 |
| `ci.yml` | `build` | 30 |
| `ci.yml` | `deploy-pages` | 15 |
| `deno-quality.yml` | `quality` | 15 |
| `cargo-audit.yml` | `audit` | 15 |
| `deno-outdated.yml` | `outdated` | 15 |
| `dependency-review.yml` | `dependency-review` | 10 |
| `gitleaks.yml` | `gitleaks` | 10 |
| `markdown-lint.yml` | `markdownlint` | 10 |
| `semgrep.yml` | `semgrep` | 15 |
| `shellcheck.yml` | `shellcheck` | 10 |

## Evidence

This is a CI configuration change with no web interface to screenshot.
Correctness is verified by a new Deno test suite that parses every workflow
YAML and asserts each job declares a positive `timeout-minutes` below the
360-minute GitHub default.

```mermaid
flowchart LR
    A[Step hangs] --> B{timeout-minutes set?}
    B -- No --> C[Runner held up to 360 min]
    B -- Yes --> D[Job killed at bound<br/>10–30 min]
```

Test run (TDD — failed before the fix, passes after):

```
running 3 tests from ./tests/workflow_timeout_test.ts
at least one workflow file is present ... ok
every job declares a timeout-minutes ... ok
every timeout-minutes is a sane positive bound below the GitHub default ... ok
ok | 3 passed | 0 failed
```

Full Deno suite: `165 passed | 0 failed`.

## Test Plan

- Added `tests/workflow_timeout_test.ts`:
  - `at least one workflow file is present` — guards against the suite
    silently passing on an empty directory.
  - `every job declares a timeout-minutes` — parses each workflow and
    asserts every job sets a numeric `timeout-minutes`.
  - `every timeout-minutes is a sane positive bound below the GitHub default`
    — asserts each value is a positive integer below 360.
- Verified the new tests fail against the unmodified workflows and pass after
  adding the timeouts.