### PR TITLE
Add Dependabot config for Cargo + GitHub Actions (Issue #75)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot configuration (Issue #75).
+#
+# Adds automated, reviewable dependency-update PRs for the Cargo crate
+# ecosystem — previously the only unmanaged ecosystem in the tree — plus
+# the GitHub Actions ecosystem. The Deno ecosystem is handled separately
+# by .github/workflows/deno-outdated.yml.
+#
+# Supply-chain quarantine: `cooldown.default-days: 1` holds back any
+# external release published less than 24h ago, so a freshly-hijacked
+# crate or action cannot land in an auto-opened PR within the same window.
+# Internal stSoftwareAU/* dependencies are excluded from the cooldown so
+# they update immediately, mirroring the deno.json minimumDependencyAge
+# policy used for the Deno ecosystem.
+version: 2
+updates:
+  # Rust crate dependencies (Cargo.toml / Cargo.lock).
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      # 24h release-age quarantine for external crates.
+      default-days: 1
+      # Internal stSoftwareAU crates bypass the quarantine (update now).
+      exclude:
+        - "stsoftware*"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(cargo)"
+
+  # GitHub Actions used by the workflows (kept pinned to fresh SHAs).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      # 24h release-age quarantine for external actions.
+      default-days: 1
+      # Internal stSoftwareAU actions bypass the quarantine (update now).
+      exclude:
+        - "stSoftwareAU/*"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(actions)"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ dependency hygiene.
 9. **Shellcheck** (`shellcheck.yml`) — lints every `*.sh` script in the
    repository.
 
+### Automated dependency updates
+
+[`.github/dependabot.yml`](.github/dependabot.yml) configures Dependabot to open
+reviewable update PRs for the **Cargo** crate ecosystem (`Cargo.toml` /
+`Cargo.lock`) and the **GitHub Actions** ecosystem on a weekly schedule. Each
+ecosystem applies a 24-hour `cooldown` (release-age quarantine) so a
+freshly-published — possibly hijacked — crate or action is held back rather than
+auto-bumped within the same window. Internal `stSoftwareAU/*` dependencies are
+excluded from the cooldown so they update immediately, mirroring the
+`minimumDependencyAge` policy that `deno.json` applies to the Deno ecosystem.
+
 ### Setup
 
 1. Enable GitHub Actions in your repository.

--- a/docs/archive/pr-summaries/pr-summary-75.md
+++ b/docs/archive/pr-summaries/pr-summary-75.md
@@ -1,0 +1,70 @@
+# PR Summary — Issue #75
+
+## Summary
+
+The repository had **no automated dependency-update tooling for the Cargo
+ecosystem**: no `.github/dependabot.yml` and no `renovate.json`. Cargo crates
+(including security patches) were never surfaced as tracked, reviewable update
+PRs — they only floated invisibly via an in-CI `cargo update`. The Deno
+ecosystem was already covered by `deno-outdated.yml`.
+
+This PR adds `.github/dependabot.yml` configuring Dependabot to open weekly,
+reviewable update PRs for:
+
+- the **Cargo** crate ecosystem (`Cargo.toml` / `Cargo.lock`), and
+- the **GitHub Actions** ecosystem (keeps action SHAs current).
+
+Each ecosystem applies a **24-hour `cooldown`** (release-age quarantine) so a
+freshly-published — possibly hijacked — crate or action is held back rather than
+auto-bumped within the same window. Internal `stSoftwareAU/*` dependencies are
+**excluded from the cooldown** so they update immediately, mirroring the
+`minimumDependencyAge` policy `deno.json` applies to the Deno ecosystem.
+
+Dependabot's native `cooldown` was chosen over a hand-rolled
+`cargo update` workflow because Cargo has no built-in release-age gate, whereas
+`cooldown` enforces the 24h quarantine declaratively with an audit trail.
+
+Closes #75
+
+## Evidence
+
+This is a CI/config-only change with no web interface to screenshot. Verified
+via the Deno test suite, which parses the new config and asserts its structure.
+
+```
+$ deno test --allow-read tests/dependabot_config_test.ts
+running 5 tests from ./tests/dependabot_config_test.ts
+dependabot config file exists ... ok
+dependabot config parses as YAML and declares version 2 ... ok
+dependabot config covers the Cargo ecosystem on a weekly schedule ... ok
+dependabot Cargo updates are gated behind a release-age quarantine (Issue #75) ... ok
+dependabot config covers the GitHub Actions ecosystem with internal exclusion ... ok
+ok | 5 passed | 0 failed
+```
+
+Full suite: `ok | 182 passed | 0 failed`. Markdown lint: `0 error(s)`.
+
+### Dependency-update flow
+
+```mermaid
+flowchart LR
+    S[Weekly schedule] --> D[Dependabot]
+    D --> C{Release age >= 24h?}
+    C -- "external crate/action" --> Q{within cooldown?}
+    Q -- yes --> H[Hold back]
+    Q -- no --> PR[Open reviewable update PR]
+    C -- "stSoftwareAU/* internal" --> PR
+    PR --> R[Review + cargo audit + dependency-review]
+```
+
+## Test Plan
+
+- Added `tests/dependabot_config_test.ts` (TDD — written failing first):
+  - config file exists
+  - parses as YAML and declares `version: 2`
+  - covers the `cargo` ecosystem at `/` on a weekly schedule with a positive
+    `open-pull-requests-limit`
+  - Cargo updates declare a `cooldown` with `default-days >= 1` (24h quarantine)
+  - covers the `github-actions` ecosystem and excludes `stSoftwareAU/*` from the
+    cooldown
+- Confirmed the full Deno suite (182 tests) and markdown lint pass.

--- a/tests/dependabot_config_test.ts
+++ b/tests/dependabot_config_test.ts
@@ -1,0 +1,110 @@
+// Tests for the Dependabot configuration (Issue #75).
+//
+// Verify .github/dependabot.yml exists, parses as YAML, declares schema
+// version 2, and covers the Cargo crate ecosystem (the previously
+// unmanaged gap) with a weekly schedule and a release-age quarantine.
+// Internal stSoftwareAU/* dependencies must bypass the quarantine so
+// they update immediately, mirroring the deno.json minimumDependencyAge
+// policy used for the Deno ecosystem.
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const CONFIG_PATH = ".github/dependabot.yml";
+
+interface Cooldown {
+  "default-days"?: number;
+  include?: string[];
+  exclude?: string[];
+}
+
+interface Update {
+  "package-ecosystem"?: string;
+  directory?: string;
+  schedule?: { interval?: string };
+  "open-pull-requests-limit"?: number;
+  cooldown?: Cooldown;
+}
+
+async function loadConfig(): Promise<{ version?: number; updates?: Update[] }> {
+  const text = await Deno.readTextFile(CONFIG_PATH);
+  return parseYaml(text) as { version?: number; updates?: Update[] };
+}
+
+function ecosystem(updates: Update[], name: string): Update | undefined {
+  return updates.find((u) => u["package-ecosystem"] === name);
+}
+
+Deno.test("dependabot config file exists", async () => {
+  const stat = await Deno.stat(CONFIG_PATH);
+  assert(stat.isFile, `${CONFIG_PATH} should be a file`);
+});
+
+Deno.test("dependabot config parses as YAML and declares version 2", async () => {
+  const doc = await loadConfig();
+  assertEquals(doc.version, 2, "Dependabot config must declare version: 2");
+  assert(Array.isArray(doc.updates), "config must list updates");
+  assert(doc.updates!.length > 0, "config must declare at least one ecosystem");
+});
+
+Deno.test("dependabot config covers the Cargo ecosystem on a weekly schedule", async () => {
+  const doc = await loadConfig();
+  const cargo = ecosystem(doc.updates!, "cargo");
+  assert(cargo, "config must include a cargo package-ecosystem entry");
+  assertEquals(cargo!.directory, "/", "cargo updates must scan the repo root");
+  assertEquals(
+    cargo!.schedule?.interval,
+    "weekly",
+    "cargo updates must run on a weekly schedule",
+  );
+  assert(
+    typeof cargo!["open-pull-requests-limit"] === "number" &&
+      cargo!["open-pull-requests-limit"]! > 0,
+    "cargo updates must set a positive open-pull-requests-limit",
+  );
+});
+
+Deno.test("dependabot Cargo updates are gated behind a release-age quarantine (Issue #75)", async () => {
+  const doc = await loadConfig();
+  const cargo = ecosystem(doc.updates!, "cargo");
+  assert(cargo, "config must include a cargo package-ecosystem entry");
+  const cooldown = cargo!.cooldown;
+  assert(
+    cooldown,
+    "cargo updates must declare a cooldown to quarantine fresh releases",
+  );
+  // Supply-chain quarantine: external crates published less than 24h ago
+  // (default-days >= 1) are held back rather than auto-bumped, blunting the
+  // "dormant package republished by a hijacked account" attack shape.
+  assert(
+    typeof cooldown!["default-days"] === "number" &&
+      cooldown!["default-days"]! >= 1,
+    "cargo cooldown default-days must be at least 1 (24h quarantine)",
+  );
+});
+
+Deno.test("dependabot config covers the GitHub Actions ecosystem with internal exclusion", async () => {
+  const doc = await loadConfig();
+  const actions = ecosystem(doc.updates!, "github-actions");
+  assert(
+    actions,
+    "config must include a github-actions package-ecosystem entry",
+  );
+  assertEquals(
+    actions!.schedule?.interval,
+    "weekly",
+    "github-actions updates must run on a weekly schedule",
+  );
+  const cooldown = actions!.cooldown;
+  assert(cooldown, "github-actions updates must declare a cooldown");
+  assert(
+    Array.isArray(cooldown!.exclude),
+    "github-actions cooldown must declare an exclude list",
+  );
+  // Internal stSoftwareAU actions bypass the quarantine and update
+  // immediately, per the dependency-bump policy.
+  assert(
+    cooldown!.exclude!.some((p) => p.includes("stSoftwareAU")),
+    "internal stSoftwareAU/* actions must be excluded from the quarantine",
+  );
+});


### PR DESCRIPTION
# PR Summary — Issue #75

## Summary

The repository had **no automated dependency-update tooling for the Cargo
ecosystem**: no `.github/dependabot.yml` and no `renovate.json`. Cargo crates
(including security patches) were never surfaced as tracked, reviewable update
PRs — they only floated invisibly via an in-CI `cargo update`. The Deno
ecosystem was already covered by `deno-outdated.yml`.

This PR adds `.github/dependabot.yml` configuring Dependabot to open weekly,
reviewable update PRs for:

- the **Cargo** crate ecosystem (`Cargo.toml` / `Cargo.lock`), and
- the **GitHub Actions** ecosystem (keeps action SHAs current).

Each ecosystem applies a **24-hour `cooldown`** (release-age quarantine) so a
freshly-published — possibly hijacked — crate or action is held back rather than
auto-bumped within the same window. Internal `stSoftwareAU/*` dependencies are
**excluded from the cooldown** so they update immediately, mirroring the
`minimumDependencyAge` policy `deno.json` applies to the Deno ecosystem.

Dependabot's native `cooldown` was chosen over a hand-rolled
`cargo update` workflow because Cargo has no built-in release-age gate, whereas
`cooldown` enforces the 24h quarantine declaratively with an audit trail.

Closes #75

## Evidence

This is a CI/config-only change with no web interface to screenshot. Verified
via the Deno test suite, which parses the new config and asserts its structure.

```
$ deno test --allow-read tests/dependabot_config_test.ts
running 5 tests from ./tests/dependabot_config_test.ts
dependabot config file exists ... ok
dependabot config parses as YAML and declares version 2 ... ok
dependabot config covers the Cargo ecosystem on a weekly schedule ... ok
dependabot Cargo updates are gated behind a release-age quarantine (Issue #75) ... ok
dependabot config covers the GitHub Actions ecosystem with internal exclusion ... ok
ok | 5 passed | 0 failed
```

Full suite: `ok | 182 passed | 0 failed`. Markdown lint: `0 error(s)`.

### Dependency-update flow

```mermaid
flowchart LR
    S[Weekly schedule] --> D[Dependabot]
    D --> C{Release age >= 24h?}
    C -- "external crate/action" --> Q{within cooldown?}
    Q -- yes --> H[Hold back]
    Q -- no --> PR[Open reviewable update PR]
    C -- "stSoftwareAU/* internal" --> PR
    PR --> R[Review + cargo audit + dependency-review]
```

## Test Plan

- Added `tests/dependabot_config_test.ts` (TDD — written failing first):
  - config file exists
  - parses as YAML and declares `version: 2`
  - covers the `cargo` ecosystem at `/` on a weekly schedule with a positive
    `open-pull-requests-limit`
  - Cargo updates declare a `cooldown` with `default-days >= 1` (24h quarantine)
  - covers the `github-actions` ecosystem and excludes `stSoftwareAU/*` from the
    cooldown
- Confirmed the full Deno suite (182 tests) and markdown lint pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq99blc2-cf036e`<!-- vibe-worker-issue-75 -->