### PR TITLE
Replace tautological judgement/annualised tests with WHAT-tests (#121)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-121.md
+++ b/docs/archive/pr-summaries/pr-summary-121.md
@@ -1,0 +1,83 @@
+# Replace tautological judgement / annualised tests with WHAT-tests
+
+## Summary
+
+`tests/judgement_tests.ts` and `tests/annualized_performance_test.ts` imported
+nothing from the shipped dashboard code (only `@std/assert`). Each reimplemented
+production logic as a local copy and then asserted on that copy — tautologies
+that stayed green even if the real code drifted, and in the judgement case the
+local copy asserted on a string mapping (`EXCEEDED`/`MET`/`BELOW`,
+`ABOVE`/`AT`/`BELOW`) that the shipped code never produces.
+
+This change resolves the third tautology cluster called out in the issue
+(distinct from #102 and #109), using the issue's two sanctioned resolutions:
+
+- **`tests/judgement_tests.ts`** — rewritten (option a) to drive the REAL
+  exported `GRQProjection.computeJudgement` (`docs/projection.js`) and assert on
+  the shipped judgement strings (`Hit Target`, `Partial Success`,
+  `Missed Target`, `Early Days`, `Pending`). A regression in the production
+  mapping at `docs/projection.js:385` now fails. The fictional cost-of-capital
+  `ABOVE/AT/BELOW` cases and the local `Date`-arithmetic "boundary" steps were
+  deleted (option b): no shipped code produced those strings, and the real
+  cost-of-capital figure is an excess-return *number*, not a string bucket.
+
+- **`tests/annualized_performance_test.ts`** — the recompute-only "Compound
+  Interest" guard (covered in production by Rust `calculate_annualized_performance`,
+  WHAT-tested in `src/utils.rs`) and the local `calculateHybridProjection` copy
+  (covered by `GRQProjection.computeHybridProjection` via
+  `tests/projection_kernels_test.ts`) were deleted (option b). The index.json
+  averaging case was the only genuinely uncovered production logic, so it is now
+  a WHAT-test (option a): the averaging maths was extracted from
+  `docs/list.js::updateSummaryStats` into a pure, shipped helper
+  `GRQListStats.computeListAverages` (`docs/list_stats.js`) that the list page
+  delegates to and the test drives directly.
+
+These removed tests were tautological by design and verified no shipped
+behaviour; their real-module equivalents either already exist or were added
+here, so no genuine coverage is lost.
+
+Closes #121.
+
+## Change shape
+
+```mermaid
+flowchart LR
+    subgraph Before
+        T1[judgement_tests.ts] -->|asserts on| L1[local EXCEEDED/MET copy]
+        T2[annualized_performance_test.ts] -->|asserts on| L2[inline formula + averaging + hybrid copy]
+    end
+    subgraph After
+        T3[judgement_tests.ts] -->|drives| P1[GRQProjection.computeJudgement]
+        T4[annualized_performance_test.ts] -->|drives| P2[GRQListStats.computeListAverages]
+        LJS[docs/list.js updateSummaryStats] -->|delegates to| P2
+    end
+```
+
+## Evidence
+
+Backend/JS-logic change — no rendered UI change (the list page's summary cards
+display the same figures; the averaging maths is unchanged, only relocated to a
+shared kernel). Playwright MCP was unavailable in this environment, so
+verification was via the test suite:
+
+- `deno test --allow-read tests/*.ts` → **234 passed, 0 failed**.
+- The new `computeListAverages` tests assert spec-derived expected values
+  (`avg90Day = 23.705`, `avgAnnualized = 68.5475`, counts `2`/`4`/`2`) against
+  the **shipped** kernel, so a regression in the averaging path now fails.
+- `docs/list.js::updateSummaryStats` was refactored to call the extracted
+  kernel; the accumulation logic is byte-for-byte the same loop, and
+  `visibleData.toArray()` yields the same row objects the previous
+  `visibleData.each(...)` iterated — behaviour-preserving.
+- `deno fmt`, `deno lint`, `deno check` all clean.
+
+## Test Plan
+
+- `tests/judgement_tests.ts` — `computeJudgement` realised-outcome mapping
+  (Hit Target / Partial Success / Missed Target at day 90), Pending for null,
+  and early-stage reporting; all against the real `GRQProjection` helper.
+- `tests/annualized_performance_test.ts` — `computeListAverages` happy path
+  (mixed populated/null rows), negative/zero handling (positive-count edge
+  case), and the empty / all-null edge cases; all against the real
+  `GRQListStats` helper.
+- Existing `tests/projection_kernels_test.ts` continues to cover
+  `computeJudgement` and `computeHybridProjection` (no regression).

--- a/docs/list.html
+++ b/docs/list.html
@@ -237,6 +237,9 @@
     <!-- Score-file name render helper (issue #103) — must load before list.js -->
     <script src="list_render.js"></script>
 
+    <!-- Summary-statistics averaging kernel (issue #121) — must load before list.js -->
+    <script src="list_stats.js"></script>
+
     <!-- Load our main script -->
     <script src="list.js"></script>
   </body>

--- a/docs/list.js
+++ b/docs/list.js
@@ -265,33 +265,12 @@ class ScoreFilesList {
             }
             
             const visibleData = this.dataTable.rows({ search: 'applied' }).data();
-            let total90Day = 0;
-            let totalAnnualized = 0;
-            let positiveCount = 0;
-            let valid90DayCount = 0;
-            let validAnnualizedCount = 0;
-            
-            visibleData.each((row) => {
-                const performance90Day = row.performance_90_day;
-                const performanceAnnualized = row.performance_annualized;
-                
-                if (performance90Day !== null && performance90Day !== undefined) {
-                    total90Day += performance90Day;
-                    valid90DayCount++;
-                    
-                    if (performance90Day > 0) {
-                        positiveCount++;
-                    }
-                }
-                
-                if (performanceAnnualized !== null && performanceAnnualized !== undefined) {
-                    totalAnnualized += performanceAnnualized;
-                    validAnnualizedCount++;
-                }
-            });
-            
-            const avg90Day = valid90DayCount > 0 ? total90Day / valid90DayCount : 0;
-            const avgAnnualized = validAnnualizedCount > 0 ? totalAnnualized / validAnnualizedCount : 0;
+
+            // Delegate the averaging to the shared kernel (issue #121) so the
+            // browser and the Deno tests exercise the exact same maths.
+            const rows = visibleData.toArray();
+            const { avg90Day, avgAnnualized, valid90DayCount, positiveCount } =
+                globalThis.GRQListStats.computeListAverages(rows);
             const totalFiles = visibleData.count();
             
 

--- a/docs/list_stats.js
+++ b/docs/list_stats.js
@@ -1,0 +1,66 @@
+// Summary-statistics helper for the score-file list page (issue #121).
+//
+// The averaging maths that produces the list page's "average 90-day",
+// "average annualised" and "positive count" summary cards used to live only
+// inside `updateSummaryStats` in docs/list.js, fused with DataTables/DOM access
+// so no test could reach it. The Deno suite therefore reimplemented the
+// averaging loop inline and asserted on its own copy — a tautology that stayed
+// green even if list.js drifted.
+//
+// This extracts the pure accumulation/averaging kernel so BOTH the browser
+// list page (via `updateSummaryStats`) and the Deno tests exercise the exact
+// same code. Mirrors docs/list_render.js: loaded as a classic <script> in
+// docs/list.html (before list.js) and imported by the Deno tests, uses no
+// module syntax, and publishes its helper on `globalThis`.
+
+// Aggregate an array of index.json rows into the list page's summary figures.
+//
+// Each row is expected to carry numeric `performance_90_day` and
+// `performance_annualized` fields; null/undefined values are skipped so a
+// score file still awaiting its 90-day result does not drag the averages.
+// Returns the averages plus the counts the summary cards display. Pure and
+// deterministic.
+function computeListAverages(rows) {
+    let total90Day = 0;
+    let totalAnnualized = 0;
+    let positiveCount = 0;
+    let valid90DayCount = 0;
+    let validAnnualizedCount = 0;
+
+    const list = Array.isArray(rows) ? rows : [];
+    for (const row of list) {
+        const performance90Day = row ? row.performance_90_day : undefined;
+        const performanceAnnualized = row ? row.performance_annualized : undefined;
+
+        if (performance90Day !== null && performance90Day !== undefined) {
+            total90Day += performance90Day;
+            valid90DayCount++;
+
+            if (performance90Day > 0) {
+                positiveCount++;
+            }
+        }
+
+        if (
+            performanceAnnualized !== null && performanceAnnualized !== undefined
+        ) {
+            totalAnnualized += performanceAnnualized;
+            validAnnualizedCount++;
+        }
+    }
+
+    const avg90Day = valid90DayCount > 0 ? total90Day / valid90DayCount : 0;
+    const avgAnnualized = validAnnualizedCount > 0
+        ? totalAnnualized / validAnnualizedCount
+        : 0;
+
+    return {
+        avg90Day,
+        avgAnnualized,
+        valid90DayCount,
+        validAnnualizedCount,
+        positiveCount,
+    };
+}
+
+globalThis.GRQListStats = { computeListAverages };

--- a/tests/annualized_performance_test.ts
+++ b/tests/annualized_performance_test.ts
@@ -1,110 +1,52 @@
-// Test to verify annualized performance calculation uses compound interest
-// and not simple multiplication
-
-Deno.test("Annualized Performance Calculation - Compound Interest", () => {
-  // Test cases with known 90-day performances
-  const testCases = [
-    {
-      performance90Day: 6.07,
-      expectedAnnualized: 27.00,
-      description: "Positive performance",
-    },
-    {
-      performance90Day: -12.98,
-      expectedAnnualized: -43.09,
-      description: "Negative performance",
-    },
-    {
-      performance90Day: 0.48,
-      expectedAnnualized: 1.95,
-      description: "Small positive performance",
-    },
-    {
-      performance90Day: -6.52,
-      expectedAnnualized: -23.91,
-      description: "Small negative performance",
-    },
-  ];
-
-  testCases.forEach(({ performance90Day, expectedAnnualized, description }) => {
-    // Calculate using compound interest formula: (1 + r)^(365.25/90) - 1
-    const annualizedCompound =
-      ((1 + performance90Day / 100) ** (365.25 / 90) - 1) * 100;
-
-    // Calculate using simple multiplication (incorrect method)
-    const annualizedSimple = performance90Day * 4;
-
-    console.log(`${description}:`);
-    console.log(`  90-day performance: ${performance90Day}%`);
-    console.log(`  Compound interest: ${annualizedCompound.toFixed(2)}%`);
-    console.log(`  Simple multiplication: ${annualizedSimple.toFixed(2)}%`);
-    console.log(`  Expected: ${expectedAnnualized}%`);
-    console.log(
-      `  Difference: ${
-        Math.abs(annualizedCompound - expectedAnnualized).toFixed(2)
-      }%`,
-    );
-    console.log("");
-
-    // Verify compound interest calculation is close to expected
-    const tolerance = 0.5; // Allow 0.5% tolerance for rounding differences
-    const isCorrect =
-      Math.abs(annualizedCompound - expectedAnnualized) < tolerance;
-
-    if (!isCorrect) {
-      throw new Error(
-        `${description}: Compound interest calculation (${
-          annualizedCompound.toFixed(2)
-        }%) ` +
-          `does not match expected (${expectedAnnualized}%). ` +
-          `Simple multiplication would be ${annualizedSimple.toFixed(2)}%`,
-      );
-    }
-
-    // Verify that simple multiplication is significantly different (for larger values)
-    const simpleDifference = Math.abs(annualizedSimple - expectedAnnualized);
-    if (Math.abs(performance90Day) > 5 && simpleDifference < 2.0) {
-      throw new Error(
-        `${description}: Simple multiplication (${
-          annualizedSimple.toFixed(2)
-        }%) ` +
-          `is too close to expected (${expectedAnnualized}%). ` +
-          `This suggests the calculation might be using simple multiplication instead of compound interest.`,
-      );
-    }
-  });
-});
-
-// NOTE (issue #104): a block of recompute-only tests previously sat here.
-// They redefined the annualisation formula as local arrow functions
-// (`calculateAnnualized`, `calculateAnnualizedWithActualDays`,
-// `calculateAnnualizedWithFixed90Days`) and asserted on their own output, so
-// they could never catch a regression in the production annualisation path.
-// Because the dashboard does not annualise in JS — it reads the Rust-computed
-// `performance_annualized` from index.json — there is no shipped JS helper for
-// these tests to drive. The formula's production home is Rust
-// (`calculate_annualized_performance`), now WHAT-tested by
-// `tests::test_annualized_performance_calculation_with_actual_days` in
-// src/utils.rs. Per issue #104 (option b) the following recompute-only cases
-// were deleted rather than kept as HOW-tests:
-//   - "Annualized Performance Formula Verification"
-//   - "Annualized Performance Edge Cases"
-//   - "Annualized Performance - Actual Days vs Fixed 90 Days"
-//   - "Annualized Performance - Market Data Days vs Calendar Days"
-//   - "Annualized Performance - Early Stage Scenarios"
-//   - "Annualized Performance - Edge Cases and Error Handling"
-//   - "Annualized Performance - Zero Bug Investigation"
+// Behavioural tests for the score-file list page's summary-statistics kernel.
 //
-// The tests retained below cover distinct concerns: the compound-vs-simple
-// guard above is cross-checked against the documented real-data table in
-// docs/fixes/ANNUALIZED_PERFORMANCE_CALCULATION.md; the two tests that follow cover
-// index.json averaging (mirrors docs/list.js) and the hybrid-projection
-// dampening algorithm respectively.
+// History (issue #121): this file used to assert on inline reimplementations of
+// production maths — it hand-coded the annualisation formula
+// `(1 + r)^(365.25/90) - 1`, reimplemented the index.json averaging loop, and
+// defined a local `calculateHybridProjection` — then asserted each copy against
+// numbers derived from the same copy. Those were tautologies: no shipped code
+// ran, so a regression in the real annualisation, averaging or hybrid-projection
+// path left every assertion green.
+//
+// Those cases have been resolved against the real modules:
+//   - The annualisation formula's production home is Rust
+//     (`calculate_annualized_performance`), WHAT-tested by
+//     `tests::test_annualized_performance_calculation_with_actual_days` in
+//     src/utils.rs. The recompute-only "Compound Interest" guard was deleted
+//     (issue #121, option b) rather than kept as a self-referential check.
+//   - The hybrid-projection algorithm's production home is
+//     `GRQProjection.computeHybridProjection` in docs/projection.js, driven by
+//     `tests/projection_kernels_test.ts`. The local `calculateHybridProjection`
+//     copy was deleted (issue #121, option b).
+//   - The index.json averaging now lives in the shipped, pure
+//     `GRQListStats.computeListAverages` (docs/list_stats.js), which
+//     docs/list.js delegates to. The test below drives that real kernel.
+import { assertEquals } from "@std/assert";
+import "../docs/list_stats.js";
 
-// TEST FOR AVERAGE ANNUALIZED PERFORMANCE CALCULATION
-Deno.test("Average Annualized Performance Calculation", () => {
-  // Simulate the data structure from index.json
-  const mockData = [
+interface IndexRow {
+  date?: string;
+  performance_90_day: number | null;
+  performance_annualized: number | null;
+}
+
+const g = globalThis as unknown as {
+  GRQListStats: {
+    computeListAverages: (rows: IndexRow[]) => {
+      avg90Day: number;
+      avgAnnualized: number;
+      valid90DayCount: number;
+      validAnnualizedCount: number;
+      positiveCount: number;
+    };
+  };
+};
+const GRQListStats = g.GRQListStats;
+
+Deno.test("computeListAverages averages only the populated fields", () => {
+  // Two settled score files plus two still awaiting their 90-day result
+  // (90-day null, annualised reported as a hybrid projection of 0.0).
+  const rows: IndexRow[] = [
     {
       date: "2025-04-15",
       performance_90_day: 23.77,
@@ -117,223 +59,62 @@ Deno.test("Average Annualized Performance Calculation", () => {
     },
     {
       date: "2025-07-22",
-      performance_90_day: null, // No 90-day performance yet
-      performance_annualized: 0.0, // Hybrid projection
+      performance_90_day: null,
+      performance_annualized: 0.0,
     },
     {
       date: "2025-07-23",
-      performance_90_day: null, // No 90-day performance yet
-      performance_annualized: 0.0, // Hybrid projection
+      performance_90_day: null,
+      performance_annualized: 0.0,
     },
   ];
 
-  // Simulate the fixed calculation logic
-  let total90Day = 0;
-  let totalAnnualized = 0;
-  let valid90DayCount = 0;
-  let validAnnualizedCount = 0;
-  let positiveCount = 0;
+  const result = GRQListStats.computeListAverages(rows);
 
-  mockData.forEach((row) => {
-    const performance90Day = row.performance_90_day;
-    const performanceAnnualized = row.performance_annualized;
-
-    if (performance90Day !== null && performance90Day !== undefined) {
-      total90Day += performance90Day;
-      valid90DayCount++;
-
-      if (performance90Day > 0) {
-        positiveCount++;
-      }
-    }
-
-    if (performanceAnnualized !== null && performanceAnnualized !== undefined) {
-      totalAnnualized += performanceAnnualized;
-      validAnnualizedCount++;
-    }
-  });
-
-  const avg90Day = valid90DayCount > 0 ? total90Day / valid90DayCount : 0;
-  const avgAnnualized = validAnnualizedCount > 0
-    ? totalAnnualized / validAnnualizedCount
-    : 0;
-
-  console.log("Test Results:");
-  console.log(`Total 90-day: ${total90Day}`);
-  console.log(`Total annualized: ${totalAnnualized}`);
-  console.log(`Valid 90-day count: ${valid90DayCount}`);
-  console.log(`Valid annualized count: ${validAnnualizedCount}`);
-  console.log(`Average 90-day: ${avg90Day.toFixed(2)}%`);
-  console.log(`Average annualized: ${avgAnnualized.toFixed(2)}%`);
-  console.log(`Positive count: ${positiveCount}`);
-
-  // Verify the calculations are correct
-  const expectedAvg90Day = (23.77 + 23.64) / 2; // Only the 2 valid entries
-  const expectedAvgAnnualized = (137.62 + 136.57 + 0.0 + 0.0) / 4; // All 4 entries
-
-  console.log(`Expected avg 90-day: ${expectedAvg90Day.toFixed(2)}%`);
-  console.log(`Expected avg annualized: ${expectedAvgAnnualized.toFixed(2)}%`);
-
-  // Assertions
-  if (Math.abs(avg90Day - expectedAvg90Day) > 0.01) {
-    throw new Error(
-      `Average 90-day calculation wrong: expected ${
-        expectedAvg90Day.toFixed(2)
-      }%, got ${avg90Day.toFixed(2)}%`,
-    );
-  }
-
-  if (Math.abs(avgAnnualized - expectedAvgAnnualized) > 0.01) {
-    throw new Error(
-      `Average annualized calculation wrong: expected ${
-        expectedAvgAnnualized.toFixed(2)
-      }%, got ${avgAnnualized.toFixed(2)}%`,
-    );
-  }
-
-  if (valid90DayCount !== 2) {
-    throw new Error(
-      `Should have 2 valid 90-day entries, got ${valid90DayCount}`,
-    );
-  }
-
-  if (validAnnualizedCount !== 4) {
-    throw new Error(
-      `Should have 4 valid annualized entries, got ${validAnnualizedCount}`,
-    );
-  }
-
-  if (positiveCount !== 2) {
-    throw new Error(
-      `Should have 2 positive 90-day entries, got ${positiveCount}`,
-    );
-  }
-
-  console.log("✅ Average annualized performance calculation test passed");
+  // 90-day average excludes the two null entries: (23.77 + 23.64) / 2.
+  assertEquals(result.avg90Day, 23.705);
+  assertEquals(result.valid90DayCount, 2);
+  // Annualised average spans all four entries: (137.62 + 136.57 + 0 + 0) / 4.
+  assertEquals(result.avgAnnualized, 68.5475);
+  assertEquals(result.validAnnualizedCount, 4);
+  // Both populated 90-day figures are positive.
+  assertEquals(result.positiveCount, 2);
 });
 
-// TEST FOR HYBRID PROJECTION FIX
-Deno.test("Hybrid Projection - Realistic Annualized Performance", () => {
-  // Test the fix for unrealistic annualized performance in hybrid projections
-  // This simulates the scenario where a small gain over a few days was giving 119,592.89% annualized
-
-  const calculateHybridProjection = (
-    gainLossPercent: number,
-    marketDaysElapsed: number,
-  ): { projected90Day: number; annualized: number } => {
-    // Simulate the new hybrid projection logic
-    if (marketDaysElapsed <= 0) {
-      return { projected90Day: 0, annualized: 0 };
-    }
-
-    // Calculate daily rate
-    const dailyRate = gainLossPercent / marketDaysElapsed;
-
-    // Apply dampening based on market data days elapsed
-    let dampeningFactor = 0.1; // Very early days: dampen by 90%
-    if (marketDaysElapsed >= 7) dampeningFactor = 0.2; // Early days: dampen by 80%
-    if (marketDaysElapsed >= 14) dampeningFactor = 0.3; // Early days: dampen by 70%
-    if (marketDaysElapsed >= 30) dampeningFactor = 0.5; // Medium term: dampen by 50%
-    if (marketDaysElapsed >= 60) dampeningFactor = 0.7; // Later days: dampen by 30%
-
-    // Calculate raw projection
-    const rawProjection = dailyRate * 90.0;
-    let projected90Day = rawProjection * dampeningFactor;
-
-    // Apply realistic bounds based on market data days elapsed
-    let maxGain = 10.0; // Very early: max 10% gain
-    let maxLoss = -5.0; // Very early: max 5% loss
-    if (marketDaysElapsed >= 7) {
-      maxGain = 20.0;
-      maxLoss = -10.0;
-    }
-    if (marketDaysElapsed >= 14) {
-      maxGain = 40.0;
-      maxLoss = -20.0;
-    }
-    if (marketDaysElapsed >= 30) {
-      maxGain = 80.0;
-      maxLoss = -40.0;
-    }
-    if (marketDaysElapsed >= 60) {
-      maxGain = 150.0;
-      maxLoss = -80.0;
-    }
-
-    projected90Day = Math.max(maxLoss, Math.min(maxGain, projected90Day));
-
-    // Use quarterly compounding for annualized performance
-    const annualized = ((1 + projected90Day / 100) ** 4 - 1) * 100;
-
-    return { projected90Day, annualized };
-  };
-
-  // Test the problematic scenario: 1.96% gain in 3 days
-  const testCase = calculateHybridProjection(1.96, 3);
-  console.log("Test Case: 1.96% gain in 3 days");
-  console.log(`Projected 90-day: ${testCase.projected90Day.toFixed(2)}%`);
-  console.log(`Annualized: ${testCase.annualized.toFixed(2)}%`);
-
-  // Verify the results are realistic
-  if (testCase.annualized > 1000) {
-    throw new Error(
-      `Annualized performance should be realistic, got ${
-        testCase.annualized.toFixed(2)
-      }%`,
-    );
-  }
-
-  if (testCase.projected90Day > 50) {
-    throw new Error(
-      `90-day projection should be realistic, got ${
-        testCase.projected90Day.toFixed(2)
-      }%`,
-    );
-  }
-
-  // Test different scenarios
-  const scenarios = [
-    { gain: 1.96, days: 3, description: "1.96% gain in 3 days" },
-    { gain: 5.0, days: 7, description: "5% gain in 1 week" },
-    { gain: 10.0, days: 14, description: "10% gain in 2 weeks" },
-    { gain: -2.0, days: 5, description: "2% loss in 5 days" },
-    { gain: 15.0, days: 30, description: "15% gain in 1 month" },
+Deno.test("computeListAverages counts negative 90-day figures as non-positive", () => {
+  const rows: IndexRow[] = [
+    { performance_90_day: 10, performance_annualized: 40 },
+    { performance_90_day: -5, performance_annualized: -20 },
+    { performance_90_day: 0, performance_annualized: 0 },
   ];
 
-  console.log("\n=== Hybrid Projection Test Results ===");
-  scenarios.forEach(({ gain, days, description }) => {
-    const result = calculateHybridProjection(gain, days);
-    console.log(
-      `${description}: ${gain}% over ${days} days → 90-day: ${
-        result.projected90Day.toFixed(2)
-      }%, Annualized: ${result.annualized.toFixed(2)}%`,
-    );
+  const result = GRQListStats.computeListAverages(rows);
 
-    // Verify results are realistic
-    if (result.annualized > 1000) {
-      throw new Error(
-        `${description}: Annualized performance too high: ${
-          result.annualized.toFixed(2)
-        }%`,
-      );
-    }
+  assertEquals(result.avg90Day, (10 - 5 + 0) / 3);
+  assertEquals(result.valid90DayCount, 3);
+  // Only the +10 entry is strictly positive; 0 and -5 are excluded.
+  assertEquals(result.positiveCount, 1);
+});
 
-    if (result.projected90Day > 200) {
-      throw new Error(
-        `${description}: 90-day projection too high: ${
-          result.projected90Day.toFixed(2)
-        }%`,
-      );
-    }
-
-    if (result.projected90Day < -100) {
-      throw new Error(
-        `${description}: 90-day projection too low: ${
-          result.projected90Day.toFixed(2)
-        }%`,
-      );
-    }
+Deno.test("computeListAverages returns zeroed averages for no populated rows", () => {
+  const empty = GRQListStats.computeListAverages([]);
+  assertEquals(empty, {
+    avg90Day: 0,
+    avgAnnualized: 0,
+    valid90DayCount: 0,
+    validAnnualizedCount: 0,
+    positiveCount: 0,
   });
 
-  console.log("✅ Hybrid projection fix test passed");
+  const allNull = GRQListStats.computeListAverages([
+    { performance_90_day: null, performance_annualized: null },
+    { performance_90_day: null, performance_annualized: null },
+  ]);
+  assertEquals(allNull, {
+    avg90Day: 0,
+    avgAnnualized: 0,
+    valid90DayCount: 0,
+    validAnnualizedCount: 0,
+    positiveCount: 0,
+  });
 });

--- a/tests/judgement_tests.ts
+++ b/tests/judgement_tests.ts
@@ -1,98 +1,102 @@
-import { assertEquals } from "@std/assert";
+// Behavioural tests for the dashboard's judgement kernel.
+//
+// History (issue #121): this file used to define local `calculateJudgement`
+// (returning "EXCEEDED"/"MET"/"BELOW") and `calculateProgressVsCostOfCapital`
+// (returning "ABOVE"/"AT"/"BELOW") functions and assert on those copies. No
+// such string mapping exists in the shipped code — the production
+// `GRQValidator.calculateJudgement` (docs/app.js) delegates to
+// `GRQProjection.computeJudgement` (docs/projection.js), which reports outcomes
+// such as "Hit Target", "Partial Success", "Missed Target" and "Early Days".
+// The old cases were therefore tautologies asserting on a fictional mapping;
+// the cost-of-capital "ABOVE/AT/BELOW" cases and the local Date-arithmetic
+// "boundary" steps likewise never touched shipped code.
+//
+// Per issue #121 (option a) the tests below drive the REAL exported
+// `GRQProjection.computeJudgement` and assert on the shipped judgement strings,
+// so a regression in the production string mapping (docs/projection.js:385)
+// actually fails. The fictional cost-of-capital mapping was deleted (option b):
+// the real cost-of-capital figure is the excess-return value computed by
+// `GRQValidator.calculateProgressVsCostOfCapitalValue`, not a string bucket.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
-// Test case for judgement calculations and logic
+interface Projection {
+  projected90DayPerformance: number;
+  projectionMethod: string;
+  confidence: number;
+}
 
-Deno.test("Judgement Tests", async (t) => {
-  const scoreDate = new Date(2024, 10, 15); // November 15, 2024
-  const ninetyDayDate = new Date(
-    scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+const g = globalThis as unknown as {
+  GRQProjection: {
+    computeJudgement: (inputs: {
+      performance: number | null;
+      daysElapsed: number;
+      targetPercentage: number | null;
+      projection: Projection | null;
+    }) => string;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+Deno.test("computeJudgement - realised outcome from day 90", async (t) => {
+  // At/after the 90-day boundary the kernel reports the realised outcome
+  // against 80% of target. Target 20% -> threshold 16%.
+  const realised = (performance: number) =>
+    GRQProjection.computeJudgement({
+      performance,
+      daysElapsed: 90,
+      targetPercentage: 20,
+      projection: null,
+    });
+
+  await t.step("at or above 80% of target hits the target", () => {
+    assertEquals(realised(25.0), "Hit Target"); // above target
+    assertEquals(realised(16.0), "Hit Target"); // exactly the 80% threshold
+  });
+
+  await t.step("positive but below threshold is a partial success", () => {
+    assertEquals(realised(10.0), "Partial Success");
+  });
+
+  await t.step("zero or negative misses the target", () => {
+    assertEquals(realised(0.0), "Missed Target");
+    assertEquals(realised(-5.0), "Missed Target");
+  });
+});
+
+Deno.test("computeJudgement - pending and early-stage reporting", async (t) => {
+  await t.step("null performance is pending", () => {
+    assertEquals(
+      GRQProjection.computeJudgement({
+        performance: null,
+        daysElapsed: 5,
+        targetPercentage: 20,
+        projection: null,
+      }),
+      "Pending",
+    );
+  });
+
+  await t.step(
+    "before day 30 without a confident projection is early days",
+    () => {
+      const up = GRQProjection.computeJudgement({
+        performance: 3.2,
+        daysElapsed: 10,
+        targetPercentage: 20,
+        projection: null,
+      });
+      assert(up.startsWith("Early Days"));
+      assert(up.includes("+3.2%"));
+
+      const down = GRQProjection.computeJudgement({
+        performance: -2.5,
+        daysElapsed: 10,
+        targetPercentage: 20,
+        projection: null,
+      });
+      assert(down.startsWith("Early Days"));
+      assert(down.includes("-2.5%"));
+    },
   );
-
-  function calculateJudgement(performance: number, target: number): string {
-    if (performance >= target) {
-      return performance > target ? "EXCEEDED" : "MET";
-    } else {
-      return "BELOW";
-    }
-  }
-
-  function calculateProgressVsCostOfCapital(
-    performance: number,
-    costOfCapital: number,
-  ): string {
-    if (performance > costOfCapital) {
-      return "ABOVE";
-    } else if (performance === costOfCapital) {
-      return "AT";
-    } else {
-      return "BELOW";
-    }
-  }
-
-  await t.step("judgement calculation", () => {
-    // Test judgement calculation based on performance vs target
-    const testCases = [
-      { performance: 25.0, target: 20.0, expected: "EXCEEDED" },
-      { performance: 20.0, target: 20.0, expected: "MET" },
-      { performance: 15.0, target: 20.0, expected: "BELOW" },
-      { performance: 10.0, target: 20.0, expected: "BELOW" },
-      { performance: -5.0, target: 20.0, expected: "BELOW" },
-    ];
-
-    testCases.forEach((testCase, index) => {
-      const judgement = calculateJudgement(
-        testCase.performance,
-        testCase.target,
-      );
-      assertEquals(
-        judgement,
-        testCase.expected,
-        `Test ${index + 1}: Judgement should be ${testCase.expected}`,
-      );
-    });
-  });
-
-  await t.step("cost of capital comparison", () => {
-    // Test progress vs cost of capital calculation
-    const costOfCapital = 10.0; // 10% cost of capital
-    const testCases = [
-      { performance: 15.0, expected: "ABOVE" },
-      { performance: 10.0, expected: "AT" },
-      { performance: 5.0, expected: "BELOW" },
-      { performance: -5.0, expected: "BELOW" },
-    ];
-
-    testCases.forEach((testCase, index) => {
-      const progress = calculateProgressVsCostOfCapital(
-        testCase.performance,
-        costOfCapital,
-      );
-      assertEquals(
-        progress,
-        testCase.expected,
-        `Test ${index + 1}: Progress should be ${testCase.expected}`,
-      );
-    });
-  });
-
-  await t.step("date boundary logic", () => {
-    // Test that judgements are calculated within the 90-day boundary
-    const testDate = new Date("2025-02-12"); // One day before 90-day boundary
-    const isWithin90Days = testDate <= ninetyDayDate;
-
-    assertEquals(isWithin90Days, true, "Test date should be within 90 days");
-  });
-
-  await t.step("boundary date inclusion", () => {
-    // Test that the boundary date itself is included
-    const boundaryDate = new Date("2025-02-13"); // Exactly 90 days
-    // Compare only the date parts (year, month, day)
-    const isSameDay =
-      boundaryDate.getFullYear() === ninetyDayDate.getFullYear() &&
-      boundaryDate.getMonth() === ninetyDayDate.getMonth() &&
-      boundaryDate.getDate() === ninetyDayDate.getDate();
-    const isWithin90Days = isSameDay || boundaryDate < ninetyDayDate;
-
-    assertEquals(isWithin90Days, true, "Boundary date should be included");
-  });
 });


### PR DESCRIPTION
# Replace tautological judgement / annualised tests with WHAT-tests

## Summary

`tests/judgement_tests.ts` and `tests/annualized_performance_test.ts` imported
nothing from the shipped dashboard code (only `@std/assert`). Each reimplemented
production logic as a local copy and then asserted on that copy — tautologies
that stayed green even if the real code drifted, and in the judgement case the
local copy asserted on a string mapping (`EXCEEDED`/`MET`/`BELOW`,
`ABOVE`/`AT`/`BELOW`) that the shipped code never produces.

This change resolves the third tautology cluster called out in the issue
(distinct from #102 and #109), using the issue's two sanctioned resolutions:

- **`tests/judgement_tests.ts`** — rewritten (option a) to drive the REAL
  exported `GRQProjection.computeJudgement` (`docs/projection.js`) and assert on
  the shipped judgement strings (`Hit Target`, `Partial Success`,
  `Missed Target`, `Early Days`, `Pending`). A regression in the production
  mapping at `docs/projection.js:385` now fails. The fictional cost-of-capital
  `ABOVE/AT/BELOW` cases and the local `Date`-arithmetic "boundary" steps were
  deleted (option b): no shipped code produced those strings, and the real
  cost-of-capital figure is an excess-return *number*, not a string bucket.

- **`tests/annualized_performance_test.ts`** — the recompute-only "Compound
  Interest" guard (covered in production by Rust `calculate_annualized_performance`,
  WHAT-tested in `src/utils.rs`) and the local `calculateHybridProjection` copy
  (covered by `GRQProjection.computeHybridProjection` via
  `tests/projection_kernels_test.ts`) were deleted (option b). The index.json
  averaging case was the only genuinely uncovered production logic, so it is now
  a WHAT-test (option a): the averaging maths was extracted from
  `docs/list.js::updateSummaryStats` into a pure, shipped helper
  `GRQListStats.computeListAverages` (`docs/list_stats.js`) that the list page
  delegates to and the test drives directly.

These removed tests were tautological by design and verified no shipped
behaviour; their real-module equivalents either already exist or were added
here, so no genuine coverage is lost.

Closes #121.

## Change shape

```mermaid
flowchart LR
    subgraph Before
        T1[judgement_tests.ts] -->|asserts on| L1[local EXCEEDED/MET copy]
        T2[annualized_performance_test.ts] -->|asserts on| L2[inline formula + averaging + hybrid copy]
    end
    subgraph After
        T3[judgement_tests.ts] -->|drives| P1[GRQProjection.computeJudgement]
        T4[annualized_performance_test.ts] -->|drives| P2[GRQListStats.computeListAverages]
        LJS[docs/list.js updateSummaryStats] -->|delegates to| P2
    end
```

## Evidence

Backend/JS-logic change — no rendered UI change (the list page's summary cards
display the same figures; the averaging maths is unchanged, only relocated to a
shared kernel). Playwright MCP was unavailable in this environment, so
verification was via the test suite:

- `deno test --allow-read tests/*.ts` → **234 passed, 0 failed**.
- The new `computeListAverages` tests assert spec-derived expected values
  (`avg90Day = 23.705`, `avgAnnualized = 68.5475`, counts `2`/`4`/`2`) against
  the **shipped** kernel, so a regression in the averaging path now fails.
- `docs/list.js::updateSummaryStats` was refactored to call the extracted
  kernel; the accumulation logic is byte-for-byte the same loop, and
  `visibleData.toArray()` yields the same row objects the previous
  `visibleData.each(...)` iterated — behaviour-preserving.
- `deno fmt`, `deno lint`, `deno check` all clean.

## Test Plan

- `tests/judgement_tests.ts` — `computeJudgement` realised-outcome mapping
  (Hit Target / Partial Success / Missed Target at day 90), Pending for null,
  and early-stage reporting; all against the real `GRQProjection` helper.
- `tests/annualized_performance_test.ts` — `computeListAverages` happy path
  (mixed populated/null rows), negative/zero handling (positive-count edge
  case), and the empty / all-null edge cases; all against the real
  `GRQListStats` helper.
- Existing `tests/projection_kernels_test.ts` continues to cover
  `computeJudgement` and `computeHybridProjection` (no regression).
