### PR TITLE
Add missing_docs lint and document public API (Issue #97)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-97.md
+++ b/docs/archive/pr-summaries/pr-summary-97.md
@@ -1,0 +1,69 @@
+# Add `///` docs and a `missing_docs` lint to the `grq_validation` public API
+
+## Summary
+
+The library crate root carried no lint posture and most of its `pub` surface
+shipped without `///` doc comments, so `cargo doc` rendered blank entries and CI
+could not catch undocumented items. This change adds `#![warn(missing_docs)]`
+plus a crate-level summary to `src/lib.rs`, then documents every public item:
+
+- **`src/lib.rs`** — `#![warn(missing_docs)]`, a `//!` crate summary, and a
+  one-line `///` summary on each public module.
+- **`src/models.rs`** — `///` summaries on every public struct
+  (`StockRecord`, `MarketDataMeta`, `DailyData`, `MarketData`, `IndexData`,
+  `ScoreEntry`, `DividendRecord`, `DividendData`, `StockPerformance`,
+  `PortfolioPerformance`) **and each of their public fields**, plus
+  `StockRecord::new`.
+- **`src/utils.rs`** — `///` summaries on the public constants and the
+  functions that lacked them (`validate_stock_symbol`,
+  `calculate_average_score`, `read_index_json`, `extract_ticker_from_symbol`,
+  `get_market_data_path`, `read_tsv_score_file`,
+  `extract_ticker_codes_from_score_file`, `extract_symbol_from_ticker`,
+  `read_market_data`, `read_market_data_from_csv`,
+  `filter_market_data_by_date_range`). Runnable `# Examples` doctests were added
+  to `validate_stock_symbol` and `calculate_average_score`, and a `no_run`
+  example to `calculate_portfolio_performance`, per the Rust API Guidelines
+  (C-CRATE-DOC / C-EXAMPLE).
+
+Because `quality.sh` runs `cargo clippy ... -- -D warnings`, the new
+`#![warn(missing_docs)]` is effectively enforced — any future undocumented
+public item now fails CI rather than rendering blank in `cargo doc`.
+
+Closes #97.
+
+## Evidence
+
+CLI/library change — no UI to screenshot. Verified via the test suite and the
+documentation lint:
+
+- `cargo clippy --all-targets --all-features -- -D warnings` passes cleanly,
+  proving the `missing_docs` warning surfaces nothing (every public item is
+  documented).
+- `cargo test --doc` runs the new examples as real tests:
+
+  ```
+  running 3 tests
+  test src/utils.rs - utils::calculate_portfolio_performance (line ...) - compile ... ok
+  test src/utils.rs - utils::calculate_average_score (line ...) ... ok
+  test src/utils.rs - utils::validate_stock_symbol (line ...) ... ok
+  test result: ok. 3 passed; 0 failed
+  ```
+
+- `./quality.sh` completes with `✅ Quality checks completed successfully!`.
+
+```mermaid
+flowchart LR
+    A["#![warn(missing_docs)]"] --> B[cargo clippy -D warnings]
+    B -->|undocumented pub item| C[CI fails]
+    B -->|all documented| D[cargo doc renders summaries]
+```
+
+## Test Plan
+
+- Added runnable doctests (executed by `cargo test --doc`):
+  - `validate_stock_symbol` — asserts a valid and an empty symbol.
+  - `calculate_average_score` — asserts the mean and the empty-slice case.
+  - `calculate_portfolio_performance` — `no_run` usage example (compiled).
+- Existing unit, integration, and Deno tests continue to pass via `./quality.sh`.
+- The `missing_docs` lint under `-D warnings` acts as a coverage gate ensuring
+  no public item is left undocumented.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,15 @@
+#![warn(missing_docs)]
+//! Processes daily stock-score TSV files and computes portfolio performance.
+//!
+//! The crate exposes two modules:
+//!
+//! - [`models`] — serde-backed data types for score records, market data,
+//!   dividends and the computed performance results.
+//! - [`utils`] — functions to read the score/market/dividend files, build the
+//!   derived CSVs and calculate 90-day and annualised portfolio performance.
+
+/// Data types shared across the crate (score records, market data, dividends
+/// and performance results).
 pub mod models;
+/// File-reading, CSV-building and performance-calculation helpers.
 pub mod utils;

--- a/src/models.rs
+++ b/src/models.rs
@@ -70,30 +70,39 @@ where
     }
 }
 
+/// A single row from a daily score TSV file describing one stock.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StockRecord {
+    /// Full ticker symbol, e.g. `"NYSE:SEM"`.
     #[serde(rename = "Stock")]
     pub stock: String,
+    /// Analyst score for the stock.
     #[serde(rename = "Score")]
     pub score: f64,
+    /// Target price (parsed from currency-formatted text such as `"$22.63"`).
     #[serde(
         rename = "Target",
         serialize_with = "serialize_currency",
         deserialize_with = "deserialize_currency"
     )]
     pub target: f64,
+    /// Ex-dividend date, when supplied by the source file.
     #[serde(rename = "ExDividendDate")]
     pub ex_dividend_date: Option<String>,
+    /// Dividend paid per share, when supplied.
     #[serde(rename = "DividendPerShare")]
     pub dividend_per_share: Option<f64>,
+    /// Free-text notes from the source file.
     #[serde(rename = "Notes")]
     pub notes: Option<String>,
+    /// Basic intrinsic value per share (parsed from currency text).
     #[serde(
         rename = "intrinsicValuePerShareBasic",
         serialize_with = "serialize_optional_currency",
         deserialize_with = "deserialize_optional_currency"
     )]
     pub intrinsic_value_per_share_basic: Option<f64>,
+    /// Adjusted intrinsic value per share (parsed from currency text).
     #[serde(
         rename = "intrinsicValuePerShareAdjusted",
         serialize_with = "serialize_optional_currency",
@@ -103,6 +112,8 @@ pub struct StockRecord {
 }
 
 impl StockRecord {
+    /// Creates a `StockRecord` with the given `stock`, `score` and `target`,
+    /// leaving the optional fields unset.
     pub fn new(stock: String, score: f64, target: f64) -> Self {
         Self {
             stock,
@@ -117,113 +128,166 @@ impl StockRecord {
     }
 }
 
+/// Metadata block of an Alpha Vantage daily time-series JSON file.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarketDataMeta {
+    /// Human-readable description of the series.
     #[serde(rename = "1. Information")]
     pub information: String,
+    /// Ticker symbol the series belongs to.
     #[serde(rename = "2. Symbol")]
     pub symbol: String,
+    /// Timestamp of the most recent refresh.
     #[serde(rename = "3. Last Refreshed")]
     pub last_refreshed: String,
+    /// Output size (e.g. `"Compact"` or `"Full size"`).
     #[serde(rename = "4. Output Size")]
     pub output_size: String,
+    /// Time zone the timestamps are expressed in.
     #[serde(rename = "5. Time Zone")]
     pub time_zone: String,
 }
 
+/// One day's adjusted OHLCV figures from a market-data time series.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DailyData {
+    /// Opening price.
     #[serde(rename = "1. open")]
     pub open: String,
+    /// Highest traded price.
     #[serde(rename = "2. high")]
     pub high: String,
+    /// Lowest traded price.
     #[serde(rename = "3. low")]
     pub low: String,
+    /// Closing price.
     #[serde(rename = "4. close")]
     pub close: String,
+    /// Split/dividend-adjusted closing price.
     #[serde(rename = "5. adjusted close")]
     pub adjusted_close: String,
+    /// Traded volume.
     #[serde(rename = "6. volume")]
     pub volume: String,
+    /// Dividend amount paid on this date.
     #[serde(rename = "7. dividend amount")]
     pub dividend_amount: String,
+    /// Split coefficient applied on this date.
     #[serde(rename = "8. split coefficient")]
     pub split_coefficient: String,
 }
 
+/// A full market-data file: metadata plus the daily time series keyed by date.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarketData {
+    /// Series metadata.
     #[serde(rename = "Meta Data")]
     pub meta_data: MarketDataMeta,
+    /// Daily figures keyed by `YYYY-MM-DD` date string.
     #[serde(rename = "Time Series (Daily)")]
     pub time_series_daily: std::collections::HashMap<String, DailyData>,
 }
 
+/// Top-level structure of `docs/scores/index.json`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IndexData {
+    /// All known score entries, one per daily score file.
     pub scores: Vec<ScoreEntry>,
 }
 
+/// A single entry in the scores index, describing one daily score file and its
+/// computed performance.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ScoreEntry {
+    /// Year component of the score date.
     #[serde(rename = "year")]
     pub year: String,
+    /// Month component (full name, e.g. `"June"`).
     #[serde(rename = "month")]
     pub month: String,
+    /// Day-of-month component.
     #[serde(rename = "day")]
     pub day: String,
+    /// Relative path to the score file under `docs/scores/`.
     #[serde(rename = "file")]
     pub file: String,
+    /// Score date in `YYYY-MM-DD` form.
     #[serde(rename = "date")]
     pub date: String,
+    /// 90-day portfolio performance, once calculated.
     #[serde(rename = "performance_90_day", skip_serializing_if = "Option::is_none")]
     pub performance_90_day: Option<f64>,
+    /// Annualised portfolio performance, once calculated.
     #[serde(
         rename = "performance_annualized",
         skip_serializing_if = "Option::is_none"
     )]
     pub performance_annualized: Option<f64>,
+    /// Number of stocks contributing to the performance figures.
     #[serde(rename = "total_stocks", skip_serializing_if = "Option::is_none")]
     pub total_stocks: Option<i32>,
 }
 
+/// A single dividend event for a stock.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DividendRecord {
+    /// Ex-dividend date in `YYYY-MM-DD` form.
     #[serde(rename = "ex_dividend_date")]
     pub ex_dividend_date: String,
+    /// Declaration date, when known.
     #[serde(rename = "declaration_date")]
     pub declaration_date: Option<String>,
+    /// Record date, when known.
     #[serde(rename = "record_date")]
     pub record_date: Option<String>,
+    /// Payment date, when known.
     #[serde(rename = "payment_date")]
     pub payment_date: Option<String>,
+    /// Dividend amount per share, as raw text.
     #[serde(rename = "amount")]
     pub amount: String,
 }
 
+/// All dividend events for a single stock.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DividendData {
+    /// Ticker symbol the dividends belong to.
     pub symbol: String,
+    /// The dividend events, in source order.
     pub data: Vec<DividendRecord>,
 }
 
+/// Computed 90-day performance for a single stock within a portfolio.
 #[derive(Debug, Clone)]
 pub struct StockPerformance {
+    /// Full ticker symbol.
     pub ticker: String,
+    /// Buy price (close on, or just after, the score date).
     pub buy_price: f64,
+    /// Analyst target price from the score file.
     pub target_price: f64,
+    /// Latest price within the 90-day window.
     pub current_price: f64,
+    /// Price gain/loss over the period, as a percentage.
     pub gain_loss_percent: f64,
+    /// Total dividends received over the period.
     pub dividends_total: f64,
+    /// Total return (price plus dividends), as a percentage.
     pub total_return_percent: f64,
 }
 
+/// Aggregated performance of a whole portfolio for one score date.
 #[derive(Debug)]
 pub struct PortfolioPerformance {
+    /// Score date the figures relate to (`YYYY-MM-DD`).
     pub score_date: String,
+    /// Number of stocks in the portfolio.
     pub total_stocks: i32,
+    /// Average 90-day total return across the portfolio, as a percentage.
     pub performance_90_day: f64,
+    /// Annualised equivalent of the 90-day return, as a percentage.
     pub performance_annualized: f64,
+    /// Per-stock performance breakdown.
     pub individual_performances: Vec<StockPerformance>,
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,10 +6,24 @@ use chrono::{Duration, NaiveDate};
 use std::collections::HashMap;
 use std::path::Path;
 
-// Constants for external data paths
+/// Base path of the external share-price data repository.
 pub const MARKET_DATA_BASE_PATH: &str = "../GRQ-shareprices2025Q1";
+/// Base path of the external dividend data repository.
 pub const DIVIDEND_DATA_BASE_PATH: &str = "../GRQ-dividends";
 
+/// Returns `true` if `symbol` is a plausible stock symbol.
+///
+/// A symbol is valid when it is non-empty, at most 30 characters, and composed
+/// solely of alphanumerics, `.` or `:`.
+///
+/// # Examples
+///
+/// ```
+/// use grq_validation::utils::validate_stock_symbol;
+///
+/// assert!(validate_stock_symbol("NYSE:SEM"));
+/// assert!(!validate_stock_symbol(""));
+/// ```
 pub fn validate_stock_symbol(symbol: &str) -> bool {
     // Basic validation for stock symbols
     if symbol.is_empty() || symbol.len() > 30 {
@@ -21,6 +35,16 @@ pub fn validate_stock_symbol(symbol: &str) -> bool {
         .all(|c| c.is_alphanumeric() || c == '.' || c == ':')
 }
 
+/// Returns the arithmetic mean of `scores`, or `0.0` for an empty slice.
+///
+/// # Examples
+///
+/// ```
+/// use grq_validation::utils::calculate_average_score;
+///
+/// assert_eq!(calculate_average_score(&[1.0, 2.0, 3.0]), 2.0);
+/// assert_eq!(calculate_average_score(&[]), 0.0);
+/// ```
 pub fn calculate_average_score(scores: &[f64]) -> f64 {
     if scores.is_empty() {
         return 0.0;
@@ -29,6 +53,7 @@ pub fn calculate_average_score(scores: &[f64]) -> f64 {
     scores.iter().sum::<f64>() / scores.len() as f64
 }
 
+/// Reads `<docs_path>/scores/index.json` and returns its entries sorted by date.
 pub fn read_index_json(docs_path: &str) -> Result<IndexData> {
     use std::fs;
     use std::path::Path;
@@ -95,6 +120,8 @@ pub fn build_score_file_path(docs_path: &str, file: &str) -> Result<String> {
     Ok(full_path.to_string_lossy().into_owned())
 }
 
+/// Extracts the ticker following the first `:` (e.g. `"NYSE:SEM"` → `"SEM"`),
+/// returning `None` when no `:` is present.
 pub fn extract_ticker_from_symbol(symbol: &str) -> Option<String> {
     // Extract ticker from "NYSE:SEM" -> "SEM"
     symbol
@@ -102,11 +129,14 @@ pub fn extract_ticker_from_symbol(symbol: &str) -> Option<String> {
         .map(|colon_pos| symbol[colon_pos + 1..].to_string())
 }
 
+/// Builds the market-data JSON path for `ticker` under [`MARKET_DATA_BASE_PATH`],
+/// bucketed by uppercased first letter (e.g. `"SEM"` → `.../data/S/SEM.json`).
 pub fn get_market_data_path(ticker: &str) -> String {
     let first_letter = ticker.chars().next().unwrap_or('X').to_uppercase();
     format!("{MARKET_DATA_BASE_PATH}/data/{first_letter}/{ticker}.json")
 }
 
+/// Reads a tab-separated score file into a vector of [`StockRecord`]s.
 pub fn read_tsv_score_file(file_path: &str) -> Result<Vec<StockRecord>> {
     use csv::ReaderBuilder;
     use std::fs::File;
@@ -127,6 +157,7 @@ pub fn read_tsv_score_file(file_path: &str) -> Result<Vec<StockRecord>> {
     Ok(stock_records)
 }
 
+/// Reads a score file and returns just the `Stock` ticker codes, in file order.
 pub fn extract_ticker_codes_from_score_file(file_path: &str) -> Result<Vec<String>> {
     let stock_records = read_tsv_score_file(file_path)?;
     let ticker_codes: Vec<String> = stock_records
@@ -137,6 +168,8 @@ pub fn extract_ticker_codes_from_score_file(file_path: &str) -> Result<Vec<Strin
     Ok(ticker_codes)
 }
 
+/// Returns the file-system-safe symbol for `ticker`: the part after the last
+/// `:`, with `.` replaced by `-` (e.g. `"NYSE:HEI.A"` → `"HEI-A"`).
 pub fn extract_symbol_from_ticker(ticker: &str) -> String {
     let symbol = match ticker.rsplit_once(':') {
         Some((_, symbol)) => symbol.to_string(),
@@ -147,6 +180,7 @@ pub fn extract_symbol_from_ticker(ticker: &str) -> String {
     symbol.replace('.', "-")
 }
 
+/// Reads and deserialises the [`MarketData`] JSON file for `symbol`.
 pub fn read_market_data(symbol: &str) -> Result<MarketData> {
     use std::fs::File;
 
@@ -175,6 +209,10 @@ fn parse_financial_value(field: &str, context: &str, raw: &str) -> Option<f64> {
     }
 }
 
+/// Reads a derived market-data CSV into a map of `ticker → (date → close)`.
+///
+/// Rows with a non-numeric or non-positive close price are skipped (and a
+/// warning is written to stderr).
 pub fn read_market_data_from_csv(
     csv_file_path: &str,
 ) -> Result<HashMap<String, HashMap<String, f64>>> {
@@ -214,6 +252,8 @@ pub fn read_market_data_from_csv(
     Ok(market_data)
 }
 
+/// Returns `(date, close)` pairs from `market_data` whose date falls within the
+/// inclusive `start_date`..=`end_date` range, sorted oldest first.
 pub fn filter_market_data_by_date_range(
     market_data: &MarketData,
     start_date: &str,
@@ -573,7 +613,22 @@ pub fn calculate_annualized_performance(performance_pct: f64, days_elapsed: i64)
     }
 }
 
-/// Calculates portfolio performance for a given score file
+/// Calculates 90-day and annualised portfolio performance for a score file.
+///
+/// Reads the score TSV at `score_file_path` and the derived market-data CSV
+/// alongside it, then computes per-stock and portfolio-wide returns for the
+/// 90-day window starting at `score_file_date` (`YYYY-MM-DD`).
+///
+/// # Examples
+///
+/// ```no_run
+/// use grq_validation::utils::calculate_portfolio_performance;
+///
+/// let performance =
+///     calculate_portfolio_performance("docs/scores/2024/November/15.tsv", "2024-11-15")?;
+/// println!("90-day return: {:.2}%", performance.performance_90_day);
+/// # Ok::<(), anyhow::Error>(())
+/// ```
 pub fn calculate_portfolio_performance(
     score_file_path: &str,
     score_file_date: &str,


### PR DESCRIPTION
# Add `///` docs and a `missing_docs` lint to the `grq_validation` public API

## Summary

The library crate root carried no lint posture and most of its `pub` surface
shipped without `///` doc comments, so `cargo doc` rendered blank entries and CI
could not catch undocumented items. This change adds `#![warn(missing_docs)]`
plus a crate-level summary to `src/lib.rs`, then documents every public item:

- **`src/lib.rs`** — `#![warn(missing_docs)]`, a `//!` crate summary, and a
  one-line `///` summary on each public module.
- **`src/models.rs`** — `///` summaries on every public struct
  (`StockRecord`, `MarketDataMeta`, `DailyData`, `MarketData`, `IndexData`,
  `ScoreEntry`, `DividendRecord`, `DividendData`, `StockPerformance`,
  `PortfolioPerformance`) **and each of their public fields**, plus
  `StockRecord::new`.
- **`src/utils.rs`** — `///` summaries on the public constants and the
  functions that lacked them (`validate_stock_symbol`,
  `calculate_average_score`, `read_index_json`, `extract_ticker_from_symbol`,
  `get_market_data_path`, `read_tsv_score_file`,
  `extract_ticker_codes_from_score_file`, `extract_symbol_from_ticker`,
  `read_market_data`, `read_market_data_from_csv`,
  `filter_market_data_by_date_range`). Runnable `# Examples` doctests were added
  to `validate_stock_symbol` and `calculate_average_score`, and a `no_run`
  example to `calculate_portfolio_performance`, per the Rust API Guidelines
  (C-CRATE-DOC / C-EXAMPLE).

Because `quality.sh` runs `cargo clippy ... -- -D warnings`, the new
`#![warn(missing_docs)]` is effectively enforced — any future undocumented
public item now fails CI rather than rendering blank in `cargo doc`.

Closes #97.

## Evidence

CLI/library change — no UI to screenshot. Verified via the test suite and the
documentation lint:

- `cargo clippy --all-targets --all-features -- -D warnings` passes cleanly,
  proving the `missing_docs` warning surfaces nothing (every public item is
  documented).
- `cargo test --doc` runs the new examples as real tests:

  ```
  running 3 tests
  test src/utils.rs - utils::calculate_portfolio_performance (line ...) - compile ... ok
  test src/utils.rs - utils::calculate_average_score (line ...) ... ok
  test src/utils.rs - utils::validate_stock_symbol (line ...) ... ok
  test result: ok. 3 passed; 0 failed
  ```

- `./quality.sh` completes with `✅ Quality checks completed successfully!`.

```mermaid
flowchart LR
    A["#![warn(missing_docs)]"] --> B[cargo clippy -D warnings]
    B -->|undocumented pub item| C[CI fails]
    B -->|all documented| D[cargo doc renders summaries]
```

## Test Plan

- Added runnable doctests (executed by `cargo test --doc`):
  - `validate_stock_symbol` — asserts a valid and an empty symbol.
  - `calculate_average_score` — asserts the mean and the empty-slice case.
  - `calculate_portfolio_performance` — `no_run` usage example (compiled).
- Existing unit, integration, and Deno tests continue to pass via `./quality.sh`.
- The `missing_docs` lint under `-D warnings` acts as a coverage gate ensuring
  no public item is left undocumented.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqa691he-45e843`<!-- vibe-worker-issue-97 -->