### PR TITLE
Replace brittle source greps in test_page_load with real syntax check (#82)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-82.md
+++ b/docs/archive/pr-summaries/pr-summary-82.md
@@ -1,0 +1,64 @@
+## Summary
+
+`scripts/debug/test_page_load.ts` "checked" the served page by running regexes
+and substring greps over its **source text**: it scanned `app.js` for
+adjacent `const`/`let`/`var`/`function` duplicate declarations and checked the
+HTML for the literal substrings `<title>` and `app.js`. None of that asserted
+observable behaviour — the duplicate-declaration regexes only matched
+declarations that were textually *adjacent* (so they missed real duplicates and
+broke on any reformat), and the substring checks verified nothing a user can
+see. (In fact `docs/index.html` sets its title via JavaScript and has no
+literal `<title>` element, so the old `<title>` grep was already meaningless.)
+
+This replaces the grep-as-assertion logic with genuine, behaviour-based checks:
+
+- Added `helpers/js_syntax.ts` with `checkJsSyntax()`, which validates
+  JavaScript by **compiling** it with the engine (parse-only, never executed).
+  Compilation rejects real syntax errors — including non-adjacent lexical
+  redeclarations — regardless of formatting, which is exactly what the brittle
+  regexes pretended to do.
+- Rewrote the debug script to assert **observable** behaviour: the page and
+  `app.js` are served (HTTP 200) and `app.js` parses as valid JavaScript via
+  `checkJsSyntax()`. The `<title>`/`app.js` substring greps and the
+  duplicate-declaration regex array are gone.
+- Added `tests/js_syntax_test.ts` exercising the real helper (happy path,
+  empty input, non-adjacent duplicate `const`, malformed syntax, and the
+  production `docs/app.js`).
+
+Closes #82.
+
+### Deno regression avoided
+
+Validated `app.js` syntax with the engine's own `Function` constructor and
+`deno test` rather than introducing a Node bundler or linter to the Deno repo.
+
+```mermaid
+flowchart LR
+    A[Fetch served app.js] --> B{checkJsSyntax\nengine compiles source}
+    B -- valid --> C[Pass: real syntax check]
+    B -- SyntaxError --> D[Fail: reports engine message]
+```
+
+## Evidence
+
+Backend/CLI change — no web UI to screenshot. Verified via the new and existing
+Deno tests and the full quality gate.
+
+- `deno test --allow-read tests/*.ts` → `199 passed, 0 failed` (includes the 5
+  new `checkJsSyntax` tests).
+- `./quality.sh` → `Quality checks completed successfully!` (exit 0).
+- The `rejects non-adjacent duplicate const` test reproduces the case the old
+  adjacency regex silently passed, and now fails correctly.
+
+## Test Plan
+
+- Added `tests/js_syntax_test.ts`:
+  - `checkJsSyntax - accepts valid JavaScript` (happy path)
+  - `checkJsSyntax - empty source is valid` (edge case)
+  - `checkJsSyntax - rejects non-adjacent duplicate const` (regression for the
+    regex blind spot)
+  - `checkJsSyntax - rejects malformed syntax` (error path)
+  - `checkJsSyntax - production docs/app.js parses cleanly` (real asset)
+- Rewrote `scripts/debug/test_page_load.ts` to assert HTTP 200 plus genuine
+  `app.js` syntax validity; removed the source-grep blocks.
+- No existing tests were removed or disabled.

--- a/helpers/js_syntax.ts
+++ b/helpers/js_syntax.ts
@@ -1,0 +1,37 @@
+// Genuine JavaScript syntax validation (issue #82).
+//
+// Replaces the brittle "duplicate declaration" regexes that used to live in
+// scripts/debug/test_page_load.ts. Those regexes only matched two declarations
+// that happened to be textually adjacent (`const x = …; const x`), so they
+// missed real duplicates and broke on any reformat. Compiling the source with
+// the JavaScript engine parses the WHOLE file and rejects genuine syntax
+// errors — including lexical redeclarations — regardless of formatting or how
+// far apart the declarations sit.
+
+export interface JsSyntaxResult {
+  /** True when the source parses without a syntax error. */
+  valid: boolean;
+  /** The engine's message when {@link valid} is false. */
+  error?: string;
+}
+
+/**
+ * Check whether `source` is syntactically valid JavaScript.
+ *
+ * The Function constructor compiles `source` as a function body and throws a
+ * SyntaxError on malformed input. It only parses — it never runs the code — so
+ * undefined browser globals (`window`, `document`, …) are irrelevant here.
+ */
+export function checkJsSyntax(source: string): JsSyntaxResult {
+  try {
+    new Function(source);
+    return { valid: true };
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return { valid: false, error: error.message };
+    }
+    // Anything that is not a syntax problem is unexpected for a compile-only
+    // call — surface it rather than reporting a misleading "invalid syntax".
+    throw error;
+  }
+}

--- a/scripts/debug/test_page_load.ts
+++ b/scripts/debug/test_page_load.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env -S deno run --allow-net --allow-run --allow-read
 
-// Test the page load by making HTTP requests
+import { checkJsSyntax } from "../../helpers/js_syntax.ts";
+
+// Manual smoke check: boot the server and confirm observable behaviour —
+// the page and app.js are served (HTTP 200) and app.js actually parses as
+// valid JavaScript. It no longer greps the served source for substrings or
+// brittle regexes (issue #82): those asserted that strings appeared in source,
+// not anything a user can observe, and broke on any rename or reformat.
 async function testPageLoad() {
     let serverProcess: any = null;
     
@@ -27,43 +33,28 @@ async function testPageLoad() {
             throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
         
-        const html = await response.text();
-        
-        // Check for basic page structure
-        if (!html.includes('<title>')) {
-            throw new Error('Page missing title tag');
-        }
-        
-        if (!html.includes('app.js')) {
-            throw new Error('Page missing app.js reference');
-        }
-        
-        console.log('✅ Main page loads successfully');
-        
-        // Test if app.js loads without syntax errors
+        // HTTP 200 is the observable signal that the page renders — we no
+        // longer grep the body for `<title>`/`app.js` substrings.
+        console.log('✅ Main page loads successfully (HTTP 200)');
+
+        // app.js must be served...
         const appJsResponse = await fetch('http://localhost:8000/app.js');
-        
+
         if (!appJsResponse.ok) {
             throw new Error(`app.js not found: HTTP ${appJsResponse.status}`);
         }
-        
+
         const appJs = await appJsResponse.text();
-        
-        // Basic syntax check - look for common issues
-        const syntaxChecks = [
-            { pattern: /const\s+(\w+)\s*=\s*[^;]+;\s*const\s+\1/, name: 'Duplicate const declaration' },
-            { pattern: /let\s+(\w+)\s*=\s*[^;]+;\s*let\s+\1/, name: 'Duplicate let declaration' },
-            { pattern: /var\s+(\w+)\s*=\s*[^;]+;\s*var\s+\1/, name: 'Duplicate var declaration' },
-            { pattern: /function\s+(\w+)\s*\([^)]*\)\s*{[^}]*function\s+\1/, name: 'Duplicate function declaration' },
-        ];
-        
-        for (const check of syntaxChecks) {
-            if (check.pattern.test(appJs)) {
-                throw new Error(`Potential syntax issue: ${check.name}`);
-            }
+
+        // ...and parse as valid JavaScript. Compiling the source catches real
+        // syntax errors (including non-adjacent duplicate declarations) that the
+        // old adjacency regexes missed, without depending on its formatting.
+        const syntax = checkJsSyntax(appJs);
+        if (!syntax.valid) {
+            throw new Error(`app.js has a syntax error: ${syntax.error}`);
         }
-        
-        console.log('✅ app.js loads without obvious syntax errors');
+
+        console.log('✅ app.js is served and parses as valid JavaScript');
         
         // Test data files
         const dataFiles = [

--- a/tests/js_syntax_test.ts
+++ b/tests/js_syntax_test.ts
@@ -1,0 +1,44 @@
+// Tests for genuine JavaScript syntax validation (issue #82).
+//
+// These assert behaviour of the real `checkJsSyntax` helper that replaced the
+// brittle source-grep regexes in scripts/debug/test_page_load.ts.
+import { assert, assertEquals } from "@std/assert";
+import { checkJsSyntax } from "../helpers/js_syntax.ts";
+
+Deno.test("checkJsSyntax - accepts valid JavaScript", () => {
+  const result = checkJsSyntax("const a = 1; function f() { return a; }");
+  assertEquals(result.valid, true);
+  assertEquals(result.error, undefined);
+});
+
+Deno.test("checkJsSyntax - empty source is valid", () => {
+  assertEquals(checkJsSyntax("").valid, true);
+});
+
+Deno.test("checkJsSyntax - rejects non-adjacent duplicate const", () => {
+  // The old regex only caught two `const x` that were textually adjacent. Real
+  // duplicates are separated by other statements — the engine rejects them
+  // anyway, so this is the case the brittle regex silently passed.
+  const source = [
+    "const total = 1;",
+    "let running = 0;",
+    "running += total;",
+    "const total = 2;",
+  ].join("\n");
+  const result = checkJsSyntax(source);
+  assertEquals(result.valid, false);
+  assert(result.error && result.error.length > 0, "expected an error message");
+});
+
+Deno.test("checkJsSyntax - rejects malformed syntax", () => {
+  const result = checkJsSyntax("function broken() { return 1;");
+  assertEquals(result.valid, false);
+});
+
+Deno.test("checkJsSyntax - production docs/app.js parses cleanly", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../docs/app.js", import.meta.url),
+  );
+  const result = checkJsSyntax(source);
+  assertEquals(result.valid, true, result.error);
+});


### PR DESCRIPTION
## Summary

`scripts/debug/test_page_load.ts` "checked" the served page by running regexes
and substring greps over its **source text**: it scanned `app.js` for
adjacent `const`/`let`/`var`/`function` duplicate declarations and checked the
HTML for the literal substrings `<title>` and `app.js`. None of that asserted
observable behaviour — the duplicate-declaration regexes only matched
declarations that were textually *adjacent* (so they missed real duplicates and
broke on any reformat), and the substring checks verified nothing a user can
see. (In fact `docs/index.html` sets its title via JavaScript and has no
literal `<title>` element, so the old `<title>` grep was already meaningless.)

This replaces the grep-as-assertion logic with genuine, behaviour-based checks:

- Added `helpers/js_syntax.ts` with `checkJsSyntax()`, which validates
  JavaScript by **compiling** it with the engine (parse-only, never executed).
  Compilation rejects real syntax errors — including non-adjacent lexical
  redeclarations — regardless of formatting, which is exactly what the brittle
  regexes pretended to do.
- Rewrote the debug script to assert **observable** behaviour: the page and
  `app.js` are served (HTTP 200) and `app.js` parses as valid JavaScript via
  `checkJsSyntax()`. The `<title>`/`app.js` substring greps and the
  duplicate-declaration regex array are gone.
- Added `tests/js_syntax_test.ts` exercising the real helper (happy path,
  empty input, non-adjacent duplicate `const`, malformed syntax, and the
  production `docs/app.js`).

Closes #82.

### Deno regression avoided

Validated `app.js` syntax with the engine's own `Function` constructor and
`deno test` rather than introducing a Node bundler or linter to the Deno repo.

```mermaid
flowchart LR
    A[Fetch served app.js] --> B{checkJsSyntax\nengine compiles source}
    B -- valid --> C[Pass: real syntax check]
    B -- SyntaxError --> D[Fail: reports engine message]
```

## Evidence

Backend/CLI change — no web UI to screenshot. Verified via the new and existing
Deno tests and the full quality gate.

- `deno test --allow-read tests/*.ts` → `199 passed, 0 failed` (includes the 5
  new `checkJsSyntax` tests).
- `./quality.sh` → `Quality checks completed successfully!` (exit 0).
- The `rejects non-adjacent duplicate const` test reproduces the case the old
  adjacency regex silently passed, and now fails correctly.

## Test Plan

- Added `tests/js_syntax_test.ts`:
  - `checkJsSyntax - accepts valid JavaScript` (happy path)
  - `checkJsSyntax - empty source is valid` (edge case)
  - `checkJsSyntax - rejects non-adjacent duplicate const` (regression for the
    regex blind spot)
  - `checkJsSyntax - rejects malformed syntax` (error path)
  - `checkJsSyntax - production docs/app.js parses cleanly` (real asset)
- Rewrote `scripts/debug/test_page_load.ts` to assert HTTP 200 plus genuine
  `app.js` syntax validity; removed the source-grep blocks.
- No existing tests were removed or disabled.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq9ge0r0-dd581b`<!-- vibe-worker-issue-82 -->