### PR TITLE
Quarantine Cargo supply-chain in CI (Issue #124)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -19,6 +19,8 @@ jobs:
       # dtolnay/rust-toolchain@stable
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        # Pin to an explicit version with --locked so CI does not compile and
+        # run an arbitrary newest cargo-audit dependency tree (Issue #124).
+        run: cargo install cargo-audit --locked --version 0.22.2
       - name: Run cargo audit
         run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,24 +105,31 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-
           
-    - name: Update dependencies
-      run: cargo update
-      
+    # Supply-chain quarantine (Issue #124): CI builds the committed, reviewed
+    # Cargo.lock rather than running `cargo update` to float every crate to the
+    # newest in-range version on each run. `--locked` makes the build fail if
+    # Cargo.lock is stale instead of silently resolving (and executing the
+    # build.rs / proc-macros of) a freshly-published, unquarantined crate.
+    # Dependency bumps land through the quarantined Dependabot PRs instead
+    # (.github/dependabot.yml), mirroring the Deno minimumDependencyAge policy.
     - name: Check formatting
       run: cargo fmt --all -- --check
-      
+
     - name: Run linter
-      run: cargo clippy --all-targets --all-features -- -D warnings
-      
+      run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
     - name: Check types
-      run: cargo check --all-targets --all-features
-      
+      run: cargo check --locked --all-targets --all-features
+
     - name: Run tests
-      run: cargo test --all-targets --all-features --verbose
-      
+      run: cargo test --locked --all-targets --all-features --verbose
+
     - name: Generate test coverage
+      # Pin the tool to an explicit version with --locked so CI does not
+      # compile and run an arbitrary newest cargo-tarpaulin dependency tree
+      # on each run (Issue #124).
       run: |
-        cargo install cargo-tarpaulin
+        cargo install cargo-tarpaulin --locked --version 0.35.4
         cargo tarpaulin --out Xml --output-dir coverage
       continue-on-error: true
       
@@ -172,7 +179,8 @@ jobs:
           ${{ runner.os }}-cargo-
           
     - name: Build release
-      run: cargo build --release
+      # --locked: build the committed Cargo.lock, never float deps (Issue #124).
+      run: cargo build --locked --release
 
     # SCR-SBOM (Issue #53): generate a machine-readable component inventory
     # alongside the binary so post-disclosure incident triage can answer
@@ -180,7 +188,9 @@ jobs:
     - name: Generate CycloneDX SBOM
       run: |
         set -euo pipefail
-        cargo install cargo-cyclonedx
+        # Pin the tool to an explicit version with --locked so CI does not
+        # compile an arbitrary newest cargo-cyclonedx tree on each run (#124).
+        cargo install cargo-cyclonedx --locked --version 0.5.9
         cargo cyclonedx --format json
         # cargo-cyclonedx names the SBOM after the package; normalise the
         # path so the upload step always finds it.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ auto-bumped within the same window. Internal `stSoftwareAU/*` dependencies are
 excluded from the cooldown so they update immediately, mirroring the
 `minimumDependencyAge` policy that `deno.json` applies to the Deno ecosystem.
 
+The CI pipeline (`ci.yml`) complements this by building the **committed,
+reviewed `Cargo.lock`** rather than floating dependencies: every `cargo`
+build/test/check step runs with `--locked`, so a stale lockfile fails the
+build instead of silently resolving (and executing the `build.rs` /
+proc-macros of) a freshly-published, unquarantined crate. CI tool installs
+(`cargo-tarpaulin`, `cargo-cyclonedx`, `cargo-audit`) are pinned to explicit
+versions with `--locked` so they do not compile an arbitrary newest
+tool-dependency tree on each run. Crate bumps therefore arrive only through
+the quarantined Dependabot PRs above, never inline on a PR build.
+
 ### Setup
 
 1. Enable GitHub Actions in your repository.

--- a/docs/archive/pr-summaries/pr-summary-124.md
+++ b/docs/archive/pr-summaries/pr-summary-124.md
@@ -1,0 +1,57 @@
+## Summary
+
+Bring the **Cargo** ecosystem under the same supply-chain quarantine the Deno
+ecosystem already enjoys by closing the remaining CI gaps. The Dependabot 24h
+`cooldown` for Cargo crates already existed (Issue #75); this change removes the
+two ways CI still floated unquarantined code:
+
+1. **Removed the unconditional `cargo update` step** from `ci.yml`. It ran on
+   every pull request and resolved every crate to the newest in-range version,
+   executing freshly-published `build.rs` / proc-macros with zero age gate. CI
+   now builds the **committed, reviewed `Cargo.lock`**: every `cargo`
+   clippy/check/test/build step runs with `--locked`, so a stale lockfile fails
+   the build instead of silently pulling a newer crate. Crate bumps now arrive
+   only through the quarantined Dependabot PRs.
+2. **Pinned the CI tool installs** to explicit versions with `--locked` so they
+   no longer compile and run an arbitrary newest tool-dependency tree:
+   - `cargo install cargo-tarpaulin --locked --version 0.35.4` (`ci.yml`)
+   - `cargo install cargo-cyclonedx --locked --version 0.5.9` (`ci.yml`)
+   - `cargo install cargo-audit --locked --version 0.22.2` (`cargo-audit.yml`)
+
+Closes #124.
+
+### Deno regression avoided
+
+This is a Deno repo (`deno.json`, `deno.lock`). The new tests are Deno tests
+(`deno test`) and reuse the existing `@std/yaml` parser — no Node tooling,
+`package.json`, or `tsconfig.json` introduced.
+
+## Evidence
+
+Backend/CI-config change with no web interface to screenshot. Verified via the
+Deno test suite below and a full `./quality.sh` run, which completed with
+"✅ Quality checks completed successfully!".
+
+```mermaid
+flowchart LR
+    PR[Pull request] --> CI[ci.yml test/build]
+    CI -->|before| U[cargo update floats deps] --> X[build.rs of fresh crate runs]
+    CI -->|after| L[cargo --locked builds Cargo.lock] --> R[only reviewed crates run]
+    DB[Dependabot 24h cooldown] -->|quarantined bump PR| Lock[Cargo.lock]
+    Lock --> L
+```
+
+## Test Plan
+
+New `tests/cargo_supply_chain_quarantine_test.ts` (parses the workflow YAML and
+asserts behaviour, not source text):
+
+- `ci.yml` test job no longer runs `cargo update`.
+- `ci.yml` build job does not run `cargo update`.
+- `ci.yml` test job runs `cargo check` / `cargo test` with `--locked`.
+- `ci.yml` release build runs `cargo build --locked`.
+- `ci.yml` pins `cargo-tarpaulin` / `cargo-cyclonedx` with `--locked --version`.
+- `cargo-audit.yml` pins `cargo-audit` with `--locked --version`.
+
+Existing `ci_workflow_test.ts`, `cargo_audit_workflow_test.ts`, and
+`dependabot_config_test.ts` continue to pass unchanged (27 tests green).

--- a/tests/cargo_supply_chain_quarantine_test.ts
+++ b/tests/cargo_supply_chain_quarantine_test.ts
@@ -1,0 +1,88 @@
+// Tests for the Cargo supply-chain quarantine hardening (Issue #124).
+//
+// The Deno ecosystem is already quarantined (deno.json minimumDependencyAge
+// P1D + deno-outdated.yml --minimum-dependency-age=P1D), and Dependabot now
+// gates Cargo bumps behind a 24h cooldown (Issue #75). The remaining gap is
+// the CI pipeline itself:
+//
+//   1. ci.yml ran an unconditional `cargo update` on every PR, floating every
+//      crate to the newest in-range version and executing its build.rs /
+//      proc-macros with zero age gate.
+//   2. The CI tool installs (cargo-tarpaulin, cargo-cyclonedx, cargo-audit)
+//      were unpinned, compiling and running an arbitrary newest tool tree.
+//
+// These tests assert the pipeline builds the committed, reviewed Cargo.lock
+// (`--locked`) and pins its tool installs to explicit versions.
+
+import { assert } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const CI_PATH = ".github/workflows/ci.yml";
+const AUDIT_PATH = ".github/workflows/cargo-audit.yml";
+
+type Step = { name?: string; run?: string; uses?: string };
+
+async function jobSteps(path: string, job: string): Promise<Step[]> {
+  const text = await Deno.readTextFile(path);
+  const doc = parseYaml(text) as { jobs?: Record<string, { steps?: Step[] }> };
+  return doc.jobs?.[job]?.steps ?? [];
+}
+
+function runText(steps: Step[]): string {
+  return steps.map((s) => s.run ?? "").join("\n");
+}
+
+Deno.test("ci.yml test job no longer runs an unconditional cargo update (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "test"));
+  assert(
+    !/\bcargo\s+update\b/.test(runs),
+    "ci.yml test job must not float deps with `cargo update`; build the committed Cargo.lock",
+  );
+});
+
+Deno.test("ci.yml build job does not run cargo update (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "build"));
+  assert(
+    !/\bcargo\s+update\b/.test(runs),
+    "ci.yml build job must not float deps with `cargo update`",
+  );
+});
+
+Deno.test("ci.yml test job builds/tests with --locked to honour Cargo.lock (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "test"));
+  for (const cmd of ["cargo check", "cargo test"]) {
+    const re = new RegExp(`${cmd.replace(/ /g, "\\s+")}[^\\n]*--locked`);
+    assert(re.test(runs), `ci.yml test job: \`${cmd}\` must pass --locked`);
+  }
+});
+
+Deno.test("ci.yml release build uses --locked (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "build"));
+  assert(
+    /cargo\s+build\b[^\n]*--locked/.test(runs),
+    "ci.yml build job: `cargo build --release` must pass --locked",
+  );
+});
+
+Deno.test("ci.yml pins cargo tool installs to explicit versions with --locked (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "test")) + "\n" +
+    runText(await jobSteps(CI_PATH, "build"));
+  for (const tool of ["cargo-tarpaulin", "cargo-cyclonedx"]) {
+    const installRe = new RegExp(
+      `cargo\\s+install\\s+${tool}\\b[^\\n]*--locked[^\\n]*--version\\s+\\d+\\.\\d+`,
+    );
+    assert(
+      installRe.test(runs),
+      `ci.yml must install ${tool} with --locked and a pinned --version`,
+    );
+  }
+});
+
+Deno.test("cargo-audit.yml pins cargo-audit install to an explicit version with --locked (Issue #124)", async () => {
+  const runs = runText(await jobSteps(AUDIT_PATH, "audit"));
+  assert(
+    /cargo\s+install\s+cargo-audit\b[^\n]*--locked[^\n]*--version\s+\d+\.\d+/
+      .test(runs),
+    "cargo-audit.yml must install cargo-audit with --locked and a pinned --version",
+  );
+});


### PR DESCRIPTION
## Summary

Bring the **Cargo** ecosystem under the same supply-chain quarantine the Deno
ecosystem already enjoys by closing the remaining CI gaps. The Dependabot 24h
`cooldown` for Cargo crates already existed (Issue #75); this change removes the
two ways CI still floated unquarantined code:

1. **Removed the unconditional `cargo update` step** from `ci.yml`. It ran on
   every pull request and resolved every crate to the newest in-range version,
   executing freshly-published `build.rs` / proc-macros with zero age gate. CI
   now builds the **committed, reviewed `Cargo.lock`**: every `cargo`
   clippy/check/test/build step runs with `--locked`, so a stale lockfile fails
   the build instead of silently pulling a newer crate. Crate bumps now arrive
   only through the quarantined Dependabot PRs.
2. **Pinned the CI tool installs** to explicit versions with `--locked` so they
   no longer compile and run an arbitrary newest tool-dependency tree:
   - `cargo install cargo-tarpaulin --locked --version 0.35.4` (`ci.yml`)
   - `cargo install cargo-cyclonedx --locked --version 0.5.9` (`ci.yml`)
   - `cargo install cargo-audit --locked --version 0.22.2` (`cargo-audit.yml`)

Closes #124.

### Deno regression avoided

This is a Deno repo (`deno.json`, `deno.lock`). The new tests are Deno tests
(`deno test`) and reuse the existing `@std/yaml` parser — no Node tooling,
`package.json`, or `tsconfig.json` introduced.

## Evidence

Backend/CI-config change with no web interface to screenshot. Verified via the
Deno test suite below and a full `./quality.sh` run, which completed with
"✅ Quality checks completed successfully!".

```mermaid
flowchart LR
    PR[Pull request] --> CI[ci.yml test/build]
    CI -->|before| U[cargo update floats deps] --> X[build.rs of fresh crate runs]
    CI -->|after| L[cargo --locked builds Cargo.lock] --> R[only reviewed crates run]
    DB[Dependabot 24h cooldown] -->|quarantined bump PR| Lock[Cargo.lock]
    Lock --> L
```

## Test Plan

New `tests/cargo_supply_chain_quarantine_test.ts` (parses the workflow YAML and
asserts behaviour, not source text):

- `ci.yml` test job no longer runs `cargo update`.
- `ci.yml` build job does not run `cargo update`.
- `ci.yml` test job runs `cargo check` / `cargo test` with `--locked`.
- `ci.yml` release build runs `cargo build --locked`.
- `ci.yml` pins `cargo-tarpaulin` / `cargo-cyclonedx` with `--locked --version`.
- `cargo-audit.yml` pins `cargo-audit` with `--locked --version`.

Existing `ci_workflow_test.ts`, `cargo_audit_workflow_test.ts`, and
`dependabot_config_test.ts` continue to pass unchanged (27 tests green).



## Milestone
This PR is part of the **security-scan** milestone and targets the `milestone/security-scan` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqanv9gi-cedcc8`<!-- vibe-worker-issue-124 -->