### PR TITLE
Add crate-root lint posture to library crate (Issue #116)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"

--- a/docs/archive/pr-summaries/pr-summary-116.md
+++ b/docs/archive/pr-summaries/pr-summary-116.md
@@ -1,0 +1,67 @@
+# Add a crate-root lint posture to the library crate
+
+## Summary
+
+The library crate root (`src/lib.rs`) previously declared only
+`#![warn(missing_docs)]` (added in #97) and no other lint posture. This PR
+adds explicit per-lint denies at the crate root so hygiene is enforced at
+compile time rather than discovered later. Closes #116.
+
+Changes to `src/lib.rs`:
+
+```diff
+ #![warn(missing_docs)]
++#![deny(unsafe_code)]
++#![deny(unsafe_op_in_unsafe_fn)]
+```
+
+- `deny(unsafe_code)` — the crate is pure safe Rust (no `unsafe` blocks or
+  functions), so denying unsafe at the root makes any future `unsafe` an
+  explicit, reviewed decision.
+- `deny(unsafe_op_in_unsafe_fn)` — future-proofs the crate so unsafe
+  operations inside any future `unsafe fn` require their own `unsafe` block.
+
+### Why not `#![deny(warnings)]` in source?
+
+The issue notes `#![deny(warnings)]` is often too strict for day-to-day
+builds and suggests scoping it to CI. The repo already does exactly this:
+`quality.sh` runs `cargo clippy --all-targets --all-features -- -D warnings`,
+so warnings already fail CI. Hard-coding `#![deny(warnings)]` into the source
+would break local builds on compiler upgrades, so it is deliberately left to
+CI.
+
+## Evidence
+
+Backend/library-only change — no web interface to screenshot.
+
+- `cargo clippy --lib --all-features -- -D warnings` passes with the new
+  posture (no warnings surfaced).
+- Full `./quality.sh` passes: `cargo fmt --check`, clippy (`-D warnings`),
+  `cargo check`, `cargo test` (Rust), and the Deno test/lint/check suite —
+  `233 passed | 0 failed`.
+
+```mermaid
+flowchart LR
+    A["src/lib.rs<br/>crate root"] -->|warn| B[missing_docs]
+    A -->|deny| C[unsafe_code]
+    A -->|deny| D[unsafe_op_in_unsafe_fn]
+    E["quality.sh CI<br/>clippy -D warnings"] -->|enforces| F[deny warnings]
+```
+
+## Test Plan
+
+Added `tests/crate_lint_posture_test.rs` (TDD — written before the source
+change; the two new assertions failed first, then passed after editing
+`src/lib.rs`):
+
+- `crate_root_warns_on_missing_docs` — guards the existing `missing_docs`
+  warning against removal.
+- `crate_root_denies_unsafe_code` — asserts the new `deny(unsafe_code)`.
+- `crate_root_denies_unsafe_op_in_unsafe_fn` — asserts the new
+  `deny(unsafe_op_in_unsafe_fn)`.
+
+A lint posture is compile-time configuration with no runtime surface, so the
+tests assert on the committed crate root — mirroring the existing
+`license_metadata_test.rs`, which verifies the committed LICENSE against the
+manifest. They fail loudly if the posture is later removed or weakened, which
+is the regression the issue describes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![warn(missing_docs)]
+#![deny(unsafe_code)]
+#![deny(unsafe_op_in_unsafe_fn)]
 //! Processes daily stock-score TSV files and computes portfolio performance.
 //!
 //! The crate exposes two modules:

--- a/tests/crate_lint_posture_test.rs
+++ b/tests/crate_lint_posture_test.rs
@@ -1,0 +1,49 @@
+//! Tests that the library crate root declares an explicit lint posture
+//! (Issue #116).
+//!
+//! A lint posture is a compile-time configuration, not a runtime function, so
+//! — like `license_metadata_test.rs`, which verifies the committed LICENSE
+//! against the manifest — these tests assert on the committed crate root
+//! (`src/lib.rs`). The whole point of the issue is that without an explicit,
+//! committed posture, hygiene lints accumulate or get dropped silently; these
+//! tests fail loudly if the posture is removed or weakened.
+//!
+//! The complementary half of the posture — `deny(warnings)` — is enforced in
+//! CI by `quality.sh` (`cargo clippy ... -D warnings`) rather than hard-coded
+//! into the source, which would break day-to-day builds on compiler upgrades.
+
+use std::fs;
+
+/// Read the inner attributes (`#![...]`) declared at the top of the crate root.
+fn crate_root_attributes() -> String {
+    fs::read_to_string("src/lib.rs").expect("src/lib.rs must exist")
+}
+
+#[test]
+fn crate_root_warns_on_missing_docs() {
+    let src = crate_root_attributes();
+    assert!(
+        src.contains("#![warn(missing_docs)]"),
+        "src/lib.rs must keep `#![warn(missing_docs)]` so the public API stays documented"
+    );
+}
+
+#[test]
+fn crate_root_denies_unsafe_code() {
+    let src = crate_root_attributes();
+    assert!(
+        src.contains("#![deny(unsafe_code)]"),
+        "src/lib.rs must declare `#![deny(unsafe_code)]`: this crate is pure safe \
+         Rust, so any future `unsafe` must be an explicit, reviewed decision"
+    );
+}
+
+#[test]
+fn crate_root_denies_unsafe_op_in_unsafe_fn() {
+    let src = crate_root_attributes();
+    assert!(
+        src.contains("#![deny(unsafe_op_in_unsafe_fn)]"),
+        "src/lib.rs must declare `#![deny(unsafe_op_in_unsafe_fn)]` so unsafe \
+         operations inside any future unsafe fn require their own unsafe block"
+    );
+}


### PR DESCRIPTION
# Add a crate-root lint posture to the library crate

## Summary

The library crate root (`src/lib.rs`) previously declared only
`#![warn(missing_docs)]` (added in #97) and no other lint posture. This PR
adds explicit per-lint denies at the crate root so hygiene is enforced at
compile time rather than discovered later. Closes #116.

Changes to `src/lib.rs`:

```diff
 #![warn(missing_docs)]
+#![deny(unsafe_code)]
+#![deny(unsafe_op_in_unsafe_fn)]
```

- `deny(unsafe_code)` — the crate is pure safe Rust (no `unsafe` blocks or
  functions), so denying unsafe at the root makes any future `unsafe` an
  explicit, reviewed decision.
- `deny(unsafe_op_in_unsafe_fn)` — future-proofs the crate so unsafe
  operations inside any future `unsafe fn` require their own `unsafe` block.

### Why not `#![deny(warnings)]` in source?

The issue notes `#![deny(warnings)]` is often too strict for day-to-day
builds and suggests scoping it to CI. The repo already does exactly this:
`quality.sh` runs `cargo clippy --all-targets --all-features -- -D warnings`,
so warnings already fail CI. Hard-coding `#![deny(warnings)]` into the source
would break local builds on compiler upgrades, so it is deliberately left to
CI.

## Evidence

Backend/library-only change — no web interface to screenshot.

- `cargo clippy --lib --all-features -- -D warnings` passes with the new
  posture (no warnings surfaced).
- Full `./quality.sh` passes: `cargo fmt --check`, clippy (`-D warnings`),
  `cargo check`, `cargo test` (Rust), and the Deno test/lint/check suite —
  `233 passed | 0 failed`.

```mermaid
flowchart LR
    A["src/lib.rs<br/>crate root"] -->|warn| B[missing_docs]
    A -->|deny| C[unsafe_code]
    A -->|deny| D[unsafe_op_in_unsafe_fn]
    E["quality.sh CI<br/>clippy -D warnings"] -->|enforces| F[deny warnings]
```

## Test Plan

Added `tests/crate_lint_posture_test.rs` (TDD — written before the source
change; the two new assertions failed first, then passed after editing
`src/lib.rs`):

- `crate_root_warns_on_missing_docs` — guards the existing `missing_docs`
  warning against removal.
- `crate_root_denies_unsafe_code` — asserts the new `deny(unsafe_code)`.
- `crate_root_denies_unsafe_op_in_unsafe_fn` — asserts the new
  `deny(unsafe_op_in_unsafe_fn)`.

A lint posture is compile-time configuration with no runtime surface, so the
tests assert on the committed crate root — mirroring the existing
`license_metadata_test.rs`, which verifies the committed LICENSE against the
manifest. They fail loudly if the posture is later removed or weakened, which
is the regression the issue describes.



## Milestone
This PR is part of the **security-scan** milestone and targets the `milestone/security-scan` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqaj8lid-83534e`<!-- vibe-worker-issue-116 -->