### PR TITLE
Add concurrency cancellation to seven PR-triggered workflows (Issue #139)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -6,6 +6,13 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -7,6 +7,13 @@ on:
     # Weekly audit so a JSR/@std compromise is caught even with no open PR.
     - cron: "0 6 * * 1"
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,6 +11,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main, master]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,6 +16,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main, master]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/docs/archive/pr-summaries/pr-summary-139.md
+++ b/docs/archive/pr-summaries/pr-summary-139.md
@@ -1,0 +1,77 @@
+# Add concurrency cancellation to seven PR-triggered workflows
+
+## Summary
+
+Seven pull-request-triggered workflows in `.github/workflows/` ran without a
+`concurrency:` group, so rapid pushes to the same PR queued redundant,
+overlapping runs that each held a runner and wasted CI minutes on results that
+were immediately superseded. Only `ci.yml` declared a concurrency group.
+
+This change adds a top-level `concurrency:` block — identical to the canonical
+pattern proven in `ci.yml` — to each of the seven workflows, immediately after
+the `on:` block:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Keying on {% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %}
+scopes cancellation per-workflow-per-ref, so distinct workflows and distinct branches never cancel
+one another, while repeated pushes to the same ref keep only the latest run
+alive. `deno-outdated.yml` is intentionally excluded — it runs only on
+`schedule`/`workflow_dispatch` and is not pile-up-prone.
+
+Workflows updated:
+
+- `cargo-audit.yml`
+- `deno-quality.yml`
+- `dependency-review.yml`
+- `gitleaks.yml`
+- `markdown-lint.yml`
+- `semgrep.yml`
+- `shellcheck.yml`
+
+Closes #139.
+
+## Evidence
+
+This is a CI-configuration change with no web interface to screenshot.
+Verification is via the Deno test suite, which parses each workflow's YAML and
+asserts the concurrency group is present and correctly keyed. Full suite:
+`254 passed | 0 failed`.
+
+```mermaid
+flowchart LR
+    P1[push #1] --> R1[run #1 starts]
+    P2[push #2 same ref] --> C{concurrency group<br/>workflow-ref}
+    R1 --> C
+    C -->|cancel-in-progress| X[run #1 cancelled]
+    C --> R2[run #2 runs]
+```
+
+## Test Plan
+
+Followed TDD — added a failing concurrency assertion per workflow first, then
+added the workflow blocks to make them pass.
+
+- Added `... workflow declares a concurrency group that cancels superseded runs`
+  test to each of:
+  - `tests/cargo_audit_workflow_test.ts`
+  - `tests/deno_quality_workflow_test.ts`
+  - `tests/dependency_review_workflow_test.ts`
+  - `tests/semgrep_workflow_test.ts`
+  - `tests/markdown_lint_workflow_test.ts`
+- Added new test files `tests/gitleaks_workflow_test.ts` and
+  `tests/shellcheck_workflow_test.ts` (these workflows had no test file),
+  covering existence, YAML parse, `pull_request` trigger, read-only contents
+  permission, and the concurrency group.
+
+Each test parses the workflow YAML and asserts
+{% raw %}`concurrency.group === "${{ github.workflow }}-${{ github.ref }}"`{% endraw %}
+and `concurrency["cancel-in-progress"] === true`.
+
+Verified red before the workflow change (7 failures), then green after
+(`47 passed`); full suite `254 passed | 0 failed`. `deno fmt --check`,
+`deno lint`, and `deno check` all pass.

--- a/tests/cargo_audit_workflow_test.ts
+++ b/tests/cargo_audit_workflow_test.ts
@@ -82,3 +82,25 @@ Deno.test("Cargo Audit workflow pins actions to commit SHAs", async () => {
     );
   }
 });
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Cargo Audit workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/deno_quality_workflow_test.ts
+++ b/tests/deno_quality_workflow_test.ts
@@ -136,3 +136,25 @@ Deno.test("Deno Quality workflow pins actions to commit SHAs", async () => {
     );
   }
 });
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Deno Quality workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/dependency_review_workflow_test.ts
+++ b/tests/dependency_review_workflow_test.ts
@@ -41,3 +41,25 @@ Deno.test("Dependency Review workflow pins every action to a 40-char commit SHA"
 // enforced by the parsed "pins every action to a 40-char commit SHA" test
 // above. The annotation convention, if wanted, belongs in a dedicated
 // lint/actionlint rule rather than a unit assertion.
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Dependency Review workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/gitleaks_workflow_test.ts
+++ b/tests/gitleaks_workflow_test.ts
@@ -1,0 +1,62 @@
+// Tests for the Gitleaks secret-scanning GitHub Actions workflow.
+//
+// Verify the workflow file exists, parses as YAML, triggers on pull_request,
+// declares read-only contents permission, and declares a concurrency group
+// that cancels superseded in-progress runs (Issue #139).
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/gitleaks.yml";
+
+Deno.test("Gitleaks workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("Gitleaks workflow parses as valid YAML with expected name", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "Gitleaks");
+});
+
+Deno.test("Gitleaks workflow triggers on pull_request", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  // YAML "on" key sometimes parses to boolean true — accept either key.
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("pull_request" in on, "must trigger on pull_request");
+});
+
+Deno.test("Gitleaks workflow declares read-only contents permission", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { permissions?: Record<string, string> };
+  assert(doc.permissions, "workflow must declare top-level permissions");
+  assertEquals(doc.permissions.contents, "read");
+});
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Gitleaks workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/markdown_lint_workflow_test.ts
+++ b/tests/markdown_lint_workflow_test.ts
@@ -123,3 +123,25 @@ Deno.test("markdownlint-cli2 passes against repository markdown files", async ()
     );
   }
 });
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Markdown Lint workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/semgrep_workflow_test.ts
+++ b/tests/semgrep_workflow_test.ts
@@ -99,3 +99,25 @@ Deno.test("Semgrep workflow pins actions to commit SHAs", async () => {
     );
   }
 });
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Semgrep workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/shellcheck_workflow_test.ts
+++ b/tests/shellcheck_workflow_test.ts
@@ -1,0 +1,62 @@
+// Tests for the ShellCheck GitHub Actions workflow.
+//
+// Verify the workflow file exists, parses as YAML, triggers on pull_request,
+// declares read-only contents permission, and declares a concurrency group
+// that cancels superseded in-progress runs (Issue #139).
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/shellcheck.yml";
+
+Deno.test("ShellCheck workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("ShellCheck workflow parses as valid YAML with expected name", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "ShellCheck");
+});
+
+Deno.test("ShellCheck workflow triggers on pull_request", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  // YAML "on" key sometimes parses to boolean true — accept either key.
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("pull_request" in on, "must trigger on pull_request");
+});
+
+Deno.test("ShellCheck workflow declares read-only contents permission", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { permissions?: Record<string, string> };
+  assert(doc.permissions, "workflow must declare top-level permissions");
+  assertEquals(doc.permissions.contents, "read");
+});
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("ShellCheck workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});


### PR DESCRIPTION
# Add concurrency cancellation to seven PR-triggered workflows

## Summary

Seven pull-request-triggered workflows in `.github/workflows/` ran without a
`concurrency:` group, so rapid pushes to the same PR queued redundant,
overlapping runs that each held a runner and wasted CI minutes on results that
were immediately superseded. Only `ci.yml` declared a concurrency group.

This change adds a top-level `concurrency:` block — identical to the canonical
pattern proven in `ci.yml` — to each of the seven workflows, immediately after
the `on:` block:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Keying on {% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %}
scopes cancellation per-workflow-per-ref, so distinct workflows and distinct branches never cancel
one another, while repeated pushes to the same ref keep only the latest run
alive. `deno-outdated.yml` is intentionally excluded — it runs only on
`schedule`/`workflow_dispatch` and is not pile-up-prone.

Workflows updated:

- `cargo-audit.yml`
- `deno-quality.yml`
- `dependency-review.yml`
- `gitleaks.yml`
- `markdown-lint.yml`
- `semgrep.yml`
- `shellcheck.yml`

Closes #139.

## Evidence

This is a CI-configuration change with no web interface to screenshot.
Verification is via the Deno test suite, which parses each workflow's YAML and
asserts the concurrency group is present and correctly keyed. Full suite:
`254 passed | 0 failed`.

```mermaid
flowchart LR
    P1[push #1] --> R1[run #1 starts]
    P2[push #2 same ref] --> C{concurrency group<br/>workflow-ref}
    R1 --> C
    C -->|cancel-in-progress| X[run #1 cancelled]
    C --> R2[run #2 runs]
```

## Test Plan

Followed TDD — added a failing concurrency assertion per workflow first, then
added the workflow blocks to make them pass.

- Added `... workflow declares a concurrency group that cancels superseded runs`
  test to each of:
  - `tests/cargo_audit_workflow_test.ts`
  - `tests/deno_quality_workflow_test.ts`
  - `tests/dependency_review_workflow_test.ts`
  - `tests/semgrep_workflow_test.ts`
  - `tests/markdown_lint_workflow_test.ts`
- Added new test files `tests/gitleaks_workflow_test.ts` and
  `tests/shellcheck_workflow_test.ts` (these workflows had no test file),
  covering existence, YAML parse, `pull_request` trigger, read-only contents
  permission, and the concurrency group.

Each test parses the workflow YAML and asserts
{% raw %}`concurrency.group === "${{ github.workflow }}-${{ github.ref }}"`{% endraw %}
and `concurrency["cancel-in-progress"] === true`.

Verified red before the workflow change (7 failures), then green after
(`47 passed`); full suite `254 passed | 0 failed`. `deno fmt --check`,
`deno lint`, and `deno check` all pass.



## Milestone
This PR is part of the **security-scan** milestone and targets the `milestone/security-scan` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqanv9gi-cedcc8`<!-- vibe-worker-issue-139 -->