### PR TITLE
Add CONTRIBUTING.md and CHANGELOG.md to complete the docs floor (Issue #77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `CONTRIBUTING.md` documenting the build, test, lint, and pull-request
+  workflow.
+- `CHANGELOG.md` (this file) tracking notable changes between releases.
+
+## [0.1.10] - 2026-06-11
+
+### Added
+
+- Hybrid projection for score files less than 90 days old, projecting
+  performance from current actual prices.
+- A shared projection module so the TypeScript tests exercise production
+  projection logic.
+- Static dashboard (published via GitHub Pages from `docs/`) with interactive
+  charts and tables for performance analysis.
+- Dividend tracking and total-return calculation.
+- CI/CD workflows for continuous integration, `cargo audit`, `deno audit`,
+  Dependency Review, Gitleaks, Markdown Lint, Semgrep, and Shellcheck.
+- Dependabot configuration for the Cargo and GitHub Actions ecosystems with a
+  release-age cooldown.
+- `SECURITY.md` supply-chain runbook with a disclosure contact and emergency
+  dependency-bump procedures for both the Rust and Deno sides.
+
+### Changed
+
+- The binary now consumes the `grq_validation` library crate rather than
+  duplicating logic.
+- Untrusted TSV fields are escaped to prevent stored/DOM XSS in the dashboard.
+
+[Unreleased]: https://github.com/stSoftwareAU/GRQ-validation/compare/v0.1.10...HEAD
+[0.1.10]: https://github.com/stSoftwareAU/GRQ-validation/releases/tag/v0.1.10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing to GRQ Validation
+
+Thanks for your interest in improving GRQ Validation. This project is a hybrid
+codebase — a Rust library and binary that process daily stock scores, paired
+with a static dashboard and a Deno (TypeScript) test suite. The notes below
+cover how to build, test, and submit changes.
+
+## Prerequisites
+
+- **Rust** (latest stable) — the library and CLI.
+- **Deno** — the dashboard and TypeScript tests.
+- **Git**.
+
+## Getting started
+
+```bash
+git clone https://github.com/stSoftwareAU/GRQ-validation.git
+cd GRQ-validation
+cargo build --release
+```
+
+## Building and running
+
+```bash
+# Build the release binary
+cargo build --release
+
+# Process recent score files (within 100 days)
+./run.sh
+
+# Process every score file, including older ones
+./run.sh --process-all
+
+# Process a specific date
+./target/release/grq-validation --docs-path docs --date 2025-01-15
+```
+
+## Testing
+
+```bash
+# Run all Rust tests
+cargo test
+
+# Run a single Rust test
+cargo test test_name
+
+# Run the Deno test suite (dashboard / workflow tests)
+deno test --allow-read tests/
+```
+
+## Formatting and linting
+
+```bash
+# Format Rust code
+cargo fmt --all
+
+# Lint Rust code (warnings are treated as errors)
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Format and lint the Deno side
+deno fmt docs/*.js docs/*.html docs/*.css tests/*.ts
+deno lint tests/*.ts
+deno check tests/*.ts
+```
+
+## The local quality gate
+
+Before opening a pull request, run the full quality gate. It mirrors CI by
+running formatting checks, Clippy, the Rust tests with coverage, a release
+build, and the Deno format/lint/check/test steps:
+
+```bash
+./quality.sh
+```
+
+Keep running `./quality.sh` until it passes cleanly. On unattended machines,
+redirect stdin to avoid hangs: `./quality.sh < /dev/null`.
+
+## Submitting changes — the pull-request workflow
+
+1. **Fork** the repository (external contributors) or create a branch.
+2. **Create a feature branch** off `main`.
+3. **Make your changes** following Test-Driven Development: add a failing test
+   that defines the expected behaviour, then implement the code to make it pass.
+4. **Run `./quality.sh`** and ensure it passes cleanly.
+5. **Update documentation** (`README.md`, `CHANGELOG.md`, and any relevant docs)
+   when your change affects usage, behaviour, or the public surface.
+6. **Open a pull request** with a clear description of what changed and why,
+   referencing any related issue.
+
+## Conventions
+
+- **Australian English** — use Australian spelling in code, comments, and
+  documentation (e.g. colour, behaviour, organisation, favour, centre).
+- **Keep the changelog current** — record notable changes in `CHANGELOG.md`
+  under the `[Unreleased]` heading, and move them under a versioned heading
+  when the `Cargo.toml` version is bumped.
+- **Security** — see [SECURITY.md](SECURITY.md) for disclosure and the
+  emergency dependency-bump procedure.
+
+## Licence
+
+By contributing, you agree that your contributions are licensed under the
+Apache License, Version 2.0. See [LICENSE](LICENSE) for the full text.

--- a/docs/archive/pr-summaries/pr-summary-77.md
+++ b/docs/archive/pr-summaries/pr-summary-77.md
@@ -1,0 +1,53 @@
+## Summary
+
+Completes the repository's documentation floor by adding the two missing
+contributor-facing root files. The repo already published `README.md`,
+`LICENSE`, and `SECURITY.md` but had no `CONTRIBUTING.md` or `CHANGELOG.md`.
+Closes #77.
+
+- **`CONTRIBUTING.md`** — documents the build, test, and lint commands for both
+  sides of this hybrid project (Rust via `cargo`, the dashboard/tests via
+  `deno`), anchors on the existing `quality.sh` local gate, and describes the
+  TDD pull-request workflow. Notes the Australian-English convention and points
+  at `SECURITY.md`.
+- **`CHANGELOG.md`** — follows the [Keep a Changelog](https://keepachangelog.com/)
+  format with a Semantic Versioning reference, an `[Unreleased]` section, and a
+  `[0.1.10]` section seeded from the current `Cargo.toml` version.
+
+## Evidence
+
+This is a docs + test-suite change with no web interface to screenshot.
+Verification is via the new Deno tests and the existing quality gates.
+
+```mermaid
+flowchart LR
+    A[Cargo.toml version 0.1.10] --> B[CHANGELOG.md 0.1.10 section]
+    C[quality.sh / cargo / deno commands] --> D[CONTRIBUTING.md]
+    B --> E[contributing_changelog_test.ts]
+    D --> E
+    E --> F[deno test: 8 new, 194 total passing]
+```
+
+- New tests pass: `deno test --allow-read tests/contributing_changelog_test.ts`
+  → `8 passed | 0 failed`.
+- Full Deno suite: `deno test --allow-read tests/*.ts` → `194 passed | 0 failed`.
+- `deno fmt`, `deno lint`, `deno check` clean on the new test.
+- `markdownlint-cli2` clean on `CONTRIBUTING.md` and `CHANGELOG.md`
+  (`0 error(s)`).
+
+## Test Plan
+
+Added `tests/contributing_changelog_test.ts` (TDD — failing before the docs
+were added, passing after):
+
+- `CONTRIBUTING.md` exists at the repository root.
+- `CONTRIBUTING.md` documents the Rust build/test/lint commands
+  (`cargo test`/`fmt`/`clippy`/`build`).
+- `CONTRIBUTING.md` documents the Deno test suite (`deno test`).
+- `CONTRIBUTING.md` anchors on the `quality.sh` local gate.
+- `CONTRIBUTING.md` describes the pull-request workflow.
+- `CHANGELOG.md` exists at the repository root.
+- `CHANGELOG.md` follows the Keep a Changelog format (Keep a Changelog +
+  Semantic Versioning references).
+- `CHANGELOG.md` is seeded with the current `Cargo.toml` version (reads the
+  version from `Cargo.toml` and asserts a matching `[version]` section).

--- a/tests/contributing_changelog_test.ts
+++ b/tests/contributing_changelog_test.ts
@@ -1,0 +1,80 @@
+// Tests for the contributor-facing docs floor (Issue #77).
+//
+// The repo already publishes README.md, LICENSE, and SECURITY.md but was
+// missing CONTRIBUTING.md and CHANGELOG.md. These tests assert that both
+// files now exist at the repository root and carry the substance contributors
+// and consumers expect: build/test/lint commands and the PR workflow for
+// CONTRIBUTING.md, and a Keep a Changelog structure seeded with the current
+// Cargo.toml version for CHANGELOG.md.
+
+import { assert } from "@std/assert";
+
+const CONTRIBUTING_PATH = "CONTRIBUTING.md";
+const CHANGELOG_PATH = "CHANGELOG.md";
+
+async function read(path: string): Promise<string> {
+  return await Deno.readTextFile(path);
+}
+
+Deno.test("CONTRIBUTING.md exists at the repository root", async () => {
+  const stat = await Deno.stat(CONTRIBUTING_PATH);
+  assert(stat.isFile, `${CONTRIBUTING_PATH} should be a file`);
+});
+
+Deno.test("CONTRIBUTING.md documents the Rust build/test/lint commands", async () => {
+  const text = await read(CONTRIBUTING_PATH);
+  assert(/cargo test/.test(text), "must reference cargo test");
+  assert(/cargo fmt/.test(text), "must reference cargo fmt");
+  assert(/cargo clippy/.test(text), "must reference cargo clippy");
+  assert(/cargo build/.test(text), "must reference cargo build");
+});
+
+Deno.test("CONTRIBUTING.md documents the Deno test suite", async () => {
+  const text = await read(CONTRIBUTING_PATH);
+  assert(/deno test/.test(text), "must reference the Deno test suite");
+});
+
+Deno.test("CONTRIBUTING.md anchors on the existing quality gate", async () => {
+  const text = await read(CONTRIBUTING_PATH);
+  assert(
+    text.includes("quality.sh"),
+    "must reference the quality.sh local gate",
+  );
+});
+
+Deno.test("CONTRIBUTING.md describes the pull-request workflow", async () => {
+  const text = await read(CONTRIBUTING_PATH);
+  assert(
+    /pull request/i.test(text),
+    "must describe the pull-request submission workflow",
+  );
+});
+
+Deno.test("CHANGELOG.md exists at the repository root", async () => {
+  const stat = await Deno.stat(CHANGELOG_PATH);
+  assert(stat.isFile, `${CHANGELOG_PATH} should be a file`);
+});
+
+Deno.test("CHANGELOG.md follows the Keep a Changelog format", async () => {
+  const text = await read(CHANGELOG_PATH);
+  assert(
+    text.includes("Keep a Changelog"),
+    "must reference the Keep a Changelog format",
+  );
+  assert(
+    text.includes("Semantic Versioning"),
+    "must reference Semantic Versioning",
+  );
+});
+
+Deno.test("CHANGELOG.md is seeded with the current Cargo.toml version", async () => {
+  const cargo = await read("Cargo.toml");
+  const match = cargo.match(/^version\s*=\s*"([^"]+)"/m);
+  assert(match, "Cargo.toml must declare a version");
+  const version = match![1];
+  const text = await read(CHANGELOG_PATH);
+  assert(
+    text.includes(`[${version}]`),
+    `CHANGELOG.md must contain a section for the current version ${version}`,
+  );
+});


### PR DESCRIPTION
## Summary

Completes the repository's documentation floor by adding the two missing
contributor-facing root files. The repo already published `README.md`,
`LICENSE`, and `SECURITY.md` but had no `CONTRIBUTING.md` or `CHANGELOG.md`.
Closes #77.

- **`CONTRIBUTING.md`** — documents the build, test, and lint commands for both
  sides of this hybrid project (Rust via `cargo`, the dashboard/tests via
  `deno`), anchors on the existing `quality.sh` local gate, and describes the
  TDD pull-request workflow. Notes the Australian-English convention and points
  at `SECURITY.md`.
- **`CHANGELOG.md`** — follows the [Keep a Changelog](https://keepachangelog.com/)
  format with a Semantic Versioning reference, an `[Unreleased]` section, and a
  `[0.1.10]` section seeded from the current `Cargo.toml` version.

## Evidence

This is a docs + test-suite change with no web interface to screenshot.
Verification is via the new Deno tests and the existing quality gates.

```mermaid
flowchart LR
    A[Cargo.toml version 0.1.10] --> B[CHANGELOG.md 0.1.10 section]
    C[quality.sh / cargo / deno commands] --> D[CONTRIBUTING.md]
    B --> E[contributing_changelog_test.ts]
    D --> E
    E --> F[deno test: 8 new, 194 total passing]
```

- New tests pass: `deno test --allow-read tests/contributing_changelog_test.ts`
  → `8 passed | 0 failed`.
- Full Deno suite: `deno test --allow-read tests/*.ts` → `194 passed | 0 failed`.
- `deno fmt`, `deno lint`, `deno check` clean on the new test.
- `markdownlint-cli2` clean on `CONTRIBUTING.md` and `CHANGELOG.md`
  (`0 error(s)`).

## Test Plan

Added `tests/contributing_changelog_test.ts` (TDD — failing before the docs
were added, passing after):

- `CONTRIBUTING.md` exists at the repository root.
- `CONTRIBUTING.md` documents the Rust build/test/lint commands
  (`cargo test`/`fmt`/`clippy`/`build`).
- `CONTRIBUTING.md` documents the Deno test suite (`deno test`).
- `CONTRIBUTING.md` anchors on the `quality.sh` local gate.
- `CONTRIBUTING.md` describes the pull-request workflow.
- `CHANGELOG.md` exists at the repository root.
- `CHANGELOG.md` follows the Keep a Changelog format (Keep a Changelog +
  Semantic Versioning references).
- `CHANGELOG.md` is seeded with the current `Cargo.toml` version (reads the
  version from `Cargo.toml` and asserts a matching `[version]` section).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq9bpyyh-4e6e4c`<!-- vibe-worker-issue-77 -->