### PR TITLE
Add concurrency group to CI workflow (Issue #69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Cancel superseded runs (Issue #69). Force-pushes and rapid commits to the
+# same ref otherwise queue redundant full runs (test, release build, SBOM,
+# Pages deploy) that each hold a runner and can race on shared resources such
+# as the Pages deployment. Keying on workflow + ref with cancel-in-progress
+# leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege default GITHUB_TOKEN scope (Issue #70). check-changes, test,
 # and build only ever read repository contents, so they inherit this. The
 # deploy-pages job overrides it below where elevation is genuinely needed.

--- a/docs/archive/pr-summaries/pr-summary-69.md
+++ b/docs/archive/pr-summaries/pr-summary-69.md
@@ -1,0 +1,45 @@
+## Summary
+
+Added a top-level `concurrency:` group to `.github/workflows/ci.yml` so that
+force-pushes and rapid commits to the same ref cancel any superseded in-flight
+run instead of queuing redundant full pipelines. The group is keyed on the
+workflow and ref with `cancel-in-progress: true`, so only the latest run for a
+given ref survives — saving runner minutes and avoiding races on shared
+resources such as the GitHub Pages deployment. Closes #69.
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+## Evidence
+
+This is a CI/configuration change with no web interface to screenshot. It is
+verified by the Deno workflow tests in `tests/ci_workflow_test.ts`, which parse
+`ci.yml` as YAML and assert on the concurrency block.
+
+Concurrency behaviour the change introduces:
+
+```mermaid
+flowchart LR
+    P1[Push A to main] --> R1[Run A starts]
+    P2[Push B to main same ref] --> C{Same concurrency group?}
+    C -- yes --> X[Cancel Run A] --> R2[Run B runs]
+```
+
+Test run:
+
+```
+deno test --allow-read tests/ci_workflow_test.ts
+ok | 11 passed | 0 failed
+```
+
+## Test Plan
+
+- Added `tests/ci_workflow_test.ts::"CI workflow declares a top-level concurrency group"`
+  which fails against the unfixed workflow and passes after the fix. It asserts:
+  - a top-level `concurrency` block exists,
+  - `group` equals `${{ github.workflow }}-${{ github.ref }}`,
+  - `cancel-in-progress` is `true`.
+- Full Deno suite re-run: `deno test --allow-read tests/*.ts` → 172 passed, 0 failed.

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -124,6 +124,29 @@ Deno.test("build/test jobs do not declare their own permissions (inherit top-lev
   }
 });
 
+// Concurrency control (Issue #69). The pipeline triggers on push to main and
+// pull_request to main but, without a concurrency group, successive pushes or
+// rapid PR updates start a fresh full run (test, release build, SBOM, Pages
+// deploy) without cancelling the superseded run. A top-level concurrency block
+// keyed on the workflow and ref, with cancel-in-progress, ensures only the
+// latest run for a given ref survives.
+Deno.test("CI workflow declares a top-level concurrency group", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});
+
 // Multi-line bash run: blocks must fail fast (Issue #73). Without
 // `set -euo pipefail` an intermediate command that fails (or an unset
 // variable) is masked by the success of the final command, so the step


### PR DESCRIPTION
## Summary

Added a top-level `concurrency:` group to `.github/workflows/ci.yml` so that
force-pushes and rapid commits to the same ref cancel any superseded in-flight
run instead of queuing redundant full pipelines. The group is keyed on the
workflow and ref with `cancel-in-progress: true`, so only the latest run for a
given ref survives — saving runner minutes and avoiding races on shared
resources such as the GitHub Pages deployment. Closes #69.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Evidence

This is a CI/configuration change with no web interface to screenshot. It is
verified by the Deno workflow tests in `tests/ci_workflow_test.ts`, which parse
`ci.yml` as YAML and assert on the concurrency block.

Concurrency behaviour the change introduces:

```mermaid
flowchart LR
    P1[Push A to main] --> R1[Run A starts]
    P2[Push B to main same ref] --> C{Same concurrency group?}
    C -- yes --> X[Cancel Run A] --> R2[Run B runs]
```

Test run:

```
deno test --allow-read tests/ci_workflow_test.ts
ok | 11 passed | 0 failed
```

## Test Plan

- Added `tests/ci_workflow_test.ts::"CI workflow declares a top-level concurrency group"`
  which fails against the unfixed workflow and passes after the fix. It asserts:
  - a top-level `concurrency` block exists,
  - `group` equals `${{ github.workflow }}-${{ github.ref }}`,
  - `cancel-in-progress` is `true`.
- Full Deno suite re-run: `deno test --allow-read tests/*.ts` → 172 passed, 0 failed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq908fag-53020f`<!-- vibe-worker-issue-69 -->