### PR TITLE
Replace nested match + return Err with ? propagation in src/main.rs (#95)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-95.md
+++ b/docs/archive/pr-summaries/pr-summary-95.md
@@ -1,0 +1,70 @@
+## Summary
+
+Replaced the nested `match { Ok(v) => …, Err(e) => { log::error!(…); return Err(e) } }`
+ladders in the single-date branch of `src/main.rs` with `?` propagation plus
+`anyhow` context. Both the regular-date branch (≥ 90 days) and the
+hybrid-projection branch (< 90 days) now read at one indentation level, so the
+happy-path projection logic is no longer buried under ~28 columns of rightward
+drift. Each fallible call carries a `.with_context(…)`/`.context(…)` message,
+which `main` (already `anyhow::Result<()>`) prints as a full error chain on exit
+— preserving the per-call diagnostics the old `log::error!` lines provided.
+
+Added `use anyhow::Context;` to enable the context combinators. The
+log-and-`continue` arms in the batch-processing loop were intentionally left
+unchanged: they recover and carry on rather than propagate, so `?` does not
+apply.
+
+Closes #95.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via a new
+integration test that drives the real binary end-to-end and asserts on the
+observable behaviour (non-zero exit and a contextualised error chain), not the
+implementation:
+
+```mermaid
+flowchart TD
+    A[--date YYYY-MM-DD] --> B{days since score ≥ 90?}
+    B -->|yes| C["calculate_portfolio_performance(…)?\n.with_context(calculating performance)"]
+    B -->|no| D["read_tsv_score_file(…)?\n.with_context(reading TSV file)"]
+    D --> E["read_market_data_from_csv(…)?\n.context(reading market data CSV)"]
+    E --> F["calculate_hybrid_projection(…)?\n.with_context(calculating projection)"]
+    C --> G[update index.json]
+    F --> G
+    C -. error .-> H[main prints anyhow chain, exit 1]
+    D -. error .-> H
+    E -. error .-> H
+    F -. error .-> H
+```
+
+Test run:
+
+```
+running 3 tests
+test invalid_date_format_is_rejected ... ok
+test regular_branch_missing_file_propagates_with_context ... ok
+test hybrid_branch_missing_tsv_propagates_with_context ... ok
+
+test result: ok. 3 passed; 0 failed
+```
+
+Full `./quality.sh` passes (cargo fmt/clippy/check/test + coverage + Deno
+checks).
+
+## Test Plan
+
+New `tests/main_error_propagation_test.rs`:
+- `hybrid_branch_missing_tsv_propagates_with_context` — a recent date (< 90 days)
+  with an absent TSV file exits non-zero and the error chain contains
+  `reading TSV file`.
+- `regular_branch_missing_file_propagates_with_context` — an old date (≥ 90 days)
+  with no score file exits non-zero and the chain contains
+  `calculating performance`.
+- `invalid_date_format_is_rejected` — a malformed date (`2026-06`) is rejected
+  before any file access (`Invalid date format`).
+
+The two propagation tests were confirmed to fail against the pre-refactor code
+(which emitted only the bare `No such file or directory` cause with no context)
+and to pass after the refactor. All existing Rust and Deno tests continue to
+pass.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use chrono::{NaiveDate, Utc};
 use clap::Parser;
 use grq_validation::utils::{
@@ -93,138 +93,109 @@ fn main() -> Result<()> {
         let days_since_score = (current_date - score_date).num_days();
 
         if days_since_score >= 90 {
-            // Use regular performance calculation
-            match grq_validation::utils::calculate_portfolio_performance(
+            // Use regular performance calculation. `?` propagates the error to
+            // `main`, which prints the full context chain on exit.
+            let performance = grq_validation::utils::calculate_portfolio_performance(
                 &score_file_path,
                 score_file_date,
-            ) {
-                Ok(performance) => {
-                    println!("\n=== {date} Performance Results ===");
-                    println!("Score Date: {}", performance.score_date);
-                    println!("Total Stocks: {}", performance.total_stocks);
-                    println!("90-Day Performance: {:.2}%", performance.performance_90_day);
-                    println!(
-                        "Annualized Performance: {:.2}%",
-                        performance.performance_annualized
-                    );
-                    println!();
+            )
+            .with_context(|| format!("calculating performance for {date}"))?;
 
-                    println!("Individual Stock Performances:");
-                    for stock_perf in &performance.individual_performances {
-                        println!("  {}: Buy=${:.2}, Current=${:.2}, Gain/Loss={:.2}%, Dividends=${:.2}, Total Return={:.2}%",
-                        stock_perf.ticker,
-                        stock_perf.buy_price,
-                        stock_perf.current_price,
-                        stock_perf.gain_loss_percent,
-                        stock_perf.dividends_total,
-                        stock_perf.total_return_percent
-                    );
-                    }
+            println!("\n=== {date} Performance Results ===");
+            println!("Score Date: {}", performance.score_date);
+            println!("Total Stocks: {}", performance.total_stocks);
+            println!("90-Day Performance: {:.2}%", performance.performance_90_day);
+            println!(
+                "Annualized Performance: {:.2}%",
+                performance.performance_annualized
+            );
+            println!();
 
-                    // Update the index.json with this performance data
-                    let mut index_data = grq_validation::utils::read_index_json(&args.docs_path)?;
-                    for score_entry in &mut index_data.scores {
-                        if score_entry.date == date {
-                            score_entry.performance_90_day = Some(performance.performance_90_day);
-                            score_entry.performance_annualized =
-                                Some(performance.performance_annualized);
-                            score_entry.total_stocks = Some(performance.total_stocks);
-                            break;
-                        }
-                    }
+            println!("Individual Stock Performances:");
+            for stock_perf in &performance.individual_performances {
+                println!("  {}: Buy=${:.2}, Current=${:.2}, Gain/Loss={:.2}%, Dividends=${:.2}, Total Return={:.2}%",
+                    stock_perf.ticker,
+                    stock_perf.buy_price,
+                    stock_perf.current_price,
+                    stock_perf.gain_loss_percent,
+                    stock_perf.dividends_total,
+                    stock_perf.total_return_percent
+                );
+            }
 
-                    // Write updated index back to file
-                    let index_path = Path::new(&args.docs_path).join("scores").join("index.json");
-                    let json_content = serde_json::to_string_pretty(&index_data)?;
-                    std::fs::write(index_path, json_content)?;
-                    println!("\nUpdated index.json with performance data for {date}");
-                }
-                Err(e) => {
-                    log::error!("Failed to calculate performance: {e}");
-                    return Err(e);
+            // Update the index.json with this performance data
+            let mut index_data = grq_validation::utils::read_index_json(&args.docs_path)?;
+            for score_entry in &mut index_data.scores {
+                if score_entry.date == date {
+                    score_entry.performance_90_day = Some(performance.performance_90_day);
+                    score_entry.performance_annualized = Some(performance.performance_annualized);
+                    score_entry.total_stocks = Some(performance.total_stocks);
+                    break;
                 }
             }
+
+            // Write updated index back to file
+            let index_path = Path::new(&args.docs_path).join("scores").join("index.json");
+            let json_content = serde_json::to_string_pretty(&index_data)?;
+            std::fs::write(index_path, json_content)?;
+            println!("\nUpdated index.json with performance data for {date}");
         } else {
-            // Use hybrid projection for dates less than 90 days old
-            match grq_validation::utils::read_tsv_score_file(&score_file_path) {
-                Ok(stock_records) => {
-                    match grq_validation::utils::read_market_data_from_csv(
-                        &grq_validation::utils::derive_csv_output_path(&score_file_path),
-                    ) {
-                        Ok(market_data_csv) => {
-                            match grq_validation::utils::calculate_hybrid_projection(
-                                &stock_records,
-                                score_file_date,
-                                &market_data_csv,
-                            ) {
-                                Ok(performance) => {
-                                    println!("\n=== {date} Projection Results ===");
-                                    println!("Score Date: {}", performance.score_date);
-                                    println!("Total Stocks: {}", performance.total_stocks);
-                                    println!(
-                                        "Projected 90-Day Performance: {:.2}%",
-                                        performance.performance_90_day
-                                    );
-                                    println!(
-                                        "Projected Annualized Performance: {:.2}%",
-                                        performance.performance_annualized
-                                    );
-                                    println!();
+            // Use hybrid projection for dates less than 90 days old. Each step
+            // propagates with `?` plus context instead of a nested match ladder.
+            let stock_records = grq_validation::utils::read_tsv_score_file(&score_file_path)
+                .with_context(|| format!("reading TSV file {score_file_path}"))?;
+            let market_data_csv = grq_validation::utils::read_market_data_from_csv(
+                &grq_validation::utils::derive_csv_output_path(&score_file_path),
+            )
+            .context("reading market data CSV")?;
+            let performance = grq_validation::utils::calculate_hybrid_projection(
+                &stock_records,
+                score_file_date,
+                &market_data_csv,
+            )
+            .with_context(|| format!("calculating projection for {date}"))?;
 
-                                    println!("Individual Stock Projections:");
-                                    for stock_perf in &performance.individual_performances {
-                                        println!("  {}: Buy=${:.2}, Current=${:.2}, Projected Gain/Loss={:.2}%, Dividends=${:.2}, Total Return={:.2}%",
-                                            stock_perf.ticker,
-                                            stock_perf.buy_price,
-                                            stock_perf.current_price,
-                                            stock_perf.gain_loss_percent,
-                                            stock_perf.dividends_total,
-                                            stock_perf.total_return_percent
-                                        );
-                                    }
+            println!("\n=== {date} Projection Results ===");
+            println!("Score Date: {}", performance.score_date);
+            println!("Total Stocks: {}", performance.total_stocks);
+            println!(
+                "Projected 90-Day Performance: {:.2}%",
+                performance.performance_90_day
+            );
+            println!(
+                "Projected Annualized Performance: {:.2}%",
+                performance.performance_annualized
+            );
+            println!();
 
-                                    // Update the index.json with this projection data
-                                    let mut index_data =
-                                        grq_validation::utils::read_index_json(&args.docs_path)?;
-                                    for score_entry in &mut index_data.scores {
-                                        if score_entry.date == date {
-                                            score_entry.performance_90_day =
-                                                Some(performance.performance_90_day);
-                                            score_entry.performance_annualized =
-                                                Some(performance.performance_annualized);
-                                            score_entry.total_stocks =
-                                                Some(performance.total_stocks);
-                                            break;
-                                        }
-                                    }
+            println!("Individual Stock Projections:");
+            for stock_perf in &performance.individual_performances {
+                println!("  {}: Buy=${:.2}, Current=${:.2}, Projected Gain/Loss={:.2}%, Dividends=${:.2}, Total Return={:.2}%",
+                    stock_perf.ticker,
+                    stock_perf.buy_price,
+                    stock_perf.current_price,
+                    stock_perf.gain_loss_percent,
+                    stock_perf.dividends_total,
+                    stock_perf.total_return_percent
+                );
+            }
 
-                                    // Write updated index back to file
-                                    let index_path = Path::new(&args.docs_path)
-                                        .join("scores")
-                                        .join("index.json");
-                                    let json_content = serde_json::to_string_pretty(&index_data)?;
-                                    std::fs::write(index_path, json_content)?;
-                                    println!(
-                                        "\nUpdated index.json with projection data for {date}"
-                                    );
-                                }
-                                Err(e) => {
-                                    log::error!("Failed to calculate projection: {e}");
-                                    return Err(e);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            log::error!("Failed to read market data CSV: {e}");
-                            return Err(e);
-                        }
-                    }
-                }
-                Err(e) => {
-                    log::error!("Failed to read TSV file: {e}");
-                    return Err(e);
+            // Update the index.json with this projection data
+            let mut index_data = grq_validation::utils::read_index_json(&args.docs_path)?;
+            for score_entry in &mut index_data.scores {
+                if score_entry.date == date {
+                    score_entry.performance_90_day = Some(performance.performance_90_day);
+                    score_entry.performance_annualized = Some(performance.performance_annualized);
+                    score_entry.total_stocks = Some(performance.total_stocks);
+                    break;
                 }
             }
+
+            // Write updated index back to file
+            let index_path = Path::new(&args.docs_path).join("scores").join("index.json");
+            let json_content = serde_json::to_string_pretty(&index_data)?;
+            std::fs::write(index_path, json_content)?;
+            println!("\nUpdated index.json with projection data for {date}");
         }
 
         info!("Single date processing completed");

--- a/tests/main_error_propagation_test.rs
+++ b/tests/main_error_propagation_test.rs
@@ -1,0 +1,83 @@
+//! Integration tests for error propagation in the single-date branch of `main`.
+//!
+//! These exercise the real binary end-to-end. The refactor in issue #95
+//! replaces nested `match { Err(e) => { log::error!(..); return Err(e) } }`
+//! ladders with `?` propagation plus `anyhow` context. We assert on the
+//! resulting error chain so the tests track observable behaviour (non-zero
+//! exit and a contextualised error message), not the implementation.
+
+use chrono::{Duration, Utc};
+use std::process::Command;
+
+/// Build a `YYYY-MM-DD` date string `days` before today (UTC).
+fn date_days_ago(days: i64) -> String {
+    let date = Utc::now().naive_utc().date() - Duration::days(days);
+    date.format("%Y-%m-%d").to_string()
+}
+
+/// Run the binary for a single date against an empty docs directory.
+fn run_for_date(date: &str) -> std::process::Output {
+    let docs_dir = tempfile::tempdir().expect("create temp docs dir");
+    Command::new(env!("CARGO_BIN_EXE_grq-validation"))
+        .args([
+            "--date",
+            date,
+            "--docs-path",
+            docs_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run grq-validation binary")
+}
+
+#[test]
+fn hybrid_branch_missing_tsv_propagates_with_context() {
+    // A date less than 90 days old takes the hybrid-projection branch, which
+    // first reads the TSV score file. The file is absent, so the error must
+    // propagate with the "reading TSV file" context and a non-zero exit.
+    let output = run_for_date(&date_days_ago(10));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("reading TSV file"),
+        "expected TSV context in error chain, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn regular_branch_missing_file_propagates_with_context() {
+    // A date at least 90 days old takes the regular performance branch. With
+    // no score file present the calculation fails and must propagate with the
+    // "calculating performance" context and a non-zero exit.
+    let output = run_for_date(&date_days_ago(200));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("calculating performance"),
+        "expected performance context in error chain, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn invalid_date_format_is_rejected() {
+    // Behaviour preserved by the refactor: a malformed date is rejected before
+    // any file access.
+    let output = run_for_date("2026-06");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Invalid date format"),
+        "expected invalid-date-format error, stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Replaced the nested `match { Ok(v) => …, Err(e) => { log::error!(…); return Err(e) } }`
ladders in the single-date branch of `src/main.rs` with `?` propagation plus
`anyhow` context. Both the regular-date branch (≥ 90 days) and the
hybrid-projection branch (< 90 days) now read at one indentation level, so the
happy-path projection logic is no longer buried under ~28 columns of rightward
drift. Each fallible call carries a `.with_context(…)`/`.context(…)` message,
which `main` (already `anyhow::Result<()>`) prints as a full error chain on exit
— preserving the per-call diagnostics the old `log::error!` lines provided.

Added `use anyhow::Context;` to enable the context combinators. The
log-and-`continue` arms in the batch-processing loop were intentionally left
unchanged: they recover and carry on rather than propagate, so `?` does not
apply.

Closes #95.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via a new
integration test that drives the real binary end-to-end and asserts on the
observable behaviour (non-zero exit and a contextualised error chain), not the
implementation:

```mermaid
flowchart TD
    A[--date YYYY-MM-DD] --> B{days since score ≥ 90?}
    B -->|yes| C["calculate_portfolio_performance(…)?\n.with_context(calculating performance)"]
    B -->|no| D["read_tsv_score_file(…)?\n.with_context(reading TSV file)"]
    D --> E["read_market_data_from_csv(…)?\n.context(reading market data CSV)"]
    E --> F["calculate_hybrid_projection(…)?\n.with_context(calculating projection)"]
    C --> G[update index.json]
    F --> G
    C -. error .-> H[main prints anyhow chain, exit 1]
    D -. error .-> H
    E -. error .-> H
    F -. error .-> H
```

Test run:

```
running 3 tests
test invalid_date_format_is_rejected ... ok
test regular_branch_missing_file_propagates_with_context ... ok
test hybrid_branch_missing_tsv_propagates_with_context ... ok

test result: ok. 3 passed; 0 failed
```

Full `./quality.sh` passes (cargo fmt/clippy/check/test + coverage + Deno
checks).

## Test Plan

New `tests/main_error_propagation_test.rs`:
- `hybrid_branch_missing_tsv_propagates_with_context` — a recent date (< 90 days)
  with an absent TSV file exits non-zero and the error chain contains
  `reading TSV file`.
- `regular_branch_missing_file_propagates_with_context` — an old date (≥ 90 days)
  with no score file exits non-zero and the chain contains
  `calculating performance`.
- `invalid_date_format_is_rejected` — a malformed date (`2026-06`) is rejected
  before any file access (`Invalid date format`).

The two propagation tests were confirmed to fail against the pre-refactor code
(which emitted only the bare `No such file or directory` cause with no context)
and to pass after the refactor. All existing Rust and Deno tests continue to
pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqa1szpo-cc668c`<!-- vibe-worker-issue-95 -->