### PR TITLE
Test real projection helpers in arithmetic suites (Issue #109)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-109.md
+++ b/docs/archive/pr-summaries/pr-summary-109.md
@@ -1,0 +1,57 @@
+# PR Summary — Issue #109
+
+## Summary
+
+`tests/target_percentage_tests.ts` and `tests/portfolio_target_tests.ts`
+imported nothing from the shipped code. Each test recomputed the
+target-percentage / split-adjustment / portfolio-return formula **inline** and
+asserted the result against a hand-evaluation of the same arithmetic — and
+`portfolio_target_tests.ts` even asserted the literal `20.0` against itself.
+These were tautologies: they exercised zero production code, so a genuine
+regression in the real maths left every assertion green.
+
+This PR rewrites both suites as WHAT-tests (resolution (a) from the issue): they
+now `import "../docs/projection.js"` and drive the shipped helpers
+(`calculateTargetPercentage`, `getSplitAdjustment`,
+`adjustHistoricalPriceToCurrent`, `calculatePerformanceReturn`) with the fixture
+inputs, asserting on the helpers' **return values** against spec-derived expected
+numbers. The inline formula recomputation and the literal-versus-itself check are
+gone. `portfolio_target_tests.ts` fixtures were corrected so each stock models a
+genuine ~20% target spread (`buyPrice` below `target`) instead of the previous
+`buyPrice == target`, which produced a 0% target the tautological test masked.
+
+Closes #109.
+
+## Evidence
+
+This is a test-only change (TypeScript) with no web interface, so no screenshot
+applies. The fix is verified by behaviour:
+
+- Full Deno suite green: `233 passed (57 steps) | 0 failed`.
+- **Regression check** — temporarily breaking `calculateTargetPercentage` in
+  `docs/projection.js` (returning `* 90` instead of `* 100`) now turns **7 steps
+  red** across both files; the unmodified production code keeps them green. The
+  former tests stayed green under the same break.
+
+```mermaid
+flowchart LR
+    F[Fixture inputs] --> P["docs/projection.js<br/>shipped helper"]
+    P --> R[Return value]
+    R --> A{assert ≈ spec expected}
+    S[Spec-derived expected] --> A
+```
+
+Before: the test computed the formula itself and compared against its own
+hand-evaluation — production code (`P`) was never on the path.
+
+## Test Plan
+
+- `tests/target_percentage_tests.ts` — rewrote every arithmetic step to call
+  `GRQProjection.calculateTargetPercentage`, plus `getSplitAdjustment` /
+  `adjustHistoricalPriceToCurrent` for the split-adjustment steps; added a
+  null-guard edge case.
+- `tests/portfolio_target_tests.ts` — replaced the `20.0 ≈ 20.0` literal check
+  and the inline portfolio-return recomputation with calls to
+  `calculateTargetPercentage` and `calculatePerformanceReturn`; corrected
+  fixtures to a real 20% target spread.
+- Verified with `deno test --allow-read tests/*.ts` and the full `./quality.sh`.

--- a/tests/portfolio_target_tests.ts
+++ b/tests/portfolio_target_tests.ts
@@ -1,6 +1,37 @@
 import { assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
-// Test case for portfolio target percentage and 90-day performance calculation
+// Portfolio target / 90-day performance tests (issue #109).
+//
+// These drive the REAL shipped helpers from docs/projection.js with fixture
+// inputs and assert on their RETURN VALUES. The former version asserted a
+// literal against itself (20.0 ≈ 20.0) and recomputed the portfolio return
+// inline against an answer baked into the fixture, exercising no production
+// code. Buy prices and targets below model a genuine 20% target spread so the
+// shipped target-percentage / performance-return helpers are actually tested.
+
+interface PortfolioStock {
+  stock: string;
+  target: number;
+  buyPrice: number;
+  shares: number;
+  dividends: { exDivDate: Date; amount: number }[];
+}
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+    calculatePerformanceReturn: (
+      buyPrice: number,
+      currentPrice: number,
+      totalDividends?: number,
+    ) => number | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
 
 Deno.test("Portfolio Target Tests", async (t) => {
   const scoreDate = new Date(2024, 10, 15); // November 15, 2024
@@ -8,13 +39,14 @@ Deno.test("Portfolio Target Tests", async (t) => {
     scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
   );
 
-  // Mock portfolio data - equal investment amounts (~$6,000 each)
-  const mockPortfolio = [
+  // Mock portfolio data - equal investment amounts (~$6,000 each). Each stock's
+  // target sits ~20% above its buy price (a real spread, not buyPrice == target).
+  const mockPortfolio: PortfolioStock[] = [
     {
       stock: "NYSE:WFG",
       target: 98.90,
-      buyPrice: 98.90,
-      shares: Math.floor(6000 / 98.90), // ~60 shares
+      buyPrice: 82.42,
+      shares: Math.floor(6000 / 82.42), // ~72 shares
       dividends: [
         { exDivDate: new Date("2024-12-19"), amount: 0.135 },
         { exDivDate: new Date("2024-12-27"), amount: 0.32 },
@@ -23,8 +55,8 @@ Deno.test("Portfolio Target Tests", async (t) => {
     {
       stock: "NYSE:CX",
       target: 5.85,
-      buyPrice: 5.85,
-      shares: Math.floor(6000 / 5.85), // ~1025 shares
+      buyPrice: 4.88,
+      shares: Math.floor(6000 / 4.88), // ~1229 shares
       dividends: [
         { exDivDate: new Date("2024-12-10"), amount: 0.02067 },
       ],
@@ -32,8 +64,8 @@ Deno.test("Portfolio Target Tests", async (t) => {
     {
       stock: "NASDAQ:KLAC",
       target: 695.01,
-      buyPrice: 695.01,
-      shares: Math.floor(6000 / 695.01), // ~8 shares
+      buyPrice: 579.18,
+      shares: Math.floor(6000 / 579.18), // ~10 shares
       dividends: [
         { exDivDate: new Date("2024-11-18"), amount: 1.7 },
       ],
@@ -41,24 +73,31 @@ Deno.test("Portfolio Target Tests", async (t) => {
   ];
 
   await t.step("portfolio target calculation", () => {
-    // Each stock has a 20% target, so portfolio target should be 20%
-    const expectedTarget = 20.0;
-    const calculatedTarget = 20.0; // This is the simplified calculation
+    // Drive each stock's target through the shipped helper, then average.
+    const targetPercentages = mockPortfolio.map((stock) =>
+      GRQProjection.calculateTargetPercentage(
+        stock.buyPrice,
+        stock.target,
+      ) as number
+    );
+    const portfolioTarget = targetPercentages.reduce((sum, t) => sum + t, 0) /
+      targetPercentages.length;
 
+    // Each stock targets ~20%, so the portfolio target should be ~20%.
     assertAlmostEquals(
-      calculatedTarget,
-      expectedTarget,
-      0.1,
-      "Portfolio target should be 20%",
+      portfolioTarget,
+      20.0,
+      0.2,
+      "Portfolio target should be ~20%",
     );
   });
 
   await t.step("portfolio 90-day performance", () => {
-    // Mock 90-day prices (assuming 20% target achieved)
-    const mock90DayPrices = {
-      "NYSE:WFG": 98.90 * 1.20, // 20% gain
-      "NYSE:CX": 5.85 * 1.20, // 20% gain
-      "NASDAQ:KLAC": 695.01 * 1.20, // 20% gain
+    // Mock 90-day prices: a 20% price gain on each stock's buy price.
+    const mock90DayPrices: Record<string, number> = {
+      "NYSE:WFG": 82.42 * 1.20,
+      "NYSE:CX": 4.88 * 1.20,
+      "NASDAQ:KLAC": 579.18 * 1.20,
     };
 
     let totalPortfolioValue = 0;
@@ -66,26 +105,28 @@ Deno.test("Portfolio Target Tests", async (t) => {
 
     mockPortfolio.forEach((stock) => {
       const investment = stock.shares * stock.buyPrice;
-      const dividends = stock.dividends.reduce(
+      const totalDividends = stock.dividends.reduce(
         (sum, div) => sum + div.amount,
         0,
       );
-      const dividendIncome = stock.shares * dividends;
-      const stockValue = stock.shares *
-        mock90DayPrices[stock.stock as keyof typeof mock90DayPrices];
-      const totalStockValue = stockValue + dividendIncome;
+      // Per-stock total return (price + dividend) from the shipped helper.
+      const returnPct = GRQProjection.calculatePerformanceReturn(
+        stock.buyPrice,
+        mock90DayPrices[stock.stock],
+        totalDividends,
+      ) as number;
+      const stockValue = investment * (1 + returnPct / 100);
 
       totalInvestment += investment;
-      totalPortfolioValue += totalStockValue;
+      totalPortfolioValue += stockValue;
     });
 
     const portfolioReturn =
       ((totalPortfolioValue - totalInvestment) / totalInvestment) * 100;
-    const expectedReturn = 20.0; // Should be close to 20% with equal weighting
-
+    // ~20% price gain plus small dividend contributions.
     assertAlmostEquals(
       portfolioReturn,
-      expectedReturn,
+      20.0,
       2.0,
       "Portfolio return should be close to 20%",
     );

--- a/tests/target_percentage_tests.ts
+++ b/tests/target_percentage_tests.ts
@@ -1,6 +1,15 @@
 import { assertAlmostEquals, assertEquals, assertExists } from "@std/assert";
+import "../docs/projection.js";
 
-// Test case for target percentage calculations with stock dilution handling
+// Target-percentage and split-adjustment tests (issue #109).
+//
+// These drive the REAL shipped helpers from docs/projection.js — the same code
+// the dashboard's GRQValidator delegates to — with fixture inputs and assert on
+// their RETURN VALUES against spec-derived expected numbers. A regression in the
+// production target-percentage / split-adjustment logic now fails the suite.
+// The former version recomputed the formula inline and asserted it against a
+// hand-evaluation of the same formula, so it could never fail for any reason
+// connected to production behaviour.
 
 // Type definitions
 interface MockStock {
@@ -9,6 +18,7 @@ interface MockStock {
   buyPrice: number;
   originalBuyPrice: number;
   splitAdjustment: number;
+  // Spec-required target return (%), independent of the production formula.
   expectedTargetPercentage: number;
 }
 
@@ -19,13 +29,33 @@ interface MarketDataPoint {
   splitCoefficient: number;
 }
 
+const g = globalThis as unknown as {
+  GRQProjection: {
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+    getSplitAdjustment: (
+      marketData: MarketDataPoint[] | null,
+      historicalDate: Date,
+    ) => number;
+    adjustHistoricalPriceToCurrent: (
+      price: number,
+      marketData: MarketDataPoint[] | null,
+      historicalDate: Date,
+    ) => number;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
 Deno.test("Target Percentage Calculation Tests", async (t) => {
   const scoreDate = new Date(2024, 10, 15); // November 15, 2024
   const ninetyDayDate = new Date(
     scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
   );
 
-  // Mock stock data with different scenarios
+  // Mock stock data with different scenarios. Buy prices are split-adjusted;
+  // expectedTargetPercentage is the spec answer the shipped helper must return.
   const mockStocks: MockStock[] = [
     {
       stock: "NYSE:WFG",
@@ -33,7 +63,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 82.42, // Split-adjusted buy price
       originalBuyPrice: 82.42, // Original price before any splits
       splitAdjustment: 1.0, // No splits
-      expectedTargetPercentage: 20.0, // (98.90 - 82.42) / 82.42 * 100
+      expectedTargetPercentage: 20.0,
     },
     {
       stock: "NYSE:CX",
@@ -41,7 +71,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 4.88, // Split-adjusted buy price
       originalBuyPrice: 4.88, // Original price before any splits
       splitAdjustment: 1.0, // No splits
-      expectedTargetPercentage: 19.9, // (5.85 - 4.88) / 4.88 * 100
+      expectedTargetPercentage: 19.9,
     },
     {
       stock: "NASDAQ:KLAC",
@@ -49,7 +79,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 579.18, // Split-adjusted buy price
       originalBuyPrice: 579.18, // Original price before any splits
       splitAdjustment: 1.0, // No splits
-      expectedTargetPercentage: 20.0, // (695.01 - 579.18) / 579.18 * 100
+      expectedTargetPercentage: 20.0,
     },
     {
       stock: "NASDAQ:TSLA",
@@ -57,7 +87,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 125.00, // Split-adjusted buy price (after 2:1 split)
       originalBuyPrice: 250.00, // Original price before 2:1 split
       splitAdjustment: 2.0, // 2:1 split occurred
-      expectedTargetPercentage: 100.0, // (250.00 - 125.00) / 125.00 * 100
+      expectedTargetPercentage: 100.0,
     },
     {
       stock: "NASDAQ:AAPL",
@@ -65,7 +95,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 50.00, // Split-adjusted buy price (after 3:1 split)
       originalBuyPrice: 150.00, // Original price before 3:1 split
       splitAdjustment: 3.0, // 3:1 split occurred
-      expectedTargetPercentage: 200.0, // (150.00 - 50.00) / 50.00 * 100
+      expectedTargetPercentage: 200.0,
     },
   ];
 
@@ -107,11 +137,13 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
 
   await t.step("single stock target percentage calculation - no splits", () => {
     const testStock = mockStocks[0]; // NYSE:WFG
-    const targetPercentage =
-      ((testStock.target - testStock.buyPrice) / testStock.buyPrice) * 100;
+    const targetPercentage = GRQProjection.calculateTargetPercentage(
+      testStock.buyPrice,
+      testStock.target,
+    );
 
     assertAlmostEquals(
-      targetPercentage,
+      targetPercentage as number,
       testStock.expectedTargetPercentage,
       0.1,
       `Target percentage for ${testStock.stock} should be ${testStock.expectedTargetPercentage}%`,
@@ -123,13 +155,15 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
     () => {
       const testStock = mockStocks[3]; // NASDAQ:TSLA
 
-      // When there's a split, both target and buy price are adjusted by the same factor
-      // So the target percentage remains the same: (250 - 125) / 125 * 100 = 100%
-      const targetPercentage =
-        ((testStock.target - testStock.buyPrice) / testStock.buyPrice) * 100;
+      // Both target and buy price are split-adjusted by the same factor, so the
+      // shipped helper should still return 100%: (250 - 125) / 125 * 100.
+      const targetPercentage = GRQProjection.calculateTargetPercentage(
+        testStock.buyPrice,
+        testStock.target,
+      );
 
       assertAlmostEquals(
-        targetPercentage,
+        targetPercentage as number,
         testStock.expectedTargetPercentage,
         0.1,
         `Target percentage for ${testStock.stock} with 2:1 split should be ${testStock.expectedTargetPercentage}%`,
@@ -142,13 +176,15 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
     () => {
       const testStock = mockStocks[4]; // NASDAQ:AAPL
 
-      // When there's a split, both target and buy price are adjusted by the same factor
-      // So the target percentage remains the same: (150 - 50) / 50 * 100 = 200%
-      const targetPercentage =
-        ((testStock.target - testStock.buyPrice) / testStock.buyPrice) * 100;
+      // Split-adjusted on both sides, so the shipped helper returns 200%:
+      // (150 - 50) / 50 * 100.
+      const targetPercentage = GRQProjection.calculateTargetPercentage(
+        testStock.buyPrice,
+        testStock.target,
+      );
 
       assertAlmostEquals(
-        targetPercentage,
+        targetPercentage as number,
         testStock.expectedTargetPercentage,
         0.1,
         `Target percentage for ${testStock.stock} with 3:1 split should be ${testStock.expectedTargetPercentage}%`,
@@ -157,15 +193,18 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
   );
 
   await t.step("portfolio target percentage calculation", () => {
-    // Calculate individual target percentages (split-adjusted prices are already provided)
-    const targetPercentages = mockStocks.map((stock) => {
-      return ((stock.target - stock.buyPrice) / stock.buyPrice) * 100;
-    });
+    // Drive each stock through the shipped helper, then average.
+    const targetPercentages = mockStocks.map((stock) =>
+      GRQProjection.calculateTargetPercentage(
+        stock.buyPrice,
+        stock.target,
+      ) as number
+    );
 
     // Calculate portfolio target (average of individual targets)
     const portfolioTarget = targetPercentages.reduce((sum, target) =>
       sum + target, 0) / targetPercentages.length;
-    const expectedPortfolioTarget = 72.0; // Average of all target percentages
+    const expectedPortfolioTarget = 72.0; // Average of all spec target percentages
 
     assertAlmostEquals(
       portfolioTarget,
@@ -177,22 +216,31 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
 
   await t.step("split adjustment calculation", () => {
     const testStock = mockStocks[3]; // NASDAQ:TSLA with 2:1 split
+    const marketData = createMockMarketData(testStock);
 
-    // Test split adjustment logic
-    const originalPrice = testStock.originalBuyPrice;
-    const splitAdjustment = testStock.splitAdjustment;
-    const adjustedPrice = originalPrice / splitAdjustment;
-
-    assertEquals(
-      adjustedPrice,
-      testStock.buyPrice,
-      "Split-adjusted price should match expected buy price",
+    // The shipped helper walks the market data and multiplies post-score splits.
+    const splitAdjustment = GRQProjection.getSplitAdjustment(
+      marketData,
+      scoreDate,
     );
-
     assertEquals(
       splitAdjustment,
       2.0,
       "Split adjustment should be 2.0 for 2:1 split",
+    );
+
+    // Restating the original price in current terms should yield the
+    // split-adjusted buy price.
+    const adjustedPrice = GRQProjection.adjustHistoricalPriceToCurrent(
+      testStock.originalBuyPrice,
+      marketData,
+      scoreDate,
+    );
+    assertAlmostEquals(
+      adjustedPrice,
+      testStock.buyPrice,
+      0.001,
+      "Split-adjusted price should match expected buy price",
     );
   });
 
@@ -200,77 +248,70 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
     const testStock = mockStocks[3]; // NASDAQ:TSLA
     const marketData = createMockMarketData(testStock);
 
-    // Find split data
-    const splitData = marketData.find((point) => point.splitCoefficient > 1.0);
-    assertExists(splitData, "Split data should exist for stocks with splits");
-    if (splitData) {
-      assertEquals(
-        splitData.splitCoefficient,
-        testStock.splitAdjustment,
-        "Split coefficient should match expected split adjustment",
-      );
-    }
+    // The shipped split helper should recover the fixture's split factor.
+    const splitAdjustment = GRQProjection.getSplitAdjustment(
+      marketData,
+      scoreDate,
+    );
+    assertEquals(
+      splitAdjustment,
+      testStock.splitAdjustment,
+      "Cumulative split adjustment should match expected split adjustment",
+    );
+
+    // No splits before the score date.
+    assertEquals(
+      GRQProjection.getSplitAdjustment(marketData, ninetyDayDate),
+      1.0,
+      "No splits should be counted after the latest split date",
+    );
   });
 
   await t.step("target percentage edge cases", () => {
-    // Test case where buy price equals target (0% target)
-    const zeroTargetStock = {
-      stock: "TEST:ZERO",
-      target: 100.00,
-      buyPrice: 100.00,
-      originalBuyPrice: 100.00,
-      splitAdjustment: 1.0,
-      expectedTargetPercentage: 0.0,
-    };
-
-    const zeroTargetPercentage =
-      ((zeroTargetStock.target - zeroTargetStock.buyPrice) /
-        zeroTargetStock.buyPrice) * 100;
+    // Buy price equals target -> 0%.
+    const zeroTargetPercentage = GRQProjection.calculateTargetPercentage(
+      100.00,
+      100.00,
+    );
     assertEquals(
       zeroTargetPercentage,
-      zeroTargetStock.expectedTargetPercentage,
+      0.0,
       "Target percentage should be 0% when buy price equals target",
     );
 
-    // Test case where target is lower than buy price (negative target)
-    const negativeTargetStock = {
-      stock: "TEST:NEG",
-      target: 80.00,
-      buyPrice: 100.00,
-      originalBuyPrice: 100.00,
-      splitAdjustment: 1.0,
-      expectedTargetPercentage: -20.0,
-    };
-
-    const negativeTargetPercentage =
-      ((negativeTargetStock.target - negativeTargetStock.buyPrice) /
-        negativeTargetStock.buyPrice) * 100;
+    // Target lower than buy price -> negative.
+    const negativeTargetPercentage = GRQProjection.calculateTargetPercentage(
+      100.00,
+      80.00,
+    );
     assertEquals(
       negativeTargetPercentage,
-      negativeTargetStock.expectedTargetPercentage,
+      -20.0,
       "Target percentage should be negative when target is lower than buy price",
+    );
+
+    // Missing inputs are guarded and return null.
+    assertEquals(
+      GRQProjection.calculateTargetPercentage(null, 100.00),
+      null,
+      "Target percentage should be null when buy price is missing",
     );
   });
 
   await t.step("multiple splits handling", () => {
-    // Test stock with multiple splits
-    const multiSplitStock = {
-      stock: "TEST:MULTI",
-      target: 300.00, // Already split-adjusted
-      buyPrice: 50.00, // Already split-adjusted (after 2:1 and 3:1 splits = 6:1 total)
-      originalBuyPrice: 300.00, // Original price before splits
-      splitAdjustment: 6.0, // 2:1 * 3:1 = 6:1 total
-      expectedTargetPercentage: 500.0, // (300.00 - 50.00) / 50.00 * 100
-    };
+    // Stock with multiple splits, already split-adjusted on both sides.
+    const target = 300.00;
+    const buyPrice = 50.00; // After 2:1 and 3:1 splits = 6:1 total
+    const expectedTargetPercentage = 500.0; // (300 - 50) / 50 * 100
 
-    // Both target and buy price are already split-adjusted, so calculate directly
-    const targetPercentage =
-      ((multiSplitStock.target - multiSplitStock.buyPrice) /
-        multiSplitStock.buyPrice) * 100;
+    const targetPercentage = GRQProjection.calculateTargetPercentage(
+      buyPrice,
+      target,
+    );
 
     assertAlmostEquals(
-      targetPercentage,
-      multiSplitStock.expectedTargetPercentage,
+      targetPercentage as number,
+      expectedTargetPercentage,
       0.1,
       "Target percentage should handle multiple splits correctly",
     );


### PR DESCRIPTION
# PR Summary — Issue #109

## Summary

`tests/target_percentage_tests.ts` and `tests/portfolio_target_tests.ts`
imported nothing from the shipped code. Each test recomputed the
target-percentage / split-adjustment / portfolio-return formula **inline** and
asserted the result against a hand-evaluation of the same arithmetic — and
`portfolio_target_tests.ts` even asserted the literal `20.0` against itself.
These were tautologies: they exercised zero production code, so a genuine
regression in the real maths left every assertion green.

This PR rewrites both suites as WHAT-tests (resolution (a) from the issue): they
now `import "../docs/projection.js"` and drive the shipped helpers
(`calculateTargetPercentage`, `getSplitAdjustment`,
`adjustHistoricalPriceToCurrent`, `calculatePerformanceReturn`) with the fixture
inputs, asserting on the helpers' **return values** against spec-derived expected
numbers. The inline formula recomputation and the literal-versus-itself check are
gone. `portfolio_target_tests.ts` fixtures were corrected so each stock models a
genuine ~20% target spread (`buyPrice` below `target`) instead of the previous
`buyPrice == target`, which produced a 0% target the tautological test masked.

Closes #109.

## Evidence

This is a test-only change (TypeScript) with no web interface, so no screenshot
applies. The fix is verified by behaviour:

- Full Deno suite green: `233 passed (57 steps) | 0 failed`.
- **Regression check** — temporarily breaking `calculateTargetPercentage` in
  `docs/projection.js` (returning `* 90` instead of `* 100`) now turns **7 steps
  red** across both files; the unmodified production code keeps them green. The
  former tests stayed green under the same break.

```mermaid
flowchart LR
    F[Fixture inputs] --> P["docs/projection.js<br/>shipped helper"]
    P --> R[Return value]
    R --> A{assert ≈ spec expected}
    S[Spec-derived expected] --> A
```

Before: the test computed the formula itself and compared against its own
hand-evaluation — production code (`P`) was never on the path.

## Test Plan

- `tests/target_percentage_tests.ts` — rewrote every arithmetic step to call
  `GRQProjection.calculateTargetPercentage`, plus `getSplitAdjustment` /
  `adjustHistoricalPriceToCurrent` for the split-adjustment steps; added a
  null-guard edge case.
- `tests/portfolio_target_tests.ts` — replaced the `20.0 ≈ 20.0` literal check
  and the inline portfolio-return recomputation with calls to
  `calculateTargetPercentage` and `calculatePerformanceReturn`; corrected
  fixtures to a real 20% target spread.
- Verified with `deno test --allow-read tests/*.ts` and the full `./quality.sh`.



## Milestone
This PR is part of the **security-scan** milestone and targets the `milestone/security-scan` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqaj8lid-83534e`<!-- vibe-worker-issue-109 -->