### PR TITLE
Replace doc-prose grep assertions with derivable invariants (Issue #81)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-81.md
+++ b/docs/archive/pr-summaries/pr-summary-81.md
@@ -1,0 +1,77 @@
+# Remove source-text grep assertions on documentation prose
+
+## Summary
+
+Replaced the grep-as-assertion anti-pattern in two test files that asserted on
+the *prose* of Markdown documentation rather than on any behaviour or derivable
+invariant. Rewording the docs broke these tests even when nothing regressed,
+and the docs could drift factually wrong as long as the magic substrings
+survived. Closes #81.
+
+Changes:
+
+- **`tests/documentation_accuracy_test.ts`**
+  - **Rewrote** the recent-files-window test as a WHAT-test: it now parses the
+    window (in days) from `run.sh` — the canonical source — and asserts the
+    README documents the *same* value. Editing the window in both files keeps
+    the test green; a drift between `run.sh` and the README fails it. This
+    replaces the hardcoded `within 100 days` / `within 180 days` substring
+    magic values copied from the implementation.
+  - **Deleted** the brittle prose-grep cases that verified nothing about
+    behaviour: the Australian-English spelling police (`behavior`,
+    `organization`, `color-coded`), the `helpers/`/`scripts/` directory and
+    literal CLI-flag string checks, and the `# Test comment` ban.
+  - **Kept** the genuine derivable-relationship checks: README references every
+    workflow that exists (compared against `Deno.readDir(.github/workflows)`),
+    README does not reference removed workflows, the licence-placeholder check,
+    and the workflow-listing helper sanity test.
+- **`tests/security_md_test.ts`**
+  - **Kept** the behavioural check that `SECURITY.md` exists at the repository
+    root (a `Deno.stat` file check).
+  - **Deleted** the substring greps over the runbook prose (disclosure email,
+    `deno.json`/`deno.lock`/`deno test`, `cargo update -p`/`cargo audit`/
+    `cargo test`). Runbook contents are better policed by the Markdown linter
+    and human review than by string asserts in the unit-test runner.
+
+These deletions are the explicit requirement of the issue, not an incidental
+change: documentation accuracy is served by the Markdown linter and review
+checklist, while the unit-test runner now only asserts derivable invariants.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verified by running
+the affected suites and the full quality gate.
+
+```mermaid
+flowchart LR
+    R[run.sh\nwithin N days] -->|parsed| T[documentation_accuracy_test]
+    M[README.md] -->|compared| T
+    T -->|fails on drift| X[Window mismatch]
+```
+
+The recent-files-window test before and after:
+
+- **Before:** `assert(text.includes("within 100 days"))` — a hand-copied magic
+  value; rewording the README breaks it, and a stale README passes as long as
+  the literal string survives.
+- **After:** parse `within (\d+) days` from `run.sh`, assert the README
+  documents that same number — a derivable relationship between two files.
+
+`./quality.sh` passes cleanly: `179 passed | 0 failed` for the Deno suite,
+plus `cargo fmt`/`clippy`/`test`, `deno fmt`/`lint`/`check`.
+
+## Test Plan
+
+- Modified `tests/documentation_accuracy_test.ts`:
+  - `README.md documents the recent-files window used by run.sh` — new
+    parse-from-`run.sh` invariant (replaces the hardcoded substring test).
+  - Retained: workflow-existence, removed-workflow, licence-placeholder, and
+    workflow-listing-helper tests.
+  - Removed: helpers/scripts directory, CLI-flag strings, `# Test comment`,
+    and Australian-English spelling grep tests.
+- Modified `tests/security_md_test.ts`:
+  - Retained: `SECURITY.md exists at the repository root`.
+  - Removed: disclosure-contact and Deno/Rust emergency-bump substring greps.
+- Ran `deno test --allow-read tests/documentation_accuracy_test.ts tests/security_md_test.ts`
+  → `6 passed | 0 failed`.
+- Ran `./quality.sh < /dev/null` → all checks pass.

--- a/tests/documentation_accuracy_test.ts
+++ b/tests/documentation_accuracy_test.ts
@@ -1,13 +1,21 @@
-// Tests for documentation accuracy (Issue #42).
+// Tests for documentation accuracy (Issue #42, refined in Issue #81).
 //
-// These tests verify the top-level README.md and docs/README.md describe the
-// repository accurately. They catch stale references to workflows that no
-// longer exist, placeholder text, and misstated CLI behaviour.
+// These tests verify the top-level README.md describes the repository
+// accurately by asserting *derivable relationships* rather than hand-copied
+// prose. They catch stale references to workflows that no longer exist,
+// placeholder text, and a documented recent-files window that drifts from the
+// value actually used by run.sh.
+//
+// Brittle source-text grep assertions (spelling police, literal CLI-flag
+// strings, "# Test comment" bans, hardcoded "100 days") were removed in
+// Issue #81: they verified prose, not behaviour, broke on harmless rewording,
+// and duplicated magic values from the implementation. Documentation prose is
+// better policed by the Markdown linter and review checklist.
 
-import { assert, assertEquals } from "@std/assert";
+import { assert } from "@std/assert";
 
 const README = "README.md";
-const DOCS_README = "docs/README.md";
+const RUN_SH = "run.sh";
 const WORKFLOWS_DIR = ".github/workflows";
 
 async function readText(path: string): Promise<string> {
@@ -22,6 +30,19 @@ async function listWorkflowFiles(): Promise<string[]> {
     }
   }
   return names.sort();
+}
+
+// Parse the recent-files window (in days) from run.sh, the canonical source of
+// the value. The README is then checked against this, so editing run.sh and
+// the README together keeps the test green while a drift between them fails.
+async function recentWindowDaysFromRunSh(): Promise<number> {
+  const text = await readText(RUN_SH);
+  const match = text.match(/within (\d+) days/);
+  assert(
+    match,
+    "run.sh must document the recent-files window as 'within N days'",
+  );
+  return Number(match[1]);
 }
 
 Deno.test("README.md does not reference workflows that do not exist", async () => {
@@ -59,83 +80,21 @@ Deno.test("README.md does not contain the license placeholder", async () => {
   );
 });
 
-Deno.test("README.md describes the correct recent-files window", async () => {
+Deno.test("README.md documents the recent-files window used by run.sh", async () => {
   const text = await readText(README);
+  const days = await recentWindowDaysFromRunSh();
   assert(
-    !text.includes("within 180 days"),
-    "README.md must not describe the recent window as 180 days (run.sh uses 100)",
+    text.includes(`within ${days} days`),
+    `README.md must describe the recent window as ${days} days to match run.sh`,
   );
-  assert(
-    text.includes("within 100 days"),
-    "README.md should describe the recent window as 100 days",
-  );
-});
-
-Deno.test("README.md documents the helpers and scripts directories", async () => {
-  const text = await readText(README);
-  assert(
-    text.includes("helpers/"),
-    "README.md project structure should mention helpers/",
-  );
-  assert(
-    text.includes("scripts/"),
-    "README.md project structure should mention scripts/",
-  );
-});
-
-Deno.test("README.md lists every documented CLI flag", async () => {
-  const text = await readText(README);
-  // Flags exposed by src/main.rs Args struct.
-  const flags = [
-    "--docs-path",
-    "--process-all",
-    "--calculate-performance",
-    "--performance-only",
-    "--date",
-    "--verbose",
-  ];
-  for (const f of flags) {
-    assert(text.includes(f), `README.md must document the ${f} CLI flag`);
-  }
-});
-
-Deno.test("docs/README.md does not contain stray test comments", async () => {
-  const text = await readText(DOCS_README);
-  assert(
-    !text.includes("# Test comment"),
-    "docs/README.md must not contain stray '# Test comment' lines",
-  );
-  assert(
-    !text.includes("# Another test comment"),
-    "docs/README.md must not contain stray '# Another test comment' lines",
-  );
-});
-
-Deno.test("README.md uses Australian English spellings", async () => {
-  const text = await readText(README);
-  // Spot-check for common American spellings that should be Australianised in
-  // text we own. Only check tokens we have actually authored — do not flag
-  // CLI/library names or third-party project names.
-  const banned = [
-    /\bcolor-coded\b/i,
-    /\bbehavior\b/i,
-    /\borganization\b/i,
-  ];
-  for (const re of banned) {
-    assert(
-      !re.test(text),
-      `README.md must use Australian English; matched ${re}`,
-    );
-  }
 });
 
 Deno.test("Workflow listing helper finds the expected workflows", async () => {
   const workflows = await listWorkflowFiles();
   // Sanity check that the test environment can see the workflows directory.
   assert(workflows.length > 0, "expected at least one workflow file");
-  assertEquals(
+  assert(
     workflows.includes("ci.yml"),
-    true,
     "ci.yml is expected to be present",
   );
 });

--- a/tests/security_md_test.ts
+++ b/tests/security_md_test.ts
@@ -1,61 +1,22 @@
-// Tests for SECURITY.md supply-chain readiness runbook (Issue #52).
+// Tests for the SECURITY.md supply-chain readiness runbook (Issue #52,
+// refined in Issue #81).
 //
-// Verify the repository publishes a root SECURITY.md that names a
-// disclosure contact and documents an emergency dependency-bump
-// procedure for both the Deno (JSR) and Rust (Cargo) sides of this
-// hybrid project. This is the SCR-RUNBOOK posture/readiness gap: a
-// reporter must know who to tell, and the team must have a rehearsed
-// steer for an out-of-band update.
+// Verify the repository publishes a root SECURITY.md. This is the SCR-RUNBOOK
+// posture/readiness gap: the file must exist so reporters know where to find
+// the disclosure contact and the emergency dependency-bump procedure.
+//
+// The earlier substring greps (disclosure email, deno.json/deno.lock/deno
+// test, cargo update/audit/test) were removed in Issue #81: they asserted on
+// documentation prose rather than behaviour, broke on harmless rewording, and
+// duplicated implementation detail. The contents of the runbook are policed by
+// the Markdown linter and human review, not by string asserts in the unit-test
+// runner.
 
 import { assert } from "@std/assert";
 
 const SECURITY_PATH = "SECURITY.md";
 
-async function readSecurity(): Promise<string> {
-  return await Deno.readTextFile(SECURITY_PATH);
-}
-
 Deno.test("SECURITY.md exists at the repository root", async () => {
   const stat = await Deno.stat(SECURITY_PATH);
   assert(stat.isFile, `${SECURITY_PATH} should be a file`);
-});
-
-Deno.test("SECURITY.md publishes a disclosure contact", async () => {
-  const text = await readSecurity();
-  assert(
-    text.includes("security@stsoftware.com.au"),
-    "SECURITY.md must publish a disclosure contact email",
-  );
-});
-
-Deno.test("SECURITY.md documents the Deno emergency-bump procedure", async () => {
-  const text = await readSecurity();
-  assert(
-    text.includes("deno.json"),
-    "Deno procedure must reference pinning the safe version in deno.json",
-  );
-  assert(
-    text.includes("deno.lock"),
-    "Deno procedure must reference refreshing deno.lock",
-  );
-  assert(
-    /deno test/.test(text),
-    "Deno procedure must reference running deno test before merging",
-  );
-});
-
-Deno.test("SECURITY.md documents the Rust emergency-bump procedure", async () => {
-  const text = await readSecurity();
-  assert(
-    /cargo update -p/.test(text),
-    "Rust procedure must reference cargo update -p <crate> --precise",
-  );
-  assert(
-    /cargo audit/.test(text),
-    "Rust procedure must reference cargo audit",
-  );
-  assert(
-    /cargo test/.test(text),
-    "Rust procedure must reference running cargo test",
-  );
 });


### PR DESCRIPTION
# Remove source-text grep assertions on documentation prose

## Summary

Replaced the grep-as-assertion anti-pattern in two test files that asserted on
the *prose* of Markdown documentation rather than on any behaviour or derivable
invariant. Rewording the docs broke these tests even when nothing regressed,
and the docs could drift factually wrong as long as the magic substrings
survived. Closes #81.

Changes:

- **`tests/documentation_accuracy_test.ts`**
  - **Rewrote** the recent-files-window test as a WHAT-test: it now parses the
    window (in days) from `run.sh` — the canonical source — and asserts the
    README documents the *same* value. Editing the window in both files keeps
    the test green; a drift between `run.sh` and the README fails it. This
    replaces the hardcoded `within 100 days` / `within 180 days` substring
    magic values copied from the implementation.
  - **Deleted** the brittle prose-grep cases that verified nothing about
    behaviour: the Australian-English spelling police (`behavior`,
    `organization`, `color-coded`), the `helpers/`/`scripts/` directory and
    literal CLI-flag string checks, and the `# Test comment` ban.
  - **Kept** the genuine derivable-relationship checks: README references every
    workflow that exists (compared against `Deno.readDir(.github/workflows)`),
    README does not reference removed workflows, the licence-placeholder check,
    and the workflow-listing helper sanity test.
- **`tests/security_md_test.ts`**
  - **Kept** the behavioural check that `SECURITY.md` exists at the repository
    root (a `Deno.stat` file check).
  - **Deleted** the substring greps over the runbook prose (disclosure email,
    `deno.json`/`deno.lock`/`deno test`, `cargo update -p`/`cargo audit`/
    `cargo test`). Runbook contents are better policed by the Markdown linter
    and human review than by string asserts in the unit-test runner.

These deletions are the explicit requirement of the issue, not an incidental
change: documentation accuracy is served by the Markdown linter and review
checklist, while the unit-test runner now only asserts derivable invariants.

## Evidence

Backend/test-only change — no web interface to screenshot. Verified by running
the affected suites and the full quality gate.

```mermaid
flowchart LR
    R[run.sh\nwithin N days] -->|parsed| T[documentation_accuracy_test]
    M[README.md] -->|compared| T
    T -->|fails on drift| X[Window mismatch]
```

The recent-files-window test before and after:

- **Before:** `assert(text.includes("within 100 days"))` — a hand-copied magic
  value; rewording the README breaks it, and a stale README passes as long as
  the literal string survives.
- **After:** parse `within (\d+) days` from `run.sh`, assert the README
  documents that same number — a derivable relationship between two files.

`./quality.sh` passes cleanly: `179 passed | 0 failed` for the Deno suite,
plus `cargo fmt`/`clippy`/`test`, `deno fmt`/`lint`/`check`.

## Test Plan

- Modified `tests/documentation_accuracy_test.ts`:
  - `README.md documents the recent-files window used by run.sh` — new
    parse-from-`run.sh` invariant (replaces the hardcoded substring test).
  - Retained: workflow-existence, removed-workflow, licence-placeholder, and
    workflow-listing-helper tests.
  - Removed: helpers/scripts directory, CLI-flag strings, `# Test comment`,
    and Australian-English spelling grep tests.
- Modified `tests/security_md_test.ts`:
  - Retained: `SECURITY.md exists at the repository root`.
  - Removed: disclosure-contact and Deno/Rust emergency-bump substring greps.
- Ran `deno test --allow-read tests/documentation_accuracy_test.ts tests/security_md_test.ts`
  → `6 passed | 0 failed`.
- Ran `./quality.sh < /dev/null` → all checks pass.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq9bpyyh-4e6e4c`<!-- vibe-worker-issue-81 -->