### PR TITLE
Add CODEOWNERS coverage for privileged workflow surface (Issue #74)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,25 @@
+# CODEOWNERS — required reviewers for the GRQ-validation repository (Issue #74).
+#
+# GitHub uses this file to request reviews automatically and, once the default
+# branch enables "Require review from Code Owners" branch protection, to enforce
+# that a named owner approves changes to the matched paths.
+#
+# Owners MUST have write access to this repository, otherwise GitHub silently
+# ignores the rule. The org has no `maintainers` team with access here, so the
+# trusted human administrators are listed directly. Update this list if the set
+# of trusted maintainers changes (e.g. once a dedicated team is granted access).
+
+# Default owners for everything in the repository.
+*                       @nleck @Green-Beret @stservice
+
+# Privileged CI/CD surface. These workflows run with id-token: write and consume
+# non-GITHUB_TOKEN secrets (SEMGREP_APP_TOKEN, CODECOV_TOKEN, GITLEAKS_LICENSE,
+# ACTIONS_PUSH), so every change here needs a trusted reviewer's approval to
+# guard against the tj-actions / OIDC-theft supply-chain attack shape.
+/.github/workflows/     @nleck @Green-Beret @stservice
+
+# Composite/local actions invoked by the workflows above.
+/.github/actions/       @nleck @Green-Beret @stservice
+
+# CODEOWNERS governs its own reviewers — changing trusted owners needs approval.
+/.github/CODEOWNERS      @nleck @Green-Beret @stservice

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,6 +20,28 @@ You may also use GitHub's
 [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
 to open a private advisory on this repository.
 
+## Code ownership and branch protection
+
+The repository ships a [`CODEOWNERS`](.github/CODEOWNERS) file that puts a
+trusted reviewer on its privileged surface. The CI/CD workflows run with
+`id-token: write` and consume non-`GITHUB_TOKEN` secrets (`SEMGREP_APP_TOKEN`,
+`CODECOV_TOKEN`, `GITLEAKS_LICENSE`, `ACTIONS_PUSH`), so `CODEOWNERS` requires a
+named owner to approve any change under `/.github/workflows/` and
+`/.github/actions/` — raising the bar against the tj-actions / OIDC-theft
+supply-chain attack shape.
+
+`CODEOWNERS` only requests reviews on its own; enforcement comes from
+branch-protection settings, which a repository administrator must enable on the
+default branch (they are not stored in the tree). The recommended settings are:
+
+- Require at least one approving pull-request review.
+- **Require review from Code Owners.**
+- Block direct pushes and force-pushes to the default branch.
+- Require linear history (to suit the rebase/squash workflow).
+
+Note: commit-signature verification is a separate, optional control and is not
+asserted here.
+
 ## Emergency dependency-bump procedure
 
 When a malicious or vulnerable version of a dependency is disclosed, pin the

--- a/docs/archive/pr-summaries/pr-summary-74.md
+++ b/docs/archive/pr-summaries/pr-summary-74.md
@@ -1,0 +1,72 @@
+# PR Summary — Issue #74
+
+## Summary
+
+This repository runs **privileged workflows** but shipped no `CODEOWNERS` file,
+so no required reviewer guarded changes to `.github/workflows/`. A self-approving
+or compromised account could quietly alter a workflow that runs with
+`id-token: write` and non-`GITHUB_TOKEN` secrets — the tj-actions / OIDC-theft
+attack shape.
+
+This change adds a `.github/CODEOWNERS` file that places a trusted reviewer on
+the privileged CI/CD surface, documents the recommended branch-protection
+settings, and adds tests that validate the governance file. Closes #74.
+
+**Owner choice.** The issue suggested `@stSoftwareAU/maintainers`, but that team
+does not exist and no org team other than the bot's own `vibe-coders` has write
+access to this repo. A CODEOWNERS rule whose owner lacks write access is
+silently ignored by GitHub, so the file instead names the repository's existing
+admin collaborators (`@nleck`, `@Green-Beret`, `@stservice`) — valid owners and,
+deliberately, trusted humans rather than the bot account. The file comments note
+how to swap in a dedicated team if one is later granted access.
+
+**Branch protection.** Enabling "require review from Code Owners" is a
+repository-administrator setting that is not stored in the tree and cannot be set
+from a PR (the worker has push, not admin). The recommended settings are
+documented in `SECURITY.md` for an admin to apply:
+
+- Require at least one approving PR review.
+- Require review from Code Owners.
+- Block direct pushes and force-pushes to the default branch.
+- Require linear history.
+
+## Evidence
+
+This is a governance/config change with no web interface to screenshot. Evidence
+is the new test suite, which parses the real `CODEOWNERS` file and asserts on its
+contents.
+
+```mermaid
+flowchart LR
+    A[PR edits .github/workflows/] --> B{CODEOWNERS match}
+    B -->|owner review required| C[Trusted admin approves]
+    C --> D[Merge allowed]
+    B -.->|no owner approval| E[Merge blocked once branch protection on]
+```
+
+Test run:
+
+```text
+deno test --allow-read tests/*.ts
+ok | 176 passed (57 steps) | 0 failed
+```
+
+## Test Plan
+
+Added `tests/codeowners_test.ts`, which exercises a real CODEOWNERS parser
+against the committed file:
+
+- `CODEOWNERS exists at a GitHub-recognised location` — file present at
+  `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`.
+- `CODEOWNERS defines a default owner for the whole repository` — a `*` rule
+  with at least one owner.
+- `CODEOWNERS guards the privileged .github/workflows/ surface` — a rule covers
+  the workflows directory with at least one owner.
+- `CODEOWNERS guards the .github/actions/ surface` — a rule covers the actions
+  directory with at least one owner.
+- `CODEOWNERS owners are syntactically valid GitHub handles` — every owner is a
+  valid `@user` or `@org/team` handle.
+
+The suite was confirmed to fail before the `CODEOWNERS` file was added (TDD red)
+and pass after. The existing `tests/security_md_test.ts` continues to pass with
+the `SECURITY.md` additions.

--- a/tests/codeowners_test.ts
+++ b/tests/codeowners_test.ts
@@ -1,0 +1,132 @@
+// Tests for the repository CODEOWNERS governance file (Issue #74).
+//
+// This repository runs privileged workflows — the deploy-pages job grants
+// id-token: write, and several workflows consume non-GITHUB_TOKEN secrets
+// (SEMGREP_APP_TOKEN, CODECOV_TOKEN, GITLEAKS_LICENSE, ACTIONS_PUSH). Without a
+// CODEOWNERS rule guarding `.github/workflows/`, a single self-approving account
+// could quietly alter a workflow that runs with those secrets — the tj-actions /
+// OIDC-theft attack shape. These tests verify the repo ships a CODEOWNERS file at
+// a GitHub-recognised location that puts a named owner on the privileged surface.
+
+import { assert } from "@std/assert";
+
+// GitHub recognises CODEOWNERS at exactly these three locations.
+const CODEOWNERS_LOCATIONS = [
+  "CODEOWNERS",
+  ".github/CODEOWNERS",
+  "docs/CODEOWNERS",
+];
+
+interface CodeownersRule {
+  pattern: string;
+  owners: string[];
+}
+
+/** Locate the CODEOWNERS file in one of GitHub's recognised locations. */
+async function findCodeownersPath(): Promise<string | null> {
+  for (const path of CODEOWNERS_LOCATIONS) {
+    try {
+      const stat = await Deno.stat(path);
+      if (stat.isFile) return path;
+    } catch {
+      // Not present at this location; keep looking.
+    }
+  }
+  return null;
+}
+
+/** Parse CODEOWNERS text into pattern → owners rules, skipping comments/blanks. */
+function parseCodeowners(text: string): CodeownersRule[] {
+  const rules: CodeownersRule[] = [];
+  for (const raw of text.split("\n")) {
+    const line = raw.replace(/#.*$/, "").trim();
+    if (line === "") continue;
+    const [pattern, ...owners] = line.split(/\s+/);
+    rules.push({ pattern, owners });
+  }
+  return rules;
+}
+
+/** True when `pattern` is the catch-all default rule. */
+function isDefaultPattern(pattern: string): boolean {
+  return pattern === "*";
+}
+
+/** True when `pattern` guards the given directory path. */
+function coversDirectory(pattern: string, dir: string): boolean {
+  const normalised = pattern.replace(/^\/+/, "").replace(/\/+$/, "");
+  const target = dir.replace(/^\/+/, "").replace(/\/+$/, "");
+  return normalised === target;
+}
+
+// A valid GitHub owner is a @user or a @org/team handle.
+const OWNER_RE =
+  /^@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\/[A-Za-z0-9._-]+)?$/;
+
+async function loadRules(): Promise<CodeownersRule[]> {
+  const path = await findCodeownersPath();
+  assert(
+    path !== null,
+    `No CODEOWNERS file found in any of: ${CODEOWNERS_LOCATIONS.join(", ")}`,
+  );
+  const text = await Deno.readTextFile(path);
+  return parseCodeowners(text);
+}
+
+Deno.test("CODEOWNERS exists at a GitHub-recognised location", async () => {
+  const path = await findCodeownersPath();
+  assert(
+    path !== null,
+    `CODEOWNERS must exist at one of: ${CODEOWNERS_LOCATIONS.join(", ")}`,
+  );
+});
+
+Deno.test("CODEOWNERS defines a default owner for the whole repository", async () => {
+  const rules = await loadRules();
+  const def = rules.find((r) => isDefaultPattern(r.pattern));
+  assert(def !== undefined, "CODEOWNERS must define a default `*` rule");
+  assert(
+    def.owners.length > 0,
+    "the default `*` rule must name at least one owner",
+  );
+});
+
+Deno.test("CODEOWNERS guards the privileged .github/workflows/ surface", async () => {
+  const rules = await loadRules();
+  const rule = rules.find((r) =>
+    coversDirectory(r.pattern, ".github/workflows")
+  );
+  assert(
+    rule !== undefined,
+    "CODEOWNERS must include a rule covering /.github/workflows/",
+  );
+  assert(
+    rule.owners.length > 0,
+    "the /.github/workflows/ rule must name at least one owner",
+  );
+});
+
+Deno.test("CODEOWNERS guards the .github/actions/ surface", async () => {
+  const rules = await loadRules();
+  const rule = rules.find((r) => coversDirectory(r.pattern, ".github/actions"));
+  assert(
+    rule !== undefined,
+    "CODEOWNERS must include a rule covering /.github/actions/",
+  );
+  assert(
+    rule.owners.length > 0,
+    "the /.github/actions/ rule must name at least one owner",
+  );
+});
+
+Deno.test("CODEOWNERS owners are syntactically valid GitHub handles", async () => {
+  const rules = await loadRules();
+  for (const rule of rules) {
+    for (const owner of rule.owners) {
+      assert(
+        OWNER_RE.test(owner),
+        `invalid owner handle "${owner}" for pattern "${rule.pattern}"`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
# PR Summary — Issue #74

## Summary

This repository runs **privileged workflows** but shipped no `CODEOWNERS` file,
so no required reviewer guarded changes to `.github/workflows/`. A self-approving
or compromised account could quietly alter a workflow that runs with
`id-token: write` and non-`GITHUB_TOKEN` secrets — the tj-actions / OIDC-theft
attack shape.

This change adds a `.github/CODEOWNERS` file that places a trusted reviewer on
the privileged CI/CD surface, documents the recommended branch-protection
settings, and adds tests that validate the governance file. Closes #74.

**Owner choice.** The issue suggested `@stSoftwareAU/maintainers`, but that team
does not exist and no org team other than the bot's own `vibe-coders` has write
access to this repo. A CODEOWNERS rule whose owner lacks write access is
silently ignored by GitHub, so the file instead names the repository's existing
admin collaborators (`@nleck`, `@Green-Beret`, `@stservice`) — valid owners and,
deliberately, trusted humans rather than the bot account. The file comments note
how to swap in a dedicated team if one is later granted access.

**Branch protection.** Enabling "require review from Code Owners" is a
repository-administrator setting that is not stored in the tree and cannot be set
from a PR (the worker has push, not admin). The recommended settings are
documented in `SECURITY.md` for an admin to apply:

- Require at least one approving PR review.
- Require review from Code Owners.
- Block direct pushes and force-pushes to the default branch.
- Require linear history.

## Evidence

This is a governance/config change with no web interface to screenshot. Evidence
is the new test suite, which parses the real `CODEOWNERS` file and asserts on its
contents.

```mermaid
flowchart LR
    A[PR edits .github/workflows/] --> B{CODEOWNERS match}
    B -->|owner review required| C[Trusted admin approves]
    C --> D[Merge allowed]
    B -.->|no owner approval| E[Merge blocked once branch protection on]
```

Test run:

```text
deno test --allow-read tests/*.ts
ok | 176 passed (57 steps) | 0 failed
```

## Test Plan

Added `tests/codeowners_test.ts`, which exercises a real CODEOWNERS parser
against the committed file:

- `CODEOWNERS exists at a GitHub-recognised location` — file present at
  `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`.
- `CODEOWNERS defines a default owner for the whole repository` — a `*` rule
  with at least one owner.
- `CODEOWNERS guards the privileged .github/workflows/ surface` — a rule covers
  the workflows directory with at least one owner.
- `CODEOWNERS guards the .github/actions/ surface` — a rule covers the actions
  directory with at least one owner.
- `CODEOWNERS owners are syntactically valid GitHub handles` — every owner is a
  valid `@user` or `@org/team` handle.

The suite was confirmed to fail before the `CODEOWNERS` file was added (TDD red)
and pass after. The existing `tests/security_md_test.ts` continues to pass with
the `SECURITY.md` additions.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq90x8ir-4a660a`<!-- vibe-worker-issue-74 -->