### PR TITLE
Remove dead dependencies walkdir and thiserror (Issue #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow.
 - `CHANGELOG.md` (this file) tracking notable changes between releases.
 
+### Removed
+
+- Dead `[dependencies]` `walkdir` and `thiserror`, which were declared but
+  never referenced in `src/` or `tests/`. Removing them trims build time, the
+  lockfile, and the supply-chain surface.
+
 ## [0.1.10] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,8 +304,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
- "walkdir",
 ]
 
 [[package]]
@@ -579,15 +577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,26 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,16 +684,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "wasip2"
@@ -821,15 +780,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,8 @@ serde_json = "1.0"
 # For date/time handling
 chrono = { version = "0.4", features = ["serde"] }
 
-# For file system operations
-walkdir = "2.4"
-
 # For error handling
 anyhow = "1.0"
-thiserror = "2.0"
 
 # For command line argument parsing
 clap = { version = "4.4", features = ["derive"] }

--- a/docs/archive/pr-summaries/pr-summary-96.md
+++ b/docs/archive/pr-summaries/pr-summary-96.md
@@ -1,0 +1,65 @@
+# Remove dead dependencies `walkdir` and `thiserror`
+
+## Summary
+
+Removed two declared-but-unused crates from `[dependencies]` in `Cargo.toml`
+and refreshed `Cargo.lock`. A whole-crate search (`src/**/*.rs`,
+`tests/**/*.rs`; there is no `build.rs` or `benches/`) found zero references to
+either crate — no `use`, no `extern crate`, no fully-qualified path, and no
+`thiserror` derive macro. Error handling is done entirely with `anyhow`.
+Dropping them trims build time, the lockfile, and the supply-chain surface
+(their transitives `same-file`, `thiserror-impl`, and `winapi-util` are gone
+from `Cargo.lock` too). Closes #96.
+
+**Correction to the issue:** the issue also asked to remove the
+`tempfile` dev-dependency, but `tempfile` **is** in use — `src/utils.rs`
+(`tempfile::NamedTempFile` inside the `#[cfg(test)]` module) and
+`tests/main_error_propagation_test.rs` (`tempfile::tempdir`). The issue warned
+its read-only grep might miss `cfg`-gated usage, and that is exactly what
+happened. `tempfile` has therefore been **kept**; removing it would break the
+test suite.
+
+```diff
+-# For file system operations
+-walkdir = "2.4"
+-
+ # For error handling
+ anyhow = "1.0"
+-thiserror = "2.0"
+```
+
+```mermaid
+flowchart LR
+    A[Cargo.toml deps] --> B{Referenced in src/ or tests/?}
+    B -- walkdir: no --> C[Removed]
+    B -- thiserror: no --> C
+    B -- tempfile: yes, in #cfg test --> D[Kept]
+```
+
+## Evidence
+
+Backend/CLI change only — no web interface to screenshot. Verified by build,
+the full test suite, and the repository quality gate:
+
+- `cargo build` — succeeds with the two crates removed.
+- `cargo test` — all tests pass, including the `tempfile`-using tests
+  (`test_read_market_data_from_csv_skips_unparseable_close`,
+  `tests/main_error_propagation_test.rs`), confirming `tempfile` is genuinely
+  required.
+- `cargo update -p walkdir -p thiserror` — `Cargo.lock` no longer contains
+  `walkdir`, `thiserror`, `thiserror-impl`, `same-file`, or `winapi-util`.
+- `./quality.sh` — passes cleanly (fmt, clippy `-D warnings`, type checks,
+  Rust tests, tarpaulin coverage, release build, Deno tests/lint/check:
+  `227 passed | 0 failed`).
+
+## Test Plan
+
+No new test files were added — this is a build-manifest change whose correct
+behaviour is "everything still compiles and every existing test still passes".
+The existing suite provides the verification:
+
+- The full `cargo test --all-targets --all-features` run is the regression
+  guard: had any source path actually depended on `walkdir` or `thiserror`,
+  compilation would fail.
+- The `tempfile`-using tests prove `tempfile` must stay, justifying the
+  deviation from the issue's suggested diff.


### PR DESCRIPTION
# Remove dead dependencies `walkdir` and `thiserror`

## Summary

Removed two declared-but-unused crates from `[dependencies]` in `Cargo.toml`
and refreshed `Cargo.lock`. A whole-crate search (`src/**/*.rs`,
`tests/**/*.rs`; there is no `build.rs` or `benches/`) found zero references to
either crate — no `use`, no `extern crate`, no fully-qualified path, and no
`thiserror` derive macro. Error handling is done entirely with `anyhow`.
Dropping them trims build time, the lockfile, and the supply-chain surface
(their transitives `same-file`, `thiserror-impl`, and `winapi-util` are gone
from `Cargo.lock` too). Closes #96.

**Correction to the issue:** the issue also asked to remove the
`tempfile` dev-dependency, but `tempfile` **is** in use — `src/utils.rs`
(`tempfile::NamedTempFile` inside the `#[cfg(test)]` module) and
`tests/main_error_propagation_test.rs` (`tempfile::tempdir`). The issue warned
its read-only grep might miss `cfg`-gated usage, and that is exactly what
happened. `tempfile` has therefore been **kept**; removing it would break the
test suite.

```diff
-# For file system operations
-walkdir = "2.4"
-
 # For error handling
 anyhow = "1.0"
-thiserror = "2.0"
```

```mermaid
flowchart LR
    A[Cargo.toml deps] --> B{Referenced in src/ or tests/?}
    B -- walkdir: no --> C[Removed]
    B -- thiserror: no --> C
    B -- tempfile: yes, in #cfg test --> D[Kept]
```

## Evidence

Backend/CLI change only — no web interface to screenshot. Verified by build,
the full test suite, and the repository quality gate:

- `cargo build` — succeeds with the two crates removed.
- `cargo test` — all tests pass, including the `tempfile`-using tests
  (`test_read_market_data_from_csv_skips_unparseable_close`,
  `tests/main_error_propagation_test.rs`), confirming `tempfile` is genuinely
  required.
- `cargo update -p walkdir -p thiserror` — `Cargo.lock` no longer contains
  `walkdir`, `thiserror`, `thiserror-impl`, `same-file`, or `winapi-util`.
- `./quality.sh` — passes cleanly (fmt, clippy `-D warnings`, type checks,
  Rust tests, tarpaulin coverage, release build, Deno tests/lint/check:
  `227 passed | 0 failed`).

## Test Plan

No new test files were added — this is a build-manifest change whose correct
behaviour is "everything still compiles and every existing test still passes".
The existing suite provides the verification:

- The full `cargo test --all-targets --all-features` run is the regression
  guard: had any source path actually depended on `walkdir` or `thiserror`,
  compilation would fail.
- The `tempfile`-using tests prove `tempfile` must stay, justifying the
  deviation from the issue's suggested diff.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqa58f3w-862105`<!-- vibe-worker-issue-96 -->