### PR TITLE
Add set -euo pipefail to multi-line run blocks (Issue #173)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -34,6 +34,7 @@ jobs:
           node-version: "20"
       - name: Serve docs/ dashboard and wait for it to come up
         run: |
+          set -euo pipefail
           npx --yes http-server docs -p 8080 --silent &
           for i in $(seq 1 30); do
             if curl -sSf http://localhost:8080/index.html >/dev/null 2>&1; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
     # Check bash script syntax
     - name: Check Bash Script Syntax
       run: |
+        set -euo pipefail
         echo "Checking bash script syntax..."
         find . -name "*.sh" -type f -exec bash -n {} \;
         echo "All bash scripts have valid syntax"

--- a/docs/archive/pr-summaries/pr-summary-173.md
+++ b/docs/archive/pr-summaries/pr-summary-173.md
@@ -1,0 +1,40 @@
+## Summary
+
+Two multi-line bash `run:` blocks in the workflows did not begin with
+`set -euo pipefail`, so a failing command mid-script was silently ignored and
+could surface later as a confusing error (or be masked entirely). This PR
+prefixes both blocks with the strict-mode preamble, matching the convention
+already used by the more careful steps in `ci.yml` (`check-changes`, SBOM).
+
+Changed call sites:
+
+- `.github/workflows/a11y.yml` — "Serve docs/ dashboard and wait for it to
+  come up" (backgrounds `npx http-server`, then a readiness loop).
+- `.github/workflows/ci.yml` — job `build`, "Check Bash Script Syntax"
+  (`find ... -exec bash -n`).
+
+Closes #173.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the Deno
+workflow tests, which parse the YAML and assert the first executable line of
+each multi-line `run:` block is `set -euo pipefail`.
+
+```mermaid
+flowchart LR
+    A[run: block fails early] -->|without strict mode| B[failure masked, step reports success]
+    A -->|set -euo pipefail| C[step aborts, failure surfaced]
+```
+
+## Test Plan
+
+- Extended `tests/ci_workflow_test.ts::multi-line bash run blocks begin with
+  set -euo pipefail` to also cover the `build` job's "Check Bash Script Syntax"
+  step.
+- Added `tests/a11y_workflow_test.ts::a11y multi-line bash run blocks begin
+  with set -euo pipefail`, asserting every multi-line `run:` block in
+  `a11y.yml` starts with the strict-mode preamble.
+- Both tests fail against the unfixed workflows and pass after the fix.
+  `deno test --allow-read tests/ci_workflow_test.ts tests/a11y_workflow_test.ts`
+  → 20 passed, 0 failed.

--- a/tests/a11y_workflow_test.ts
+++ b/tests/a11y_workflow_test.ts
@@ -142,6 +142,30 @@ Deno.test("a11y workflow serves the docs/ directory before checking", async () =
   );
 });
 
+// Multi-line bash run: blocks must fail fast (Issue #173). Without
+// `set -euo pipefail` an intermediate command that fails (e.g. npx failing to
+// install http-server) is masked by the success of a later command, so the
+// step reports success even when an earlier stage broke.
+Deno.test("a11y multi-line bash run blocks begin with set -euo pipefail", async () => {
+  const doc = await loadWorkflow();
+  const multiLineRuns = allSteps(doc)
+    .map((s) => s.run ?? "")
+    .filter((run) => run.includes("\n"));
+  assert(
+    multiLineRuns.length > 0,
+    "workflow must contain at least one multi-line run block",
+  );
+  for (const run of multiLineRuns) {
+    const firstLine = run.split("\n").map((l) => l.trim())
+      .filter((l) => l.length > 0)[0] ?? "";
+    assertEquals(
+      firstLine,
+      "set -euo pipefail",
+      "every multi-line bash run block must start with set -euo pipefail",
+    );
+  }
+});
+
 Deno.test("a11y workflow pins actions to 40-character commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -171,6 +171,7 @@ Deno.test("multi-line bash run blocks begin with set -euo pipefail", async () =>
   const targets: Array<[string, string]> = [
     ["check-changes", "Check for changes"],
     ["build", "Generate CycloneDX SBOM"],
+    ["build", "Check Bash Script Syntax"],
   ];
   for (const [job, step] of targets) {
     const run = findRun(doc, job, step);


### PR DESCRIPTION
## Summary

Two multi-line bash `run:` blocks in the workflows did not begin with
`set -euo pipefail`, so a failing command mid-script was silently ignored and
could surface later as a confusing error (or be masked entirely). This PR
prefixes both blocks with the strict-mode preamble, matching the convention
already used by the more careful steps in `ci.yml` (`check-changes`, SBOM).

Changed call sites:

- `.github/workflows/a11y.yml` — "Serve docs/ dashboard and wait for it to
  come up" (backgrounds `npx http-server`, then a readiness loop).
- `.github/workflows/ci.yml` — job `build`, "Check Bash Script Syntax"
  (`find ... -exec bash -n`).

Closes #173.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the Deno
workflow tests, which parse the YAML and assert the first executable line of
each multi-line `run:` block is `set -euo pipefail`.

```mermaid
flowchart LR
    A[run: block fails early] -->|without strict mode| B[failure masked, step reports success]
    A -->|set -euo pipefail| C[step aborts, failure surfaced]
```

## Test Plan

- Extended `tests/ci_workflow_test.ts::multi-line bash run blocks begin with
  set -euo pipefail` to also cover the `build` job's "Check Bash Script Syntax"
  step.
- Added `tests/a11y_workflow_test.ts::a11y multi-line bash run blocks begin
  with set -euo pipefail`, asserting every multi-line `run:` block in
  `a11y.yml` starts with the strict-mode preamble.
- Both tests fail against the unfixed workflows and pass after the fix.
  `deno test --allow-read tests/ci_workflow_test.ts tests/a11y_workflow_test.ts`
  → 20 passed, 0 failed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqbmxw7y-fd31b6`<!-- vibe-worker-issue-173 -->