### PR TITLE
Replace raw source-text greps in workflow tests (Issue #86)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-86.md
+++ b/docs/archive/pr-summaries/pr-summary-86.md
@@ -1,0 +1,67 @@
+## Summary
+
+Removed the raw source-text greps from the workflow YAML tests, replacing the
+grep-as-assertion / source-formatting anti-pattern with parsed WHAT checks (or
+removing it where no real invariant existed). Closes #86.
+
+Three brittle cases were addressed:
+
+- **`tests/ci_workflow_test.ts`** and **`tests/dependency_review_workflow_test.ts`** —
+  removed the "carries a version comment above each pinned action" tests. These
+  split the file into lines and required a `# org/action@tag` comment textually
+  *immediately above* every `uses:` line. That asserts a layout convention, not
+  behaviour: moving the annotation inline (`uses: x@sha # x@tag`), reformatting,
+  or blank-lining between the comment and `uses:` would break the test while CI
+  behaves identically. The genuine supply-chain guard — SHA pinning — is still
+  enforced by the parsed "pins every action to a 40-char commit SHA" test, which
+  is untouched. A short explanatory comment was left in place of each deleted
+  test noting the convention belongs in a dedicated lint/`actionlint` rule.
+
+- **`tests/markdown_lint_workflow_test.ts`** — rewrote "installs markdownlint-cli2
+  and runs it" (previously two whole-file `assertStringIncludes` greps for the
+  exact strings `npm install -g markdownlint-cli2` and `markdownlint-cli2`) into
+  a WHAT/policy check. The new test parses the YAML, reads the `markdownlint`
+  job's steps, and asserts that one of their `run` blocks invokes
+  `markdownlint-cli2`. This keeps the real invariant (the lint job runs the
+  linter) while tolerating behaviour-preserving install changes (pinning a
+  version, `npm i -g`, or a setup action).
+
+### Documented test modification
+
+Per the TDD guidance, this issue is specifically about removing/rewriting brittle
+HOW-tests. Two version-comment tests were deleted (the issue lists deletion as an
+acceptable resolution) and one grep test was rewritten as a parsed check. No
+behaviour-verifying coverage was lost: SHA pinning and the linter invocation
+remain asserted through parsed config.
+
+## Evidence
+
+Backend/CLI/test-only change — no web interface to screenshot. Verified via the
+test suite and the full quality gate.
+
+```mermaid
+flowchart LR
+    A["Raw source-text grep<br/>(HOW-test)"] -->|ci / dependency-review| B["Deleted<br/>SHA-pinning still parsed-checked"]
+    A -->|markdown-lint| C["Parsed WHAT-check<br/>job runs markdownlint-cli2"]
+```
+
+Targeted run of the three affected files — 21 passed, 0 failed:
+
+```
+ok | 21 passed | 0 failed (614ms)
+```
+
+`./quality.sh` completes successfully (`✅ Quality checks completed successfully!`).
+
+## Test Plan
+
+- `tests/ci_workflow_test.ts` — removed the brittle version-comment test; the
+  remaining parsed SHA-pinning, permissions, concurrency, and `set -euo pipefail`
+  tests still pass.
+- `tests/dependency_review_workflow_test.ts` — removed the brittle version-comment
+  test; the parsed SHA-pinning test still passes.
+- `tests/markdown_lint_workflow_test.ts` — replaced the literal-install-string
+  greps with "Markdown Lint workflow runs markdownlint-cli2 in its job", a parsed
+  check on the `markdownlint` job's `run` steps; passes against the current YAML.
+- Full `./quality.sh` run passes (fmt, lint, type-check, all Deno tests, Rust
+  tests, coverage).

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -46,18 +46,15 @@ Deno.test("CI workflow no longer references the mutable rust-toolchain stable br
   );
 });
 
-Deno.test("CI workflow carries a version comment above each pinned action", async () => {
-  const text = await Deno.readTextFile(WORKFLOW_PATH);
-  const lines = text.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    if (!/^\s*-?\s*uses:/.test(lines[i])) continue;
-    const prev = (lines[i - 1] ?? "").trim();
-    assert(
-      /^#\s*\S+\/\S+@\S+/.test(prev),
-      `missing version comment above: ${lines[i].trim()}`,
-    );
-  }
-});
+// Note: the "readable version comment above each pinned action" convention is
+// deliberately NOT asserted here (Issue #86). It was a raw source-text /
+// string-adjacency check on the YAML layout, not behaviour: moving the
+// annotation inline (`uses: x@sha # x@tag`), reformatting, or blank-lining
+// between the comment and `uses:` would break the test while CI behaves
+// identically. The genuine supply-chain guard — SHA pinning — is enforced by
+// the parsed "pins every action to a 40-char commit SHA" test above. The
+// annotation convention, if wanted, belongs in a dedicated lint/actionlint
+// rule rather than a unit assertion.
 
 // Least-privilege GITHUB_TOKEN scoping (Issue #70). The workflow must declare
 // an explicit restrictive top-level `permissions:` default so build/test jobs

--- a/tests/dependency_review_workflow_test.ts
+++ b/tests/dependency_review_workflow_test.ts
@@ -32,15 +32,12 @@ Deno.test("Dependency Review workflow pins every action to a 40-char commit SHA"
   }
 });
 
-Deno.test("Dependency Review workflow carries a version comment above each pinned action", async () => {
-  const text = await Deno.readTextFile(WORKFLOW_PATH);
-  const lines = text.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    if (!/^\s*-?\s*uses:/.test(lines[i])) continue;
-    const prev = (lines[i - 1] ?? "").trim();
-    assert(
-      /^#\s*\S+\/\S+@\S+/.test(prev),
-      `missing version comment above: ${lines[i].trim()}`,
-    );
-  }
-});
+// Note: the "readable version comment above each pinned action" convention is
+// deliberately NOT asserted here (Issue #86). It was a raw source-text /
+// string-adjacency check on the YAML layout, not behaviour: moving the
+// annotation inline (`uses: x@sha # x@tag`), reformatting, or blank-lining
+// between the comment and `uses:` would break the test while the workflow
+// behaves identically. The genuine supply-chain guard — SHA pinning — is
+// enforced by the parsed "pins every action to a 40-char commit SHA" test
+// above. The annotation convention, if wanted, belongs in a dedicated
+// lint/actionlint rule rather than a unit assertion.

--- a/tests/markdown_lint_workflow_test.ts
+++ b/tests/markdown_lint_workflow_test.ts
@@ -11,6 +11,8 @@ import { parse as parseJsonc } from "@std/jsonc";
 const WORKFLOW_PATH = ".github/workflows/markdown-lint.yml";
 const CONFIG_PATH = ".markdownlint-cli2.jsonc";
 
+type Step = { name?: string; run?: string };
+
 Deno.test("Markdown Lint workflow file exists", async () => {
   const stat = await Deno.stat(WORKFLOW_PATH);
   assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
@@ -48,10 +50,23 @@ Deno.test("Markdown Lint workflow defines markdownlint job", async () => {
   );
 });
 
-Deno.test("Markdown Lint workflow installs markdownlint-cli2 and runs it", async () => {
+Deno.test("Markdown Lint workflow runs markdownlint-cli2 in its job", async () => {
+  // WHAT check (Issue #86): parse the YAML and confirm the markdownlint job
+  // actually invokes markdownlint-cli2 in one of its `run` steps, rather than
+  // grepping the raw file for one exact install incantation. This keeps the
+  // real invariant (the lint job runs the linter) while tolerating a
+  // behaviour-preserving change to how the tool is installed (e.g. pinning a
+  // version, `npm i -g`, or a setup action).
   const text = await Deno.readTextFile(WORKFLOW_PATH);
-  assertStringIncludes(text, "npm install -g markdownlint-cli2");
-  assertStringIncludes(text, "markdownlint-cli2");
+  const doc = parseYaml(text) as { jobs: Record<string, { steps?: Step[] }> };
+  const steps = doc.jobs?.markdownlint?.steps ?? [];
+  assert(steps.length > 0, "markdownlint job must declare steps");
+  const runText = steps.map((s) => s.run ?? "").join("\n");
+  assertStringIncludes(
+    runText,
+    "markdownlint-cli2",
+    "markdownlint job must invoke markdownlint-cli2 in a run step",
+  );
 });
 
 Deno.test("Markdown Lint workflow pins actions to commit SHAs", async () => {


### PR DESCRIPTION
## Summary

Removed the raw source-text greps from the workflow YAML tests, replacing the
grep-as-assertion / source-formatting anti-pattern with parsed WHAT checks (or
removing it where no real invariant existed). Closes #86.

Three brittle cases were addressed:

- **`tests/ci_workflow_test.ts`** and **`tests/dependency_review_workflow_test.ts`** —
  removed the "carries a version comment above each pinned action" tests. These
  split the file into lines and required a `# org/action@tag` comment textually
  *immediately above* every `uses:` line. That asserts a layout convention, not
  behaviour: moving the annotation inline (`uses: x@sha # x@tag`), reformatting,
  or blank-lining between the comment and `uses:` would break the test while CI
  behaves identically. The genuine supply-chain guard — SHA pinning — is still
  enforced by the parsed "pins every action to a 40-char commit SHA" test, which
  is untouched. A short explanatory comment was left in place of each deleted
  test noting the convention belongs in a dedicated lint/`actionlint` rule.

- **`tests/markdown_lint_workflow_test.ts`** — rewrote "installs markdownlint-cli2
  and runs it" (previously two whole-file `assertStringIncludes` greps for the
  exact strings `npm install -g markdownlint-cli2` and `markdownlint-cli2`) into
  a WHAT/policy check. The new test parses the YAML, reads the `markdownlint`
  job's steps, and asserts that one of their `run` blocks invokes
  `markdownlint-cli2`. This keeps the real invariant (the lint job runs the
  linter) while tolerating behaviour-preserving install changes (pinning a
  version, `npm i -g`, or a setup action).

### Documented test modification

Per the TDD guidance, this issue is specifically about removing/rewriting brittle
HOW-tests. Two version-comment tests were deleted (the issue lists deletion as an
acceptable resolution) and one grep test was rewritten as a parsed check. No
behaviour-verifying coverage was lost: SHA pinning and the linter invocation
remain asserted through parsed config.

## Evidence

Backend/CLI/test-only change — no web interface to screenshot. Verified via the
test suite and the full quality gate.

```mermaid
flowchart LR
    A["Raw source-text grep<br/>(HOW-test)"] -->|ci / dependency-review| B["Deleted<br/>SHA-pinning still parsed-checked"]
    A -->|markdown-lint| C["Parsed WHAT-check<br/>job runs markdownlint-cli2"]
```

Targeted run of the three affected files — 21 passed, 0 failed:

```
ok | 21 passed | 0 failed (614ms)
```

`./quality.sh` completes successfully (`✅ Quality checks completed successfully!`).

## Test Plan

- `tests/ci_workflow_test.ts` — removed the brittle version-comment test; the
  remaining parsed SHA-pinning, permissions, concurrency, and `set -euo pipefail`
  tests still pass.
- `tests/dependency_review_workflow_test.ts` — removed the brittle version-comment
  test; the parsed SHA-pinning test still passes.
- `tests/markdown_lint_workflow_test.ts` — replaced the literal-install-string
  greps with "Markdown Lint workflow runs markdownlint-cli2 in its job", a parsed
  check on the `markdownlint` job's `run` steps; passes against the current YAML.
- Full `./quality.sh` run passes (fmt, lint, type-check, all Deno tests, Rust
  tests, coverage).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mq9opr3v-1a7c9e`<!-- vibe-worker-issue-86 -->