### PR TITLE
Remove dead CLI-flag code in src/main.rs (Issue #99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dead `[dependencies]` `walkdir` and `thiserror`, which were declared but
   never referenced in `src/` or `tests/`. Removing them trims build time, the
   lockfile, and the supply-chain surface.
+- Dead CLI code in `src/main.rs`: the `--performance-only` flag (parsed but
+  never read, so it silently did nothing) and the unreachable second
+  `--calculate-performance` block (dominated by an earlier early-return).
 
 ## [0.1.10] - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -208,8 +208,6 @@ deno test --allow-read tests/
 - `--docs-path` — path to the docs directory (default: `docs`).
 - `--process-all` — process every score file, not just recent ones.
 - `--calculate-performance` — calculate performance metrics for score files.
-- `--performance-only` — only calculate performance metrics; skip CSV
-  generation.
 - `--date` — process a specific date in `YYYY-MM-DD` format.
 - `--verbose` — enable verbose logging.
 

--- a/docs/archive/pr-summaries/pr-summary-99.md
+++ b/docs/archive/pr-summaries/pr-summary-99.md
@@ -1,0 +1,46 @@
+## Summary
+
+Removed two pieces of dead CLI-flag code from `src/main.rs`. Closes #99.
+
+1. **`--performance-only` flag** — declared on the `Args` struct but never
+   read anywhere in the crate. A caller passing `--performance-only` got the
+   full CSV-generation path regardless, so the documented flag silently did
+   nothing. Removed the flag and its help text, and dropped the matching line
+   from the README CLI options.
+2. **Unreachable `--calculate-performance` re-check** — `main` early-returns
+   inside the first `if args.calculate_performance { … return Ok(()); }`, so
+   the later `if args.calculate_performance { … }` block (two `info!` lines)
+   could never run. Removed the dead block.
+
+Both removals are behaviour-preserving: neither item affected runtime
+behaviour. The retained `--calculate-performance` flag is unchanged.
+
+## Evidence
+
+Backend/CLI change with no web interface to screenshot. Verified via the real
+binary end-to-end in `tests/cli_flag_cleanup_test.rs`:
+
+- `--performance-only` is now rejected by clap as an unknown argument
+  (non-zero exit) instead of being silently accepted.
+- `--calculate-performance` is still accepted and exits successfully, and the
+  removed unreachable block's log messages never appear.
+
+```mermaid
+flowchart TD
+    A[main] --> B{args.calculate_performance?}
+    B -- true --> C[update_index_with_performance] --> D[return Ok]
+    B -- false --> E[read index, process score files]
+    E --> F[completed successfully]
+    G[Removed: unreachable second\nif calculate_performance block] -.->|never reached| F
+    H[Removed: --performance-only flag\nparsed but never read] -.-> A
+```
+
+## Test Plan
+
+- Added `tests/cli_flag_cleanup_test.rs`:
+  - `performance_only_flag_is_no_longer_accepted` — asserts the removed flag
+    is rejected with a non-zero exit (fails against the unfixed code).
+  - `calculate_performance_flag_is_still_accepted` — asserts the retained flag
+    still parses and that the unreachable block's messages are gone.
+- Existing `tests/main_error_propagation_test.rs` continues to pass.
+- `./quality.sh` passes cleanly.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,6 @@ struct Args {
     #[arg(long)]
     calculate_performance: bool,
 
-    /// Only calculate performance metrics (skip CSV generation)
-    #[arg(long)]
-    performance_only: bool,
-
     /// Process a specific date (format: YYYY-MM-DD)
     #[arg(long)]
     date: Option<String>,
@@ -351,13 +347,6 @@ fn main() -> Result<()> {
                 log::error!("Failed to read ticker codes from {score_file_path}: {e}");
             }
         }
-    }
-
-    // Note: Performance is now calculated inline for each score file
-    // The --calculate-performance flag is kept for backward compatibility
-    if args.calculate_performance {
-        info!("Performance calculation is now done inline for each score file");
-        info!("The --calculate-performance flag is no longer needed for normal operation");
     }
 
     info!("GRQ Validation processor completed successfully");

--- a/tests/cli_flag_cleanup_test.rs
+++ b/tests/cli_flag_cleanup_test.rs
@@ -1,0 +1,59 @@
+//! Tests for the CLI-flag cleanup in issue #99.
+//!
+//! Two pieces of dead code were removed from `src/main.rs`:
+//!   1. The `--performance-only` flag, which was parsed but never read.
+//!   2. The unreachable second `if args.calculate_performance { … }` block,
+//!      dominated by an earlier early-return on the same condition.
+//!
+//! These tests exercise the real binary end-to-end and assert on observable
+//! behaviour (accepted/rejected flags and exit codes), not implementation.
+
+use std::process::Command;
+
+/// Run the binary with the given arguments and capture its output.
+fn run_with_args(extra: &[&str]) -> std::process::Output {
+    let docs_dir = tempfile::tempdir().expect("create temp docs dir");
+    let mut args = vec!["--docs-path", docs_dir.path().to_str().unwrap()];
+    args.extend_from_slice(extra);
+    Command::new(env!("CARGO_BIN_EXE_grq-validation"))
+        .args(&args)
+        .output()
+        .expect("run grq-validation binary")
+}
+
+#[test]
+fn performance_only_flag_is_no_longer_accepted() {
+    // The removed `--performance-only` flag must now be rejected by clap as an
+    // unknown argument, rather than silently accepted and ignored.
+    let output = run_with_args(&["--performance-only"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for removed flag, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("unexpected argument") || stderr.contains("--performance-only"),
+        "expected an unknown-argument error mentioning the removed flag, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn calculate_performance_flag_is_still_accepted() {
+    // The retained `--calculate-performance` flag must still be parsed. With an
+    // empty docs directory the binary takes the early-return performance branch
+    // and exits successfully (it logs a failure but does not error out).
+    let output = run_with_args(&["--calculate-performance"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "expected --calculate-performance to be accepted, stderr: {stderr}"
+    );
+    // The unreachable second block's messages must never appear: that branch
+    // only ran when the flag was false, which the early return makes impossible.
+    assert!(
+        !stderr.contains("no longer needed for normal operation"),
+        "unreachable calculate-performance block should be gone, stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Removed two pieces of dead CLI-flag code from `src/main.rs`. Closes #99.

1. **`--performance-only` flag** — declared on the `Args` struct but never
   read anywhere in the crate. A caller passing `--performance-only` got the
   full CSV-generation path regardless, so the documented flag silently did
   nothing. Removed the flag and its help text, and dropped the matching line
   from the README CLI options.
2. **Unreachable `--calculate-performance` re-check** — `main` early-returns
   inside the first `if args.calculate_performance { … return Ok(()); }`, so
   the later `if args.calculate_performance { … }` block (two `info!` lines)
   could never run. Removed the dead block.

Both removals are behaviour-preserving: neither item affected runtime
behaviour. The retained `--calculate-performance` flag is unchanged.

## Evidence

Backend/CLI change with no web interface to screenshot. Verified via the real
binary end-to-end in `tests/cli_flag_cleanup_test.rs`:

- `--performance-only` is now rejected by clap as an unknown argument
  (non-zero exit) instead of being silently accepted.
- `--calculate-performance` is still accepted and exits successfully, and the
  removed unreachable block's log messages never appear.

```mermaid
flowchart TD
    A[main] --> B{args.calculate_performance?}
    B -- true --> C[update_index_with_performance] --> D[return Ok]
    B -- false --> E[read index, process score files]
    E --> F[completed successfully]
    G[Removed: unreachable second\nif calculate_performance block] -.->|never reached| F
    H[Removed: --performance-only flag\nparsed but never read] -.-> A
```

## Test Plan

- Added `tests/cli_flag_cleanup_test.rs`:
  - `performance_only_flag_is_no_longer_accepted` — asserts the removed flag
    is rejected with a non-zero exit (fails against the unfixed code).
  - `calculate_performance_flag_is_still_accepted` — asserts the retained flag
    still parses and that the unreachable block's messages are gone.
- Existing `tests/main_error_propagation_test.rs` continues to pass.
- `./quality.sh` passes cleanly.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqag1am8-c5cf9d`<!-- vibe-worker-issue-99 -->