### PR TITLE
Remove source-text prose greps from contributing_changelog_test (Issue #149)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-149.md
+++ b/docs/archive/pr-summaries/pr-summary-149.md
@@ -1,0 +1,58 @@
+## Summary
+
+Removed the source-text prose-grep assertions from
+`tests/contributing_changelog_test.ts`. Most of the file read a Markdown doc
+and asserted that a literal substring (or loose regex) appeared in the prose —
+a grep-as-assertion that verifies nothing observable and breaks on harmless
+rewording that preserves meaning. This is the same anti-pattern the repository
+deliberately removed from `tests/security_md_test.ts` and
+`tests/documentation_accuracy_test.ts` under Issue #81; this file was missed in
+that pass.
+
+Applied resolution (a) from the issue: kept the two existence checks
+(`CONTRIBUTING.md` / `CHANGELOG.md` exist) and the already-good version-seeding
+test (which derives its expectation from `Cargo.toml` and asserts a *derivable
+relationship*), and removed the brittle prose greps:
+
+- `cargo test` / `cargo fmt` / `cargo clippy` / `cargo build`
+- `deno test`
+- `quality.sh`
+- `pull request`
+- `Keep a Changelog` / `Semantic Versioning`
+
+The header comment now records the removal under Issue #149, matching the
+wording style of the sibling files. Documentation prose remains policed by the
+Markdown linter and human review.
+
+Closes #149.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+`deno test` for the affected file (3 behavioural tests retained, all passing):
+
+```
+running 3 tests from ./tests/contributing_changelog_test.ts
+CONTRIBUTING.md exists at the repository root ... ok
+CHANGELOG.md exists at the repository root ... ok
+CHANGELOG.md is seeded with the current Cargo.toml version ... ok
+
+ok | 3 passed | 0 failed
+```
+
+`./quality.sh` completes successfully across the full suite.
+
+## Test Plan
+
+- Modified `tests/contributing_changelog_test.ts`:
+  - Retained: `CONTRIBUTING.md exists at the repository root`,
+    `CHANGELOG.md exists at the repository root`,
+    `CHANGELOG.md is seeded with the current Cargo.toml version`.
+  - Removed: the five prose-grep tests
+    (`documents the Rust build/test/lint commands`,
+    `documents the Deno test suite`, `anchors on the existing quality gate`,
+    `describes the pull-request workflow`,
+    `follows the Keep a Changelog format`).
+- Ran `deno test tests/contributing_changelog_test.ts` — 3 passed.
+- Ran `./quality.sh` — passes cleanly.

--- a/tests/contributing_changelog_test.ts
+++ b/tests/contributing_changelog_test.ts
@@ -1,11 +1,20 @@
-// Tests for the contributor-facing docs floor (Issue #77).
+// Tests for the contributor-facing docs floor (Issue #77, refined in
+// Issue #149).
 //
 // The repo already publishes README.md, LICENSE, and SECURITY.md but was
 // missing CONTRIBUTING.md and CHANGELOG.md. These tests assert that both
-// files now exist at the repository root and carry the substance contributors
-// and consumers expect: build/test/lint commands and the PR workflow for
-// CONTRIBUTING.md, and a Keep a Changelog structure seeded with the current
-// Cargo.toml version for CHANGELOG.md.
+// files exist at the repository root and that the changelog is seeded with a
+// section for the current Cargo.toml version — a *derivable relationship*
+// rather than a hand-copied phrase.
+//
+// The earlier substring greps (cargo test/fmt/clippy/build, deno test,
+// quality.sh, "pull request", "Keep a Changelog", "Semantic Versioning") were
+// removed in Issue #149: they asserted on documentation prose rather than
+// behaviour, broke on harmless rewording that preserved meaning, and
+// duplicated implementation detail. This is the same anti-pattern removed from
+// security_md_test.ts and documentation_accuracy_test.ts under Issue #81.
+// Documentation prose is policed by the Markdown linter and human review, not
+// by string asserts in the unit-test runner.
 
 import { assert } from "@std/assert";
 
@@ -21,50 +30,9 @@ Deno.test("CONTRIBUTING.md exists at the repository root", async () => {
   assert(stat.isFile, `${CONTRIBUTING_PATH} should be a file`);
 });
 
-Deno.test("CONTRIBUTING.md documents the Rust build/test/lint commands", async () => {
-  const text = await read(CONTRIBUTING_PATH);
-  assert(/cargo test/.test(text), "must reference cargo test");
-  assert(/cargo fmt/.test(text), "must reference cargo fmt");
-  assert(/cargo clippy/.test(text), "must reference cargo clippy");
-  assert(/cargo build/.test(text), "must reference cargo build");
-});
-
-Deno.test("CONTRIBUTING.md documents the Deno test suite", async () => {
-  const text = await read(CONTRIBUTING_PATH);
-  assert(/deno test/.test(text), "must reference the Deno test suite");
-});
-
-Deno.test("CONTRIBUTING.md anchors on the existing quality gate", async () => {
-  const text = await read(CONTRIBUTING_PATH);
-  assert(
-    text.includes("quality.sh"),
-    "must reference the quality.sh local gate",
-  );
-});
-
-Deno.test("CONTRIBUTING.md describes the pull-request workflow", async () => {
-  const text = await read(CONTRIBUTING_PATH);
-  assert(
-    /pull request/i.test(text),
-    "must describe the pull-request submission workflow",
-  );
-});
-
 Deno.test("CHANGELOG.md exists at the repository root", async () => {
   const stat = await Deno.stat(CHANGELOG_PATH);
   assert(stat.isFile, `${CHANGELOG_PATH} should be a file`);
-});
-
-Deno.test("CHANGELOG.md follows the Keep a Changelog format", async () => {
-  const text = await read(CHANGELOG_PATH);
-  assert(
-    text.includes("Keep a Changelog"),
-    "must reference the Keep a Changelog format",
-  );
-  assert(
-    text.includes("Semantic Versioning"),
-    "must reference Semantic Versioning",
-  );
 });
 
 Deno.test("CHANGELOG.md is seeded with the current Cargo.toml version", async () => {


### PR DESCRIPTION
## Summary

Removed the source-text prose-grep assertions from
`tests/contributing_changelog_test.ts`. Most of the file read a Markdown doc
and asserted that a literal substring (or loose regex) appeared in the prose —
a grep-as-assertion that verifies nothing observable and breaks on harmless
rewording that preserves meaning. This is the same anti-pattern the repository
deliberately removed from `tests/security_md_test.ts` and
`tests/documentation_accuracy_test.ts` under Issue #81; this file was missed in
that pass.

Applied resolution (a) from the issue: kept the two existence checks
(`CONTRIBUTING.md` / `CHANGELOG.md` exist) and the already-good version-seeding
test (which derives its expectation from `Cargo.toml` and asserts a *derivable
relationship*), and removed the brittle prose greps:

- `cargo test` / `cargo fmt` / `cargo clippy` / `cargo build`
- `deno test`
- `quality.sh`
- `pull request`
- `Keep a Changelog` / `Semantic Versioning`

The header comment now records the removal under Issue #149, matching the
wording style of the sibling files. Documentation prose remains policed by the
Markdown linter and human review.

Closes #149.

## Evidence

Backend/test-only change — no web interface to screenshot.

`deno test` for the affected file (3 behavioural tests retained, all passing):

```
running 3 tests from ./tests/contributing_changelog_test.ts
CONTRIBUTING.md exists at the repository root ... ok
CHANGELOG.md exists at the repository root ... ok
CHANGELOG.md is seeded with the current Cargo.toml version ... ok

ok | 3 passed | 0 failed
```

`./quality.sh` completes successfully across the full suite.

## Test Plan

- Modified `tests/contributing_changelog_test.ts`:
  - Retained: `CONTRIBUTING.md exists at the repository root`,
    `CHANGELOG.md exists at the repository root`,
    `CHANGELOG.md is seeded with the current Cargo.toml version`.
  - Removed: the five prose-grep tests
    (`documents the Rust build/test/lint commands`,
    `documents the Deno test suite`, `anchors on the existing quality gate`,
    `describes the pull-request workflow`,
    `follows the Keep a Changelog format`).
- Ran `deno test tests/contributing_changelog_test.ts` — 3 passed.
- Ran `./quality.sh` — passes cleanly.
