### PR TITLE
Broaden Deno quality scope to cover application code (Issue #88)

### DIFF
--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Deno fmt check
         run: deno fmt --check
       - name: Deno type check
-        run: deno check tests/*.ts
+        run: deno check helpers/*.ts tests/*.ts
       # Scan the resolved JSR/@std dependency graph against the advisory
       # database — the Deno-side counterpart to `cargo audit` (Issue #59).
       - name: Deno audit

--- a/deno.json
+++ b/deno.json
@@ -17,14 +17,16 @@
     "node_modules/**/*"
   ],
   "include": [
-    "tests/**/*"
+    "tests/**/*",
+    "helpers/**/*.ts",
+    "*.ts"
   ],
   "lint": {
-    "include": ["tests/**/*"],
+    "include": ["tests/**/*", "helpers/**/*.ts", "*.ts"],
     "exclude": ["docs/**/*", "src/**/*"]
   },
   "fmt": {
-    "include": ["tests/**/*"],
+    "include": ["tests/**/*", "helpers/**/*.ts", "*.ts"],
     "exclude": ["docs/**/*", "src/**/*"]
   },
   "test": {

--- a/docs/archive/pr-summaries/pr-summary-88.md
+++ b/docs/archive/pr-summaries/pr-summary-88.md
@@ -1,0 +1,71 @@
+# Broaden Deno quality scope to cover application code (Issue #88)
+
+## Summary
+
+`deno.json` scoped `lint`, `fmt`, `test` and the top-level `include` to the
+`tests/**/*` tree only, so the application code in `helpers/server.ts` was
+never linted, formatted, or type-checked. Both runners confirmed the gap: the
+`deno-quality.yml` CI workflow type-checked `tests/*.ts` only, and `quality.sh`
+ran `deno fmt`/`deno lint`/`deno check` over `tests/*.ts` only. A regression in
+the security-sensitive path-traversal logic (`getFilePath`) would have passed
+CI green.
+
+This PR broadens the scope so application code is covered:
+
+- `deno.json` — added `helpers/**/*.ts` and `*.ts` to the top-level `include`,
+  `lint.include` and `fmt.include` (the `exclude` of `docs/**/*` and `src/**/*`
+  is unchanged, so generated/Rust-side code stays out of scope).
+- `quality.sh` — `deno fmt`/`deno lint`/`deno check` now cover `helpers/*.ts`
+  alongside `tests/*.ts`.
+- `.github/workflows/deno-quality.yml` — the type-check step now runs
+  `deno check helpers/*.ts tests/*.ts`.
+
+Broadening the scope immediately surfaced a real `no-import-prefix` lint
+violation in `helpers/server.ts`: it imported `@std/path` via a full
+`https://deno.land/std@0.208.0/...` URL instead of the bare specifier already
+declared in `deno.json` imports. Fixed by switching to `import { ... } from
+"@std/path"`. With that fix, `deno lint`, `deno fmt --check` and
+`deno check` all pass cleanly across the broadened 39-file scope.
+
+The `test.include` stays scoped to `tests/**/*` — test discovery should not
+pull non-test helper modules into the runner — which is asserted by a
+regression test.
+
+Closes #88.
+
+## Evidence
+
+Backend/config change with no web interface to screenshot. Verified via the
+Deno quality commands and the test suite:
+
+- `deno lint` → `Checked 39 files`, now including `helpers/server.ts`.
+- `deno fmt --check` → `Checked 42 files`, no drift.
+- `deno check helpers/*.ts tests/*.ts` → passes.
+- `deno test --allow-read --allow-env tests/*.ts` → `200 passed | 0 failed`.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        T1[tests/**/*] --> Q1[deno lint / fmt / check]
+        H1[helpers/server.ts] -. excluded .-> Q1
+    end
+    subgraph After
+        T2[tests/**/*] --> Q2[deno lint / fmt / check]
+        H2[helpers/server.ts] --> Q2
+        R2[root *.ts] --> Q2
+    end
+```
+
+## Test Plan
+
+Added `tests/deno_scope_config_test.ts` (TDD — failed before the config change,
+passes after):
+
+- `deno.json` top-level `include`, `lint.include` and `fmt.include` each cover
+  `helpers/**/*.ts` and `*.ts`.
+- `test.include` still covers `tests/**/*` (no regression in test discovery).
+- `quality.sh` runs `deno check`, `deno lint` and `deno fmt` over `helpers/*.ts`.
+- `deno-quality.yml` runs `deno check` over `helpers/*.ts`.
+
+Existing `tests/server_path_traversal_test.ts` continues to pass, confirming the
+`server.ts` import change did not alter behaviour.

--- a/helpers/server.ts
+++ b/helpers/server.ts
@@ -10,12 +10,7 @@
  * Default port is 8000 if not specified.
  */
 
-import {
-  isAbsolute,
-  join,
-  relative,
-  resolve,
-} from "https://deno.land/std@0.208.0/path/mod.ts";
+import { isAbsolute, join, relative, resolve } from "@std/path";
 
 const DEFAULT_PORT = 8000;
 const DOCS_DIR = "docs";

--- a/quality.sh
+++ b/quality.sh
@@ -47,13 +47,13 @@ echo "🔍 Running DenoJS tests..."
 deno test --allow-read tests/*.ts
 
 echo "📝 Formatting JS, HTML, and CSS files with deno fmt..."
-deno fmt docs/*.js docs/*.html docs/*.css tests/*.ts
+deno fmt docs/*.js docs/*.html docs/*.css helpers/*.ts tests/*.ts
 
 echo "🔍 Running Deno lint..."
-deno lint tests/*.ts
+deno lint helpers/*.ts tests/*.ts
 
 echo "✅ Running Deno check..."
-deno check tests/*.ts
+deno check helpers/*.ts tests/*.ts
 
 echo "✅ Quality checks completed successfully!"
 if [ -d ".coverage" ]; then

--- a/tests/deno_scope_config_test.ts
+++ b/tests/deno_scope_config_test.ts
@@ -1,0 +1,111 @@
+// Tests for the Deno quality scope configuration (Issue #88).
+//
+// `deno.json` previously scoped lint/fmt/test/type-check to the
+// `tests/**/*` tree only, so the application code in `helpers/server.ts`
+// (and any root `*.ts` scripts) was never linted, formatted, or
+// type-checked. These tests assert the scope is broadened to cover the
+// application code, and that both runners (`quality.sh` and the
+// `deno-quality.yml` CI workflow) type-check the helpers.
+
+import { assert } from "@std/assert";
+import { parse as parseJsonc } from "@std/jsonc";
+
+const DENO_JSON = "deno.json";
+const QUALITY_SH = "quality.sh";
+const WORKFLOW = ".github/workflows/deno-quality.yml";
+
+// The application-code globs the quality scope must include.
+const HELPERS_GLOB = "helpers/**/*.ts";
+const ROOT_GLOB = "*.ts";
+
+async function loadDenoConfig(): Promise<Record<string, unknown>> {
+  const text = await Deno.readTextFile(DENO_JSON);
+  return parseJsonc(text) as Record<string, unknown>;
+}
+
+function includeList(
+  config: Record<string, unknown>,
+  section: "top" | "lint" | "fmt" | "test",
+): string[] {
+  if (section === "top") {
+    return (config.include as string[]) ?? [];
+  }
+  const sub = config[section] as { include?: string[] } | undefined;
+  return sub?.include ?? [];
+}
+
+Deno.test("deno.json top-level include covers helpers and root scripts", async () => {
+  const config = await loadDenoConfig();
+  const include = includeList(config, "top");
+  assert(
+    include.includes(HELPERS_GLOB),
+    `top-level include must cover ${HELPERS_GLOB}, got ${
+      JSON.stringify(include)
+    }`,
+  );
+  assert(
+    include.includes(ROOT_GLOB),
+    `top-level include must cover ${ROOT_GLOB}, got ${JSON.stringify(include)}`,
+  );
+});
+
+Deno.test("deno.json lint.include covers helpers and root scripts", async () => {
+  const config = await loadDenoConfig();
+  const include = includeList(config, "lint");
+  assert(
+    include.includes(HELPERS_GLOB),
+    `lint.include must cover ${HELPERS_GLOB}, got ${JSON.stringify(include)}`,
+  );
+  assert(
+    include.includes(ROOT_GLOB),
+    `lint.include must cover ${ROOT_GLOB}, got ${JSON.stringify(include)}`,
+  );
+});
+
+Deno.test("deno.json fmt.include covers helpers and root scripts", async () => {
+  const config = await loadDenoConfig();
+  const include = includeList(config, "fmt");
+  assert(
+    include.includes(HELPERS_GLOB),
+    `fmt.include must cover ${HELPERS_GLOB}, got ${JSON.stringify(include)}`,
+  );
+  assert(
+    include.includes(ROOT_GLOB),
+    `fmt.include must cover ${ROOT_GLOB}, got ${JSON.stringify(include)}`,
+  );
+});
+
+Deno.test("deno.json test.include still covers the tests tree", async () => {
+  const config = await loadDenoConfig();
+  const include = includeList(config, "test");
+  assert(
+    include.includes("tests/**/*"),
+    `test.include must still cover tests/**/*, got ${JSON.stringify(include)}`,
+  );
+});
+
+Deno.test("quality.sh type-checks and lints the helpers directory", async () => {
+  const text = await Deno.readTextFile(QUALITY_SH);
+  // The local runner must type-check and lint helpers/*.ts, not just tests.
+  assert(
+    /\bdeno\s+check\b[^\n]*\bhelpers\/[^\n]*\.ts\b/.test(text),
+    "quality.sh must run `deno check` over helpers/*.ts",
+  );
+  assert(
+    /\bdeno\s+lint\b[^\n]*\bhelpers\/[^\n]*\.ts\b/.test(text),
+    "quality.sh must run `deno lint` over helpers/*.ts",
+  );
+  assert(
+    /\bdeno\s+fmt\b[^\n]*\bhelpers\/[^\n]*\.ts\b/.test(text),
+    "quality.sh must run `deno fmt` over helpers/*.ts",
+  );
+});
+
+Deno.test("deno-quality.yml type-checks the helpers directory", async () => {
+  const text = await Deno.readTextFile(WORKFLOW);
+  // The CI `deno check` step must cover helpers/*.ts alongside tests/*.ts.
+  assert(
+    /\bdeno\s+check\b[^\n]*\bhelpers\/[^\n]*\.ts\b/.test(text),
+    "deno-quality.yml must run `deno check` over helpers/*.ts",
+  );
+});


### PR DESCRIPTION
# Broaden Deno quality scope to cover application code (Issue #88)

## Summary

`deno.json` scoped `lint`, `fmt`, `test` and the top-level `include` to the
`tests/**/*` tree only, so the application code in `helpers/server.ts` was
never linted, formatted, or type-checked. Both runners confirmed the gap: the
`deno-quality.yml` CI workflow type-checked `tests/*.ts` only, and `quality.sh`
ran `deno fmt`/`deno lint`/`deno check` over `tests/*.ts` only. A regression in
the security-sensitive path-traversal logic (`getFilePath`) would have passed
CI green.

This PR broadens the scope so application code is covered:

- `deno.json` — added `helpers/**/*.ts` and `*.ts` to the top-level `include`,
  `lint.include` and `fmt.include` (the `exclude` of `docs/**/*` and `src/**/*`
  is unchanged, so generated/Rust-side code stays out of scope).
- `quality.sh` — `deno fmt`/`deno lint`/`deno check` now cover `helpers/*.ts`
  alongside `tests/*.ts`.
- `.github/workflows/deno-quality.yml` — the type-check step now runs
  `deno check helpers/*.ts tests/*.ts`.

Broadening the scope immediately surfaced a real `no-import-prefix` lint
violation in `helpers/server.ts`: it imported `@std/path` via a full
`https://deno.land/std@0.208.0/...` URL instead of the bare specifier already
declared in `deno.json` imports. Fixed by switching to `import { ... } from
"@std/path"`. With that fix, `deno lint`, `deno fmt --check` and
`deno check` all pass cleanly across the broadened 39-file scope.

The `test.include` stays scoped to `tests/**/*` — test discovery should not
pull non-test helper modules into the runner — which is asserted by a
regression test.

Closes #88.

## Evidence

Backend/config change with no web interface to screenshot. Verified via the
Deno quality commands and the test suite:

- `deno lint` → `Checked 39 files`, now including `helpers/server.ts`.
- `deno fmt --check` → `Checked 42 files`, no drift.
- `deno check helpers/*.ts tests/*.ts` → passes.
- `deno test --allow-read --allow-env tests/*.ts` → `200 passed | 0 failed`.

```mermaid
flowchart LR
    subgraph Before
        T1[tests/**/*] --> Q1[deno lint / fmt / check]
        H1[helpers/server.ts] -. excluded .-> Q1
    end
    subgraph After
        T2[tests/**/*] --> Q2[deno lint / fmt / check]
        H2[helpers/server.ts] --> Q2
        R2[root *.ts] --> Q2
    end
```

## Test Plan

Added `tests/deno_scope_config_test.ts` (TDD — failed before the config change,
passes after):

- `deno.json` top-level `include`, `lint.include` and `fmt.include` each cover
  `helpers/**/*.ts` and `*.ts`.
- `test.include` still covers `tests/**/*` (no regression in test discovery).
- `quality.sh` runs `deno check`, `deno lint` and `deno fmt` over `helpers/*.ts`.
- `deno-quality.yml` runs `deno check` over `helpers/*.ts`.

Existing `tests/server_path_traversal_test.ts` continues to pass, confirming the
`server.ts` import change did not alter behaviour.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq9ion9f-d6b208`<!-- vibe-worker-issue-88 -->