### PR TITLE
Sanitise index.json file field to prevent path traversal (Issue #91)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-91.md
+++ b/docs/archive/pr-summaries/pr-summary-91.md
@@ -1,0 +1,51 @@
+## Summary
+
+Fixed a path-traversal weakness where the `file` field read from
+`docs/scores/index.json` was concatenated straight into a filesystem path with
+no sanitisation, allowing a crafted entry such as `"../../../../tmp/evil.csv"`
+to escape the intended `docs/scores/` directory for both reads and writes.
+
+A new `build_score_file_path(docs_path, file)` helper in `src/utils.rs` now
+validates the `file` value before joining: it rejects any absolute path or
+parent-directory (`..`) segment and builds the result with `Path::join`,
+keeping only normal path segments. With neither traversal nor absolute
+components present, the joined path is lexically guaranteed to stay within
+`<docs_path>/scores`. This mirrors the containment guard already used in
+`helpers/server.ts::getFilePath`.
+
+Both unsanitised call sites now route through the helper and skip (with a
+logged warning) any entry whose `file` value fails validation:
+
+- `src/main.rs` — the `--process-all` processing loop.
+- `src/utils.rs::update_index_with_performance`.
+
+Closes #91.
+
+## Evidence
+
+This is a backend/CLI change with no web interface, so there is no screenshot.
+The fix is verified by unit tests that call the real `build_score_file_path`
+function with malicious and benign inputs and assert on the result.
+
+```mermaid
+flowchart LR
+    A[index.json file field] --> B{build_score_file_path}
+    B -->|absolute or .. segment| C[Err: rejected, entry skipped]
+    B -->|normal segments only| D[docs/scores/&lt;file&gt;]
+    D --> E[read / write CSV stays in scores root]
+```
+
+## Test Plan
+
+Added the following unit tests in `src/utils.rs` (`mod tests`):
+
+- `test_build_score_file_path_valid` — a nested file and a `./`-prefixed file
+  both resolve cleanly within `docs/scores`.
+- `test_build_score_file_path_rejects_parent_traversal` — `../`-based and
+  mid-path `..` traversal attempts are rejected.
+- `test_build_score_file_path_rejects_absolute` — an absolute `/etc/passwd`
+  value is rejected.
+- `test_build_score_file_path_rejects_empty` — empty/whitespace values are
+  rejected.
+
+All existing tests continue to pass; no tests were removed or disabled.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,9 @@ use anyhow::{anyhow, Result};
 use chrono::{NaiveDate, Utc};
 use clap::Parser;
 use grq_validation::utils::{
-    create_dividend_csv_for_score_file, create_market_data_long_csv_for_score_file,
-    extract_ticker_codes_from_score_file, read_index_json,
+    build_score_file_path, create_dividend_csv_for_score_file,
+    create_market_data_long_csv_for_score_file, extract_ticker_codes_from_score_file,
+    read_index_json,
 };
 use log::info;
 use std::path::Path;
@@ -278,7 +279,13 @@ fn main() -> Result<()> {
 
     // Process each score file
     for (i, score_entry) in scores_to_process.iter().enumerate() {
-        let score_file_path = format!("{}/scores/{}", args.docs_path, score_entry.file);
+        let score_file_path = match build_score_file_path(&args.docs_path, &score_entry.file) {
+            Ok(path) => path,
+            Err(e) => {
+                log::error!("Skipping unsafe score file path {}: {e}", score_entry.file);
+                continue;
+            }
+        };
 
         info!(
             "Processing score file {}/{}: {}",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,6 +54,47 @@ pub fn read_index_json(docs_path: &str) -> Result<IndexData> {
     Ok(index_data)
 }
 
+/// Builds the on-disk path for a score file, guarding against path traversal.
+///
+/// The `file` field originates from `docs/scores/index.json`, which can be
+/// influenced by contributors or upstream tooling. To stop a crafted entry
+/// such as `"../../../tmp/evil"` escaping the intended `docs/scores/`
+/// directory, this rejects any `file` value that is absolute or that contains
+/// a parent-directory (`..`) segment before joining. With neither present, the
+/// joined path is lexically guaranteed to stay within `<docs_path>/scores`.
+/// Mirrors the containment guard in `helpers/server.ts::getFilePath`.
+pub fn build_score_file_path(docs_path: &str, file: &str) -> Result<String> {
+    use std::path::Component;
+
+    if file.trim().is_empty() {
+        return Err(anyhow!("Refusing empty score file path"));
+    }
+
+    let candidate = Path::new(file);
+
+    // Build within the scores root via join rather than string concatenation,
+    // keeping only normal segments. Any `..`, root, or prefix component is a
+    // traversal attempt and is rejected.
+    let mut full_path = Path::new(docs_path).join("scores");
+    for component in candidate.components() {
+        match component {
+            Component::ParentDir => {
+                return Err(anyhow!(
+                    "Refusing score file path with parent-directory segment: {file:?}"
+                ));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(anyhow!("Refusing absolute score file path: {file:?}"));
+            }
+            // `.` adds nothing; normal segments extend the path.
+            Component::CurDir => {}
+            Component::Normal(segment) => full_path.push(segment),
+        }
+    }
+
+    Ok(full_path.to_string_lossy().into_owned())
+}
+
 pub fn extract_ticker_from_symbol(symbol: &str) -> Option<String> {
     // Extract ticker from "NYSE:SEM" -> "SEM"
     symbol
@@ -871,7 +912,16 @@ pub fn update_index_with_performance(docs_path: &str) -> Result<()> {
     let mut index_data = read_index_json(docs_path)?;
 
     for score_entry in &mut index_data.scores {
-        let score_file_path = format!("{}/scores/{}", docs_path, score_entry.file);
+        let score_file_path = match build_score_file_path(docs_path, &score_entry.file) {
+            Ok(path) => path,
+            Err(e) => {
+                println!(
+                    "Warning: Skipping unsafe score file path {}: {}",
+                    score_entry.file, e
+                );
+                continue;
+            }
+        };
 
         // Only calculate performance for files that are at least 90 days old
         let score_date = NaiveDate::parse_from_str(&score_entry.date, "%Y-%m-%d")?;
@@ -957,6 +1007,38 @@ mod tests {
         assert!(!validate_stock_symbol(
             "THISISAREALLYLONGSTOCKSYMBOLTHATEXCEEDSTHELIMIT"
         ));
+    }
+
+    #[test]
+    fn test_build_score_file_path_valid() {
+        // A normal nested score file resolves within docs/scores.
+        let path = build_score_file_path("docs", "2025/June/20.tsv").unwrap();
+        assert_eq!(path, "docs/scores/2025/June/20.tsv");
+
+        // A leading "./" is harmless and stays contained.
+        let path = build_score_file_path("docs", "./2025/June/20.tsv").unwrap();
+        assert_eq!(path, "docs/scores/2025/June/20.tsv");
+    }
+
+    #[test]
+    fn test_build_score_file_path_rejects_parent_traversal() {
+        let err = build_score_file_path("docs", "../../../../tmp/evil.csv").unwrap_err();
+        assert!(err.to_string().contains("parent-directory"));
+
+        // Traversal hidden mid-path is also rejected.
+        assert!(build_score_file_path("docs", "2025/../../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_build_score_file_path_rejects_absolute() {
+        let err = build_score_file_path("docs", "/etc/passwd").unwrap_err();
+        assert!(err.to_string().contains("absolute"));
+    }
+
+    #[test]
+    fn test_build_score_file_path_rejects_empty() {
+        assert!(build_score_file_path("docs", "").is_err());
+        assert!(build_score_file_path("docs", "   ").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixed a path-traversal weakness where the `file` field read from
`docs/scores/index.json` was concatenated straight into a filesystem path with
no sanitisation, allowing a crafted entry such as `"../../../../tmp/evil.csv"`
to escape the intended `docs/scores/` directory for both reads and writes.

A new `build_score_file_path(docs_path, file)` helper in `src/utils.rs` now
validates the `file` value before joining: it rejects any absolute path or
parent-directory (`..`) segment and builds the result with `Path::join`,
keeping only normal path segments. With neither traversal nor absolute
components present, the joined path is lexically guaranteed to stay within
`<docs_path>/scores`. This mirrors the containment guard already used in
`helpers/server.ts::getFilePath`.

Both unsanitised call sites now route through the helper and skip (with a
logged warning) any entry whose `file` value fails validation:

- `src/main.rs` — the `--process-all` processing loop.
- `src/utils.rs::update_index_with_performance`.

Closes #91.

## Evidence

This is a backend/CLI change with no web interface, so there is no screenshot.
The fix is verified by unit tests that call the real `build_score_file_path`
function with malicious and benign inputs and assert on the result.

```mermaid
flowchart LR
    A[index.json file field] --> B{build_score_file_path}
    B -->|absolute or .. segment| C[Err: rejected, entry skipped]
    B -->|normal segments only| D[docs/scores/&lt;file&gt;]
    D --> E[read / write CSV stays in scores root]
```

## Test Plan

Added the following unit tests in `src/utils.rs` (`mod tests`):

- `test_build_score_file_path_valid` — a nested file and a `./`-prefixed file
  both resolve cleanly within `docs/scores`.
- `test_build_score_file_path_rejects_parent_traversal` — `../`-based and
  mid-path `..` traversal attempts are rejected.
- `test_build_score_file_path_rejects_absolute` — an absolute `/etc/passwd`
  value is rejected.
- `test_build_score_file_path_rejects_empty` — empty/whitespace values are
  rejected.

All existing tests continue to pass; no tests were removed or disabled.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mq9x5tis-6e3d4f`<!-- vibe-worker-issue-91 -->