### PR TITLE
Declare Apache-2.0 SPDX license in Cargo.toml (Issue #76)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.10"
 edition = "2021"
 authors = ["Nigel Leck nigel@stsoftware.com.au"]
 description = "A Rust program to process daily stock scores from TSV files"
+license = "Apache-2.0"
 
 [lib]
 name = "grq_validation"

--- a/docs/archive/pr-summaries/pr-summary-76.md
+++ b/docs/archive/pr-summaries/pr-summary-76.md
@@ -1,0 +1,49 @@
+## Summary
+
+Declared the SPDX `license` field in `Cargo.toml` so the manifest's
+machine-readable licence metadata matches the committed Apache-2.0 `LICENSE`
+file. Previously `Cargo.toml` had no `license` field, so SBOM generators
+(`cargo-cyclonedx` in `ci.yml`), dependency scanners and crates.io could not
+determine the crate's licence, and the declared licence drifted silently from
+the committed file.
+
+The fix adds `license = "Apache-2.0"` to the `[package]` table — the SPDX short
+code matching `LICENSE` ("Apache License, Version 2.0").
+
+Closes #76.
+
+## Evidence
+
+Backend/manifest-only change — no web interface to screenshot.
+
+`CARGO_PKG_LICENSE` is the value Cargo derives from the manifest at compile
+time and the value tooling reads. Verified the new tests pass:
+
+```
+running 2 tests
+test manifest_declares_apache_2_0_spdx_licence ... ok
+test manifest_licence_matches_committed_license_file ... ok
+
+test result: ok. 2 passed; 0 failed
+```
+
+Full `./quality.sh` passes cleanly (cargo fmt/clippy/check/test + tarpaulin +
+Deno test/lint/check; 177 Deno tests passed).
+
+```mermaid
+flowchart LR
+    A[LICENSE: Apache-2.0] --> C{Consistent?}
+    B[Cargo.toml license = Apache-2.0] --> C
+    C -->|CARGO_PKG_LICENSE| D[SBOM / scanners / crates.io]
+```
+
+## Test Plan
+
+Added `tests/license_metadata_test.rs`:
+
+- `manifest_declares_apache_2_0_spdx_licence` — asserts `CARGO_PKG_LICENSE`
+  equals the SPDX code `Apache-2.0`. Fails when the manifest has no `license`
+  field (the unfixed state, where the value is empty).
+- `manifest_licence_matches_committed_license_file` — asserts the manifest
+  licence agrees with the committed `LICENSE` file (Apache License, Version
+  2.0), so the two cannot drift silently.

--- a/tests/license_metadata_test.rs
+++ b/tests/license_metadata_test.rs
@@ -1,0 +1,34 @@
+// Tests that the manifest's machine-readable licence metadata matches the
+// committed Apache-2.0 LICENSE file (Issue #76).
+//
+// `CARGO_PKG_LICENSE` is populated by Cargo from the `[package] license`
+// field at compile time — it is the value that SBOM generators, dependency
+// scanners and crates.io read. These tests verify the manifest declares the
+// SPDX short code and that it agrees with the committed LICENSE file, so the
+// two cannot drift silently.
+
+/// The SPDX licence declared in the manifest must be the Apache-2.0 short code.
+#[test]
+fn manifest_declares_apache_2_0_spdx_licence() {
+    assert_eq!(
+        env!("CARGO_PKG_LICENSE"),
+        "Apache-2.0",
+        "Cargo.toml [package] license must be the SPDX identifier 'Apache-2.0'"
+    );
+}
+
+/// The declared SPDX licence must agree with the committed LICENSE file.
+#[test]
+fn manifest_licence_matches_committed_license_file() {
+    let manifest = env!("CARGO_PKG_LICENSE");
+    assert_eq!(
+        manifest, "Apache-2.0",
+        "expected Apache-2.0 manifest licence"
+    );
+
+    let license = std::fs::read_to_string("LICENSE").expect("LICENSE file must exist");
+    assert!(
+        license.contains("Apache License") && license.contains("Version 2.0"),
+        "committed LICENSE must be the Apache License, Version 2.0 to match the manifest"
+    );
+}


### PR DESCRIPTION
## Summary

Declared the SPDX `license` field in `Cargo.toml` so the manifest's
machine-readable licence metadata matches the committed Apache-2.0 `LICENSE`
file. Previously `Cargo.toml` had no `license` field, so SBOM generators
(`cargo-cyclonedx` in `ci.yml`), dependency scanners and crates.io could not
determine the crate's licence, and the declared licence drifted silently from
the committed file.

The fix adds `license = "Apache-2.0"` to the `[package]` table — the SPDX short
code matching `LICENSE` ("Apache License, Version 2.0").

Closes #76.

## Evidence

Backend/manifest-only change — no web interface to screenshot.

`CARGO_PKG_LICENSE` is the value Cargo derives from the manifest at compile
time and the value tooling reads. Verified the new tests pass:

```
running 2 tests
test manifest_declares_apache_2_0_spdx_licence ... ok
test manifest_licence_matches_committed_license_file ... ok

test result: ok. 2 passed; 0 failed
```

Full `./quality.sh` passes cleanly (cargo fmt/clippy/check/test + tarpaulin +
Deno test/lint/check; 177 Deno tests passed).

```mermaid
flowchart LR
    A[LICENSE: Apache-2.0] --> C{Consistent?}
    B[Cargo.toml license = Apache-2.0] --> C
    C -->|CARGO_PKG_LICENSE| D[SBOM / scanners / crates.io]
```

## Test Plan

Added `tests/license_metadata_test.rs`:

- `manifest_declares_apache_2_0_spdx_licence` — asserts `CARGO_PKG_LICENSE`
  equals the SPDX code `Apache-2.0`. Fails when the manifest has no `license`
  field (the unfixed state, where the value is empty).
- `manifest_licence_matches_committed_license_file` — asserts the manifest
  licence agrees with the committed `LICENSE` file (Apache License, Version
  2.0), so the two cannot drift silently.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq94fdj3-837497`<!-- vibe-worker-issue-76 -->