### PR TITLE
Milestone: security-scan

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -6,6 +6,13 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -19,6 +19,8 @@ jobs:
       # dtolnay/rust-toolchain@stable
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        # Pin to an explicit version with --locked so CI does not compile and
+        # run an arbitrary newest cargo-audit dependency tree (Issue #124).
+        run: cargo install cargo-audit --locked --version 0.22.2
       - name: Run cargo audit
         run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,24 +105,31 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-
           
-    - name: Update dependencies
-      run: cargo update
-      
+    # Supply-chain quarantine (Issue #124): CI builds the committed, reviewed
+    # Cargo.lock rather than running `cargo update` to float every crate to the
+    # newest in-range version on each run. `--locked` makes the build fail if
+    # Cargo.lock is stale instead of silently resolving (and executing the
+    # build.rs / proc-macros of) a freshly-published, unquarantined crate.
+    # Dependency bumps land through the quarantined Dependabot PRs instead
+    # (.github/dependabot.yml), mirroring the Deno minimumDependencyAge policy.
     - name: Check formatting
       run: cargo fmt --all -- --check
-      
+
     - name: Run linter
-      run: cargo clippy --all-targets --all-features -- -D warnings
-      
+      run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
     - name: Check types
-      run: cargo check --all-targets --all-features
-      
+      run: cargo check --locked --all-targets --all-features
+
     - name: Run tests
-      run: cargo test --all-targets --all-features --verbose
-      
+      run: cargo test --locked --all-targets --all-features --verbose
+
     - name: Generate test coverage
+      # Pin the tool to an explicit version with --locked so CI does not
+      # compile and run an arbitrary newest cargo-tarpaulin dependency tree
+      # on each run (Issue #124).
       run: |
-        cargo install cargo-tarpaulin
+        cargo install cargo-tarpaulin --locked --version 0.35.4
         cargo tarpaulin --out Xml --output-dir coverage
       continue-on-error: true
       
@@ -172,7 +179,8 @@ jobs:
           ${{ runner.os }}-cargo-
           
     - name: Build release
-      run: cargo build --release
+      # --locked: build the committed Cargo.lock, never float deps (Issue #124).
+      run: cargo build --locked --release
 
     # SCR-SBOM (Issue #53): generate a machine-readable component inventory
     # alongside the binary so post-disclosure incident triage can answer
@@ -180,7 +188,9 @@ jobs:
     - name: Generate CycloneDX SBOM
       run: |
         set -euo pipefail
-        cargo install cargo-cyclonedx
+        # Pin the tool to an explicit version with --locked so CI does not
+        # compile an arbitrary newest cargo-cyclonedx tree on each run (#124).
+        cargo install cargo-cyclonedx --locked --version 0.5.9
         cargo cyclonedx --format json
         # cargo-cyclonedx names the SBOM after the package; normalise the
         # path so the upload step always finds it.

--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -7,6 +7,13 @@ on:
     # Weekly audit so a JSR/@std compromise is caught even with no open PR.
     - cron: "0 6 * * 1"
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,6 +11,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main, master]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,6 +16,13 @@ on:
   pull_request:
     branches: ["*"]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main, master]
 
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,9 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "num-traits"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ auto-bumped within the same window. Internal `stSoftwareAU/*` dependencies are
 excluded from the cooldown so they update immediately, mirroring the
 `minimumDependencyAge` policy that `deno.json` applies to the Deno ecosystem.
 
+The CI pipeline (`ci.yml`) complements this by building the **committed,
+reviewed `Cargo.lock`** rather than floating dependencies: every `cargo`
+build/test/check step runs with `--locked`, so a stale lockfile fails the
+build instead of silently resolving (and executing the `build.rs` /
+proc-macros of) a freshly-published, unquarantined crate. CI tool installs
+(`cargo-tarpaulin`, `cargo-cyclonedx`, `cargo-audit`) are pinned to explicit
+versions with `--locked` so they do not compile an arbitrary newest
+tool-dependency tree on each run. Crate bumps therefore arrive only through
+the quarantined Dependabot PRs above, never inline on a PR build.
+
 ### Setup
 
 1. Enable GitHub Actions in your repository.

--- a/docs/app.js
+++ b/docs/app.js
@@ -2878,15 +2878,11 @@ class GRQValidator {
     }
 
     getDividendsWithin90Days(stockSymbol) {
+        // Window filtering lives in the shared projection module (issue #145)
+        // so production and the Deno tests exercise the same kernel.
         const dividends = this.dividendData?.[stockSymbol] || [];
         const scoreDate = this.getScoreDate(this.selectedFile);
-        const ninetyDayDate = new Date(
-            scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
-        );
-
-        return dividends.filter((dividend) =>
-            dividend.exDivDate <= ninetyDayDate
-        );
+        return GRQProjection.filterDividendsWithin90Days(dividends, scoreDate);
     }
 
     getCurrentPrice(stockSymbol) {
@@ -3401,7 +3397,7 @@ class GRQValidator {
                 }
                 
                 const gainLossDividends = this.getDividendsWithin90Days(stockSymbol);
-                const gainLossTotalDividends = gainLossDividends.reduce((sum, div) => sum + div.amount, 0);
+                const gainLossTotalDividends = GRQProjection.sumDividends(gainLossDividends);
                 
                 // Get current price for display
                 const gainLossMarketData = this.marketData[stockSymbol];
@@ -3758,7 +3754,7 @@ class GRQValidator {
 
         // Add dividend return within 90 days
         const dividends = this.getDividendsWithin90Days(stock.stock);
-        const totalDividends = dividends.reduce((sum, div) => sum + div.amount, 0);
+        const totalDividends = GRQProjection.sumDividends(dividends);
         const dividendReturn = (totalDividends / buyPriceObj.price) * 100;
 
         return priceReturn + dividendReturn;
@@ -3803,7 +3799,7 @@ class GRQValidator {
                 const priceReturn = ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
                 const dividends = this.getDividendsWithin90Days(stock.stock);
                 const dividendsUpToDate = dividends.filter((d) => d.exDivDate <= point.date);
-                const totalDividends = dividendsUpToDate.reduce((sum, div) => sum + div.amount, 0);
+                const totalDividends = GRQProjection.sumDividends(dividendsUpToDate);
                 const dividendReturn = (totalDividends / buyPriceObj.price) * 100;
                 const totalReturn = priceReturn + dividendReturn;
                 

--- a/docs/app.js
+++ b/docs/app.js
@@ -3768,17 +3768,8 @@ class GRQValidator {
             return null;
         }
 
-        const scoreDateTimestamp = scoreDate.getTime();
-        // Use the latest market data date if no endDate is provided, not today's date
-        const trendEndDate = endDate || (marketData && marketData.length > 0 ? marketData[marketData.length - 1].date : new Date());
-        
-        console.log(`calculateTrendLine - ${stock.stock}: Score date: ${scoreDate.toISOString().split('T')[0]}, Today: ${trendEndDate.toISOString().split('T')[0]}`);
-        console.log(`calculateTrendLine - ${stock.stock}: Total market data points: ${marketData.length}`);
-        
-        // Get data points from score date to today (but only if we have at least 3 data points)
-        const dataPoints = [];
         const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-        
+
         if (!buyPriceObj || buyPriceObj.price <= 0) {
             console.log(`calculateTrendLine - ${stock.stock}: No valid buy price. Buy price obj:`, buyPriceObj);
             return null;
@@ -3786,29 +3777,16 @@ class GRQValidator {
 
         console.log(`calculateTrendLine - ${stock.stock}: Buy price: $${buyPriceObj.price.toFixed(2)}`);
 
-        marketData.forEach((point) => {
-            if (point.date >= scoreDate && point.date <= trendEndDate) {
-                const daysSinceScore = (point.date.getTime() - scoreDateTimestamp) / (1000 * 60 * 60 * 24);
-                const currentPrice = this.adjustHistoricalPriceToCurrent(
-                    (point.high + point.low) / 2,
-                    stock.stock,
-                    point.date
-                );
-                
-                // Calculate performance including dividends up to this point
-                const priceReturn = ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-                const dividends = this.getDividendsWithin90Days(stock.stock);
-                const dividendsUpToDate = dividends.filter((d) => d.exDivDate <= point.date);
-                const totalDividends = GRQProjection.sumDividends(dividendsUpToDate);
-                const dividendReturn = (totalDividends / buyPriceObj.price) * 100;
-                const totalReturn = priceReturn + dividendReturn;
-                
-                dataPoints.push({
-                    x: daysSinceScore,
-                    y: totalReturn
-                });
-            }
-        });
+        // Data-window / end-date selection lives in the shared projection module
+        // (issue #144) so production and the Deno tests exercise the same window:
+        // score date to the latest market-data date (not today) unless endDate set.
+        const dataPoints = GRQProjection.buildTrendLineDataPoints(
+            marketData,
+            scoreDate,
+            buyPriceObj.price,
+            this.getDividendsWithin90Days(stock.stock),
+            endDate,
+        );
 
         console.log(`calculateTrendLine - ${stock.stock}: Data points collected: ${dataPoints.length}`);
         if (dataPoints.length > 0) {

--- a/docs/archive/pr-summaries/pr-summary-109.md
+++ b/docs/archive/pr-summaries/pr-summary-109.md
@@ -1,0 +1,57 @@
+# PR Summary — Issue #109
+
+## Summary
+
+`tests/target_percentage_tests.ts` and `tests/portfolio_target_tests.ts`
+imported nothing from the shipped code. Each test recomputed the
+target-percentage / split-adjustment / portfolio-return formula **inline** and
+asserted the result against a hand-evaluation of the same arithmetic — and
+`portfolio_target_tests.ts` even asserted the literal `20.0` against itself.
+These were tautologies: they exercised zero production code, so a genuine
+regression in the real maths left every assertion green.
+
+This PR rewrites both suites as WHAT-tests (resolution (a) from the issue): they
+now `import "../docs/projection.js"` and drive the shipped helpers
+(`calculateTargetPercentage`, `getSplitAdjustment`,
+`adjustHistoricalPriceToCurrent`, `calculatePerformanceReturn`) with the fixture
+inputs, asserting on the helpers' **return values** against spec-derived expected
+numbers. The inline formula recomputation and the literal-versus-itself check are
+gone. `portfolio_target_tests.ts` fixtures were corrected so each stock models a
+genuine ~20% target spread (`buyPrice` below `target`) instead of the previous
+`buyPrice == target`, which produced a 0% target the tautological test masked.
+
+Closes #109.
+
+## Evidence
+
+This is a test-only change (TypeScript) with no web interface, so no screenshot
+applies. The fix is verified by behaviour:
+
+- Full Deno suite green: `233 passed (57 steps) | 0 failed`.
+- **Regression check** — temporarily breaking `calculateTargetPercentage` in
+  `docs/projection.js` (returning `* 90` instead of `* 100`) now turns **7 steps
+  red** across both files; the unmodified production code keeps them green. The
+  former tests stayed green under the same break.
+
+```mermaid
+flowchart LR
+    F[Fixture inputs] --> P["docs/projection.js<br/>shipped helper"]
+    P --> R[Return value]
+    R --> A{assert ≈ spec expected}
+    S[Spec-derived expected] --> A
+```
+
+Before: the test computed the formula itself and compared against its own
+hand-evaluation — production code (`P`) was never on the path.
+
+## Test Plan
+
+- `tests/target_percentage_tests.ts` — rewrote every arithmetic step to call
+  `GRQProjection.calculateTargetPercentage`, plus `getSplitAdjustment` /
+  `adjustHistoricalPriceToCurrent` for the split-adjustment steps; added a
+  null-guard edge case.
+- `tests/portfolio_target_tests.ts` — replaced the `20.0 ≈ 20.0` literal check
+  and the inline portfolio-return recomputation with calls to
+  `calculateTargetPercentage` and `calculatePerformanceReturn`; corrected
+  fixtures to a real 20% target spread.
+- Verified with `deno test --allow-read tests/*.ts` and the full `./quality.sh`.

--- a/docs/archive/pr-summaries/pr-summary-116.md
+++ b/docs/archive/pr-summaries/pr-summary-116.md
@@ -1,0 +1,67 @@
+# Add a crate-root lint posture to the library crate
+
+## Summary
+
+The library crate root (`src/lib.rs`) previously declared only
+`#![warn(missing_docs)]` (added in #97) and no other lint posture. This PR
+adds explicit per-lint denies at the crate root so hygiene is enforced at
+compile time rather than discovered later. Closes #116.
+
+Changes to `src/lib.rs`:
+
+```diff
+ #![warn(missing_docs)]
++#![deny(unsafe_code)]
++#![deny(unsafe_op_in_unsafe_fn)]
+```
+
+- `deny(unsafe_code)` — the crate is pure safe Rust (no `unsafe` blocks or
+  functions), so denying unsafe at the root makes any future `unsafe` an
+  explicit, reviewed decision.
+- `deny(unsafe_op_in_unsafe_fn)` — future-proofs the crate so unsafe
+  operations inside any future `unsafe fn` require their own `unsafe` block.
+
+### Why not `#![deny(warnings)]` in source?
+
+The issue notes `#![deny(warnings)]` is often too strict for day-to-day
+builds and suggests scoping it to CI. The repo already does exactly this:
+`quality.sh` runs `cargo clippy --all-targets --all-features -- -D warnings`,
+so warnings already fail CI. Hard-coding `#![deny(warnings)]` into the source
+would break local builds on compiler upgrades, so it is deliberately left to
+CI.
+
+## Evidence
+
+Backend/library-only change — no web interface to screenshot.
+
+- `cargo clippy --lib --all-features -- -D warnings` passes with the new
+  posture (no warnings surfaced).
+- Full `./quality.sh` passes: `cargo fmt --check`, clippy (`-D warnings`),
+  `cargo check`, `cargo test` (Rust), and the Deno test/lint/check suite —
+  `233 passed | 0 failed`.
+
+```mermaid
+flowchart LR
+    A["src/lib.rs<br/>crate root"] -->|warn| B[missing_docs]
+    A -->|deny| C[unsafe_code]
+    A -->|deny| D[unsafe_op_in_unsafe_fn]
+    E["quality.sh CI<br/>clippy -D warnings"] -->|enforces| F[deny warnings]
+```
+
+## Test Plan
+
+Added `tests/crate_lint_posture_test.rs` (TDD — written before the source
+change; the two new assertions failed first, then passed after editing
+`src/lib.rs`):
+
+- `crate_root_warns_on_missing_docs` — guards the existing `missing_docs`
+  warning against removal.
+- `crate_root_denies_unsafe_code` — asserts the new `deny(unsafe_code)`.
+- `crate_root_denies_unsafe_op_in_unsafe_fn` — asserts the new
+  `deny(unsafe_op_in_unsafe_fn)`.
+
+A lint posture is compile-time configuration with no runtime surface, so the
+tests assert on the committed crate root — mirroring the existing
+`license_metadata_test.rs`, which verifies the committed LICENSE against the
+manifest. They fail loudly if the posture is later removed or weakened, which
+is the regression the issue describes.

--- a/docs/archive/pr-summaries/pr-summary-117.md
+++ b/docs/archive/pr-summaries/pr-summary-117.md
@@ -1,0 +1,68 @@
+# PR Summary — Document failure modes on public utils functions
+
+## Summary
+
+`src/utils.rs` already carried a one-line `///` summary on every public item
+(enforced by the existing `#![warn(missing_docs)]`), but none of its
+`Result`-returning functions documented their failure modes. This left the
+Rust API Guidelines C-FAILURE gap called out in the issue.
+
+This PR adds a `# Errors` section to all 17 `Result`-returning public functions
+in `src/utils.rs`, describing the conditions under which each returns an error
+(missing/invalid files, malformed JSON, invalid dates, path-traversal guards,
+etc.). It also enables `#![warn(clippy::missing_errors_doc)]` at the crate root
+so the compiler enforces this coverage going forward, complementing the
+existing `#![warn(missing_docs)]` posture.
+
+Closes #117.
+
+## Approach
+
+```mermaid
+flowchart LR
+    A["#![warn(clippy::missing_errors_doc)]<br/>added to lib.rs"] --> B["cargo clippy<br/>17 warnings (red)"]
+    B --> C["Add # Errors to each<br/>Result-returning pub fn"]
+    C --> D["cargo clippy -D warnings<br/>clean (green)"]
+```
+
+Functions documented: `read_index_json`, `build_score_file_path`,
+`read_tsv_score_file`, `extract_ticker_codes_from_score_file`,
+`read_market_data`, `read_market_data_from_csv`,
+`filter_market_data_by_date_range`, `create_market_data_csv_for_score_file`,
+`create_market_data_csv`, `create_market_data_long_csv`,
+`create_market_data_long_csv_for_score_file`, `read_dividend_data`,
+`filter_dividend_data_by_date_range`, `create_dividend_csv`,
+`create_dividend_csv_for_score_file`, `calculate_portfolio_performance`,
+`calculate_hybrid_projection`, `update_index_with_performance`.
+
+## Evidence
+
+Backend/CLI documentation change — no web interface to screenshot.
+
+The change is compiler-verifiable rather than runtime behaviour:
+
+- **Before:** `cargo clippy --lib` reported 17 `docs for function returning
+  Result missing # Errors section` warnings once the lint was enabled.
+- **After:** `cargo clippy --all-targets --all-features -- -D warnings` passes
+  with zero warnings.
+- `cargo test --doc` — 3 doctests pass (existing examples still compile).
+- `./quality.sh` — completed successfully (fmt, clippy `-D warnings`, type
+  checks, Rust tests + coverage, Deno tests/lint/check all green).
+
+## Test Plan
+
+This is a documentation-only change; correctness is enforced by the compiler:
+
+- `#![warn(clippy::missing_errors_doc)]` + `#![warn(missing_docs)]` at the crate
+  root, combined with quality.sh's `cargo clippy ... -D warnings`, fail the
+  build if any public item lacks a doc summary or any `Result`-returning public
+  function lacks a `# Errors` section. This is the regression guard going
+  forward.
+- `cargo test --doc` continues to pass, confirming the existing runnable
+  examples still compile.
+- No existing tests were modified or removed.
+
+## Deno regression avoided
+
+`quality.sh` continues to drive the Deno test/lint/check steps via `deno`; no
+Node tooling was introduced.

--- a/docs/archive/pr-summaries/pr-summary-121.md
+++ b/docs/archive/pr-summaries/pr-summary-121.md
@@ -1,0 +1,83 @@
+# Replace tautological judgement / annualised tests with WHAT-tests
+
+## Summary
+
+`tests/judgement_tests.ts` and `tests/annualized_performance_test.ts` imported
+nothing from the shipped dashboard code (only `@std/assert`). Each reimplemented
+production logic as a local copy and then asserted on that copy — tautologies
+that stayed green even if the real code drifted, and in the judgement case the
+local copy asserted on a string mapping (`EXCEEDED`/`MET`/`BELOW`,
+`ABOVE`/`AT`/`BELOW`) that the shipped code never produces.
+
+This change resolves the third tautology cluster called out in the issue
+(distinct from #102 and #109), using the issue's two sanctioned resolutions:
+
+- **`tests/judgement_tests.ts`** — rewritten (option a) to drive the REAL
+  exported `GRQProjection.computeJudgement` (`docs/projection.js`) and assert on
+  the shipped judgement strings (`Hit Target`, `Partial Success`,
+  `Missed Target`, `Early Days`, `Pending`). A regression in the production
+  mapping at `docs/projection.js:385` now fails. The fictional cost-of-capital
+  `ABOVE/AT/BELOW` cases and the local `Date`-arithmetic "boundary" steps were
+  deleted (option b): no shipped code produced those strings, and the real
+  cost-of-capital figure is an excess-return *number*, not a string bucket.
+
+- **`tests/annualized_performance_test.ts`** — the recompute-only "Compound
+  Interest" guard (covered in production by Rust `calculate_annualized_performance`,
+  WHAT-tested in `src/utils.rs`) and the local `calculateHybridProjection` copy
+  (covered by `GRQProjection.computeHybridProjection` via
+  `tests/projection_kernels_test.ts`) were deleted (option b). The index.json
+  averaging case was the only genuinely uncovered production logic, so it is now
+  a WHAT-test (option a): the averaging maths was extracted from
+  `docs/list.js::updateSummaryStats` into a pure, shipped helper
+  `GRQListStats.computeListAverages` (`docs/list_stats.js`) that the list page
+  delegates to and the test drives directly.
+
+These removed tests were tautological by design and verified no shipped
+behaviour; their real-module equivalents either already exist or were added
+here, so no genuine coverage is lost.
+
+Closes #121.
+
+## Change shape
+
+```mermaid
+flowchart LR
+    subgraph Before
+        T1[judgement_tests.ts] -->|asserts on| L1[local EXCEEDED/MET copy]
+        T2[annualized_performance_test.ts] -->|asserts on| L2[inline formula + averaging + hybrid copy]
+    end
+    subgraph After
+        T3[judgement_tests.ts] -->|drives| P1[GRQProjection.computeJudgement]
+        T4[annualized_performance_test.ts] -->|drives| P2[GRQListStats.computeListAverages]
+        LJS[docs/list.js updateSummaryStats] -->|delegates to| P2
+    end
+```
+
+## Evidence
+
+Backend/JS-logic change — no rendered UI change (the list page's summary cards
+display the same figures; the averaging maths is unchanged, only relocated to a
+shared kernel). Playwright MCP was unavailable in this environment, so
+verification was via the test suite:
+
+- `deno test --allow-read tests/*.ts` → **234 passed, 0 failed**.
+- The new `computeListAverages` tests assert spec-derived expected values
+  (`avg90Day = 23.705`, `avgAnnualized = 68.5475`, counts `2`/`4`/`2`) against
+  the **shipped** kernel, so a regression in the averaging path now fails.
+- `docs/list.js::updateSummaryStats` was refactored to call the extracted
+  kernel; the accumulation logic is byte-for-byte the same loop, and
+  `visibleData.toArray()` yields the same row objects the previous
+  `visibleData.each(...)` iterated — behaviour-preserving.
+- `deno fmt`, `deno lint`, `deno check` all clean.
+
+## Test Plan
+
+- `tests/judgement_tests.ts` — `computeJudgement` realised-outcome mapping
+  (Hit Target / Partial Success / Missed Target at day 90), Pending for null,
+  and early-stage reporting; all against the real `GRQProjection` helper.
+- `tests/annualized_performance_test.ts` — `computeListAverages` happy path
+  (mixed populated/null rows), negative/zero handling (positive-count edge
+  case), and the empty / all-null edge cases; all against the real
+  `GRQListStats` helper.
+- Existing `tests/projection_kernels_test.ts` continues to cover
+  `computeJudgement` and `computeHybridProjection` (no regression).

--- a/docs/archive/pr-summaries/pr-summary-124.md
+++ b/docs/archive/pr-summaries/pr-summary-124.md
@@ -1,0 +1,57 @@
+## Summary
+
+Bring the **Cargo** ecosystem under the same supply-chain quarantine the Deno
+ecosystem already enjoys by closing the remaining CI gaps. The Dependabot 24h
+`cooldown` for Cargo crates already existed (Issue #75); this change removes the
+two ways CI still floated unquarantined code:
+
+1. **Removed the unconditional `cargo update` step** from `ci.yml`. It ran on
+   every pull request and resolved every crate to the newest in-range version,
+   executing freshly-published `build.rs` / proc-macros with zero age gate. CI
+   now builds the **committed, reviewed `Cargo.lock`**: every `cargo`
+   clippy/check/test/build step runs with `--locked`, so a stale lockfile fails
+   the build instead of silently pulling a newer crate. Crate bumps now arrive
+   only through the quarantined Dependabot PRs.
+2. **Pinned the CI tool installs** to explicit versions with `--locked` so they
+   no longer compile and run an arbitrary newest tool-dependency tree:
+   - `cargo install cargo-tarpaulin --locked --version 0.35.4` (`ci.yml`)
+   - `cargo install cargo-cyclonedx --locked --version 0.5.9` (`ci.yml`)
+   - `cargo install cargo-audit --locked --version 0.22.2` (`cargo-audit.yml`)
+
+Closes #124.
+
+### Deno regression avoided
+
+This is a Deno repo (`deno.json`, `deno.lock`). The new tests are Deno tests
+(`deno test`) and reuse the existing `@std/yaml` parser — no Node tooling,
+`package.json`, or `tsconfig.json` introduced.
+
+## Evidence
+
+Backend/CI-config change with no web interface to screenshot. Verified via the
+Deno test suite below and a full `./quality.sh` run, which completed with
+"✅ Quality checks completed successfully!".
+
+```mermaid
+flowchart LR
+    PR[Pull request] --> CI[ci.yml test/build]
+    CI -->|before| U[cargo update floats deps] --> X[build.rs of fresh crate runs]
+    CI -->|after| L[cargo --locked builds Cargo.lock] --> R[only reviewed crates run]
+    DB[Dependabot 24h cooldown] -->|quarantined bump PR| Lock[Cargo.lock]
+    Lock --> L
+```
+
+## Test Plan
+
+New `tests/cargo_supply_chain_quarantine_test.ts` (parses the workflow YAML and
+asserts behaviour, not source text):
+
+- `ci.yml` test job no longer runs `cargo update`.
+- `ci.yml` build job does not run `cargo update`.
+- `ci.yml` test job runs `cargo check` / `cargo test` with `--locked`.
+- `ci.yml` release build runs `cargo build --locked`.
+- `ci.yml` pins `cargo-tarpaulin` / `cargo-cyclonedx` with `--locked --version`.
+- `cargo-audit.yml` pins `cargo-audit` with `--locked --version`.
+
+Existing `ci_workflow_test.ts`, `cargo_audit_workflow_test.ts`, and
+`dependabot_config_test.ts` continue to pass unchanged (27 tests green).

--- a/docs/archive/pr-summaries/pr-summary-139.md
+++ b/docs/archive/pr-summaries/pr-summary-139.md
@@ -1,0 +1,77 @@
+# Add concurrency cancellation to seven PR-triggered workflows
+
+## Summary
+
+Seven pull-request-triggered workflows in `.github/workflows/` ran without a
+`concurrency:` group, so rapid pushes to the same PR queued redundant,
+overlapping runs that each held a runner and wasted CI minutes on results that
+were immediately superseded. Only `ci.yml` declared a concurrency group.
+
+This change adds a top-level `concurrency:` block — identical to the canonical
+pattern proven in `ci.yml` — to each of the seven workflows, immediately after
+the `on:` block:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Keying on {% raw %}`${{ github.workflow }}-${{ github.ref }}`{% endraw %}
+scopes cancellation per-workflow-per-ref, so distinct workflows and distinct branches never cancel
+one another, while repeated pushes to the same ref keep only the latest run
+alive. `deno-outdated.yml` is intentionally excluded — it runs only on
+`schedule`/`workflow_dispatch` and is not pile-up-prone.
+
+Workflows updated:
+
+- `cargo-audit.yml`
+- `deno-quality.yml`
+- `dependency-review.yml`
+- `gitleaks.yml`
+- `markdown-lint.yml`
+- `semgrep.yml`
+- `shellcheck.yml`
+
+Closes #139.
+
+## Evidence
+
+This is a CI-configuration change with no web interface to screenshot.
+Verification is via the Deno test suite, which parses each workflow's YAML and
+asserts the concurrency group is present and correctly keyed. Full suite:
+`254 passed | 0 failed`.
+
+```mermaid
+flowchart LR
+    P1[push #1] --> R1[run #1 starts]
+    P2[push #2 same ref] --> C{concurrency group<br/>workflow-ref}
+    R1 --> C
+    C -->|cancel-in-progress| X[run #1 cancelled]
+    C --> R2[run #2 runs]
+```
+
+## Test Plan
+
+Followed TDD — added a failing concurrency assertion per workflow first, then
+added the workflow blocks to make them pass.
+
+- Added `... workflow declares a concurrency group that cancels superseded runs`
+  test to each of:
+  - `tests/cargo_audit_workflow_test.ts`
+  - `tests/deno_quality_workflow_test.ts`
+  - `tests/dependency_review_workflow_test.ts`
+  - `tests/semgrep_workflow_test.ts`
+  - `tests/markdown_lint_workflow_test.ts`
+- Added new test files `tests/gitleaks_workflow_test.ts` and
+  `tests/shellcheck_workflow_test.ts` (these workflows had no test file),
+  covering existence, YAML parse, `pull_request` trigger, read-only contents
+  permission, and the concurrency group.
+
+Each test parses the workflow YAML and asserts
+{% raw %}`concurrency.group === "${{ github.workflow }}-${{ github.ref }}"`{% endraw %}
+and `concurrency["cancel-in-progress"] === true`.
+
+Verified red before the workflow change (7 failures), then green after
+(`47 passed`); full suite `254 passed | 0 failed`. `deno fmt --check`,
+`deno lint`, and `deno check` all pass.

--- a/docs/archive/pr-summaries/pr-summary-144.md
+++ b/docs/archive/pr-summaries/pr-summary-144.md
@@ -1,0 +1,76 @@
+# PR Summary — Issue #144
+
+## Summary
+
+Completed the partial migration of `tests/trend_line_extension_test.ts`. The
+final test (`"Trend Line Uses Latest Market Data Date"`) still built a local
+`validator` object whose `calculateTrendLine` was a ~150-line inline
+reimplementation of the production regression pipeline, then asserted on that
+copy — a HOW-test that could never catch a regression in the shipped code.
+
+This PR applies resolution **(a)** from the issue: extract the remaining
+data-window / end-date selection out of `GRQValidator.calculateTrendLine` into
+the shared `docs/projection.js` module as `buildTrendLineDataPoints`, refactor
+production to delegate to it, and rewrite the test to drive the REAL shipped
+helpers (`getBuyPrice` → `buildTrendLineDataPoints` → `computeTrendLine`). The
+inline copy is deleted; the assertions now exercise shipped code, so a
+regression in the trend-window selection ("use latest market data date, not
+today") actually fails the suite.
+
+Closes #144.
+
+## What changed
+
+- **`docs/projection.js`** — new pure helper `buildTrendLineDataPoints(marketData, scoreDate, buyPrice, dividends, endDate)`.
+  It performs the window selection (score date → latest market-data date when
+  `endDate` is omitted, never today) and builds the
+  `{ x: daysSinceScore, y: totalReturn }` regression points, combining the
+  split-adjusted price move with dividends paid up to each point. Published on
+  `globalThis.GRQProjection`.
+- **`docs/app.js`** — `GRQValidator.calculateTrendLine` now delegates the
+  windowing to `GRQProjection.buildTrendLineDataPoints` instead of building the
+  points inline. Behaviour is preserved; production and the Deno tests share one
+  implementation (the same pattern already used for `computeTrendLine`).
+- **`tests/trend_line_extension_test.ts`** — replaced the inline-mirror test
+  with three WHAT-tests against the real helpers.
+
+## Data flow
+
+```mermaid
+flowchart LR
+    A[GRQValidator.calculateTrendLine] --> B[getBuyPrice]
+    A --> C[buildTrendLineDataPoints<br/>window + end-date selection]
+    C --> D[computeTrendLine<br/>regression]
+    E[trend_line_extension_test.ts] --> B
+    E --> C
+    E --> D
+```
+
+The test now drives the exact shared kernels production delegates to — no inline
+copy of the algorithm remains.
+
+## Evidence
+
+Backend/JS change with no web UI to screenshot. Verified via the Deno test
+suite driving the real shipped helpers:
+
+- `Real buildTrendLineDataPoints - Window extends to latest market data date` —
+  with no `endDate`, the window runs to the latest market-data point (~77 days),
+  starting at zero on the score date.
+- `Real buildTrendLineDataPoints - Explicit endDate truncates the window` — an
+  explicit earlier `endDate` excludes the later point, proving the end-date
+  selection is the real windowing logic, not a fixed default.
+- `Real computeTrendLine - Projection reflects SCHW growth pattern` — the
+  shipped regression produces a 90-day projection between 15% and 25% (forced
+  through the origin) for the SCHW growth fixture.
+
+Full suite: `257 passed | 0 failed`.
+
+## Test Plan
+
+- Rewrote `tests/trend_line_extension_test.ts` to drive `GRQProjection.getBuyPrice`,
+  `GRQProjection.buildTrendLineDataPoints`, and `GRQProjection.computeTrendLine`.
+- Confirmed the new tests fail before the `buildTrendLineDataPoints` extraction
+  exists and pass after.
+- Ran `deno test --allow-read tests/*.ts` (257 passed), plus `deno fmt --check`,
+  `deno lint`, and `deno check` over the changed files.

--- a/docs/archive/pr-summaries/pr-summary-145.md
+++ b/docs/archive/pr-summaries/pr-summary-145.md
@@ -1,0 +1,76 @@
+## Summary
+
+`tests/dividend_calculation_tests.ts` imported nothing from the shipped code and
+asserted on logic re-authored inside the test: it reimplemented the 90-day
+dividend-window `filter`, the `+ 90 days` date arithmetic, the `reduce` sum, and
+a bare `exDivDate <= ninetyDayDate` comparison — then asserted each expression
+against itself. The shipped `getDividendsWithin90Days` / dividend-summation path
+on `GRQValidator` was never called, so a real regression in dividend selection
+or summation left every assertion green.
+
+This PR applies resolution (a) from the issue: extract the pure dividend kernels
+into the shared projection module so production and tests exercise the same
+code, then rewrite the file as a WHAT-test against those kernels.
+
+- Added `filterDividendsWithin90Days(dividends, scoreDate)` and
+  `sumDividends(dividends)` to `docs/projection.js` and published them on
+  `globalThis.GRQProjection`, mirroring the issue #80/#100 kernel-extraction
+  pattern.
+- Delegated `GRQValidator.getDividendsWithin90Days` to the shared filter and the
+  three dividend-summation sites (`docs/app.js`) to `sumDividends`, removing the
+  duplicated inline `filter`/`reduce` copies (DRY — single source of truth).
+- Rewrote `tests/dividend_calculation_tests.ts` to drive the real
+  `filterDividendsWithin90Days`, `sumDividends`, and `calculatePerformanceReturn`
+  kernels against the NYSE:WFG 2024-11-15 fixture and assert on their return
+  values. A regression in the shipped window/sum now fails the suite.
+
+Closes #145.
+
+## Evidence
+
+Backend/JS change with no web UI to screenshot. Verified via `deno test` and the
+full quality gate.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        T1[dividend tests] -. assert filter/sum/&le; against itself .-> T1
+        V1[GRQValidator.getDividendsWithin90Days] -. untested .-> X[(shipped code)]
+    end
+    subgraph After
+        K[GRQProjection.filterDividendsWithin90Days / sumDividends]
+        T2[dividend tests] --> K
+        V2[GRQValidator.getDividendsWithin90Days] --> K
+    end
+```
+
+Test run:
+
+```
+running 6 tests from ./tests/dividend_calculation_tests.ts
+filterDividendsWithin90Days keeps only in-window payments ... ok
+filterDividendsWithin90Days includes a payment on the boundary day ... ok
+filterDividendsWithin90Days returns empty for missing or empty input ... ok
+sumDividends totals the in-window WFG payments ... ok
+sumDividends returns 0 for missing or empty input ... ok
+dividend total flows into the shipped performance return ... ok
+ok | 6 passed | 0 failed
+```
+
+`./quality.sh` passes cleanly (lint, fmt, type-check, full Deno + Rust suite).
+
+## Test Plan
+
+Rewritten `tests/dividend_calculation_tests.ts` (now WHAT-tests against shipped kernels):
+
+- `filterDividendsWithin90Days keeps only in-window payments` — happy path: 2 of
+  3 WFG dividends retained.
+- `filterDividendsWithin90Days includes a payment on the boundary day` — edge:
+  ex-div date exactly on the 90-day edge is inclusive (`<=`).
+- `filterDividendsWithin90Days returns empty for missing or empty input` — error
+  path: `[]` and `undefined`.
+- `sumDividends totals the in-window WFG payments` — happy path: `$0.455`.
+- `sumDividends returns 0 for missing or empty input` — error path.
+- `dividend total flows into the shipped performance return` — drives
+  `calculatePerformanceReturn` to prove the filtered/summed dividends reach
+  production output (dividend-return component `(0.455 / buyPrice) * 100`).

--- a/docs/archive/pr-summaries/pr-summary-149.md
+++ b/docs/archive/pr-summaries/pr-summary-149.md
@@ -1,0 +1,58 @@
+## Summary
+
+Removed the source-text prose-grep assertions from
+`tests/contributing_changelog_test.ts`. Most of the file read a Markdown doc
+and asserted that a literal substring (or loose regex) appeared in the prose —
+a grep-as-assertion that verifies nothing observable and breaks on harmless
+rewording that preserves meaning. This is the same anti-pattern the repository
+deliberately removed from `tests/security_md_test.ts` and
+`tests/documentation_accuracy_test.ts` under Issue #81; this file was missed in
+that pass.
+
+Applied resolution (a) from the issue: kept the two existence checks
+(`CONTRIBUTING.md` / `CHANGELOG.md` exist) and the already-good version-seeding
+test (which derives its expectation from `Cargo.toml` and asserts a *derivable
+relationship*), and removed the brittle prose greps:
+
+- `cargo test` / `cargo fmt` / `cargo clippy` / `cargo build`
+- `deno test`
+- `quality.sh`
+- `pull request`
+- `Keep a Changelog` / `Semantic Versioning`
+
+The header comment now records the removal under Issue #149, matching the
+wording style of the sibling files. Documentation prose remains policed by the
+Markdown linter and human review.
+
+Closes #149.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+`deno test` for the affected file (3 behavioural tests retained, all passing):
+
+```
+running 3 tests from ./tests/contributing_changelog_test.ts
+CONTRIBUTING.md exists at the repository root ... ok
+CHANGELOG.md exists at the repository root ... ok
+CHANGELOG.md is seeded with the current Cargo.toml version ... ok
+
+ok | 3 passed | 0 failed
+```
+
+`./quality.sh` completes successfully across the full suite.
+
+## Test Plan
+
+- Modified `tests/contributing_changelog_test.ts`:
+  - Retained: `CONTRIBUTING.md exists at the repository root`,
+    `CHANGELOG.md exists at the repository root`,
+    `CHANGELOG.md is seeded with the current Cargo.toml version`.
+  - Removed: the five prose-grep tests
+    (`documents the Rust build/test/lint commands`,
+    `documents the Deno test suite`, `anchors on the existing quality gate`,
+    `describes the pull-request workflow`,
+    `follows the Keep a Changelog format`).
+- Ran `deno test tests/contributing_changelog_test.ts` — 3 passed.
+- Ran `./quality.sh` — passes cleanly.

--- a/docs/archive/pr-summaries/pr-summary-150.md
+++ b/docs/archive/pr-summaries/pr-summary-150.md
@@ -1,0 +1,67 @@
+## Summary
+
+The two runner tests in `tests/deno_scope_config_test.ts:87-111` asserted on
+the **source text** of `quality.sh` and `.github/workflows/deno-quality.yml`
+with whole-file regexes. They matched the *spelling* of each
+`deno check`/`lint`/`fmt` command and its `helpers/…ts` argument on a single
+line, not the *outcome*. Behaviour-preserving edits — a `helpers/**/*.ts`
+glob, a line split with `\`, a `$HELPERS` variable, or a loop over a file list
+— broke them with no real regression, while a commented-out command would
+still pass as long as the text appeared.
+
+Rewrote both tests to assert the genuine behavioural intent: *the local gate
+and CI actually cover the real `helpers/` TypeScript files*. The tests now
+resolve each invocation's path arguments as globs against the helper files on
+disk, and parse the workflow as structured YAML (via `@std/yaml`) to inspect
+the `deno check` step's `run` text rather than regex-matching the whole file.
+
+The good structural `deno.json` tests (`:37-85`, `parseJsonc` + `include`
+arrays) are left untouched as the issue requested.
+
+Closes #150.
+
+## Evidence
+
+Backend/test-only change — no UI to screenshot. Verified by running the
+Deno gate locally:
+
+- `deno test --allow-read tests/*.ts` → `ok | 260 passed | 0 failed`
+- `deno lint helpers/*.ts tests/*.ts` → clean
+- `deno check helpers/*.ts tests/*.ts` → clean
+- `deno fmt helpers/*.ts tests/*.ts` → no changes
+
+**Red/robustness verification** of the new resolver logic (same regex/glob
+helpers used in the tests):
+
+| Input to `deno check` | Covers `helpers/server.ts`? |
+| --- | --- |
+| `helpers/*.ts tests/*.ts` | ✅ true |
+| `helpers/**/*.ts tests/*.ts` (glob change) | ✅ true |
+| `deno check \`<newline>` helpers/*.ts …` (line split) | ✅ true |
+| `tests/*.ts` only (coverage dropped) | ❌ false — test fails |
+
+```mermaid
+flowchart LR
+    A[quality.sh / deno-quality.yml] --> B[Extract deno check/lint/fmt args]
+    B --> C[Resolve globs vs helpers/*.ts on disk]
+    D[helpers/*.ts files] --> C
+    C --> E{All helpers covered?}
+    E -->|yes| F[pass]
+    E -->|no| G[fail]
+```
+
+## Test Plan
+
+Modified `tests/deno_scope_config_test.ts`:
+
+- Replaced `quality.sh type-checks and lints the helpers directory` with
+  `quality.sh checks, lints and formats the real helpers files` — resolves the
+  `deno check`/`lint`/`fmt` path arguments against the real `helpers/*.ts`
+  files and asserts every helper is covered.
+- Replaced `deno-quality.yml type-checks the helpers directory` with
+  `deno-quality.yml type-checks the real helpers files` — parses the workflow
+  YAML structurally, finds the `deno check` step, and asserts its arguments
+  cover every real helper file.
+- Unchanged: the four structural `deno.json` `parseJsonc`/`include` tests.
+
+All 260 Deno tests pass.

--- a/docs/archive/pr-summaries/pr-summary-150.md
+++ b/docs/archive/pr-summaries/pr-summary-150.md
@@ -37,7 +37,7 @@ helpers used in the tests):
 | --- | --- |
 | `helpers/*.ts tests/*.ts` | ✅ true |
 | `helpers/**/*.ts tests/*.ts` (glob change) | ✅ true |
-| `deno check \`<newline>` helpers/*.ts …` (line split) | ✅ true |
+| `deno check \ helpers/*.ts …` (backslash line continuation) | ✅ true |
 | `tests/*.ts` only (coverage dropped) | ❌ false — test fails |
 
 ```mermaid

--- a/docs/archive/pr-summaries/pr-summary-151.md
+++ b/docs/archive/pr-summaries/pr-summary-151.md
@@ -1,0 +1,49 @@
+# PR Summary — Issue #151
+
+## Summary
+
+Removed the HOW-assertion in `tests/floating_promises_guard_test.ts`. The
+`"entry functions are async (return a promise)"` test asserted on
+`checkSyntax.constructor.name === "AsyncFunction"` — a structural check pinned
+to the `async` keyword rather than the observable contract the test name claims.
+A behaviour-preserving refactor (e.g. `function checkSyntax() { return (async () => {…})() }`)
+or a bundler/minifier that wraps the function still returns a promise the guard
+can `.catch`, but its `constructor.name` becomes `"Function"` and the assertion
+breaks for no real reason.
+
+Following the issue's **option (b)**, the test was deleted. The behaviour that
+actually matters — importing each debug module is side-effect-free, so the entry
+point stays guarded behind `import.meta.main` — is already covered by the three
+sibling WHAT-tests (`:16-29`), which were left untouched. The now-unused `assert`
+import was dropped to keep the lint clean.
+
+**Why not option (a)?** Rewriting the test to call `checkSyntax()` and assert the
+return value is a thenable was unsafe here: the function body reads files and calls
+`Deno.exit(1)` on duplicate declarations or errors, which would terminate the
+`deno test` runner mid-suite. Deletion is the safe, issue-endorsed outcome.
+
+Closes #151.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verified via the Deno
+test suite and quality checks:
+
+- `deno test --allow-read tests/*.ts` → `256 passed | 0 failed`
+- `deno fmt`, `deno lint`, `deno check` on the modified file → all clean
+
+```mermaid
+flowchart LR
+    A["constructor.name === 'AsyncFunction'<br/>(HOW: pinned to async keyword)"] -->|deleted| B["3 sibling WHAT-tests<br/>side-effect-free import behind<br/>import.meta.main"]
+    B --> C["Behaviour still fully covered"]
+```
+
+## Test Plan
+
+- Modified `tests/floating_promises_guard_test.ts`: removed the
+  `"entry functions are async (return a promise)"` test and the unused `assert`
+  import.
+- Confirmed the three remaining guard tests
+  (`check_syntax.ts`, `debug_schw_current_price.ts`, `test_page_load.ts` import
+  without running) still pass.
+- Full Deno suite: `256 passed | 0 failed`.

--- a/docs/list.html
+++ b/docs/list.html
@@ -237,6 +237,9 @@
     <!-- Score-file name render helper (issue #103) — must load before list.js -->
     <script src="list_render.js"></script>
 
+    <!-- Summary-statistics averaging kernel (issue #121) — must load before list.js -->
+    <script src="list_stats.js"></script>
+
     <!-- Load our main script -->
     <script src="list.js"></script>
   </body>

--- a/docs/list.js
+++ b/docs/list.js
@@ -265,33 +265,12 @@ class ScoreFilesList {
             }
             
             const visibleData = this.dataTable.rows({ search: 'applied' }).data();
-            let total90Day = 0;
-            let totalAnnualized = 0;
-            let positiveCount = 0;
-            let valid90DayCount = 0;
-            let validAnnualizedCount = 0;
-            
-            visibleData.each((row) => {
-                const performance90Day = row.performance_90_day;
-                const performanceAnnualized = row.performance_annualized;
-                
-                if (performance90Day !== null && performance90Day !== undefined) {
-                    total90Day += performance90Day;
-                    valid90DayCount++;
-                    
-                    if (performance90Day > 0) {
-                        positiveCount++;
-                    }
-                }
-                
-                if (performanceAnnualized !== null && performanceAnnualized !== undefined) {
-                    totalAnnualized += performanceAnnualized;
-                    validAnnualizedCount++;
-                }
-            });
-            
-            const avg90Day = valid90DayCount > 0 ? total90Day / valid90DayCount : 0;
-            const avgAnnualized = validAnnualizedCount > 0 ? totalAnnualized / validAnnualizedCount : 0;
+
+            // Delegate the averaging to the shared kernel (issue #121) so the
+            // browser and the Deno tests exercise the exact same maths.
+            const rows = visibleData.toArray();
+            const { avg90Day, avgAnnualized, valid90DayCount, positiveCount } =
+                globalThis.GRQListStats.computeListAverages(rows);
             const totalFiles = visibleData.count();
             
 

--- a/docs/list_stats.js
+++ b/docs/list_stats.js
@@ -1,0 +1,66 @@
+// Summary-statistics helper for the score-file list page (issue #121).
+//
+// The averaging maths that produces the list page's "average 90-day",
+// "average annualised" and "positive count" summary cards used to live only
+// inside `updateSummaryStats` in docs/list.js, fused with DataTables/DOM access
+// so no test could reach it. The Deno suite therefore reimplemented the
+// averaging loop inline and asserted on its own copy — a tautology that stayed
+// green even if list.js drifted.
+//
+// This extracts the pure accumulation/averaging kernel so BOTH the browser
+// list page (via `updateSummaryStats`) and the Deno tests exercise the exact
+// same code. Mirrors docs/list_render.js: loaded as a classic <script> in
+// docs/list.html (before list.js) and imported by the Deno tests, uses no
+// module syntax, and publishes its helper on `globalThis`.
+
+// Aggregate an array of index.json rows into the list page's summary figures.
+//
+// Each row is expected to carry numeric `performance_90_day` and
+// `performance_annualized` fields; null/undefined values are skipped so a
+// score file still awaiting its 90-day result does not drag the averages.
+// Returns the averages plus the counts the summary cards display. Pure and
+// deterministic.
+function computeListAverages(rows) {
+    let total90Day = 0;
+    let totalAnnualized = 0;
+    let positiveCount = 0;
+    let valid90DayCount = 0;
+    let validAnnualizedCount = 0;
+
+    const list = Array.isArray(rows) ? rows : [];
+    for (const row of list) {
+        const performance90Day = row ? row.performance_90_day : undefined;
+        const performanceAnnualized = row ? row.performance_annualized : undefined;
+
+        if (performance90Day !== null && performance90Day !== undefined) {
+            total90Day += performance90Day;
+            valid90DayCount++;
+
+            if (performance90Day > 0) {
+                positiveCount++;
+            }
+        }
+
+        if (
+            performanceAnnualized !== null && performanceAnnualized !== undefined
+        ) {
+            totalAnnualized += performanceAnnualized;
+            validAnnualizedCount++;
+        }
+    }
+
+    const avg90Day = valid90DayCount > 0 ? total90Day / valid90DayCount : 0;
+    const avgAnnualized = validAnnualizedCount > 0
+        ? totalAnnualized / validAnnualizedCount
+        : 0;
+
+    return {
+        avg90Day,
+        avgAnnualized,
+        valid90DayCount,
+        validAnnualizedCount,
+        positiveCount,
+    };
+}
+
+globalThis.GRQListStats = { computeListAverages };

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -40,6 +40,25 @@ function calculatePerformanceReturn(buyPrice, currentPrice, totalDividends) {
     return priceReturn + dividendReturn;
 }
 
+// Dividends whose ex-dividend date falls on or before the 90-day validation
+// window measured from the score date. Pure given the dividend list and score
+// date; the dashboard's GRQValidator looks the list up per stock and delegates
+// here so production and tests share one window filter (issue #145).
+function filterDividendsWithin90Days(dividends, scoreDate) {
+    const ninetyDayDate = new Date(
+        scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+    );
+    return (dividends || []).filter((dividend) =>
+        dividend.exDivDate <= ninetyDayDate
+    );
+}
+
+// Sum the cash amount of a dividend list. Returns 0 for an empty or missing
+// list, mirroring the dashboard's per-stock dividend-return summation.
+function sumDividends(dividends) {
+    return (dividends || []).reduce((sum, div) => sum + div.amount, 0);
+}
+
 // Build the weekly trend-data series for a hybrid projection chart.
 //
 // `projection` is the result of GRQValidator.calculateHybridProjection (its
@@ -472,6 +491,8 @@ globalThis.GRQProjection = {
     setDateToMidnight,
     getDaysElapsed,
     calculatePerformanceReturn,
+    filterDividendsWithin90Days,
+    sumDividends,
     buildHybridProjectionData,
     formatCurrency,
     getSplitAdjustment,

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -279,6 +279,56 @@ function computeTrendLine(dataPoints) {
     };
 }
 
+// Build the regression input for a stock's trend line: one
+// `{ x: daysSinceScore, y: totalReturn }` per market-data point inside the
+// window from the score date to `endDate`. When `endDate` is omitted the window
+// runs to the LATEST market-data date (not today's date), so the trend reflects
+// observed data only. Each y combines the split-adjusted price move against the
+// buy price with dividends paid up to that point. Pure given its inputs; the
+// dashboard's GRQValidator gathers the inputs and delegates here (issue #144).
+function buildTrendLineDataPoints(
+    marketData,
+    scoreDate,
+    buyPrice,
+    dividends,
+    endDate,
+) {
+    if (!marketData || marketData.length === 0) return [];
+
+    const scoreDateTimestamp = scoreDate.getTime();
+    // Default to the latest market-data date, never today's date.
+    const trendEndDate = endDate || marketData[marketData.length - 1].date;
+    const dividendList = dividends || [];
+
+    const dataPoints = [];
+    marketData.forEach((point) => {
+        if (point.date >= scoreDate && point.date <= trendEndDate) {
+            const daysSinceScore = (point.date.getTime() - scoreDateTimestamp) /
+                (1000 * 60 * 60 * 24);
+            const currentPrice = adjustHistoricalPriceToCurrent(
+                (point.high + point.low) / 2,
+                marketData,
+                point.date,
+            );
+
+            // Performance including dividends paid up to this point.
+            const priceReturn =
+                ((currentPrice - buyPrice) / buyPrice) * 100;
+            const dividendsUpToDate = dividendList.filter(
+                (d) => d.exDivDate <= point.date,
+            );
+            const totalDividends = sumDividends(dividendsUpToDate);
+            const dividendReturn = (totalDividends / buyPrice) * 100;
+
+            dataPoints.push({
+                x: daysSinceScore,
+                y: priceReturn + dividendReturn,
+            });
+        }
+    });
+    return dataPoints;
+}
+
 // Days elapsed from the score date to the latest market-data date, capped at 90
 // (the validation window). Pure given the two dates.
 function daysElapsedFromMarketData(scoreDate, latestMarketDate) {
@@ -502,6 +552,7 @@ globalThis.GRQProjection = {
     calculateTargetPercentage,
     calculateRSquared,
     computeTrendLine,
+    buildTrendLineDataPoints,
     daysElapsedFromMarketData,
     computeHybridProjection,
     computeJudgement,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![warn(missing_docs)]
+#![deny(unsafe_code)]
+#![deny(unsafe_op_in_unsafe_fn)]
 //! Processes daily stock-score TSV files and computes portfolio performance.
 //!
 //! The crate exposes two modules:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![warn(clippy::missing_errors_doc)]
 #![deny(unsafe_code)]
 #![deny(unsafe_op_in_unsafe_fn)]
 //! Processes daily stock-score TSV files and computes portfolio performance.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,6 +54,11 @@ pub fn calculate_average_score(scores: &[f64]) -> f64 {
 }
 
 /// Reads `<docs_path>/scores/index.json` and returns its entries sorted by date.
+///
+/// # Errors
+///
+/// Returns an error if the index file cannot be read or does not contain valid
+/// JSON matching [`IndexData`].
 pub fn read_index_json(docs_path: &str) -> Result<IndexData> {
     use std::fs;
     use std::path::Path;
@@ -88,6 +93,11 @@ pub fn read_index_json(docs_path: &str) -> Result<IndexData> {
 /// a parent-directory (`..`) segment before joining. With neither present, the
 /// joined path is lexically guaranteed to stay within `<docs_path>/scores`.
 /// Mirrors the containment guard in `helpers/server.ts::getFilePath`.
+///
+/// # Errors
+///
+/// Returns an error if `file` is empty, absolute, or contains a
+/// parent-directory (`..`) segment.
 pub fn build_score_file_path(docs_path: &str, file: &str) -> Result<String> {
     use std::path::Component;
 
@@ -137,6 +147,11 @@ pub fn get_market_data_path(ticker: &str) -> String {
 }
 
 /// Reads a tab-separated score file into a vector of [`StockRecord`]s.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened or a row cannot be
+/// deserialised into a [`StockRecord`].
 pub fn read_tsv_score_file(file_path: &str) -> Result<Vec<StockRecord>> {
     use csv::ReaderBuilder;
     use std::fs::File;
@@ -158,6 +173,11 @@ pub fn read_tsv_score_file(file_path: &str) -> Result<Vec<StockRecord>> {
 }
 
 /// Reads a score file and returns just the `Stock` ticker codes, in file order.
+///
+/// # Errors
+///
+/// Returns an error if the underlying score file cannot be read or parsed (see
+/// [`read_tsv_score_file`]).
 pub fn extract_ticker_codes_from_score_file(file_path: &str) -> Result<Vec<String>> {
     let stock_records = read_tsv_score_file(file_path)?;
     let ticker_codes: Vec<String> = stock_records
@@ -181,6 +201,11 @@ pub fn extract_symbol_from_ticker(ticker: &str) -> String {
 }
 
 /// Reads and deserialises the [`MarketData`] JSON file for `symbol`.
+///
+/// # Errors
+///
+/// Returns an error if the market-data file cannot be opened or does not
+/// contain valid JSON matching [`MarketData`].
 pub fn read_market_data(symbol: &str) -> Result<MarketData> {
     use std::fs::File;
 
@@ -213,6 +238,11 @@ fn parse_financial_value(field: &str, context: &str, raw: &str) -> Option<f64> {
 ///
 /// Rows with a non-numeric or non-positive close price are skipped (and a
 /// warning is written to stderr).
+///
+/// # Errors
+///
+/// Returns an error if the CSV file cannot be opened or a record cannot be
+/// read.
 pub fn read_market_data_from_csv(
     csv_file_path: &str,
 ) -> Result<HashMap<String, HashMap<String, f64>>> {
@@ -254,6 +284,11 @@ pub fn read_market_data_from_csv(
 
 /// Returns `(date, close)` pairs from `market_data` whose date falls within the
 /// inclusive `start_date`..=`end_date` range, sorted oldest first.
+///
+/// # Errors
+///
+/// Returns an error if `start_date` or `end_date` is not a valid `%Y-%m-%d`
+/// date.
 pub fn filter_market_data_by_date_range(
     market_data: &MarketData,
     start_date: &str,
@@ -300,6 +335,11 @@ pub fn derive_csv_output_path(score_file_path: &str) -> String {
 
 /// Creates a CSV file with market data for the given symbols and date range
 /// The CSV file will be created in the same directory as the score file with the same base name
+///
+/// # Errors
+///
+/// Returns an error if the market data cannot be read or the CSV file cannot be
+/// written (see [`create_market_data_csv`]).
 pub fn create_market_data_csv_for_score_file(
     score_file_path: &str,
     symbols: &[String],
@@ -310,6 +350,11 @@ pub fn create_market_data_csv_for_score_file(
 }
 
 /// Creates a CSV file with market data for the given symbols and date range
+///
+/// # Errors
+///
+/// Returns an error if `score_file_date` is not a valid date, a symbol's
+/// market data cannot be read, or the output CSV cannot be written.
 pub fn create_market_data_csv(
     symbols: &[String],
     score_file_date: &str,
@@ -394,6 +439,12 @@ pub fn create_market_data_csv(
 /// Creates a CSV file with market data for the given tickers and date range, in long format.
 /// Each row: date, ticker, high, low, open, close
 /// The ticker is the full code from the scores file (e.g., NYSE:SEM)
+///
+/// # Errors
+///
+/// Returns an error if `score_file_date` is not a valid date or the output CSV
+/// cannot be created or written. Tickers with missing market data are skipped
+/// rather than failing.
 pub fn create_market_data_long_csv(
     tickers: &[String],
     score_file_date: &str,
@@ -449,6 +500,11 @@ pub fn create_market_data_long_csv(
 }
 
 /// Like create_market_data_csv_for_score_file, but outputs long format and allows custom output dir (for tests)
+///
+/// # Errors
+///
+/// Returns an error if the long-format CSV cannot be created or written (see
+/// [`create_market_data_long_csv`]).
 pub fn create_market_data_long_csv_for_score_file(
     score_file_path: &str,
     tickers: &[String],
@@ -475,6 +531,11 @@ pub fn get_dividend_data_path(ticker: &str) -> String {
 }
 
 /// Reads dividend data for a given ticker
+///
+/// # Errors
+///
+/// Returns an error if the dividend file cannot be opened or does not contain
+/// valid JSON matching [`DividendData`].
 pub fn read_dividend_data(ticker: &str) -> Result<DividendData> {
     use std::fs::File;
 
@@ -486,6 +547,11 @@ pub fn read_dividend_data(ticker: &str) -> Result<DividendData> {
 }
 
 /// Filters dividend data by date range
+///
+/// # Errors
+///
+/// Returns an error if `start_date` or `end_date` is not a valid `%Y-%m-%d`
+/// date.
 pub fn filter_dividend_data_by_date_range(
     dividend_data: &DividendData,
     start_date: &str,
@@ -535,6 +601,12 @@ pub fn derive_dividend_csv_output_path(score_file_path: &str) -> String {
 }
 
 /// Creates a dividend CSV file for the given symbols and date range
+///
+/// # Errors
+///
+/// Returns an error if `score_file_date` is not a valid date or the output CSV
+/// cannot be created or written. Symbols with missing dividend data are skipped
+/// with a warning rather than failing.
 pub fn create_dividend_csv(
     symbols: &[String],
     score_file_date: &str,
@@ -588,6 +660,11 @@ pub fn create_dividend_csv(
 }
 
 /// Creates a dividend CSV file for a score file
+///
+/// # Errors
+///
+/// Returns an error if the dividend CSV cannot be created or written (see
+/// [`create_dividend_csv`]).
 pub fn create_dividend_csv_for_score_file(
     score_file_path: &str,
     symbols: &[String],
@@ -629,6 +706,11 @@ pub fn calculate_annualized_performance(performance_pct: f64, days_elapsed: i64)
 /// println!("90-day return: {:.2}%", performance.performance_90_day);
 /// # Ok::<(), anyhow::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns an error if the score file or the derived market-data CSV cannot be
+/// read, or if `score_file_date` is not a valid `%Y-%m-%d` date.
 pub fn calculate_portfolio_performance(
     score_file_path: &str,
     score_file_date: &str,
@@ -768,6 +850,12 @@ pub fn calculate_portfolio_performance(
 }
 
 /// Calculates hybrid projection for scores less than 90 days old
+///
+/// # Errors
+///
+/// Returns an error if `score_file_date` is not a valid `%Y-%m-%d` date, or if
+/// the score is already 90 days or more old (use
+/// [`calculate_portfolio_performance`] instead).
 pub fn calculate_hybrid_projection(
     stock_records: &[StockRecord],
     score_file_date: &str,
@@ -963,6 +1051,11 @@ fn calculate_dividends_for_period(symbol: &str, start_date: &str, end_date: &str
 }
 
 /// Updates the index.json file with performance metrics
+///
+/// # Errors
+///
+/// Returns an error if the index file cannot be read, or if the updated index
+/// cannot be serialised or written back to disk.
 pub fn update_index_with_performance(docs_path: &str) -> Result<()> {
     let mut index_data = read_index_json(docs_path)?;
 

--- a/tests/annualized_performance_test.ts
+++ b/tests/annualized_performance_test.ts
@@ -1,110 +1,52 @@
-// Test to verify annualized performance calculation uses compound interest
-// and not simple multiplication
-
-Deno.test("Annualized Performance Calculation - Compound Interest", () => {
-  // Test cases with known 90-day performances
-  const testCases = [
-    {
-      performance90Day: 6.07,
-      expectedAnnualized: 27.00,
-      description: "Positive performance",
-    },
-    {
-      performance90Day: -12.98,
-      expectedAnnualized: -43.09,
-      description: "Negative performance",
-    },
-    {
-      performance90Day: 0.48,
-      expectedAnnualized: 1.95,
-      description: "Small positive performance",
-    },
-    {
-      performance90Day: -6.52,
-      expectedAnnualized: -23.91,
-      description: "Small negative performance",
-    },
-  ];
-
-  testCases.forEach(({ performance90Day, expectedAnnualized, description }) => {
-    // Calculate using compound interest formula: (1 + r)^(365.25/90) - 1
-    const annualizedCompound =
-      ((1 + performance90Day / 100) ** (365.25 / 90) - 1) * 100;
-
-    // Calculate using simple multiplication (incorrect method)
-    const annualizedSimple = performance90Day * 4;
-
-    console.log(`${description}:`);
-    console.log(`  90-day performance: ${performance90Day}%`);
-    console.log(`  Compound interest: ${annualizedCompound.toFixed(2)}%`);
-    console.log(`  Simple multiplication: ${annualizedSimple.toFixed(2)}%`);
-    console.log(`  Expected: ${expectedAnnualized}%`);
-    console.log(
-      `  Difference: ${
-        Math.abs(annualizedCompound - expectedAnnualized).toFixed(2)
-      }%`,
-    );
-    console.log("");
-
-    // Verify compound interest calculation is close to expected
-    const tolerance = 0.5; // Allow 0.5% tolerance for rounding differences
-    const isCorrect =
-      Math.abs(annualizedCompound - expectedAnnualized) < tolerance;
-
-    if (!isCorrect) {
-      throw new Error(
-        `${description}: Compound interest calculation (${
-          annualizedCompound.toFixed(2)
-        }%) ` +
-          `does not match expected (${expectedAnnualized}%). ` +
-          `Simple multiplication would be ${annualizedSimple.toFixed(2)}%`,
-      );
-    }
-
-    // Verify that simple multiplication is significantly different (for larger values)
-    const simpleDifference = Math.abs(annualizedSimple - expectedAnnualized);
-    if (Math.abs(performance90Day) > 5 && simpleDifference < 2.0) {
-      throw new Error(
-        `${description}: Simple multiplication (${
-          annualizedSimple.toFixed(2)
-        }%) ` +
-          `is too close to expected (${expectedAnnualized}%). ` +
-          `This suggests the calculation might be using simple multiplication instead of compound interest.`,
-      );
-    }
-  });
-});
-
-// NOTE (issue #104): a block of recompute-only tests previously sat here.
-// They redefined the annualisation formula as local arrow functions
-// (`calculateAnnualized`, `calculateAnnualizedWithActualDays`,
-// `calculateAnnualizedWithFixed90Days`) and asserted on their own output, so
-// they could never catch a regression in the production annualisation path.
-// Because the dashboard does not annualise in JS — it reads the Rust-computed
-// `performance_annualized` from index.json — there is no shipped JS helper for
-// these tests to drive. The formula's production home is Rust
-// (`calculate_annualized_performance`), now WHAT-tested by
-// `tests::test_annualized_performance_calculation_with_actual_days` in
-// src/utils.rs. Per issue #104 (option b) the following recompute-only cases
-// were deleted rather than kept as HOW-tests:
-//   - "Annualized Performance Formula Verification"
-//   - "Annualized Performance Edge Cases"
-//   - "Annualized Performance - Actual Days vs Fixed 90 Days"
-//   - "Annualized Performance - Market Data Days vs Calendar Days"
-//   - "Annualized Performance - Early Stage Scenarios"
-//   - "Annualized Performance - Edge Cases and Error Handling"
-//   - "Annualized Performance - Zero Bug Investigation"
+// Behavioural tests for the score-file list page's summary-statistics kernel.
 //
-// The tests retained below cover distinct concerns: the compound-vs-simple
-// guard above is cross-checked against the documented real-data table in
-// docs/fixes/ANNUALIZED_PERFORMANCE_CALCULATION.md; the two tests that follow cover
-// index.json averaging (mirrors docs/list.js) and the hybrid-projection
-// dampening algorithm respectively.
+// History (issue #121): this file used to assert on inline reimplementations of
+// production maths — it hand-coded the annualisation formula
+// `(1 + r)^(365.25/90) - 1`, reimplemented the index.json averaging loop, and
+// defined a local `calculateHybridProjection` — then asserted each copy against
+// numbers derived from the same copy. Those were tautologies: no shipped code
+// ran, so a regression in the real annualisation, averaging or hybrid-projection
+// path left every assertion green.
+//
+// Those cases have been resolved against the real modules:
+//   - The annualisation formula's production home is Rust
+//     (`calculate_annualized_performance`), WHAT-tested by
+//     `tests::test_annualized_performance_calculation_with_actual_days` in
+//     src/utils.rs. The recompute-only "Compound Interest" guard was deleted
+//     (issue #121, option b) rather than kept as a self-referential check.
+//   - The hybrid-projection algorithm's production home is
+//     `GRQProjection.computeHybridProjection` in docs/projection.js, driven by
+//     `tests/projection_kernels_test.ts`. The local `calculateHybridProjection`
+//     copy was deleted (issue #121, option b).
+//   - The index.json averaging now lives in the shipped, pure
+//     `GRQListStats.computeListAverages` (docs/list_stats.js), which
+//     docs/list.js delegates to. The test below drives that real kernel.
+import { assertEquals } from "@std/assert";
+import "../docs/list_stats.js";
 
-// TEST FOR AVERAGE ANNUALIZED PERFORMANCE CALCULATION
-Deno.test("Average Annualized Performance Calculation", () => {
-  // Simulate the data structure from index.json
-  const mockData = [
+interface IndexRow {
+  date?: string;
+  performance_90_day: number | null;
+  performance_annualized: number | null;
+}
+
+const g = globalThis as unknown as {
+  GRQListStats: {
+    computeListAverages: (rows: IndexRow[]) => {
+      avg90Day: number;
+      avgAnnualized: number;
+      valid90DayCount: number;
+      validAnnualizedCount: number;
+      positiveCount: number;
+    };
+  };
+};
+const GRQListStats = g.GRQListStats;
+
+Deno.test("computeListAverages averages only the populated fields", () => {
+  // Two settled score files plus two still awaiting their 90-day result
+  // (90-day null, annualised reported as a hybrid projection of 0.0).
+  const rows: IndexRow[] = [
     {
       date: "2025-04-15",
       performance_90_day: 23.77,
@@ -117,223 +59,62 @@ Deno.test("Average Annualized Performance Calculation", () => {
     },
     {
       date: "2025-07-22",
-      performance_90_day: null, // No 90-day performance yet
-      performance_annualized: 0.0, // Hybrid projection
+      performance_90_day: null,
+      performance_annualized: 0.0,
     },
     {
       date: "2025-07-23",
-      performance_90_day: null, // No 90-day performance yet
-      performance_annualized: 0.0, // Hybrid projection
+      performance_90_day: null,
+      performance_annualized: 0.0,
     },
   ];
 
-  // Simulate the fixed calculation logic
-  let total90Day = 0;
-  let totalAnnualized = 0;
-  let valid90DayCount = 0;
-  let validAnnualizedCount = 0;
-  let positiveCount = 0;
+  const result = GRQListStats.computeListAverages(rows);
 
-  mockData.forEach((row) => {
-    const performance90Day = row.performance_90_day;
-    const performanceAnnualized = row.performance_annualized;
-
-    if (performance90Day !== null && performance90Day !== undefined) {
-      total90Day += performance90Day;
-      valid90DayCount++;
-
-      if (performance90Day > 0) {
-        positiveCount++;
-      }
-    }
-
-    if (performanceAnnualized !== null && performanceAnnualized !== undefined) {
-      totalAnnualized += performanceAnnualized;
-      validAnnualizedCount++;
-    }
-  });
-
-  const avg90Day = valid90DayCount > 0 ? total90Day / valid90DayCount : 0;
-  const avgAnnualized = validAnnualizedCount > 0
-    ? totalAnnualized / validAnnualizedCount
-    : 0;
-
-  console.log("Test Results:");
-  console.log(`Total 90-day: ${total90Day}`);
-  console.log(`Total annualized: ${totalAnnualized}`);
-  console.log(`Valid 90-day count: ${valid90DayCount}`);
-  console.log(`Valid annualized count: ${validAnnualizedCount}`);
-  console.log(`Average 90-day: ${avg90Day.toFixed(2)}%`);
-  console.log(`Average annualized: ${avgAnnualized.toFixed(2)}%`);
-  console.log(`Positive count: ${positiveCount}`);
-
-  // Verify the calculations are correct
-  const expectedAvg90Day = (23.77 + 23.64) / 2; // Only the 2 valid entries
-  const expectedAvgAnnualized = (137.62 + 136.57 + 0.0 + 0.0) / 4; // All 4 entries
-
-  console.log(`Expected avg 90-day: ${expectedAvg90Day.toFixed(2)}%`);
-  console.log(`Expected avg annualized: ${expectedAvgAnnualized.toFixed(2)}%`);
-
-  // Assertions
-  if (Math.abs(avg90Day - expectedAvg90Day) > 0.01) {
-    throw new Error(
-      `Average 90-day calculation wrong: expected ${
-        expectedAvg90Day.toFixed(2)
-      }%, got ${avg90Day.toFixed(2)}%`,
-    );
-  }
-
-  if (Math.abs(avgAnnualized - expectedAvgAnnualized) > 0.01) {
-    throw new Error(
-      `Average annualized calculation wrong: expected ${
-        expectedAvgAnnualized.toFixed(2)
-      }%, got ${avgAnnualized.toFixed(2)}%`,
-    );
-  }
-
-  if (valid90DayCount !== 2) {
-    throw new Error(
-      `Should have 2 valid 90-day entries, got ${valid90DayCount}`,
-    );
-  }
-
-  if (validAnnualizedCount !== 4) {
-    throw new Error(
-      `Should have 4 valid annualized entries, got ${validAnnualizedCount}`,
-    );
-  }
-
-  if (positiveCount !== 2) {
-    throw new Error(
-      `Should have 2 positive 90-day entries, got ${positiveCount}`,
-    );
-  }
-
-  console.log("✅ Average annualized performance calculation test passed");
+  // 90-day average excludes the two null entries: (23.77 + 23.64) / 2.
+  assertEquals(result.avg90Day, 23.705);
+  assertEquals(result.valid90DayCount, 2);
+  // Annualised average spans all four entries: (137.62 + 136.57 + 0 + 0) / 4.
+  assertEquals(result.avgAnnualized, 68.5475);
+  assertEquals(result.validAnnualizedCount, 4);
+  // Both populated 90-day figures are positive.
+  assertEquals(result.positiveCount, 2);
 });
 
-// TEST FOR HYBRID PROJECTION FIX
-Deno.test("Hybrid Projection - Realistic Annualized Performance", () => {
-  // Test the fix for unrealistic annualized performance in hybrid projections
-  // This simulates the scenario where a small gain over a few days was giving 119,592.89% annualized
-
-  const calculateHybridProjection = (
-    gainLossPercent: number,
-    marketDaysElapsed: number,
-  ): { projected90Day: number; annualized: number } => {
-    // Simulate the new hybrid projection logic
-    if (marketDaysElapsed <= 0) {
-      return { projected90Day: 0, annualized: 0 };
-    }
-
-    // Calculate daily rate
-    const dailyRate = gainLossPercent / marketDaysElapsed;
-
-    // Apply dampening based on market data days elapsed
-    let dampeningFactor = 0.1; // Very early days: dampen by 90%
-    if (marketDaysElapsed >= 7) dampeningFactor = 0.2; // Early days: dampen by 80%
-    if (marketDaysElapsed >= 14) dampeningFactor = 0.3; // Early days: dampen by 70%
-    if (marketDaysElapsed >= 30) dampeningFactor = 0.5; // Medium term: dampen by 50%
-    if (marketDaysElapsed >= 60) dampeningFactor = 0.7; // Later days: dampen by 30%
-
-    // Calculate raw projection
-    const rawProjection = dailyRate * 90.0;
-    let projected90Day = rawProjection * dampeningFactor;
-
-    // Apply realistic bounds based on market data days elapsed
-    let maxGain = 10.0; // Very early: max 10% gain
-    let maxLoss = -5.0; // Very early: max 5% loss
-    if (marketDaysElapsed >= 7) {
-      maxGain = 20.0;
-      maxLoss = -10.0;
-    }
-    if (marketDaysElapsed >= 14) {
-      maxGain = 40.0;
-      maxLoss = -20.0;
-    }
-    if (marketDaysElapsed >= 30) {
-      maxGain = 80.0;
-      maxLoss = -40.0;
-    }
-    if (marketDaysElapsed >= 60) {
-      maxGain = 150.0;
-      maxLoss = -80.0;
-    }
-
-    projected90Day = Math.max(maxLoss, Math.min(maxGain, projected90Day));
-
-    // Use quarterly compounding for annualized performance
-    const annualized = ((1 + projected90Day / 100) ** 4 - 1) * 100;
-
-    return { projected90Day, annualized };
-  };
-
-  // Test the problematic scenario: 1.96% gain in 3 days
-  const testCase = calculateHybridProjection(1.96, 3);
-  console.log("Test Case: 1.96% gain in 3 days");
-  console.log(`Projected 90-day: ${testCase.projected90Day.toFixed(2)}%`);
-  console.log(`Annualized: ${testCase.annualized.toFixed(2)}%`);
-
-  // Verify the results are realistic
-  if (testCase.annualized > 1000) {
-    throw new Error(
-      `Annualized performance should be realistic, got ${
-        testCase.annualized.toFixed(2)
-      }%`,
-    );
-  }
-
-  if (testCase.projected90Day > 50) {
-    throw new Error(
-      `90-day projection should be realistic, got ${
-        testCase.projected90Day.toFixed(2)
-      }%`,
-    );
-  }
-
-  // Test different scenarios
-  const scenarios = [
-    { gain: 1.96, days: 3, description: "1.96% gain in 3 days" },
-    { gain: 5.0, days: 7, description: "5% gain in 1 week" },
-    { gain: 10.0, days: 14, description: "10% gain in 2 weeks" },
-    { gain: -2.0, days: 5, description: "2% loss in 5 days" },
-    { gain: 15.0, days: 30, description: "15% gain in 1 month" },
+Deno.test("computeListAverages counts negative 90-day figures as non-positive", () => {
+  const rows: IndexRow[] = [
+    { performance_90_day: 10, performance_annualized: 40 },
+    { performance_90_day: -5, performance_annualized: -20 },
+    { performance_90_day: 0, performance_annualized: 0 },
   ];
 
-  console.log("\n=== Hybrid Projection Test Results ===");
-  scenarios.forEach(({ gain, days, description }) => {
-    const result = calculateHybridProjection(gain, days);
-    console.log(
-      `${description}: ${gain}% over ${days} days → 90-day: ${
-        result.projected90Day.toFixed(2)
-      }%, Annualized: ${result.annualized.toFixed(2)}%`,
-    );
+  const result = GRQListStats.computeListAverages(rows);
 
-    // Verify results are realistic
-    if (result.annualized > 1000) {
-      throw new Error(
-        `${description}: Annualized performance too high: ${
-          result.annualized.toFixed(2)
-        }%`,
-      );
-    }
+  assertEquals(result.avg90Day, (10 - 5 + 0) / 3);
+  assertEquals(result.valid90DayCount, 3);
+  // Only the +10 entry is strictly positive; 0 and -5 are excluded.
+  assertEquals(result.positiveCount, 1);
+});
 
-    if (result.projected90Day > 200) {
-      throw new Error(
-        `${description}: 90-day projection too high: ${
-          result.projected90Day.toFixed(2)
-        }%`,
-      );
-    }
-
-    if (result.projected90Day < -100) {
-      throw new Error(
-        `${description}: 90-day projection too low: ${
-          result.projected90Day.toFixed(2)
-        }%`,
-      );
-    }
+Deno.test("computeListAverages returns zeroed averages for no populated rows", () => {
+  const empty = GRQListStats.computeListAverages([]);
+  assertEquals(empty, {
+    avg90Day: 0,
+    avgAnnualized: 0,
+    valid90DayCount: 0,
+    validAnnualizedCount: 0,
+    positiveCount: 0,
   });
 
-  console.log("✅ Hybrid projection fix test passed");
+  const allNull = GRQListStats.computeListAverages([
+    { performance_90_day: null, performance_annualized: null },
+    { performance_90_day: null, performance_annualized: null },
+  ]);
+  assertEquals(allNull, {
+    avg90Day: 0,
+    avgAnnualized: 0,
+    valid90DayCount: 0,
+    validAnnualizedCount: 0,
+    positiveCount: 0,
+  });
 });

--- a/tests/cargo_audit_workflow_test.ts
+++ b/tests/cargo_audit_workflow_test.ts
@@ -82,3 +82,25 @@ Deno.test("Cargo Audit workflow pins actions to commit SHAs", async () => {
     );
   }
 });
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Cargo Audit workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/cargo_supply_chain_quarantine_test.ts
+++ b/tests/cargo_supply_chain_quarantine_test.ts
@@ -1,0 +1,88 @@
+// Tests for the Cargo supply-chain quarantine hardening (Issue #124).
+//
+// The Deno ecosystem is already quarantined (deno.json minimumDependencyAge
+// P1D + deno-outdated.yml --minimum-dependency-age=P1D), and Dependabot now
+// gates Cargo bumps behind a 24h cooldown (Issue #75). The remaining gap is
+// the CI pipeline itself:
+//
+//   1. ci.yml ran an unconditional `cargo update` on every PR, floating every
+//      crate to the newest in-range version and executing its build.rs /
+//      proc-macros with zero age gate.
+//   2. The CI tool installs (cargo-tarpaulin, cargo-cyclonedx, cargo-audit)
+//      were unpinned, compiling and running an arbitrary newest tool tree.
+//
+// These tests assert the pipeline builds the committed, reviewed Cargo.lock
+// (`--locked`) and pins its tool installs to explicit versions.
+
+import { assert } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const CI_PATH = ".github/workflows/ci.yml";
+const AUDIT_PATH = ".github/workflows/cargo-audit.yml";
+
+type Step = { name?: string; run?: string; uses?: string };
+
+async function jobSteps(path: string, job: string): Promise<Step[]> {
+  const text = await Deno.readTextFile(path);
+  const doc = parseYaml(text) as { jobs?: Record<string, { steps?: Step[] }> };
+  return doc.jobs?.[job]?.steps ?? [];
+}
+
+function runText(steps: Step[]): string {
+  return steps.map((s) => s.run ?? "").join("\n");
+}
+
+Deno.test("ci.yml test job no longer runs an unconditional cargo update (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "test"));
+  assert(
+    !/\bcargo\s+update\b/.test(runs),
+    "ci.yml test job must not float deps with `cargo update`; build the committed Cargo.lock",
+  );
+});
+
+Deno.test("ci.yml build job does not run cargo update (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "build"));
+  assert(
+    !/\bcargo\s+update\b/.test(runs),
+    "ci.yml build job must not float deps with `cargo update`",
+  );
+});
+
+Deno.test("ci.yml test job builds/tests with --locked to honour Cargo.lock (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "test"));
+  for (const cmd of ["cargo check", "cargo test"]) {
+    const re = new RegExp(`${cmd.replace(/ /g, "\\s+")}[^\\n]*--locked`);
+    assert(re.test(runs), `ci.yml test job: \`${cmd}\` must pass --locked`);
+  }
+});
+
+Deno.test("ci.yml release build uses --locked (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "build"));
+  assert(
+    /cargo\s+build\b[^\n]*--locked/.test(runs),
+    "ci.yml build job: `cargo build --release` must pass --locked",
+  );
+});
+
+Deno.test("ci.yml pins cargo tool installs to explicit versions with --locked (Issue #124)", async () => {
+  const runs = runText(await jobSteps(CI_PATH, "test")) + "\n" +
+    runText(await jobSteps(CI_PATH, "build"));
+  for (const tool of ["cargo-tarpaulin", "cargo-cyclonedx"]) {
+    const installRe = new RegExp(
+      `cargo\\s+install\\s+${tool}\\b[^\\n]*--locked[^\\n]*--version\\s+\\d+\\.\\d+`,
+    );
+    assert(
+      installRe.test(runs),
+      `ci.yml must install ${tool} with --locked and a pinned --version`,
+    );
+  }
+});
+
+Deno.test("cargo-audit.yml pins cargo-audit install to an explicit version with --locked (Issue #124)", async () => {
+  const runs = runText(await jobSteps(AUDIT_PATH, "audit"));
+  assert(
+    /cargo\s+install\s+cargo-audit\b[^\n]*--locked[^\n]*--version\s+\d+\.\d+/
+      .test(runs),
+    "cargo-audit.yml must install cargo-audit with --locked and a pinned --version",
+  );
+});

--- a/tests/contributing_changelog_test.ts
+++ b/tests/contributing_changelog_test.ts
@@ -1,11 +1,20 @@
-// Tests for the contributor-facing docs floor (Issue #77).
+// Tests for the contributor-facing docs floor (Issue #77, refined in
+// Issue #149).
 //
 // The repo already publishes README.md, LICENSE, and SECURITY.md but was
 // missing CONTRIBUTING.md and CHANGELOG.md. These tests assert that both
-// files now exist at the repository root and carry the substance contributors
-// and consumers expect: build/test/lint commands and the PR workflow for
-// CONTRIBUTING.md, and a Keep a Changelog structure seeded with the current
-// Cargo.toml version for CHANGELOG.md.
+// files exist at the repository root and that the changelog is seeded with a
+// section for the current Cargo.toml version — a *derivable relationship*
+// rather than a hand-copied phrase.
+//
+// The earlier substring greps (cargo test/fmt/clippy/build, deno test,
+// quality.sh, "pull request", "Keep a Changelog", "Semantic Versioning") were
+// removed in Issue #149: they asserted on documentation prose rather than
+// behaviour, broke on harmless rewording that preserved meaning, and
+// duplicated implementation detail. This is the same anti-pattern removed from
+// security_md_test.ts and documentation_accuracy_test.ts under Issue #81.
+// Documentation prose is policed by the Markdown linter and human review, not
+// by string asserts in the unit-test runner.
 
 import { assert } from "@std/assert";
 
@@ -21,50 +30,9 @@ Deno.test("CONTRIBUTING.md exists at the repository root", async () => {
   assert(stat.isFile, `${CONTRIBUTING_PATH} should be a file`);
 });
 
-Deno.test("CONTRIBUTING.md documents the Rust build/test/lint commands", async () => {
-  const text = await read(CONTRIBUTING_PATH);
-  assert(/cargo test/.test(text), "must reference cargo test");
-  assert(/cargo fmt/.test(text), "must reference cargo fmt");
-  assert(/cargo clippy/.test(text), "must reference cargo clippy");
-  assert(/cargo build/.test(text), "must reference cargo build");
-});
-
-Deno.test("CONTRIBUTING.md documents the Deno test suite", async () => {
-  const text = await read(CONTRIBUTING_PATH);
-  assert(/deno test/.test(text), "must reference the Deno test suite");
-});
-
-Deno.test("CONTRIBUTING.md anchors on the existing quality gate", async () => {
-  const text = await read(CONTRIBUTING_PATH);
-  assert(
-    text.includes("quality.sh"),
-    "must reference the quality.sh local gate",
-  );
-});
-
-Deno.test("CONTRIBUTING.md describes the pull-request workflow", async () => {
-  const text = await read(CONTRIBUTING_PATH);
-  assert(
-    /pull request/i.test(text),
-    "must describe the pull-request submission workflow",
-  );
-});
-
 Deno.test("CHANGELOG.md exists at the repository root", async () => {
   const stat = await Deno.stat(CHANGELOG_PATH);
   assert(stat.isFile, `${CHANGELOG_PATH} should be a file`);
-});
-
-Deno.test("CHANGELOG.md follows the Keep a Changelog format", async () => {
-  const text = await read(CHANGELOG_PATH);
-  assert(
-    text.includes("Keep a Changelog"),
-    "must reference the Keep a Changelog format",
-  );
-  assert(
-    text.includes("Semantic Versioning"),
-    "must reference Semantic Versioning",
-  );
 });
 
 Deno.test("CHANGELOG.md is seeded with the current Cargo.toml version", async () => {

--- a/tests/crate_lint_posture_test.rs
+++ b/tests/crate_lint_posture_test.rs
@@ -1,0 +1,49 @@
+//! Tests that the library crate root declares an explicit lint posture
+//! (Issue #116).
+//!
+//! A lint posture is a compile-time configuration, not a runtime function, so
+//! — like `license_metadata_test.rs`, which verifies the committed LICENSE
+//! against the manifest — these tests assert on the committed crate root
+//! (`src/lib.rs`). The whole point of the issue is that without an explicit,
+//! committed posture, hygiene lints accumulate or get dropped silently; these
+//! tests fail loudly if the posture is removed or weakened.
+//!
+//! The complementary half of the posture — `deny(warnings)` — is enforced in
+//! CI by `quality.sh` (`cargo clippy ... -D warnings`) rather than hard-coded
+//! into the source, which would break day-to-day builds on compiler upgrades.
+
+use std::fs;
+
+/// Read the inner attributes (`#![...]`) declared at the top of the crate root.
+fn crate_root_attributes() -> String {
+    fs::read_to_string("src/lib.rs").expect("src/lib.rs must exist")
+}
+
+#[test]
+fn crate_root_warns_on_missing_docs() {
+    let src = crate_root_attributes();
+    assert!(
+        src.contains("#![warn(missing_docs)]"),
+        "src/lib.rs must keep `#![warn(missing_docs)]` so the public API stays documented"
+    );
+}
+
+#[test]
+fn crate_root_denies_unsafe_code() {
+    let src = crate_root_attributes();
+    assert!(
+        src.contains("#![deny(unsafe_code)]"),
+        "src/lib.rs must declare `#![deny(unsafe_code)]`: this crate is pure safe \
+         Rust, so any future `unsafe` must be an explicit, reviewed decision"
+    );
+}
+
+#[test]
+fn crate_root_denies_unsafe_op_in_unsafe_fn() {
+    let src = crate_root_attributes();
+    assert!(
+        src.contains("#![deny(unsafe_op_in_unsafe_fn)]"),
+        "src/lib.rs must declare `#![deny(unsafe_op_in_unsafe_fn)]` so unsafe \
+         operations inside any future unsafe fn require their own unsafe block"
+    );
+}

--- a/tests/deno_quality_workflow_test.ts
+++ b/tests/deno_quality_workflow_test.ts
@@ -136,3 +136,25 @@ Deno.test("Deno Quality workflow pins actions to commit SHAs", async () => {
     );
   }
 });
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Deno Quality workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/deno_scope_config_test.ts
+++ b/tests/deno_scope_config_test.ts
@@ -5,14 +5,22 @@
 // (and any root `*.ts` scripts) was never linted, formatted, or
 // type-checked. These tests assert the scope is broadened to cover the
 // application code, and that both runners (`quality.sh` and the
-// `deno-quality.yml` CI workflow) type-check the helpers.
+// `deno-quality.yml` CI workflow) actually cover the real helpers files.
+//
+// The runner tests resolve each `deno check`/`lint`/`fmt` invocation's path
+// arguments against the helpers files on disk, rather than grepping the
+// command's source text — so behaviour-preserving edits do not break them
+// (Issue #150).
 
 import { assert } from "@std/assert";
 import { parse as parseJsonc } from "@std/jsonc";
+import { parse as parseYaml } from "@std/yaml";
+import { globToRegExp } from "@std/path";
 
 const DENO_JSON = "deno.json";
 const QUALITY_SH = "quality.sh";
 const WORKFLOW = ".github/workflows/deno-quality.yml";
+const HELPERS_DIR = "helpers";
 
 // The application-code globs the quality scope must include.
 const HELPERS_GLOB = "helpers/**/*.ts";
@@ -84,28 +92,102 @@ Deno.test("deno.json test.include still covers the tests tree", async () => {
   );
 });
 
-Deno.test("quality.sh type-checks and lints the helpers directory", async () => {
-  const text = await Deno.readTextFile(QUALITY_SH);
-  // The local runner must type-check and lint helpers/*.ts, not just tests.
-  assert(
-    /\bdeno\s+check\b[^\n]*\bhelpers\/[^\n]*\.ts\b/.test(text),
-    "quality.sh must run `deno check` over helpers/*.ts",
+// --- Behavioural helpers for the runner tests below -------------------------
+//
+// The earlier tests assert the `deno.json` scope structurally. The tests
+// below assert the *outcome* the runners promise: that the real `helpers/`
+// TypeScript files on disk fall within the file set each `deno check`/`lint`/
+// `fmt` invocation operates on. They resolve the command's path arguments as
+// globs against the actual filesystem rather than matching the command's
+// spelling, so behaviour-preserving edits (a `helpers/**/*.ts` glob, a line
+// split with `\`, etc.) keep passing while a runner that stops covering
+// helpers fails.
+
+/** Recursively collect every `*.ts` file under `dir` as a posix path. */
+async function helperTsFiles(dir: string): Promise<string[]> {
+  const found: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isDirectory) {
+      found.push(...await helperTsFiles(path));
+    } else if (entry.isFile && entry.name.endsWith(".ts")) {
+      found.push(path);
+    }
+  }
+  return found;
+}
+
+/** True if any glob in `globs` matches `file` (posix paths). */
+function globsCover(globs: string[], file: string): boolean {
+  return globs.some((glob) =>
+    globToRegExp(glob, { globstar: true }).test(file)
   );
-  assert(
-    /\bdeno\s+lint\b[^\n]*\bhelpers\/[^\n]*\.ts\b/.test(text),
-    "quality.sh must run `deno lint` over helpers/*.ts",
-  );
-  assert(
-    /\bdeno\s+fmt\b[^\n]*\bhelpers\/[^\n]*\.ts\b/.test(text),
-    "quality.sh must run `deno fmt` over helpers/*.ts",
-  );
+}
+
+/**
+ * Join `\`-continued lines, then pull out the path arguments of every
+ * `deno <subcommand>` invocation in a shell script. Flags (`--check`, `-A`)
+ * are skipped so only file/glob operands remain.
+ */
+function denoArgsFromShell(script: string, subcommand: string): string[] {
+  const joined = script.replace(/\\\n\s*/g, " ");
+  const args: string[] = [];
+  const re = new RegExp(`\\bdeno\\s+${subcommand}\\b([^\\n;|&]*)`, "g");
+  for (const match of joined.matchAll(re)) {
+    for (const token of match[1].trim().split(/\s+/)) {
+      if (token && !token.startsWith("-")) args.push(token);
+    }
+  }
+  return args;
+}
+
+Deno.test("quality.sh checks, lints and formats the real helpers files", async () => {
+  const script = await Deno.readTextFile(QUALITY_SH);
+  const helpers = await helperTsFiles(HELPERS_DIR);
+  assert(helpers.length > 0, "expected at least one helpers/*.ts file on disk");
+
+  for (const subcommand of ["check", "lint", "fmt"]) {
+    const globs = denoArgsFromShell(script, subcommand);
+    assert(
+      globs.length > 0,
+      `quality.sh must invoke \`deno ${subcommand}\` with file arguments`,
+    );
+    for (const file of helpers) {
+      assert(
+        globsCover(globs, file),
+        `quality.sh \`deno ${subcommand}\` must cover ${file}, got ${
+          JSON.stringify(globs)
+        }`,
+      );
+    }
+  }
 });
 
-Deno.test("deno-quality.yml type-checks the helpers directory", async () => {
-  const text = await Deno.readTextFile(WORKFLOW);
-  // The CI `deno check` step must cover helpers/*.ts alongside tests/*.ts.
+Deno.test("deno-quality.yml type-checks the real helpers files", async () => {
+  const workflow = parseYaml(
+    await Deno.readTextFile(WORKFLOW),
+  ) as {
+    jobs?: Record<string, { steps?: Array<{ run?: string }> }>;
+  };
+  const helpers = await helperTsFiles(HELPERS_DIR);
+  assert(helpers.length > 0, "expected at least one helpers/*.ts file on disk");
+
+  // Inspect the workflow as structured data: collect the `run` text of every
+  // step, then find the `deno check` invocation and resolve its arguments.
+  const runs = Object.values(workflow.jobs ?? {})
+    .flatMap((job) => job.steps ?? [])
+    .map((step) => step.run ?? "");
+  const checkGlobs = runs.flatMap((run) => denoArgsFromShell(run, "check"));
   assert(
-    /\bdeno\s+check\b[^\n]*\bhelpers\/[^\n]*\.ts\b/.test(text),
-    "deno-quality.yml must run `deno check` over helpers/*.ts",
+    checkGlobs.length > 0,
+    "deno-quality.yml must have a `deno check` step with file arguments",
   );
+  for (const file of helpers) {
+    assert(
+      globsCover(checkGlobs, file),
+      `deno-quality.yml \`deno check\` must cover ${file}, got ${
+        JSON.stringify(checkGlobs)
+      }`,
+    );
+  }
 });

--- a/tests/dependency_review_workflow_test.ts
+++ b/tests/dependency_review_workflow_test.ts
@@ -41,3 +41,25 @@ Deno.test("Dependency Review workflow pins every action to a 40-char commit SHA"
 // enforced by the parsed "pins every action to a 40-char commit SHA" test
 // above. The annotation convention, if wanted, belongs in a dedicated
 // lint/actionlint rule rather than a unit assertion.
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Dependency Review workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/dividend_calculation_tests.ts
+++ b/tests/dividend_calculation_tests.ts
@@ -1,80 +1,123 @@
+// Behavioural (WHAT) tests for the dividend-window kernels (issue #145).
+//
+// These import the REAL shipped helpers from docs/projection.js — the same
+// code the dashboard's GRQValidator delegates to via
+// `getDividendsWithin90Days` and the performance/return path — and assert on
+// their observable output. They replace the previous tautological tests that
+// reimplemented the filter / 90-day sum / `<=` comparison inline and asserted
+// the copy against itself, exercising zero shipped code.
 import { assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
-// Test case for dividend calculation within 90-day period
-// Testing NYSE:WFG from 2024-11-15 score file
+interface Dividend {
+  exDivDate: Date;
+  amount: number;
+}
 
-Deno.test("Dividend Calculation Tests", async (t) => {
-  const scoreDate = new Date(2024, 10, 15); // November 15, 2024
-  const ninetyDayDate = new Date(
-    scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+const g = globalThis as unknown as {
+  GRQProjection: {
+    filterDividendsWithin90Days: (
+      dividends: Dividend[] | undefined,
+      scoreDate: Date,
+    ) => Dividend[];
+    sumDividends: (dividends: Dividend[] | undefined) => number;
+    calculatePerformanceReturn: (
+      buyPrice: number | null,
+      currentPrice: number,
+      totalDividends: number,
+    ) => number | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+// Fixture: NYSE:WFG from the 2024-11-15 score file. The 90-day window from the
+// score date ends 2025-02-13, so the first two ex-dividend dates fall inside
+// the window and the March payment falls outside it.
+const SCORE_DATE = new Date(2024, 10, 15); // 15 November 2024.
+const WFG_DIVIDENDS: Dividend[] = [
+  { exDivDate: new Date("2024-12-19"), amount: 0.135 },
+  { exDivDate: new Date("2024-12-27"), amount: 0.32 },
+  { exDivDate: new Date("2025-03-14"), amount: 0.32 },
+];
+
+Deno.test("filterDividendsWithin90Days keeps only in-window payments", () => {
+  const within = GRQProjection.filterDividendsWithin90Days(
+    WFG_DIVIDENDS,
+    SCORE_DATE,
   );
-  const testDividends = [
-    { exDivDate: new Date("2024-12-19"), amount: 0.135 },
-    { exDivDate: new Date("2024-12-27"), amount: 0.32 },
-    { exDivDate: new Date("2025-03-14"), amount: 0.32 },
-  ];
+  assertEquals(within.length, 2, "Two WFG dividends fall within 90 days");
+  assertEquals(
+    within.map((d) => d.amount),
+    [0.135, 0.32],
+    "The kept payments are the December ex-dividend dates",
+  );
+});
 
-  await t.step("dividend filtering within 90 days", () => {
-    // Test the filtering logic
-    const dividendsWithin90Days = testDividends.filter((dividend) =>
-      dividend.exDivDate <= ninetyDayDate
-    );
+Deno.test("filterDividendsWithin90Days includes a payment on the boundary day", () => {
+  // The window edge is score date + 90 days; an ex-div date exactly on the
+  // edge is inclusive (<=).
+  const boundary = new Date(SCORE_DATE.getTime() + 90 * 24 * 60 * 60 * 1000);
+  const within = GRQProjection.filterDividendsWithin90Days(
+    [{ exDivDate: boundary, amount: 0.5 }],
+    SCORE_DATE,
+  );
+  assertEquals(within.length, 1, "Boundary-day dividend is inside the window");
+});
 
-    assertEquals(
-      dividendsWithin90Days.length,
-      2,
-      "Should have 2 dividends within 90 days",
-    );
+Deno.test("filterDividendsWithin90Days returns empty for missing or empty input", () => {
+  assertEquals(GRQProjection.filterDividendsWithin90Days([], SCORE_DATE), []);
+  assertEquals(
+    GRQProjection.filterDividendsWithin90Days(undefined, SCORE_DATE),
+    [],
+  );
+});
 
-    // Calculate total dividends within 90 days
-    const totalDividends = dividendsWithin90Days.reduce(
-      (sum, div) => sum + div.amount,
-      0,
-    );
+Deno.test("sumDividends totals the in-window WFG payments", () => {
+  const within = GRQProjection.filterDividendsWithin90Days(
+    WFG_DIVIDENDS,
+    SCORE_DATE,
+  );
+  assertAlmostEquals(
+    GRQProjection.sumDividends(within),
+    0.455,
+    0.001,
+    "0.135 + 0.32 = $0.455 within 90 days",
+  );
+});
 
-    assertAlmostEquals(
-      totalDividends,
-      0.455,
-      0.001,
-      "Total dividends should be $0.455",
-    );
-  });
+Deno.test("sumDividends returns 0 for missing or empty input", () => {
+  assertEquals(GRQProjection.sumDividends([]), 0);
+  assertEquals(GRQProjection.sumDividends(undefined), 0);
+});
 
-  await t.step("date calculations", () => {
-    // Verify 90-day calculation
-    const expected90DayDate = new Date(2025, 1, 13); // February 13, 2025
-    const daysDiff = Math.round(
-      (ninetyDayDate.getTime() - scoreDate.getTime()) / (1000 * 60 * 60 * 24),
-    );
+Deno.test("dividend total flows into the shipped performance return", () => {
+  // Drive the real return kernel the dashboard uses: the in-window dividend
+  // total contributes a price-relative dividend return on top of the price
+  // return, proving the filtered/summed dividends reach production output.
+  const within = GRQProjection.filterDividendsWithin90Days(
+    WFG_DIVIDENDS,
+    SCORE_DATE,
+  );
+  const totalDividends = GRQProjection.sumDividends(within);
+  const buyPrice = 91;
+  const currentPrice = 100;
 
-    assertEquals(daysDiff, 90, "Should be exactly 90 days");
-    assertEquals(
-      ninetyDayDate.getTime(),
-      expected90DayDate.getTime(),
-      "90-day date should match expected",
-    );
-  });
+  const withDividends = GRQProjection.calculatePerformanceReturn(
+    buyPrice,
+    currentPrice,
+    totalDividends,
+  )!;
+  const withoutDividends = GRQProjection.calculatePerformanceReturn(
+    buyPrice,
+    currentPrice,
+    0,
+  )!;
 
-  await t.step("dividend date validation", () => {
-    // Test that specific dividends are correctly identified
-    const dividend1 = testDividends[0]; // 2024-12-19
-    const dividend2 = testDividends[1]; // 2024-12-27
-    const dividend3 = testDividends[2]; // 2025-03-14
-
-    assertEquals(
-      dividend1.exDivDate <= ninetyDayDate,
-      true,
-      "First dividend should be within 90 days",
-    );
-    assertEquals(
-      dividend2.exDivDate <= ninetyDayDate,
-      true,
-      "Second dividend should be within 90 days",
-    );
-    assertEquals(
-      dividend3.exDivDate <= ninetyDayDate,
-      false,
-      "Third dividend should be after 90 days",
-    );
-  });
+  // The dividend return component is (0.455 / 91) * 100 ≈ 0.5%.
+  assertAlmostEquals(
+    withDividends - withoutDividends,
+    (0.455 / buyPrice) * 100,
+    0.001,
+    "Dividend total adds a price-relative dividend return",
+  );
 });

--- a/tests/floating_promises_guard_test.ts
+++ b/tests/floating_promises_guard_test.ts
@@ -11,7 +11,7 @@
 //
 // Each module also exposes its entry function as a named export so the call can
 // be awaited/guarded rather than discarded.
-import { assert, assertEquals } from "@std/assert";
+import { assertEquals } from "@std/assert";
 
 Deno.test("check_syntax.ts - imports without running the check", async () => {
   const mod = await import("../scripts/debug/check_syntax.ts");
@@ -26,14 +26,4 @@ Deno.test("debug_schw_current_price.ts - imports without running the debug", asy
 Deno.test("test_page_load.ts - imports without booting the server", async () => {
   const mod = await import("../scripts/debug/test_page_load.ts");
   assertEquals(typeof mod.testPageLoad, "function");
-});
-
-Deno.test("entry functions are async (return a promise)", async () => {
-  const { checkSyntax } = await import("../scripts/debug/check_syntax.ts");
-  // Reading the function source is not enough; confirm it is genuinely the
-  // async entry point by checking its constructor name.
-  assert(
-    checkSyntax.constructor.name === "AsyncFunction",
-    "checkSyntax should be an async function",
-  );
 });

--- a/tests/gitleaks_workflow_test.ts
+++ b/tests/gitleaks_workflow_test.ts
@@ -1,0 +1,62 @@
+// Tests for the Gitleaks secret-scanning GitHub Actions workflow.
+//
+// Verify the workflow file exists, parses as YAML, triggers on pull_request,
+// declares read-only contents permission, and declares a concurrency group
+// that cancels superseded in-progress runs (Issue #139).
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/gitleaks.yml";
+
+Deno.test("Gitleaks workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("Gitleaks workflow parses as valid YAML with expected name", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "Gitleaks");
+});
+
+Deno.test("Gitleaks workflow triggers on pull_request", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  // YAML "on" key sometimes parses to boolean true — accept either key.
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("pull_request" in on, "must trigger on pull_request");
+});
+
+Deno.test("Gitleaks workflow declares read-only contents permission", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { permissions?: Record<string, string> };
+  assert(doc.permissions, "workflow must declare top-level permissions");
+  assertEquals(doc.permissions.contents, "read");
+});
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Gitleaks workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/judgement_tests.ts
+++ b/tests/judgement_tests.ts
@@ -1,98 +1,102 @@
-import { assertEquals } from "@std/assert";
+// Behavioural tests for the dashboard's judgement kernel.
+//
+// History (issue #121): this file used to define local `calculateJudgement`
+// (returning "EXCEEDED"/"MET"/"BELOW") and `calculateProgressVsCostOfCapital`
+// (returning "ABOVE"/"AT"/"BELOW") functions and assert on those copies. No
+// such string mapping exists in the shipped code — the production
+// `GRQValidator.calculateJudgement` (docs/app.js) delegates to
+// `GRQProjection.computeJudgement` (docs/projection.js), which reports outcomes
+// such as "Hit Target", "Partial Success", "Missed Target" and "Early Days".
+// The old cases were therefore tautologies asserting on a fictional mapping;
+// the cost-of-capital "ABOVE/AT/BELOW" cases and the local Date-arithmetic
+// "boundary" steps likewise never touched shipped code.
+//
+// Per issue #121 (option a) the tests below drive the REAL exported
+// `GRQProjection.computeJudgement` and assert on the shipped judgement strings,
+// so a regression in the production string mapping (docs/projection.js:385)
+// actually fails. The fictional cost-of-capital mapping was deleted (option b):
+// the real cost-of-capital figure is the excess-return value computed by
+// `GRQValidator.calculateProgressVsCostOfCapitalValue`, not a string bucket.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
-// Test case for judgement calculations and logic
+interface Projection {
+  projected90DayPerformance: number;
+  projectionMethod: string;
+  confidence: number;
+}
 
-Deno.test("Judgement Tests", async (t) => {
-  const scoreDate = new Date(2024, 10, 15); // November 15, 2024
-  const ninetyDayDate = new Date(
-    scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+const g = globalThis as unknown as {
+  GRQProjection: {
+    computeJudgement: (inputs: {
+      performance: number | null;
+      daysElapsed: number;
+      targetPercentage: number | null;
+      projection: Projection | null;
+    }) => string;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+Deno.test("computeJudgement - realised outcome from day 90", async (t) => {
+  // At/after the 90-day boundary the kernel reports the realised outcome
+  // against 80% of target. Target 20% -> threshold 16%.
+  const realised = (performance: number) =>
+    GRQProjection.computeJudgement({
+      performance,
+      daysElapsed: 90,
+      targetPercentage: 20,
+      projection: null,
+    });
+
+  await t.step("at or above 80% of target hits the target", () => {
+    assertEquals(realised(25.0), "Hit Target"); // above target
+    assertEquals(realised(16.0), "Hit Target"); // exactly the 80% threshold
+  });
+
+  await t.step("positive but below threshold is a partial success", () => {
+    assertEquals(realised(10.0), "Partial Success");
+  });
+
+  await t.step("zero or negative misses the target", () => {
+    assertEquals(realised(0.0), "Missed Target");
+    assertEquals(realised(-5.0), "Missed Target");
+  });
+});
+
+Deno.test("computeJudgement - pending and early-stage reporting", async (t) => {
+  await t.step("null performance is pending", () => {
+    assertEquals(
+      GRQProjection.computeJudgement({
+        performance: null,
+        daysElapsed: 5,
+        targetPercentage: 20,
+        projection: null,
+      }),
+      "Pending",
+    );
+  });
+
+  await t.step(
+    "before day 30 without a confident projection is early days",
+    () => {
+      const up = GRQProjection.computeJudgement({
+        performance: 3.2,
+        daysElapsed: 10,
+        targetPercentage: 20,
+        projection: null,
+      });
+      assert(up.startsWith("Early Days"));
+      assert(up.includes("+3.2%"));
+
+      const down = GRQProjection.computeJudgement({
+        performance: -2.5,
+        daysElapsed: 10,
+        targetPercentage: 20,
+        projection: null,
+      });
+      assert(down.startsWith("Early Days"));
+      assert(down.includes("-2.5%"));
+    },
   );
-
-  function calculateJudgement(performance: number, target: number): string {
-    if (performance >= target) {
-      return performance > target ? "EXCEEDED" : "MET";
-    } else {
-      return "BELOW";
-    }
-  }
-
-  function calculateProgressVsCostOfCapital(
-    performance: number,
-    costOfCapital: number,
-  ): string {
-    if (performance > costOfCapital) {
-      return "ABOVE";
-    } else if (performance === costOfCapital) {
-      return "AT";
-    } else {
-      return "BELOW";
-    }
-  }
-
-  await t.step("judgement calculation", () => {
-    // Test judgement calculation based on performance vs target
-    const testCases = [
-      { performance: 25.0, target: 20.0, expected: "EXCEEDED" },
-      { performance: 20.0, target: 20.0, expected: "MET" },
-      { performance: 15.0, target: 20.0, expected: "BELOW" },
-      { performance: 10.0, target: 20.0, expected: "BELOW" },
-      { performance: -5.0, target: 20.0, expected: "BELOW" },
-    ];
-
-    testCases.forEach((testCase, index) => {
-      const judgement = calculateJudgement(
-        testCase.performance,
-        testCase.target,
-      );
-      assertEquals(
-        judgement,
-        testCase.expected,
-        `Test ${index + 1}: Judgement should be ${testCase.expected}`,
-      );
-    });
-  });
-
-  await t.step("cost of capital comparison", () => {
-    // Test progress vs cost of capital calculation
-    const costOfCapital = 10.0; // 10% cost of capital
-    const testCases = [
-      { performance: 15.0, expected: "ABOVE" },
-      { performance: 10.0, expected: "AT" },
-      { performance: 5.0, expected: "BELOW" },
-      { performance: -5.0, expected: "BELOW" },
-    ];
-
-    testCases.forEach((testCase, index) => {
-      const progress = calculateProgressVsCostOfCapital(
-        testCase.performance,
-        costOfCapital,
-      );
-      assertEquals(
-        progress,
-        testCase.expected,
-        `Test ${index + 1}: Progress should be ${testCase.expected}`,
-      );
-    });
-  });
-
-  await t.step("date boundary logic", () => {
-    // Test that judgements are calculated within the 90-day boundary
-    const testDate = new Date("2025-02-12"); // One day before 90-day boundary
-    const isWithin90Days = testDate <= ninetyDayDate;
-
-    assertEquals(isWithin90Days, true, "Test date should be within 90 days");
-  });
-
-  await t.step("boundary date inclusion", () => {
-    // Test that the boundary date itself is included
-    const boundaryDate = new Date("2025-02-13"); // Exactly 90 days
-    // Compare only the date parts (year, month, day)
-    const isSameDay =
-      boundaryDate.getFullYear() === ninetyDayDate.getFullYear() &&
-      boundaryDate.getMonth() === ninetyDayDate.getMonth() &&
-      boundaryDate.getDate() === ninetyDayDate.getDate();
-    const isWithin90Days = isSameDay || boundaryDate < ninetyDayDate;
-
-    assertEquals(isWithin90Days, true, "Boundary date should be included");
-  });
 });

--- a/tests/markdown_lint_workflow_test.ts
+++ b/tests/markdown_lint_workflow_test.ts
@@ -123,3 +123,25 @@ Deno.test("markdownlint-cli2 passes against repository markdown files", async ()
     );
   }
 });
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Markdown Lint workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/portfolio_target_tests.ts
+++ b/tests/portfolio_target_tests.ts
@@ -1,6 +1,37 @@
 import { assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 
-// Test case for portfolio target percentage and 90-day performance calculation
+// Portfolio target / 90-day performance tests (issue #109).
+//
+// These drive the REAL shipped helpers from docs/projection.js with fixture
+// inputs and assert on their RETURN VALUES. The former version asserted a
+// literal against itself (20.0 ≈ 20.0) and recomputed the portfolio return
+// inline against an answer baked into the fixture, exercising no production
+// code. Buy prices and targets below model a genuine 20% target spread so the
+// shipped target-percentage / performance-return helpers are actually tested.
+
+interface PortfolioStock {
+  stock: string;
+  target: number;
+  buyPrice: number;
+  shares: number;
+  dividends: { exDivDate: Date; amount: number }[];
+}
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+    calculatePerformanceReturn: (
+      buyPrice: number,
+      currentPrice: number,
+      totalDividends?: number,
+    ) => number | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
 
 Deno.test("Portfolio Target Tests", async (t) => {
   const scoreDate = new Date(2024, 10, 15); // November 15, 2024
@@ -8,13 +39,14 @@ Deno.test("Portfolio Target Tests", async (t) => {
     scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
   );
 
-  // Mock portfolio data - equal investment amounts (~$6,000 each)
-  const mockPortfolio = [
+  // Mock portfolio data - equal investment amounts (~$6,000 each). Each stock's
+  // target sits ~20% above its buy price (a real spread, not buyPrice == target).
+  const mockPortfolio: PortfolioStock[] = [
     {
       stock: "NYSE:WFG",
       target: 98.90,
-      buyPrice: 98.90,
-      shares: Math.floor(6000 / 98.90), // ~60 shares
+      buyPrice: 82.42,
+      shares: Math.floor(6000 / 82.42), // ~72 shares
       dividends: [
         { exDivDate: new Date("2024-12-19"), amount: 0.135 },
         { exDivDate: new Date("2024-12-27"), amount: 0.32 },
@@ -23,8 +55,8 @@ Deno.test("Portfolio Target Tests", async (t) => {
     {
       stock: "NYSE:CX",
       target: 5.85,
-      buyPrice: 5.85,
-      shares: Math.floor(6000 / 5.85), // ~1025 shares
+      buyPrice: 4.88,
+      shares: Math.floor(6000 / 4.88), // ~1229 shares
       dividends: [
         { exDivDate: new Date("2024-12-10"), amount: 0.02067 },
       ],
@@ -32,8 +64,8 @@ Deno.test("Portfolio Target Tests", async (t) => {
     {
       stock: "NASDAQ:KLAC",
       target: 695.01,
-      buyPrice: 695.01,
-      shares: Math.floor(6000 / 695.01), // ~8 shares
+      buyPrice: 579.18,
+      shares: Math.floor(6000 / 579.18), // ~10 shares
       dividends: [
         { exDivDate: new Date("2024-11-18"), amount: 1.7 },
       ],
@@ -41,24 +73,31 @@ Deno.test("Portfolio Target Tests", async (t) => {
   ];
 
   await t.step("portfolio target calculation", () => {
-    // Each stock has a 20% target, so portfolio target should be 20%
-    const expectedTarget = 20.0;
-    const calculatedTarget = 20.0; // This is the simplified calculation
+    // Drive each stock's target through the shipped helper, then average.
+    const targetPercentages = mockPortfolio.map((stock) =>
+      GRQProjection.calculateTargetPercentage(
+        stock.buyPrice,
+        stock.target,
+      ) as number
+    );
+    const portfolioTarget = targetPercentages.reduce((sum, t) => sum + t, 0) /
+      targetPercentages.length;
 
+    // Each stock targets ~20%, so the portfolio target should be ~20%.
     assertAlmostEquals(
-      calculatedTarget,
-      expectedTarget,
-      0.1,
-      "Portfolio target should be 20%",
+      portfolioTarget,
+      20.0,
+      0.2,
+      "Portfolio target should be ~20%",
     );
   });
 
   await t.step("portfolio 90-day performance", () => {
-    // Mock 90-day prices (assuming 20% target achieved)
-    const mock90DayPrices = {
-      "NYSE:WFG": 98.90 * 1.20, // 20% gain
-      "NYSE:CX": 5.85 * 1.20, // 20% gain
-      "NASDAQ:KLAC": 695.01 * 1.20, // 20% gain
+    // Mock 90-day prices: a 20% price gain on each stock's buy price.
+    const mock90DayPrices: Record<string, number> = {
+      "NYSE:WFG": 82.42 * 1.20,
+      "NYSE:CX": 4.88 * 1.20,
+      "NASDAQ:KLAC": 579.18 * 1.20,
     };
 
     let totalPortfolioValue = 0;
@@ -66,26 +105,28 @@ Deno.test("Portfolio Target Tests", async (t) => {
 
     mockPortfolio.forEach((stock) => {
       const investment = stock.shares * stock.buyPrice;
-      const dividends = stock.dividends.reduce(
+      const totalDividends = stock.dividends.reduce(
         (sum, div) => sum + div.amount,
         0,
       );
-      const dividendIncome = stock.shares * dividends;
-      const stockValue = stock.shares *
-        mock90DayPrices[stock.stock as keyof typeof mock90DayPrices];
-      const totalStockValue = stockValue + dividendIncome;
+      // Per-stock total return (price + dividend) from the shipped helper.
+      const returnPct = GRQProjection.calculatePerformanceReturn(
+        stock.buyPrice,
+        mock90DayPrices[stock.stock],
+        totalDividends,
+      ) as number;
+      const stockValue = investment * (1 + returnPct / 100);
 
       totalInvestment += investment;
-      totalPortfolioValue += totalStockValue;
+      totalPortfolioValue += stockValue;
     });
 
     const portfolioReturn =
       ((totalPortfolioValue - totalInvestment) / totalInvestment) * 100;
-    const expectedReturn = 20.0; // Should be close to 20% with equal weighting
-
+    // ~20% price gain plus small dividend contributions.
     assertAlmostEquals(
       portfolioReturn,
-      expectedReturn,
+      20.0,
       2.0,
       "Portfolio return should be close to 20%",
     );

--- a/tests/semgrep_workflow_test.ts
+++ b/tests/semgrep_workflow_test.ts
@@ -99,3 +99,25 @@ Deno.test("Semgrep workflow pins actions to commit SHAs", async () => {
     );
   }
 });
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("Semgrep workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/shellcheck_workflow_test.ts
+++ b/tests/shellcheck_workflow_test.ts
@@ -1,0 +1,62 @@
+// Tests for the ShellCheck GitHub Actions workflow.
+//
+// Verify the workflow file exists, parses as YAML, triggers on pull_request,
+// declares read-only contents permission, and declares a concurrency group
+// that cancels superseded in-progress runs (Issue #139).
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const WORKFLOW_PATH = ".github/workflows/shellcheck.yml";
+
+Deno.test("ShellCheck workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("ShellCheck workflow parses as valid YAML with expected name", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  assertEquals(doc.name, "ShellCheck");
+});
+
+Deno.test("ShellCheck workflow triggers on pull_request", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  // YAML "on" key sometimes parses to boolean true — accept either key.
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("pull_request" in on, "must trigger on pull_request");
+});
+
+Deno.test("ShellCheck workflow declares read-only contents permission", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { permissions?: Record<string, string> };
+  assert(doc.permissions, "workflow must declare top-level permissions");
+  assertEquals(doc.permissions.contents, "read");
+});
+
+// Concurrency cancellation (Issue #139). Without a concurrency group, rapid
+// pushes to the same ref queue redundant, overlapping runs that each hold a
+// runner. A top-level concurrency block keyed on workflow + ref with
+// cancel-in-progress leaves only the latest run for a given ref alive,
+// mirroring the canonical pattern already proven in ci.yml.
+Deno.test("ShellCheck workflow declares a concurrency group that cancels superseded runs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});

--- a/tests/target_percentage_tests.ts
+++ b/tests/target_percentage_tests.ts
@@ -1,6 +1,15 @@
 import { assertAlmostEquals, assertEquals, assertExists } from "@std/assert";
+import "../docs/projection.js";
 
-// Test case for target percentage calculations with stock dilution handling
+// Target-percentage and split-adjustment tests (issue #109).
+//
+// These drive the REAL shipped helpers from docs/projection.js — the same code
+// the dashboard's GRQValidator delegates to — with fixture inputs and assert on
+// their RETURN VALUES against spec-derived expected numbers. A regression in the
+// production target-percentage / split-adjustment logic now fails the suite.
+// The former version recomputed the formula inline and asserted it against a
+// hand-evaluation of the same formula, so it could never fail for any reason
+// connected to production behaviour.
 
 // Type definitions
 interface MockStock {
@@ -9,6 +18,7 @@ interface MockStock {
   buyPrice: number;
   originalBuyPrice: number;
   splitAdjustment: number;
+  // Spec-required target return (%), independent of the production formula.
   expectedTargetPercentage: number;
 }
 
@@ -19,13 +29,33 @@ interface MarketDataPoint {
   splitCoefficient: number;
 }
 
+const g = globalThis as unknown as {
+  GRQProjection: {
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+    getSplitAdjustment: (
+      marketData: MarketDataPoint[] | null,
+      historicalDate: Date,
+    ) => number;
+    adjustHistoricalPriceToCurrent: (
+      price: number,
+      marketData: MarketDataPoint[] | null,
+      historicalDate: Date,
+    ) => number;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
 Deno.test("Target Percentage Calculation Tests", async (t) => {
   const scoreDate = new Date(2024, 10, 15); // November 15, 2024
   const ninetyDayDate = new Date(
     scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
   );
 
-  // Mock stock data with different scenarios
+  // Mock stock data with different scenarios. Buy prices are split-adjusted;
+  // expectedTargetPercentage is the spec answer the shipped helper must return.
   const mockStocks: MockStock[] = [
     {
       stock: "NYSE:WFG",
@@ -33,7 +63,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 82.42, // Split-adjusted buy price
       originalBuyPrice: 82.42, // Original price before any splits
       splitAdjustment: 1.0, // No splits
-      expectedTargetPercentage: 20.0, // (98.90 - 82.42) / 82.42 * 100
+      expectedTargetPercentage: 20.0,
     },
     {
       stock: "NYSE:CX",
@@ -41,7 +71,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 4.88, // Split-adjusted buy price
       originalBuyPrice: 4.88, // Original price before any splits
       splitAdjustment: 1.0, // No splits
-      expectedTargetPercentage: 19.9, // (5.85 - 4.88) / 4.88 * 100
+      expectedTargetPercentage: 19.9,
     },
     {
       stock: "NASDAQ:KLAC",
@@ -49,7 +79,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 579.18, // Split-adjusted buy price
       originalBuyPrice: 579.18, // Original price before any splits
       splitAdjustment: 1.0, // No splits
-      expectedTargetPercentage: 20.0, // (695.01 - 579.18) / 579.18 * 100
+      expectedTargetPercentage: 20.0,
     },
     {
       stock: "NASDAQ:TSLA",
@@ -57,7 +87,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 125.00, // Split-adjusted buy price (after 2:1 split)
       originalBuyPrice: 250.00, // Original price before 2:1 split
       splitAdjustment: 2.0, // 2:1 split occurred
-      expectedTargetPercentage: 100.0, // (250.00 - 125.00) / 125.00 * 100
+      expectedTargetPercentage: 100.0,
     },
     {
       stock: "NASDAQ:AAPL",
@@ -65,7 +95,7 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
       buyPrice: 50.00, // Split-adjusted buy price (after 3:1 split)
       originalBuyPrice: 150.00, // Original price before 3:1 split
       splitAdjustment: 3.0, // 3:1 split occurred
-      expectedTargetPercentage: 200.0, // (150.00 - 50.00) / 50.00 * 100
+      expectedTargetPercentage: 200.0,
     },
   ];
 
@@ -107,11 +137,13 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
 
   await t.step("single stock target percentage calculation - no splits", () => {
     const testStock = mockStocks[0]; // NYSE:WFG
-    const targetPercentage =
-      ((testStock.target - testStock.buyPrice) / testStock.buyPrice) * 100;
+    const targetPercentage = GRQProjection.calculateTargetPercentage(
+      testStock.buyPrice,
+      testStock.target,
+    );
 
     assertAlmostEquals(
-      targetPercentage,
+      targetPercentage as number,
       testStock.expectedTargetPercentage,
       0.1,
       `Target percentage for ${testStock.stock} should be ${testStock.expectedTargetPercentage}%`,
@@ -123,13 +155,15 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
     () => {
       const testStock = mockStocks[3]; // NASDAQ:TSLA
 
-      // When there's a split, both target and buy price are adjusted by the same factor
-      // So the target percentage remains the same: (250 - 125) / 125 * 100 = 100%
-      const targetPercentage =
-        ((testStock.target - testStock.buyPrice) / testStock.buyPrice) * 100;
+      // Both target and buy price are split-adjusted by the same factor, so the
+      // shipped helper should still return 100%: (250 - 125) / 125 * 100.
+      const targetPercentage = GRQProjection.calculateTargetPercentage(
+        testStock.buyPrice,
+        testStock.target,
+      );
 
       assertAlmostEquals(
-        targetPercentage,
+        targetPercentage as number,
         testStock.expectedTargetPercentage,
         0.1,
         `Target percentage for ${testStock.stock} with 2:1 split should be ${testStock.expectedTargetPercentage}%`,
@@ -142,13 +176,15 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
     () => {
       const testStock = mockStocks[4]; // NASDAQ:AAPL
 
-      // When there's a split, both target and buy price are adjusted by the same factor
-      // So the target percentage remains the same: (150 - 50) / 50 * 100 = 200%
-      const targetPercentage =
-        ((testStock.target - testStock.buyPrice) / testStock.buyPrice) * 100;
+      // Split-adjusted on both sides, so the shipped helper returns 200%:
+      // (150 - 50) / 50 * 100.
+      const targetPercentage = GRQProjection.calculateTargetPercentage(
+        testStock.buyPrice,
+        testStock.target,
+      );
 
       assertAlmostEquals(
-        targetPercentage,
+        targetPercentage as number,
         testStock.expectedTargetPercentage,
         0.1,
         `Target percentage for ${testStock.stock} with 3:1 split should be ${testStock.expectedTargetPercentage}%`,
@@ -157,15 +193,18 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
   );
 
   await t.step("portfolio target percentage calculation", () => {
-    // Calculate individual target percentages (split-adjusted prices are already provided)
-    const targetPercentages = mockStocks.map((stock) => {
-      return ((stock.target - stock.buyPrice) / stock.buyPrice) * 100;
-    });
+    // Drive each stock through the shipped helper, then average.
+    const targetPercentages = mockStocks.map((stock) =>
+      GRQProjection.calculateTargetPercentage(
+        stock.buyPrice,
+        stock.target,
+      ) as number
+    );
 
     // Calculate portfolio target (average of individual targets)
     const portfolioTarget = targetPercentages.reduce((sum, target) =>
       sum + target, 0) / targetPercentages.length;
-    const expectedPortfolioTarget = 72.0; // Average of all target percentages
+    const expectedPortfolioTarget = 72.0; // Average of all spec target percentages
 
     assertAlmostEquals(
       portfolioTarget,
@@ -177,22 +216,31 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
 
   await t.step("split adjustment calculation", () => {
     const testStock = mockStocks[3]; // NASDAQ:TSLA with 2:1 split
+    const marketData = createMockMarketData(testStock);
 
-    // Test split adjustment logic
-    const originalPrice = testStock.originalBuyPrice;
-    const splitAdjustment = testStock.splitAdjustment;
-    const adjustedPrice = originalPrice / splitAdjustment;
-
-    assertEquals(
-      adjustedPrice,
-      testStock.buyPrice,
-      "Split-adjusted price should match expected buy price",
+    // The shipped helper walks the market data and multiplies post-score splits.
+    const splitAdjustment = GRQProjection.getSplitAdjustment(
+      marketData,
+      scoreDate,
     );
-
     assertEquals(
       splitAdjustment,
       2.0,
       "Split adjustment should be 2.0 for 2:1 split",
+    );
+
+    // Restating the original price in current terms should yield the
+    // split-adjusted buy price.
+    const adjustedPrice = GRQProjection.adjustHistoricalPriceToCurrent(
+      testStock.originalBuyPrice,
+      marketData,
+      scoreDate,
+    );
+    assertAlmostEquals(
+      adjustedPrice,
+      testStock.buyPrice,
+      0.001,
+      "Split-adjusted price should match expected buy price",
     );
   });
 
@@ -200,77 +248,70 @@ Deno.test("Target Percentage Calculation Tests", async (t) => {
     const testStock = mockStocks[3]; // NASDAQ:TSLA
     const marketData = createMockMarketData(testStock);
 
-    // Find split data
-    const splitData = marketData.find((point) => point.splitCoefficient > 1.0);
-    assertExists(splitData, "Split data should exist for stocks with splits");
-    if (splitData) {
-      assertEquals(
-        splitData.splitCoefficient,
-        testStock.splitAdjustment,
-        "Split coefficient should match expected split adjustment",
-      );
-    }
+    // The shipped split helper should recover the fixture's split factor.
+    const splitAdjustment = GRQProjection.getSplitAdjustment(
+      marketData,
+      scoreDate,
+    );
+    assertEquals(
+      splitAdjustment,
+      testStock.splitAdjustment,
+      "Cumulative split adjustment should match expected split adjustment",
+    );
+
+    // No splits before the score date.
+    assertEquals(
+      GRQProjection.getSplitAdjustment(marketData, ninetyDayDate),
+      1.0,
+      "No splits should be counted after the latest split date",
+    );
   });
 
   await t.step("target percentage edge cases", () => {
-    // Test case where buy price equals target (0% target)
-    const zeroTargetStock = {
-      stock: "TEST:ZERO",
-      target: 100.00,
-      buyPrice: 100.00,
-      originalBuyPrice: 100.00,
-      splitAdjustment: 1.0,
-      expectedTargetPercentage: 0.0,
-    };
-
-    const zeroTargetPercentage =
-      ((zeroTargetStock.target - zeroTargetStock.buyPrice) /
-        zeroTargetStock.buyPrice) * 100;
+    // Buy price equals target -> 0%.
+    const zeroTargetPercentage = GRQProjection.calculateTargetPercentage(
+      100.00,
+      100.00,
+    );
     assertEquals(
       zeroTargetPercentage,
-      zeroTargetStock.expectedTargetPercentage,
+      0.0,
       "Target percentage should be 0% when buy price equals target",
     );
 
-    // Test case where target is lower than buy price (negative target)
-    const negativeTargetStock = {
-      stock: "TEST:NEG",
-      target: 80.00,
-      buyPrice: 100.00,
-      originalBuyPrice: 100.00,
-      splitAdjustment: 1.0,
-      expectedTargetPercentage: -20.0,
-    };
-
-    const negativeTargetPercentage =
-      ((negativeTargetStock.target - negativeTargetStock.buyPrice) /
-        negativeTargetStock.buyPrice) * 100;
+    // Target lower than buy price -> negative.
+    const negativeTargetPercentage = GRQProjection.calculateTargetPercentage(
+      100.00,
+      80.00,
+    );
     assertEquals(
       negativeTargetPercentage,
-      negativeTargetStock.expectedTargetPercentage,
+      -20.0,
       "Target percentage should be negative when target is lower than buy price",
+    );
+
+    // Missing inputs are guarded and return null.
+    assertEquals(
+      GRQProjection.calculateTargetPercentage(null, 100.00),
+      null,
+      "Target percentage should be null when buy price is missing",
     );
   });
 
   await t.step("multiple splits handling", () => {
-    // Test stock with multiple splits
-    const multiSplitStock = {
-      stock: "TEST:MULTI",
-      target: 300.00, // Already split-adjusted
-      buyPrice: 50.00, // Already split-adjusted (after 2:1 and 3:1 splits = 6:1 total)
-      originalBuyPrice: 300.00, // Original price before splits
-      splitAdjustment: 6.0, // 2:1 * 3:1 = 6:1 total
-      expectedTargetPercentage: 500.0, // (300.00 - 50.00) / 50.00 * 100
-    };
+    // Stock with multiple splits, already split-adjusted on both sides.
+    const target = 300.00;
+    const buyPrice = 50.00; // After 2:1 and 3:1 splits = 6:1 total
+    const expectedTargetPercentage = 500.0; // (300 - 50) / 50 * 100
 
-    // Both target and buy price are already split-adjusted, so calculate directly
-    const targetPercentage =
-      ((multiSplitStock.target - multiSplitStock.buyPrice) /
-        multiSplitStock.buyPrice) * 100;
+    const targetPercentage = GRQProjection.calculateTargetPercentage(
+      buyPrice,
+      target,
+    );
 
     assertAlmostEquals(
-      targetPercentage,
-      multiSplitStock.expectedTargetPercentage,
+      targetPercentage as number,
+      expectedTargetPercentage,
       0.1,
       "Target percentage should handle multiple splits correctly",
     );

--- a/tests/trend_line_extension_test.ts
+++ b/tests/trend_line_extension_test.ts
@@ -21,6 +21,23 @@ interface Projection {
   currentPerformance: number;
 }
 
+interface MarketPoint {
+  date: Date;
+  high: number;
+  low: number;
+  open: number;
+  close: number;
+  splitCoefficient: number;
+}
+
+interface TrendLine {
+  slope: number;
+  intercept: number;
+  predicted90DayPerformance: number;
+  dataPoints: Array<{ x: number; y: number }>;
+  rSquared: number;
+}
+
 const g = globalThis as unknown as {
   GRQProjection: {
     setDateToMidnight: (date: Date) => Date;
@@ -29,6 +46,20 @@ const g = globalThis as unknown as {
       scoreDate: Date,
       trendLine: { slope: number } | null,
     ) => ProjectionPoint[];
+    getBuyPrice: (
+      marketData: MarketPoint[],
+      scoreDate: Date,
+    ) => { price: number; dateUsed: Date } | null;
+    buildTrendLineDataPoints: (
+      marketData: MarketPoint[],
+      scoreDate: Date,
+      buyPrice: number,
+      dividends: Array<{ exDivDate: Date; amount: number }>,
+      endDate?: Date,
+    ) => Array<{ x: number; y: number }>;
+    computeTrendLine: (
+      dataPoints: Array<{ x: number; y: number }>,
+    ) => TrendLine | null;
   };
 };
 const GRQProjection = g.GRQProjection;
@@ -158,191 +189,117 @@ Deno.test("Real buildHybridProjectionData - Does Not Hit Target When Projection 
   assertEquals(data[0].y, 0);
 });
 
-// Test that trend line uses latest market data date instead of today's date.
+// Trend line windowing uses the latest market-data date, not today (issue #144).
 //
-// This exercises the linear-regression shape of calculateTrendLine. The
-// regression maths still lives on GRQValidator (not yet extracted to the
-// shared module); the helper below mirrors it so the regression behaviour is
-// covered. Extracting calculateTrendLine into docs/projection.js is tracked as
-// follow-up work.
-Deno.test("Trend Line Uses Latest Market Data Date", () => {
-  // Mock market data showing SCHW growth from April 15 to July 1
-  const marketData: Record<
-    string,
-    Array<{
-      date: Date;
-      high: number;
-      low: number;
-      open: number;
-      close: number;
-      splitCoefficient: number;
-    }>
-  > = {
-    "NYSE:SCHW": [
-      {
-        date: new Date("2025-04-15"),
-        high: 78.12,
-        low: 77.03,
-        open: 77.55,
-        close: 77.19,
-        splitCoefficient: 1.0,
-      },
-      {
-        date: new Date("2025-07-01"),
-        high: 91.6772,
-        low: 90.14,
-        open: 90.92,
-        close: 91.17,
-        splitCoefficient: 1.0,
-      },
-    ],
-  };
+// This now drives the REAL shipped helpers: GRQProjection.getBuyPrice resolves
+// the buy price, GRQProjection.buildTrendLineDataPoints performs the
+// data-window / end-date selection (the part previously reimplemented inline in
+// this test), and GRQProjection.computeTrendLine runs the regression — the exact
+// pipeline GRQValidator.calculateTrendLine delegates to. A regression in the
+// shipped windowing now fails these assertions.
+// Local-component dates (year, monthIndex, day) match the shared getBuyPrice
+// day-matching, which compares local date components.
+const SCHW_FIXTURE: MarketPoint[] = [
+  {
+    date: new Date(2025, 3, 15), // 15 April 2025
+    high: 78.12,
+    low: 77.03,
+    open: 77.55,
+    close: 77.19,
+    splitCoefficient: 1.0,
+  },
+  {
+    // Intermediate point: regression needs at least three observations.
+    date: new Date(2025, 5, 1), // 1 June 2025
+    high: 85.0,
+    low: 84.0,
+    open: 84.4,
+    close: 84.6,
+    splitCoefficient: 1.0,
+  },
+  {
+    date: new Date(2025, 6, 1), // 1 July 2025
+    high: 91.6772,
+    low: 90.14,
+    open: 90.92,
+    close: 91.17,
+    splitCoefficient: 1.0,
+  },
+];
 
-  // Mock validator with trend line calculation
-  const validator = {
-    marketData,
-    setDateToMidnight: function (date: Date): Date {
-      const d = new Date(date);
-      d.setHours(0, 0, 0, 0);
-      return d;
-    },
-    getBuyPrice: function (stockSymbol: string, scoreDate: Date) {
-      const data = this.marketData[stockSymbol];
-      if (!data || data.length === 0) return null;
+Deno.test("Real buildTrendLineDataPoints - Window extends to latest market data date", () => {
+  const scoreDate = new Date(2025, 3, 15);
+  const buyPrice = GRQProjection.getBuyPrice(SCHW_FIXTURE, scoreDate);
+  assertExists(buyPrice, "Buy price should resolve from the fixture");
 
-      // Find closest point to score date
-      const scoreDateTimestamp = scoreDate.getTime();
-      let closestPoint = data[0];
-      let minDiff = Math.abs(data[0].date.getTime() - scoreDateTimestamp);
-
-      for (const point of data) {
-        const diff = Math.abs(point.date.getTime() - scoreDateTimestamp);
-        if (diff < minDiff) {
-          minDiff = diff;
-          closestPoint = point;
-        }
-      }
-
-      const buyPrice = (closestPoint.high + closestPoint.low) / 2;
-      return { price: buyPrice, date: closestPoint.date };
-    },
-    adjustHistoricalPriceToCurrent: function (price: number) {
-      return price; // No adjustments for this test
-    },
-    getDividendsWithin90Days: function () {
-      return []; // No dividends for this test
-    },
-    calculateTrendLine: function (
-      stock: { stock: string },
-      scoreDate: Date,
-      endDate?: Date,
-    ) {
-      const marketData = this.marketData[stock.stock];
-      if (!marketData || marketData.length === 0) {
-        return null;
-      }
-
-      const scoreDateTimestamp = scoreDate.getTime();
-      // Use the latest market data date if no endDate is provided, not today's date
-      const trendEndDate = endDate ||
-        (marketData && marketData.length > 0
-          ? marketData[marketData.length - 1].date
-          : new Date());
-
-      // Get data points from score date to trend end date
-      const dataPoints: Array<{ x: number; y: number }> = [];
-      const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
-
-      if (!buyPriceObj || buyPriceObj.price <= 0) {
-        return null;
-      }
-
-      marketData.forEach((point) => {
-        if (point.date >= scoreDate && point.date <= trendEndDate) {
-          const daysSinceScore = (point.date.getTime() - scoreDateTimestamp) /
-            (1000 * 60 * 60 * 24);
-          const currentPrice = this.adjustHistoricalPriceToCurrent(
-            (point.high + point.low) / 2,
-          );
-
-          // Calculate performance (no dividends in this test)
-          const priceReturn =
-            ((currentPrice - buyPriceObj.price) / buyPriceObj.price) * 100;
-          const totalReturn = priceReturn;
-
-          dataPoints.push({
-            x: daysSinceScore,
-            y: totalReturn,
-          });
-        }
-      });
-
-      if (dataPoints.length < 2) {
-        return null;
-      }
-
-      // Calculate linear regression
-      const n = dataPoints.length;
-      const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
-      const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
-      const sumXY = dataPoints.reduce(
-        (sum, point) => sum + point.x * point.y,
-        0,
-      );
-      const sumXX = dataPoints.reduce(
-        (sum, point) => sum + point.x * point.x,
-        0,
-      );
-
-      const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-      const _intercept = (sumY - slope * sumX) / n;
-
-      // Force the trend line to start at zero on the score date
-      const adjustedIntercept = 0;
-      const adjustedSlope = slope;
-
-      // Predict performance at 90 days using the adjusted line
-      const predicted90DayPerformance = adjustedSlope * 90 + adjustedIntercept;
-      const cappedPredicted90DayPerformance = Math.max(
-        predicted90DayPerformance,
-        -100,
-      );
-
-      return {
-        slope: adjustedSlope,
-        intercept: adjustedIntercept,
-        predicted90DayPerformance: cappedPredicted90DayPerformance,
-        dataPoints,
-        rSquared: 0.95,
-      };
-    },
-  };
-
-  const stock = { stock: "NYSE:SCHW" };
-  const scoreDate = new Date("2025-04-15");
-
-  // Calculate trend line without specifying endDate (should use latest market data)
-  const trendLine = validator.calculateTrendLine(stock, scoreDate);
-
-  assertExists(trendLine, "Trend line should be calculated");
-
-  // Check that the trend line uses data up to July 1 (latest market data)
-  const latestDataPoint =
-    trendLine!.dataPoints[trendLine!.dataPoints.length - 1];
-  const daysSinceScore = latestDataPoint.x;
-
-  // July 1 is about 77 days after April 15
-  assertEquals(
-    daysSinceScore >= 75 && daysSinceScore <= 80,
-    true,
-    `Should use data up to ~77 days, got ${daysSinceScore}`,
+  // No endDate -> the window must run to the latest market-data point (July 1),
+  // NOT today's date.
+  const dataPoints = GRQProjection.buildTrendLineDataPoints(
+    SCHW_FIXTURE,
+    scoreDate,
+    buyPrice!.price,
+    [],
   );
 
-  // Check that the projection reflects the actual growth pattern
-  const predicted90Day = trendLine!.predicted90DayPerformance;
+  // All three observations fall inside the window.
+  assertEquals(dataPoints.length, 3);
 
-  // With growth from ~77.58 to ~90.91 = ~17% growth in ~77 days
-  // The 90-day projection should reflect this growth rate
+  // The last point is July 1, about 77 days after April 15.
+  const lastDay = dataPoints[dataPoints.length - 1].x;
+  assertEquals(
+    lastDay >= 75 && lastDay <= 80,
+    true,
+    `Should use data up to ~77 days, got ${lastDay}`,
+  );
+
+  // The trend line starts at zero on the score date.
+  assertEquals(dataPoints[0].x, 0);
+  assertEquals(dataPoints[0].y, 0);
+});
+
+Deno.test("Real buildTrendLineDataPoints - Explicit endDate truncates the window", () => {
+  const scoreDate = new Date(2025, 3, 15);
+  const buyPrice = GRQProjection.getBuyPrice(SCHW_FIXTURE, scoreDate);
+  assertExists(buyPrice);
+
+  // An explicit earlier endDate excludes the July 1 point, proving the
+  // end-date selection is the real windowing logic and not a fixed default.
+  const dataPoints = GRQProjection.buildTrendLineDataPoints(
+    SCHW_FIXTURE,
+    scoreDate,
+    buyPrice!.price,
+    [],
+    new Date(2025, 5, 1),
+  );
+
+  assertEquals(dataPoints.length, 2);
+  const lastDay = dataPoints[dataPoints.length - 1].x;
+  // June 1 is about 47 days after April 15.
+  assertEquals(
+    lastDay >= 45 && lastDay <= 49,
+    true,
+    `Window should stop at ~47 days, got ${lastDay}`,
+  );
+});
+
+Deno.test("Real computeTrendLine - Projection reflects SCHW growth pattern", () => {
+  const scoreDate = new Date(2025, 3, 15);
+  const buyPrice = GRQProjection.getBuyPrice(SCHW_FIXTURE, scoreDate);
+  assertExists(buyPrice);
+
+  const dataPoints = GRQProjection.buildTrendLineDataPoints(
+    SCHW_FIXTURE,
+    scoreDate,
+    buyPrice!.price,
+    [],
+  );
+  const trendLine = GRQProjection.computeTrendLine(dataPoints);
+  assertExists(trendLine, "Trend line should be calculated");
+
+  // Growth from ~77.58 to ~90.91 (~17% over ~77 days); the 90-day projection
+  // tracks that rate. Driving the REAL regression (not an inline copy) proves
+  // the shipped maths produces this figure.
+  const predicted90Day = trendLine!.predicted90DayPerformance;
   assertEquals(
     predicted90Day > 15,
     true,
@@ -353,6 +310,9 @@ Deno.test("Trend Line Uses Latest Market Data Date", () => {
     true,
     `Projection should be <25%, got ${predicted90Day}%`,
   );
+
+  // The regression is forced through the origin (day 0 reads 0%).
+  assertEquals(trendLine!.intercept, 0);
 });
 
 console.log("All trend line extension tests passed! 🎉");


### PR DESCRIPTION
## Milestone: security-scan

This PR merges the completed milestone branch into main.
Closes #169

### Issues addressed
- #151: 🟢 HOW-assertion on constructor.name instead of Promise return in tests/floating_promises_guard_test.ts
- #150: 🟡 Source-text regex greps on quality.sh / workflow text in tests/deno_scope_config_test.ts
- #149: 🟡 Source-text prose greps in tests/contributing_changelog_test.ts
- #145: 🟡 Tautological dividend-filtering tests assert no production behaviour
- #144: 🟡 Partial migration: trend_line_extension_test.ts still mirrors calculateTrendLine
- #139: 🟡 Add concurrency cancellation to seven PR-triggered workflows
- #124: 🟡 Cargo dependencies have no supply-chain quarantine in .github/workflows/ci.yml:99
- #121: 🟡 Tautological tests reimplement production judgement and annualized maths inline
- #117: 🟢 Add doc comments to public API functions in src/utils.rs
- #116: 🟢 Add a crate-root lint posture to the library crate (src/lib.rs)
- #115: 🟢 Delete stale orphan `test_feb15.rs` that references a removed struct field
- #114: 🟢 Remove dead dependencies `walkdir` and `thiserror` from Cargo.toml
- #109: 🟡 Tautological self-checking arithmetic tests assert no production behaviour

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to main.