### PR TITLE
Complete trend-line test migration: drive real shipped helpers (Issue #144)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3768,17 +3768,8 @@ class GRQValidator {
             return null;
         }
 
-        const scoreDateTimestamp = scoreDate.getTime();
-        // Use the latest market data date if no endDate is provided, not today's date
-        const trendEndDate = endDate || (marketData && marketData.length > 0 ? marketData[marketData.length - 1].date : new Date());
-        
-        console.log(`calculateTrendLine - ${stock.stock}: Score date: ${scoreDate.toISOString().split('T')[0]}, Today: ${trendEndDate.toISOString().split('T')[0]}`);
-        console.log(`calculateTrendLine - ${stock.stock}: Total market data points: ${marketData.length}`);
-        
-        // Get data points from score date to today (but only if we have at least 3 data points)
-        const dataPoints = [];
         const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-        
+
         if (!buyPriceObj || buyPriceObj.price <= 0) {
             console.log(`calculateTrendLine - ${stock.stock}: No valid buy price. Buy price obj:`, buyPriceObj);
             return null;
@@ -3786,29 +3777,16 @@ class GRQValidator {
 
         console.log(`calculateTrendLine - ${stock.stock}: Buy price: $${buyPriceObj.price.toFixed(2)}`);
 
-        marketData.forEach((point) => {
-            if (point.date >= scoreDate && point.date <= trendEndDate) {
-                const daysSinceScore = (point.date.getTime() - scoreDateTimestamp) / (1000 * 60 * 60 * 24);
-                const currentPrice = this.adjustHistoricalPriceToCurrent(
-                    (point.high + point.low) / 2,
-                    stock.stock,
-                    point.date
-                );
-                
-                // Calculate performance including dividends up to this point
-                const priceReturn = ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-                const dividends = this.getDividendsWithin90Days(stock.stock);
-                const dividendsUpToDate = dividends.filter((d) => d.exDivDate <= point.date);
-                const totalDividends = GRQProjection.sumDividends(dividendsUpToDate);
-                const dividendReturn = (totalDividends / buyPriceObj.price) * 100;
-                const totalReturn = priceReturn + dividendReturn;
-                
-                dataPoints.push({
-                    x: daysSinceScore,
-                    y: totalReturn
-                });
-            }
-        });
+        // Data-window / end-date selection lives in the shared projection module
+        // (issue #144) so production and the Deno tests exercise the same window:
+        // score date to the latest market-data date (not today) unless endDate set.
+        const dataPoints = GRQProjection.buildTrendLineDataPoints(
+            marketData,
+            scoreDate,
+            buyPriceObj.price,
+            this.getDividendsWithin90Days(stock.stock),
+            endDate,
+        );
 
         console.log(`calculateTrendLine - ${stock.stock}: Data points collected: ${dataPoints.length}`);
         if (dataPoints.length > 0) {

--- a/docs/archive/pr-summaries/pr-summary-144.md
+++ b/docs/archive/pr-summaries/pr-summary-144.md
@@ -1,0 +1,76 @@
+# PR Summary — Issue #144
+
+## Summary
+
+Completed the partial migration of `tests/trend_line_extension_test.ts`. The
+final test (`"Trend Line Uses Latest Market Data Date"`) still built a local
+`validator` object whose `calculateTrendLine` was a ~150-line inline
+reimplementation of the production regression pipeline, then asserted on that
+copy — a HOW-test that could never catch a regression in the shipped code.
+
+This PR applies resolution **(a)** from the issue: extract the remaining
+data-window / end-date selection out of `GRQValidator.calculateTrendLine` into
+the shared `docs/projection.js` module as `buildTrendLineDataPoints`, refactor
+production to delegate to it, and rewrite the test to drive the REAL shipped
+helpers (`getBuyPrice` → `buildTrendLineDataPoints` → `computeTrendLine`). The
+inline copy is deleted; the assertions now exercise shipped code, so a
+regression in the trend-window selection ("use latest market data date, not
+today") actually fails the suite.
+
+Closes #144.
+
+## What changed
+
+- **`docs/projection.js`** — new pure helper `buildTrendLineDataPoints(marketData, scoreDate, buyPrice, dividends, endDate)`.
+  It performs the window selection (score date → latest market-data date when
+  `endDate` is omitted, never today) and builds the
+  `{ x: daysSinceScore, y: totalReturn }` regression points, combining the
+  split-adjusted price move with dividends paid up to each point. Published on
+  `globalThis.GRQProjection`.
+- **`docs/app.js`** — `GRQValidator.calculateTrendLine` now delegates the
+  windowing to `GRQProjection.buildTrendLineDataPoints` instead of building the
+  points inline. Behaviour is preserved; production and the Deno tests share one
+  implementation (the same pattern already used for `computeTrendLine`).
+- **`tests/trend_line_extension_test.ts`** — replaced the inline-mirror test
+  with three WHAT-tests against the real helpers.
+
+## Data flow
+
+```mermaid
+flowchart LR
+    A[GRQValidator.calculateTrendLine] --> B[getBuyPrice]
+    A --> C[buildTrendLineDataPoints<br/>window + end-date selection]
+    C --> D[computeTrendLine<br/>regression]
+    E[trend_line_extension_test.ts] --> B
+    E --> C
+    E --> D
+```
+
+The test now drives the exact shared kernels production delegates to — no inline
+copy of the algorithm remains.
+
+## Evidence
+
+Backend/JS change with no web UI to screenshot. Verified via the Deno test
+suite driving the real shipped helpers:
+
+- `Real buildTrendLineDataPoints - Window extends to latest market data date` —
+  with no `endDate`, the window runs to the latest market-data point (~77 days),
+  starting at zero on the score date.
+- `Real buildTrendLineDataPoints - Explicit endDate truncates the window` — an
+  explicit earlier `endDate` excludes the later point, proving the end-date
+  selection is the real windowing logic, not a fixed default.
+- `Real computeTrendLine - Projection reflects SCHW growth pattern` — the
+  shipped regression produces a 90-day projection between 15% and 25% (forced
+  through the origin) for the SCHW growth fixture.
+
+Full suite: `257 passed | 0 failed`.
+
+## Test Plan
+
+- Rewrote `tests/trend_line_extension_test.ts` to drive `GRQProjection.getBuyPrice`,
+  `GRQProjection.buildTrendLineDataPoints`, and `GRQProjection.computeTrendLine`.
+- Confirmed the new tests fail before the `buildTrendLineDataPoints` extraction
+  exists and pass after.
+- Ran `deno test --allow-read tests/*.ts` (257 passed), plus `deno fmt --check`,
+  `deno lint`, and `deno check` over the changed files.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -279,6 +279,56 @@ function computeTrendLine(dataPoints) {
     };
 }
 
+// Build the regression input for a stock's trend line: one
+// `{ x: daysSinceScore, y: totalReturn }` per market-data point inside the
+// window from the score date to `endDate`. When `endDate` is omitted the window
+// runs to the LATEST market-data date (not today's date), so the trend reflects
+// observed data only. Each y combines the split-adjusted price move against the
+// buy price with dividends paid up to that point. Pure given its inputs; the
+// dashboard's GRQValidator gathers the inputs and delegates here (issue #144).
+function buildTrendLineDataPoints(
+    marketData,
+    scoreDate,
+    buyPrice,
+    dividends,
+    endDate,
+) {
+    if (!marketData || marketData.length === 0) return [];
+
+    const scoreDateTimestamp = scoreDate.getTime();
+    // Default to the latest market-data date, never today's date.
+    const trendEndDate = endDate || marketData[marketData.length - 1].date;
+    const dividendList = dividends || [];
+
+    const dataPoints = [];
+    marketData.forEach((point) => {
+        if (point.date >= scoreDate && point.date <= trendEndDate) {
+            const daysSinceScore = (point.date.getTime() - scoreDateTimestamp) /
+                (1000 * 60 * 60 * 24);
+            const currentPrice = adjustHistoricalPriceToCurrent(
+                (point.high + point.low) / 2,
+                marketData,
+                point.date,
+            );
+
+            // Performance including dividends paid up to this point.
+            const priceReturn =
+                ((currentPrice - buyPrice) / buyPrice) * 100;
+            const dividendsUpToDate = dividendList.filter(
+                (d) => d.exDivDate <= point.date,
+            );
+            const totalDividends = sumDividends(dividendsUpToDate);
+            const dividendReturn = (totalDividends / buyPrice) * 100;
+
+            dataPoints.push({
+                x: daysSinceScore,
+                y: priceReturn + dividendReturn,
+            });
+        }
+    });
+    return dataPoints;
+}
+
 // Days elapsed from the score date to the latest market-data date, capped at 90
 // (the validation window). Pure given the two dates.
 function daysElapsedFromMarketData(scoreDate, latestMarketDate) {
@@ -502,6 +552,7 @@ globalThis.GRQProjection = {
     calculateTargetPercentage,
     calculateRSquared,
     computeTrendLine,
+    buildTrendLineDataPoints,
     daysElapsedFromMarketData,
     computeHybridProjection,
     computeJudgement,

--- a/tests/trend_line_extension_test.ts
+++ b/tests/trend_line_extension_test.ts
@@ -21,6 +21,23 @@ interface Projection {
   currentPerformance: number;
 }
 
+interface MarketPoint {
+  date: Date;
+  high: number;
+  low: number;
+  open: number;
+  close: number;
+  splitCoefficient: number;
+}
+
+interface TrendLine {
+  slope: number;
+  intercept: number;
+  predicted90DayPerformance: number;
+  dataPoints: Array<{ x: number; y: number }>;
+  rSquared: number;
+}
+
 const g = globalThis as unknown as {
   GRQProjection: {
     setDateToMidnight: (date: Date) => Date;
@@ -29,6 +46,20 @@ const g = globalThis as unknown as {
       scoreDate: Date,
       trendLine: { slope: number } | null,
     ) => ProjectionPoint[];
+    getBuyPrice: (
+      marketData: MarketPoint[],
+      scoreDate: Date,
+    ) => { price: number; dateUsed: Date } | null;
+    buildTrendLineDataPoints: (
+      marketData: MarketPoint[],
+      scoreDate: Date,
+      buyPrice: number,
+      dividends: Array<{ exDivDate: Date; amount: number }>,
+      endDate?: Date,
+    ) => Array<{ x: number; y: number }>;
+    computeTrendLine: (
+      dataPoints: Array<{ x: number; y: number }>,
+    ) => TrendLine | null;
   };
 };
 const GRQProjection = g.GRQProjection;
@@ -158,191 +189,117 @@ Deno.test("Real buildHybridProjectionData - Does Not Hit Target When Projection 
   assertEquals(data[0].y, 0);
 });
 
-// Test that trend line uses latest market data date instead of today's date.
+// Trend line windowing uses the latest market-data date, not today (issue #144).
 //
-// This exercises the linear-regression shape of calculateTrendLine. The
-// regression maths still lives on GRQValidator (not yet extracted to the
-// shared module); the helper below mirrors it so the regression behaviour is
-// covered. Extracting calculateTrendLine into docs/projection.js is tracked as
-// follow-up work.
-Deno.test("Trend Line Uses Latest Market Data Date", () => {
-  // Mock market data showing SCHW growth from April 15 to July 1
-  const marketData: Record<
-    string,
-    Array<{
-      date: Date;
-      high: number;
-      low: number;
-      open: number;
-      close: number;
-      splitCoefficient: number;
-    }>
-  > = {
-    "NYSE:SCHW": [
-      {
-        date: new Date("2025-04-15"),
-        high: 78.12,
-        low: 77.03,
-        open: 77.55,
-        close: 77.19,
-        splitCoefficient: 1.0,
-      },
-      {
-        date: new Date("2025-07-01"),
-        high: 91.6772,
-        low: 90.14,
-        open: 90.92,
-        close: 91.17,
-        splitCoefficient: 1.0,
-      },
-    ],
-  };
+// This now drives the REAL shipped helpers: GRQProjection.getBuyPrice resolves
+// the buy price, GRQProjection.buildTrendLineDataPoints performs the
+// data-window / end-date selection (the part previously reimplemented inline in
+// this test), and GRQProjection.computeTrendLine runs the regression — the exact
+// pipeline GRQValidator.calculateTrendLine delegates to. A regression in the
+// shipped windowing now fails these assertions.
+// Local-component dates (year, monthIndex, day) match the shared getBuyPrice
+// day-matching, which compares local date components.
+const SCHW_FIXTURE: MarketPoint[] = [
+  {
+    date: new Date(2025, 3, 15), // 15 April 2025
+    high: 78.12,
+    low: 77.03,
+    open: 77.55,
+    close: 77.19,
+    splitCoefficient: 1.0,
+  },
+  {
+    // Intermediate point: regression needs at least three observations.
+    date: new Date(2025, 5, 1), // 1 June 2025
+    high: 85.0,
+    low: 84.0,
+    open: 84.4,
+    close: 84.6,
+    splitCoefficient: 1.0,
+  },
+  {
+    date: new Date(2025, 6, 1), // 1 July 2025
+    high: 91.6772,
+    low: 90.14,
+    open: 90.92,
+    close: 91.17,
+    splitCoefficient: 1.0,
+  },
+];
 
-  // Mock validator with trend line calculation
-  const validator = {
-    marketData,
-    setDateToMidnight: function (date: Date): Date {
-      const d = new Date(date);
-      d.setHours(0, 0, 0, 0);
-      return d;
-    },
-    getBuyPrice: function (stockSymbol: string, scoreDate: Date) {
-      const data = this.marketData[stockSymbol];
-      if (!data || data.length === 0) return null;
+Deno.test("Real buildTrendLineDataPoints - Window extends to latest market data date", () => {
+  const scoreDate = new Date(2025, 3, 15);
+  const buyPrice = GRQProjection.getBuyPrice(SCHW_FIXTURE, scoreDate);
+  assertExists(buyPrice, "Buy price should resolve from the fixture");
 
-      // Find closest point to score date
-      const scoreDateTimestamp = scoreDate.getTime();
-      let closestPoint = data[0];
-      let minDiff = Math.abs(data[0].date.getTime() - scoreDateTimestamp);
-
-      for (const point of data) {
-        const diff = Math.abs(point.date.getTime() - scoreDateTimestamp);
-        if (diff < minDiff) {
-          minDiff = diff;
-          closestPoint = point;
-        }
-      }
-
-      const buyPrice = (closestPoint.high + closestPoint.low) / 2;
-      return { price: buyPrice, date: closestPoint.date };
-    },
-    adjustHistoricalPriceToCurrent: function (price: number) {
-      return price; // No adjustments for this test
-    },
-    getDividendsWithin90Days: function () {
-      return []; // No dividends for this test
-    },
-    calculateTrendLine: function (
-      stock: { stock: string },
-      scoreDate: Date,
-      endDate?: Date,
-    ) {
-      const marketData = this.marketData[stock.stock];
-      if (!marketData || marketData.length === 0) {
-        return null;
-      }
-
-      const scoreDateTimestamp = scoreDate.getTime();
-      // Use the latest market data date if no endDate is provided, not today's date
-      const trendEndDate = endDate ||
-        (marketData && marketData.length > 0
-          ? marketData[marketData.length - 1].date
-          : new Date());
-
-      // Get data points from score date to trend end date
-      const dataPoints: Array<{ x: number; y: number }> = [];
-      const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-
-      if (!buyPriceObj || buyPriceObj.price <= 0) {
-        return null;
-      }
-
-      marketData.forEach((point) => {
-        if (point.date >= scoreDate && point.date <= trendEndDate) {
-          const daysSinceScore = (point.date.getTime() - scoreDateTimestamp) /
-            (1000 * 60 * 60 * 24);
-          const currentPrice = this.adjustHistoricalPriceToCurrent(
-            (point.high + point.low) / 2,
-          );
-
-          // Calculate performance (no dividends in this test)
-          const priceReturn =
-            ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-          const totalReturn = priceReturn;
-
-          dataPoints.push({
-            x: daysSinceScore,
-            y: totalReturn,
-          });
-        }
-      });
-
-      if (dataPoints.length < 2) {
-        return null;
-      }
-
-      // Calculate linear regression
-      const n = dataPoints.length;
-      const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
-      const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
-      const sumXY = dataPoints.reduce(
-        (sum, point) => sum + point.x * point.y,
-        0,
-      );
-      const sumXX = dataPoints.reduce(
-        (sum, point) => sum + point.x * point.x,
-        0,
-      );
-
-      const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-      const _intercept = (sumY - slope * sumX) / n;
-
-      // Force the trend line to start at zero on the score date
-      const adjustedIntercept = 0;
-      const adjustedSlope = slope;
-
-      // Predict performance at 90 days using the adjusted line
-      const predicted90DayPerformance = adjustedSlope * 90 + adjustedIntercept;
-      const cappedPredicted90DayPerformance = Math.max(
-        predicted90DayPerformance,
-        -100,
-      );
-
-      return {
-        slope: adjustedSlope,
-        intercept: adjustedIntercept,
-        predicted90DayPerformance: cappedPredicted90DayPerformance,
-        dataPoints,
-        rSquared: 0.95,
-      };
-    },
-  };
-
-  const stock = { stock: "NYSE:SCHW" };
-  const scoreDate = new Date("2025-04-15");
-
-  // Calculate trend line without specifying endDate (should use latest market data)
-  const trendLine = validator.calculateTrendLine(stock, scoreDate);
-
-  assertExists(trendLine, "Trend line should be calculated");
-
-  // Check that the trend line uses data up to July 1 (latest market data)
-  const latestDataPoint =
-    trendLine!.dataPoints[trendLine!.dataPoints.length - 1];
-  const daysSinceScore = latestDataPoint.x;
-
-  // July 1 is about 77 days after April 15
-  assertEquals(
-    daysSinceScore >= 75 && daysSinceScore <= 80,
-    true,
-    `Should use data up to ~77 days, got ${daysSinceScore}`,
+  // No endDate -> the window must run to the latest market-data point (July 1),
+  // NOT today's date.
+  const dataPoints = GRQProjection.buildTrendLineDataPoints(
+    SCHW_FIXTURE,
+    scoreDate,
+    buyPrice!.price,
+    [],
   );
 
-  // Check that the projection reflects the actual growth pattern
-  const predicted90Day = trendLine!.predicted90DayPerformance;
+  // All three observations fall inside the window.
+  assertEquals(dataPoints.length, 3);
 
-  // With growth from ~77.58 to ~90.91 = ~17% growth in ~77 days
-  // The 90-day projection should reflect this growth rate
+  // The last point is July 1, about 77 days after April 15.
+  const lastDay = dataPoints[dataPoints.length - 1].x;
+  assertEquals(
+    lastDay >= 75 && lastDay <= 80,
+    true,
+    `Should use data up to ~77 days, got ${lastDay}`,
+  );
+
+  // The trend line starts at zero on the score date.
+  assertEquals(dataPoints[0].x, 0);
+  assertEquals(dataPoints[0].y, 0);
+});
+
+Deno.test("Real buildTrendLineDataPoints - Explicit endDate truncates the window", () => {
+  const scoreDate = new Date(2025, 3, 15);
+  const buyPrice = GRQProjection.getBuyPrice(SCHW_FIXTURE, scoreDate);
+  assertExists(buyPrice);
+
+  // An explicit earlier endDate excludes the July 1 point, proving the
+  // end-date selection is the real windowing logic and not a fixed default.
+  const dataPoints = GRQProjection.buildTrendLineDataPoints(
+    SCHW_FIXTURE,
+    scoreDate,
+    buyPrice!.price,
+    [],
+    new Date(2025, 5, 1),
+  );
+
+  assertEquals(dataPoints.length, 2);
+  const lastDay = dataPoints[dataPoints.length - 1].x;
+  // June 1 is about 47 days after April 15.
+  assertEquals(
+    lastDay >= 45 && lastDay <= 49,
+    true,
+    `Window should stop at ~47 days, got ${lastDay}`,
+  );
+});
+
+Deno.test("Real computeTrendLine - Projection reflects SCHW growth pattern", () => {
+  const scoreDate = new Date(2025, 3, 15);
+  const buyPrice = GRQProjection.getBuyPrice(SCHW_FIXTURE, scoreDate);
+  assertExists(buyPrice);
+
+  const dataPoints = GRQProjection.buildTrendLineDataPoints(
+    SCHW_FIXTURE,
+    scoreDate,
+    buyPrice!.price,
+    [],
+  );
+  const trendLine = GRQProjection.computeTrendLine(dataPoints);
+  assertExists(trendLine, "Trend line should be calculated");
+
+  // Growth from ~77.58 to ~90.91 (~17% over ~77 days); the 90-day projection
+  // tracks that rate. Driving the REAL regression (not an inline copy) proves
+  // the shipped maths produces this figure.
+  const predicted90Day = trendLine!.predicted90DayPerformance;
   assertEquals(
     predicted90Day > 15,
     true,
@@ -353,6 +310,9 @@ Deno.test("Trend Line Uses Latest Market Data Date", () => {
     true,
     `Projection should be <25%, got ${predicted90Day}%`,
   );
+
+  // The regression is forced through the origin (day 0 reads 0%).
+  assertEquals(trendLine!.intercept, 0);
 });
 
 console.log("All trend line extension tests passed! 🎉");


### PR DESCRIPTION
# PR Summary — Issue #144

## Summary

Completed the partial migration of `tests/trend_line_extension_test.ts`. The
final test (`"Trend Line Uses Latest Market Data Date"`) still built a local
`validator` object whose `calculateTrendLine` was a ~150-line inline
reimplementation of the production regression pipeline, then asserted on that
copy — a HOW-test that could never catch a regression in the shipped code.

This PR applies resolution **(a)** from the issue: extract the remaining
data-window / end-date selection out of `GRQValidator.calculateTrendLine` into
the shared `docs/projection.js` module as `buildTrendLineDataPoints`, refactor
production to delegate to it, and rewrite the test to drive the REAL shipped
helpers (`getBuyPrice` → `buildTrendLineDataPoints` → `computeTrendLine`). The
inline copy is deleted; the assertions now exercise shipped code, so a
regression in the trend-window selection ("use latest market data date, not
today") actually fails the suite.

Closes #144.

## What changed

- **`docs/projection.js`** — new pure helper `buildTrendLineDataPoints(marketData, scoreDate, buyPrice, dividends, endDate)`.
  It performs the window selection (score date → latest market-data date when
  `endDate` is omitted, never today) and builds the
  `{ x: daysSinceScore, y: totalReturn }` regression points, combining the
  split-adjusted price move with dividends paid up to each point. Published on
  `globalThis.GRQProjection`.
- **`docs/app.js`** — `GRQValidator.calculateTrendLine` now delegates the
  windowing to `GRQProjection.buildTrendLineDataPoints` instead of building the
  points inline. Behaviour is preserved; production and the Deno tests share one
  implementation (the same pattern already used for `computeTrendLine`).
- **`tests/trend_line_extension_test.ts`** — replaced the inline-mirror test
  with three WHAT-tests against the real helpers.

## Data flow

```mermaid
flowchart LR
    A[GRQValidator.calculateTrendLine] --> B[getBuyPrice]
    A --> C[buildTrendLineDataPoints<br/>window + end-date selection]
    C --> D[computeTrendLine<br/>regression]
    E[trend_line_extension_test.ts] --> B
    E --> C
    E --> D
```

The test now drives the exact shared kernels production delegates to — no inline
copy of the algorithm remains.

## Evidence

Backend/JS change with no web UI to screenshot. Verified via the Deno test
suite driving the real shipped helpers:

- `Real buildTrendLineDataPoints - Window extends to latest market data date` —
  with no `endDate`, the window runs to the latest market-data point (~77 days),
  starting at zero on the score date.
- `Real buildTrendLineDataPoints - Explicit endDate truncates the window` — an
  explicit earlier `endDate` excludes the later point, proving the end-date
  selection is the real windowing logic, not a fixed default.
- `Real computeTrendLine - Projection reflects SCHW growth pattern` — the
  shipped regression produces a 90-day projection between 15% and 25% (forced
  through the origin) for the SCHW growth fixture.

Full suite: `257 passed | 0 failed`.

## Test Plan

- Rewrote `tests/trend_line_extension_test.ts` to drive `GRQProjection.getBuyPrice`,
  `GRQProjection.buildTrendLineDataPoints`, and `GRQProjection.computeTrendLine`.
- Confirmed the new tests fail before the `buildTrendLineDataPoints` extraction
  exists and pass after.
- Ran `deno test --allow-read tests/*.ts` (257 passed), plus `deno fmt --check`,
  `deno lint`, and `deno check` over the changed files.
