### PR TITLE
Add set -euo pipefail to multi-line bash run steps in ci.yml (Issue #73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Check for changes
       id: filter
       run: |
+        set -euo pipefail
         # Get list of changed files
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           # For PRs, compare with base branch using GitHub's merge-base
@@ -169,6 +170,7 @@ jobs:
     # "did we ship crate X version Y?" in seconds.
     - name: Generate CycloneDX SBOM
       run: |
+        set -euo pipefail
         cargo install cargo-cyclonedx
         cargo cyclonedx --format json
         # cargo-cyclonedx names the SBOM after the package; normalise the

--- a/docs/archive/pr-summaries/pr-summary-73.md
+++ b/docs/archive/pr-summaries/pr-summary-73.md
@@ -1,0 +1,51 @@
+## Summary
+
+Added `set -euo pipefail` as the first line of the two multi-line bash `run:`
+blocks in `.github/workflows/ci.yml` so a command that fails mid-block (or an
+unset variable) aborts the step instead of being masked by the success of the
+final command. The guard makes fail-fast intent explicit and adds unset-variable
+protection (`-u`) on top of GitHub's default shell flags. Closes #73.
+
+Affected steps:
+
+- `check-changes` → **Check for changes** — the `git diff` / `grep` pipeline that
+  writes `rust`/`docs` flags to `$GITHUB_OUTPUT`.
+- `build` → **Generate CycloneDX SBOM** — the `cargo install` plus `find`/`cp`
+  fallback that produces the component inventory; a silent failure here could
+  otherwise ship a build without a valid SBOM.
+
+Both blocks remain correct under the stricter flags: every `grep`/`find` runs
+inside an `if` condition (so `-e` does not trip on a non-match) and all shell
+variables are quoted and always assigned (so `-u` is satisfied).
+
+## Evidence
+
+CI-workflow change with no web interface to screenshot. Verified by the
+behaviour-level tests in `tests/ci_workflow_test.ts`, which parse the workflow
+YAML, locate each target step by name, and assert the first non-empty line of
+its `run` block is exactly `set -euo pipefail`.
+
+```mermaid
+flowchart LR
+    A[command fails mid-block] -->|without guard| B[final command succeeds]
+    B --> C[step reports success ✗]
+    A -->|set -euo pipefail| D[step aborts immediately ✓]
+```
+
+Test run:
+
+```
+deno test --allow-read tests/ci_workflow_test.ts
+ok | 10 passed | 0 failed
+```
+
+`./quality.sh` passes cleanly: `ok | 170 passed (57 steps) | 0 failed`.
+
+## Test Plan
+
+- Added `tests/ci_workflow_test.ts::multi-line bash run blocks begin with set -euo pipefail`
+  — parses `ci.yml`, resolves the `check-changes`/Check for changes and
+  `build`/Generate CycloneDX SBOM steps, and asserts each multi-line `run` block
+  starts with `set -euo pipefail`. Confirmed it fails against the unfixed
+  workflow and passes after the fix.
+- All existing CI-workflow tests continue to pass.

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -123,3 +123,46 @@ Deno.test("build/test jobs do not declare their own permissions (inherit top-lev
     );
   }
 });
+
+// Multi-line bash run: blocks must fail fast (Issue #73). Without
+// `set -euo pipefail` an intermediate command that fails (or an unset
+// variable) is masked by the success of the final command, so the step
+// reports success even when an earlier stage broke.
+type Step = { name?: string; run?: string };
+
+function findRun(
+  doc: Record<string, unknown>,
+  jobName: string,
+  stepName: string,
+): string | undefined {
+  const jobs = doc.jobs as Record<string, { steps?: Step[] }>;
+  const step = jobs[jobName]?.steps?.find((s) => s.name === stepName);
+  return step?.run;
+}
+
+function firstScriptLine(run: string): string {
+  return run.split("\n").map((l) => l.trim()).filter((l) => l.length > 0)[0] ??
+    "";
+}
+
+Deno.test("multi-line bash run blocks begin with set -euo pipefail", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const targets: Array<[string, string]> = [
+    ["check-changes", "Check for changes"],
+    ["build", "Generate CycloneDX SBOM"],
+  ];
+  for (const [job, step] of targets) {
+    const run = findRun(doc, job, step);
+    assert(run, `step "${step}" in job "${job}" must exist with a run block`);
+    assert(
+      run.includes("\n"),
+      `step "${step}" should be a multi-line run block`,
+    );
+    assertEquals(
+      firstScriptLine(run),
+      "set -euo pipefail",
+      `step "${step}" must start its bash block with set -euo pipefail`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Added `set -euo pipefail` as the first line of the two multi-line bash `run:`
blocks in `.github/workflows/ci.yml` so a command that fails mid-block (or an
unset variable) aborts the step instead of being masked by the success of the
final command. The guard makes fail-fast intent explicit and adds unset-variable
protection (`-u`) on top of GitHub's default shell flags. Closes #73.

Affected steps:

- `check-changes` → **Check for changes** — the `git diff` / `grep` pipeline that
  writes `rust`/`docs` flags to `$GITHUB_OUTPUT`.
- `build` → **Generate CycloneDX SBOM** — the `cargo install` plus `find`/`cp`
  fallback that produces the component inventory; a silent failure here could
  otherwise ship a build without a valid SBOM.

Both blocks remain correct under the stricter flags: every `grep`/`find` runs
inside an `if` condition (so `-e` does not trip on a non-match) and all shell
variables are quoted and always assigned (so `-u` is satisfied).

## Evidence

CI-workflow change with no web interface to screenshot. Verified by the
behaviour-level tests in `tests/ci_workflow_test.ts`, which parse the workflow
YAML, locate each target step by name, and assert the first non-empty line of
its `run` block is exactly `set -euo pipefail`.

```mermaid
flowchart LR
    A[command fails mid-block] -->|without guard| B[final command succeeds]
    B --> C[step reports success ✗]
    A -->|set -euo pipefail| D[step aborts immediately ✓]
```

Test run:

```
deno test --allow-read tests/ci_workflow_test.ts
ok | 10 passed | 0 failed
```

`./quality.sh` passes cleanly: `ok | 170 passed (57 steps) | 0 failed`.

## Test Plan

- Added `tests/ci_workflow_test.ts::multi-line bash run blocks begin with set -euo pipefail`
  — parses `ci.yml`, resolves the `check-changes`/Check for changes and
  `build`/Generate CycloneDX SBOM steps, and asserts each multi-line `run` block
  starts with `set -euo pipefail`. Confirmed it fails against the unfixed
  workflow and passes after the fix.
- All existing CI-workflow tests continue to pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq8wg5q3-06a949`<!-- vibe-worker-issue-73 -->