### PR TITLE
Pin semgrep/semgrep container image to a digest (Issue #72)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,8 +8,9 @@ name: Semgrep
 # uploads findings to Semgrep AppSec Platform; without it the scan still
 # runs locally and fails the build on findings.
 #
-# Third-party actions are pinned to 40-character commit SHAs to satisfy
-# the supply-chain rule (Issue #1756 / dep-bump guidelines).
+# Third-party actions are pinned to 40-character commit SHAs and the
+# third-party container image is pinned to an immutable sha256 digest to
+# satisfy the supply-chain rule (Issue #1756 / #72 / dep-bump guidelines).
 
 on:
   pull_request:
@@ -23,7 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: semgrep/semgrep
+      # semgrep/semgrep:latest — third-party image pinned to an immutable
+      # digest (Issue #72). Refresh deliberately when bumping the scanner;
+      # resolve with `docker buildx imagetools inspect semgrep/semgrep:latest`.
+      image: semgrep/semgrep@sha256:f4791a54c891eabe1188248135574e6e03dfc31dfd3f3b747c7bec7079bfed1b
     steps:
       # actions/checkout@v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/docs/archive/pr-summaries/pr-summary-72.md
+++ b/docs/archive/pr-summaries/pr-summary-72.md
@@ -1,0 +1,45 @@
+## Summary
+
+Pinned the third-party `semgrep/semgrep` container image in
+`.github/workflows/semgrep.yml` to an immutable `@sha256:` digest instead of
+the mutable, bare `semgrep/semgrep` tag (which resolves to `:latest`). The
+`semgrep` job exposes `SEMGREP_APP_TOKEN` to whatever code the image runs, so
+a swapped upstream image was a real supply-chain risk. This brings the
+container image in line with the existing rule that `uses:` actions are pinned
+to 40-character commit SHAs. Closes #72.
+
+The digest was resolved from the Docker Hub registry for
+`semgrep/semgrep:latest` (an OCI multi-arch image index), and the
+human-readable tag plus refresh instructions are kept in a comment for
+traceability.
+
+```yaml
+    container:
+      # semgrep/semgrep:latest — third-party image pinned to an immutable
+      # digest (Issue #72). Refresh deliberately when bumping the scanner;
+      # resolve with `docker buildx imagetools inspect semgrep/semgrep:latest`.
+      image: semgrep/semgrep@sha256:f4791a54c891eabe1188248135574e6e03dfc31dfd3f3b747c7bec7079bfed1b
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the
+workflow test suite and the full quality gate (`./quality.sh`), which passed
+cleanly (170 tests, 0 failed; fmt, lint, and check all green).
+
+```mermaid
+flowchart LR
+    A["image: semgrep/semgrep<br/>(mutable :latest)"] -->|swappable upstream| B["attacker code runs<br/>with SEMGREP_APP_TOKEN"]
+    C["image: semgrep/semgrep@sha256:f479…ed1b<br/>(immutable digest)"] -->|content-addressed| D["only the audited image runs"]
+```
+
+## Test Plan
+
+- Added `tests/semgrep_workflow_test.ts::"Semgrep workflow pins the container
+  image to a sha256 digest"` — parses the workflow YAML and asserts the
+  container image matches `@sha256:<64 hex>`. It failed against the unpinned
+  workflow and passes after the digest pin (TDD regression test).
+- Existing `semgrep_workflow_test.ts` cases (image starts with
+  `semgrep/semgrep`, runs `semgrep ci`, actions pinned to SHAs, etc.) continue
+  to pass — the digest form still starts with `semgrep/semgrep`.
+- `./quality.sh` passes: 170 tests, fmt, lint, and `deno check` all green.

--- a/tests/semgrep_workflow_test.ts
+++ b/tests/semgrep_workflow_test.ts
@@ -65,6 +65,27 @@ Deno.test("Semgrep workflow defines semgrep job that runs `semgrep ci`", async (
   assert(/semgrep\s+ci/.test(runs), "semgrep job must run `semgrep ci`");
 });
 
+Deno.test("Semgrep workflow pins the container image to a sha256 digest", async () => {
+  // Supply-chain rule (Issue #72): the third-party semgrep/semgrep container
+  // must be pinned to an immutable @sha256: digest, not a mutable tag.
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { jobs: Record<string, unknown> };
+  const job = doc.jobs.semgrep as {
+    container?: { image?: string } | string;
+  };
+  const containerImage = typeof job.container === "string"
+    ? job.container
+    : job.container?.image;
+  assert(
+    typeof containerImage === "string",
+    "semgrep job must declare a container image",
+  );
+  assert(
+    /@sha256:[0-9a-f]{64}$/.test(containerImage),
+    `container image must be pinned to a sha256 digest: ${containerImage}`,
+  );
+});
+
 Deno.test("Semgrep workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a


### PR DESCRIPTION
## Summary

Pinned the third-party `semgrep/semgrep` container image in
`.github/workflows/semgrep.yml` to an immutable `@sha256:` digest instead of
the mutable, bare `semgrep/semgrep` tag (which resolves to `:latest`). The
`semgrep` job exposes `SEMGREP_APP_TOKEN` to whatever code the image runs, so
a swapped upstream image was a real supply-chain risk. This brings the
container image in line with the existing rule that `uses:` actions are pinned
to 40-character commit SHAs. Closes #72.

The digest was resolved from the Docker Hub registry for
`semgrep/semgrep:latest` (an OCI multi-arch image index), and the
human-readable tag plus refresh instructions are kept in a comment for
traceability.

```yaml
    container:
      # semgrep/semgrep:latest — third-party image pinned to an immutable
      # digest (Issue #72). Refresh deliberately when bumping the scanner;
      # resolve with `docker buildx imagetools inspect semgrep/semgrep:latest`.
      image: semgrep/semgrep@sha256:f4791a54c891eabe1188248135574e6e03dfc31dfd3f3b747c7bec7079bfed1b
```

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the
workflow test suite and the full quality gate (`./quality.sh`), which passed
cleanly (170 tests, 0 failed; fmt, lint, and check all green).

```mermaid
flowchart LR
    A["image: semgrep/semgrep<br/>(mutable :latest)"] -->|swappable upstream| B["attacker code runs<br/>with SEMGREP_APP_TOKEN"]
    C["image: semgrep/semgrep@sha256:f479…ed1b<br/>(immutable digest)"] -->|content-addressed| D["only the audited image runs"]
```

## Test Plan

- Added `tests/semgrep_workflow_test.ts::"Semgrep workflow pins the container
  image to a sha256 digest"` — parses the workflow YAML and asserts the
  container image matches `@sha256:<64 hex>`. It failed against the unpinned
  workflow and passes after the digest pin (TDD regression test).
- Existing `semgrep_workflow_test.ts` cases (image starts with
  `semgrep/semgrep`, runs `semgrep ci`, actions pinned to SHAs, etc.) continue
  to pass — the digest form still starts with `semgrep/semgrep`.
- `./quality.sh` passes: 170 tests, fmt, lint, and `deno check` all green.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq8vo8dw-b7316d`<!-- vibe-worker-issue-72 -->