### PR TITLE
Replace tautological dividend-filtering tests with WHAT-tests (#145)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -2878,15 +2878,11 @@ class GRQValidator {
     }
 
     getDividendsWithin90Days(stockSymbol) {
+        // Window filtering lives in the shared projection module (issue #145)
+        // so production and the Deno tests exercise the same kernel.
         const dividends = this.dividendData?.[stockSymbol] || [];
         const scoreDate = this.getScoreDate(this.selectedFile);
-        const ninetyDayDate = new Date(
-            scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
-        );
-
-        return dividends.filter((dividend) =>
-            dividend.exDivDate <= ninetyDayDate
-        );
+        return GRQProjection.filterDividendsWithin90Days(dividends, scoreDate);
     }
 
     getCurrentPrice(stockSymbol) {
@@ -3401,7 +3397,7 @@ class GRQValidator {
                 }
                 
                 const gainLossDividends = this.getDividendsWithin90Days(stockSymbol);
-                const gainLossTotalDividends = gainLossDividends.reduce((sum, div) => sum + div.amount, 0);
+                const gainLossTotalDividends = GRQProjection.sumDividends(gainLossDividends);
                 
                 // Get current price for display
                 const gainLossMarketData = this.marketData[stockSymbol];
@@ -3758,7 +3754,7 @@ class GRQValidator {
 
         // Add dividend return within 90 days
         const dividends = this.getDividendsWithin90Days(stock.stock);
-        const totalDividends = dividends.reduce((sum, div) => sum + div.amount, 0);
+        const totalDividends = GRQProjection.sumDividends(dividends);
         const dividendReturn = (totalDividends / buyPriceObj.price) * 100;
 
         return priceReturn + dividendReturn;
@@ -3803,7 +3799,7 @@ class GRQValidator {
                 const priceReturn = ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
                 const dividends = this.getDividendsWithin90Days(stock.stock);
                 const dividendsUpToDate = dividends.filter((d) => d.exDivDate <= point.date);
-                const totalDividends = dividendsUpToDate.reduce((sum, div) => sum + div.amount, 0);
+                const totalDividends = GRQProjection.sumDividends(dividendsUpToDate);
                 const dividendReturn = (totalDividends / buyPriceObj.price) * 100;
                 const totalReturn = priceReturn + dividendReturn;
                 

--- a/docs/archive/pr-summaries/pr-summary-145.md
+++ b/docs/archive/pr-summaries/pr-summary-145.md
@@ -1,0 +1,76 @@
+## Summary
+
+`tests/dividend_calculation_tests.ts` imported nothing from the shipped code and
+asserted on logic re-authored inside the test: it reimplemented the 90-day
+dividend-window `filter`, the `+ 90 days` date arithmetic, the `reduce` sum, and
+a bare `exDivDate <= ninetyDayDate` comparison — then asserted each expression
+against itself. The shipped `getDividendsWithin90Days` / dividend-summation path
+on `GRQValidator` was never called, so a real regression in dividend selection
+or summation left every assertion green.
+
+This PR applies resolution (a) from the issue: extract the pure dividend kernels
+into the shared projection module so production and tests exercise the same
+code, then rewrite the file as a WHAT-test against those kernels.
+
+- Added `filterDividendsWithin90Days(dividends, scoreDate)` and
+  `sumDividends(dividends)` to `docs/projection.js` and published them on
+  `globalThis.GRQProjection`, mirroring the issue #80/#100 kernel-extraction
+  pattern.
+- Delegated `GRQValidator.getDividendsWithin90Days` to the shared filter and the
+  three dividend-summation sites (`docs/app.js`) to `sumDividends`, removing the
+  duplicated inline `filter`/`reduce` copies (DRY — single source of truth).
+- Rewrote `tests/dividend_calculation_tests.ts` to drive the real
+  `filterDividendsWithin90Days`, `sumDividends`, and `calculatePerformanceReturn`
+  kernels against the NYSE:WFG 2024-11-15 fixture and assert on their return
+  values. A regression in the shipped window/sum now fails the suite.
+
+Closes #145.
+
+## Evidence
+
+Backend/JS change with no web UI to screenshot. Verified via `deno test` and the
+full quality gate.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        T1[dividend tests] -. assert filter/sum/&le; against itself .-> T1
+        V1[GRQValidator.getDividendsWithin90Days] -. untested .-> X[(shipped code)]
+    end
+    subgraph After
+        K[GRQProjection.filterDividendsWithin90Days / sumDividends]
+        T2[dividend tests] --> K
+        V2[GRQValidator.getDividendsWithin90Days] --> K
+    end
+```
+
+Test run:
+
+```
+running 6 tests from ./tests/dividend_calculation_tests.ts
+filterDividendsWithin90Days keeps only in-window payments ... ok
+filterDividendsWithin90Days includes a payment on the boundary day ... ok
+filterDividendsWithin90Days returns empty for missing or empty input ... ok
+sumDividends totals the in-window WFG payments ... ok
+sumDividends returns 0 for missing or empty input ... ok
+dividend total flows into the shipped performance return ... ok
+ok | 6 passed | 0 failed
+```
+
+`./quality.sh` passes cleanly (lint, fmt, type-check, full Deno + Rust suite).
+
+## Test Plan
+
+Rewritten `tests/dividend_calculation_tests.ts` (now WHAT-tests against shipped kernels):
+
+- `filterDividendsWithin90Days keeps only in-window payments` — happy path: 2 of
+  3 WFG dividends retained.
+- `filterDividendsWithin90Days includes a payment on the boundary day` — edge:
+  ex-div date exactly on the 90-day edge is inclusive (`<=`).
+- `filterDividendsWithin90Days returns empty for missing or empty input` — error
+  path: `[]` and `undefined`.
+- `sumDividends totals the in-window WFG payments` — happy path: `$0.455`.
+- `sumDividends returns 0 for missing or empty input` — error path.
+- `dividend total flows into the shipped performance return` — drives
+  `calculatePerformanceReturn` to prove the filtered/summed dividends reach
+  production output (dividend-return component `(0.455 / buyPrice) * 100`).

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -40,6 +40,25 @@ function calculatePerformanceReturn(buyPrice, currentPrice, totalDividends) {
     return priceReturn + dividendReturn;
 }
 
+// Dividends whose ex-dividend date falls on or before the 90-day validation
+// window measured from the score date. Pure given the dividend list and score
+// date; the dashboard's GRQValidator looks the list up per stock and delegates
+// here so production and tests share one window filter (issue #145).
+function filterDividendsWithin90Days(dividends, scoreDate) {
+    const ninetyDayDate = new Date(
+        scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+    );
+    return (dividends || []).filter((dividend) =>
+        dividend.exDivDate <= ninetyDayDate
+    );
+}
+
+// Sum the cash amount of a dividend list. Returns 0 for an empty or missing
+// list, mirroring the dashboard's per-stock dividend-return summation.
+function sumDividends(dividends) {
+    return (dividends || []).reduce((sum, div) => sum + div.amount, 0);
+}
+
 // Build the weekly trend-data series for a hybrid projection chart.
 //
 // `projection` is the result of GRQValidator.calculateHybridProjection (its
@@ -472,6 +491,8 @@ globalThis.GRQProjection = {
     setDateToMidnight,
     getDaysElapsed,
     calculatePerformanceReturn,
+    filterDividendsWithin90Days,
+    sumDividends,
     buildHybridProjectionData,
     formatCurrency,
     getSplitAdjustment,

--- a/tests/dividend_calculation_tests.ts
+++ b/tests/dividend_calculation_tests.ts
@@ -1,80 +1,123 @@
+// Behavioural (WHAT) tests for the dividend-window kernels (issue #145).
+//
+// These import the REAL shipped helpers from docs/projection.js — the same
+// code the dashboard's GRQValidator delegates to via
+// `getDividendsWithin90Days` and the performance/return path — and assert on
+// their observable output. They replace the previous tautological tests that
+// reimplemented the filter / 90-day sum / `<=` comparison inline and asserted
+// the copy against itself, exercising zero shipped code.
 import { assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
-// Test case for dividend calculation within 90-day period
-// Testing NYSE:WFG from 2024-11-15 score file
+interface Dividend {
+  exDivDate: Date;
+  amount: number;
+}
 
-Deno.test("Dividend Calculation Tests", async (t) => {
-  const scoreDate = new Date(2024, 10, 15); // November 15, 2024
-  const ninetyDayDate = new Date(
-    scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+const g = globalThis as unknown as {
+  GRQProjection: {
+    filterDividendsWithin90Days: (
+      dividends: Dividend[] | undefined,
+      scoreDate: Date,
+    ) => Dividend[];
+    sumDividends: (dividends: Dividend[] | undefined) => number;
+    calculatePerformanceReturn: (
+      buyPrice: number | null,
+      currentPrice: number,
+      totalDividends: number,
+    ) => number | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+// Fixture: NYSE:WFG from the 2024-11-15 score file. The 90-day window from the
+// score date ends 2025-02-13, so the first two ex-dividend dates fall inside
+// the window and the March payment falls outside it.
+const SCORE_DATE = new Date(2024, 10, 15); // 15 November 2024.
+const WFG_DIVIDENDS: Dividend[] = [
+  { exDivDate: new Date("2024-12-19"), amount: 0.135 },
+  { exDivDate: new Date("2024-12-27"), amount: 0.32 },
+  { exDivDate: new Date("2025-03-14"), amount: 0.32 },
+];
+
+Deno.test("filterDividendsWithin90Days keeps only in-window payments", () => {
+  const within = GRQProjection.filterDividendsWithin90Days(
+    WFG_DIVIDENDS,
+    SCORE_DATE,
   );
-  const testDividends = [
-    { exDivDate: new Date("2024-12-19"), amount: 0.135 },
-    { exDivDate: new Date("2024-12-27"), amount: 0.32 },
-    { exDivDate: new Date("2025-03-14"), amount: 0.32 },
-  ];
+  assertEquals(within.length, 2, "Two WFG dividends fall within 90 days");
+  assertEquals(
+    within.map((d) => d.amount),
+    [0.135, 0.32],
+    "The kept payments are the December ex-dividend dates",
+  );
+});
 
-  await t.step("dividend filtering within 90 days", () => {
-    // Test the filtering logic
-    const dividendsWithin90Days = testDividends.filter((dividend) =>
-      dividend.exDivDate <= ninetyDayDate
-    );
+Deno.test("filterDividendsWithin90Days includes a payment on the boundary day", () => {
+  // The window edge is score date + 90 days; an ex-div date exactly on the
+  // edge is inclusive (<=).
+  const boundary = new Date(SCORE_DATE.getTime() + 90 * 24 * 60 * 60 * 1000);
+  const within = GRQProjection.filterDividendsWithin90Days(
+    [{ exDivDate: boundary, amount: 0.5 }],
+    SCORE_DATE,
+  );
+  assertEquals(within.length, 1, "Boundary-day dividend is inside the window");
+});
 
-    assertEquals(
-      dividendsWithin90Days.length,
-      2,
-      "Should have 2 dividends within 90 days",
-    );
+Deno.test("filterDividendsWithin90Days returns empty for missing or empty input", () => {
+  assertEquals(GRQProjection.filterDividendsWithin90Days([], SCORE_DATE), []);
+  assertEquals(
+    GRQProjection.filterDividendsWithin90Days(undefined, SCORE_DATE),
+    [],
+  );
+});
 
-    // Calculate total dividends within 90 days
-    const totalDividends = dividendsWithin90Days.reduce(
-      (sum, div) => sum + div.amount,
-      0,
-    );
+Deno.test("sumDividends totals the in-window WFG payments", () => {
+  const within = GRQProjection.filterDividendsWithin90Days(
+    WFG_DIVIDENDS,
+    SCORE_DATE,
+  );
+  assertAlmostEquals(
+    GRQProjection.sumDividends(within),
+    0.455,
+    0.001,
+    "0.135 + 0.32 = $0.455 within 90 days",
+  );
+});
 
-    assertAlmostEquals(
-      totalDividends,
-      0.455,
-      0.001,
-      "Total dividends should be $0.455",
-    );
-  });
+Deno.test("sumDividends returns 0 for missing or empty input", () => {
+  assertEquals(GRQProjection.sumDividends([]), 0);
+  assertEquals(GRQProjection.sumDividends(undefined), 0);
+});
 
-  await t.step("date calculations", () => {
-    // Verify 90-day calculation
-    const expected90DayDate = new Date(2025, 1, 13); // February 13, 2025
-    const daysDiff = Math.round(
-      (ninetyDayDate.getTime() - scoreDate.getTime()) / (1000 * 60 * 60 * 24),
-    );
+Deno.test("dividend total flows into the shipped performance return", () => {
+  // Drive the real return kernel the dashboard uses: the in-window dividend
+  // total contributes a price-relative dividend return on top of the price
+  // return, proving the filtered/summed dividends reach production output.
+  const within = GRQProjection.filterDividendsWithin90Days(
+    WFG_DIVIDENDS,
+    SCORE_DATE,
+  );
+  const totalDividends = GRQProjection.sumDividends(within);
+  const buyPrice = 91;
+  const currentPrice = 100;
 
-    assertEquals(daysDiff, 90, "Should be exactly 90 days");
-    assertEquals(
-      ninetyDayDate.getTime(),
-      expected90DayDate.getTime(),
-      "90-day date should match expected",
-    );
-  });
+  const withDividends = GRQProjection.calculatePerformanceReturn(
+    buyPrice,
+    currentPrice,
+    totalDividends,
+  )!;
+  const withoutDividends = GRQProjection.calculatePerformanceReturn(
+    buyPrice,
+    currentPrice,
+    0,
+  )!;
 
-  await t.step("dividend date validation", () => {
-    // Test that specific dividends are correctly identified
-    const dividend1 = testDividends[0]; // 2024-12-19
-    const dividend2 = testDividends[1]; // 2024-12-27
-    const dividend3 = testDividends[2]; // 2025-03-14
-
-    assertEquals(
-      dividend1.exDivDate <= ninetyDayDate,
-      true,
-      "First dividend should be within 90 days",
-    );
-    assertEquals(
-      dividend2.exDivDate <= ninetyDayDate,
-      true,
-      "Second dividend should be within 90 days",
-    );
-    assertEquals(
-      dividend3.exDivDate <= ninetyDayDate,
-      false,
-      "Third dividend should be after 90 days",
-    );
-  });
+  // The dividend return component is (0.455 / 91) * 100 ≈ 0.5%.
+  assertAlmostEquals(
+    withDividends - withoutDividends,
+    (0.455 / buyPrice) * 100,
+    0.001,
+    "Dividend total adds a price-relative dividend return",
+  );
 });


### PR DESCRIPTION
## Summary

`tests/dividend_calculation_tests.ts` imported nothing from the shipped code and
asserted on logic re-authored inside the test: it reimplemented the 90-day
dividend-window `filter`, the `+ 90 days` date arithmetic, the `reduce` sum, and
a bare `exDivDate <= ninetyDayDate` comparison — then asserted each expression
against itself. The shipped `getDividendsWithin90Days` / dividend-summation path
on `GRQValidator` was never called, so a real regression in dividend selection
or summation left every assertion green.

This PR applies resolution (a) from the issue: extract the pure dividend kernels
into the shared projection module so production and tests exercise the same
code, then rewrite the file as a WHAT-test against those kernels.

- Added `filterDividendsWithin90Days(dividends, scoreDate)` and
  `sumDividends(dividends)` to `docs/projection.js` and published them on
  `globalThis.GRQProjection`, mirroring the issue #80/#100 kernel-extraction
  pattern.
- Delegated `GRQValidator.getDividendsWithin90Days` to the shared filter and the
  three dividend-summation sites (`docs/app.js`) to `sumDividends`, removing the
  duplicated inline `filter`/`reduce` copies (DRY — single source of truth).
- Rewrote `tests/dividend_calculation_tests.ts` to drive the real
  `filterDividendsWithin90Days`, `sumDividends`, and `calculatePerformanceReturn`
  kernels against the NYSE:WFG 2024-11-15 fixture and assert on their return
  values. A regression in the shipped window/sum now fails the suite.

Closes #145.

## Evidence

Backend/JS change with no web UI to screenshot. Verified via `deno test` and the
full quality gate.

```mermaid
flowchart LR
    subgraph Before
        T1[dividend tests] -. assert filter/sum/&le; against itself .-> T1
        V1[GRQValidator.getDividendsWithin90Days] -. untested .-> X[(shipped code)]
    end
    subgraph After
        K[GRQProjection.filterDividendsWithin90Days / sumDividends]
        T2[dividend tests] --> K
        V2[GRQValidator.getDividendsWithin90Days] --> K
    end
```

Test run:

```
running 6 tests from ./tests/dividend_calculation_tests.ts
filterDividendsWithin90Days keeps only in-window payments ... ok
filterDividendsWithin90Days includes a payment on the boundary day ... ok
filterDividendsWithin90Days returns empty for missing or empty input ... ok
sumDividends totals the in-window WFG payments ... ok
sumDividends returns 0 for missing or empty input ... ok
dividend total flows into the shipped performance return ... ok
ok | 6 passed | 0 failed
```

`./quality.sh` passes cleanly (lint, fmt, type-check, full Deno + Rust suite).

## Test Plan

Rewritten `tests/dividend_calculation_tests.ts` (now WHAT-tests against shipped kernels):

- `filterDividendsWithin90Days keeps only in-window payments` — happy path: 2 of
  3 WFG dividends retained.
- `filterDividendsWithin90Days includes a payment on the boundary day` — edge:
  ex-div date exactly on the 90-day edge is inclusive (`<=`).
- `filterDividendsWithin90Days returns empty for missing or empty input` — error
  path: `[]` and `undefined`.
- `sumDividends totals the in-window WFG payments` — happy path: `$0.455`.
- `sumDividends returns 0 for missing or empty input` — error path.
- `dividend total flows into the shipped performance return` — drives
  `calculatePerformanceReturn` to prove the filtered/summed dividends reach
  production output (dividend-return component `(0.455 / buyPrice) * 100`).
