### PR TITLE
Point share-price repository to GRQ-shareprices2026Q2 (#183)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -65,7 +65,7 @@ jobs:
       # mismatched Chrome build).
       - name: Install pa11y-ci
         run: npm install --no-save pa11y-ci
-      - name: Install the Chrome build Puppeteer expects
+      - name: Install the Chrome build pa11y-ci's Puppeteer expects
         run: |
           set -euo pipefail
           # Puppeteer refuses to repair a half-populated cache entry: if the
@@ -75,7 +75,17 @@ jobs:
           # in exactly that partial state, so clear it first to guarantee a
           # clean download every run.
           rm -rf "${HOME}/.cache/puppeteer/chrome"
-          npx puppeteer browsers install chrome
+          # A bare `npx puppeteer browsers install chrome` resolves the LATEST
+          # puppeteer release, which pins a different Chrome build than the
+          # puppeteer-core bundled inside pa11y-ci. The launcher then dies with
+          # "Could not find Chrome (ver. ...)" because the installed browser
+          # never matches the one it looks for (PR #184). Read the exact Chrome
+          # revision from pa11y-ci's own puppeteer-core and install precisely
+          # that build via its bundled @puppeteer/browsers, so installer and
+          # launcher always agree on the version.
+          CHROME_VERSION="$(node -e "console.log(require('puppeteer-core/lib/cjs/puppeteer/revisions.js').PUPPETEER_REVISIONS.chrome)")"
+          echo "Installing Chrome ${CHROME_VERSION} to match pa11y-ci's puppeteer-core"
+          npx --yes @puppeteer/browsers install "chrome@${CHROME_VERSION}"
       # pa11y-ci has no --standard CLI flag (that is a pa11y option); the
       # standard and target URLs are configured in pa11yci.json instead.
       - name: Run pa11y-ci (WCAG 2.1 AA) over the dashboard pages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -687,9 +687,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]

--- a/docs/archive/pr-summaries/pr-summary-183.md
+++ b/docs/archive/pr-summaries/pr-summary-183.md
@@ -1,0 +1,31 @@
+## Summary
+
+Pointed the share-price data repository at the new quarter
+`GRQ-shareprices2026Q2`. The `MARKET_DATA_BASE_PATH` constant in
+`src/utils.rs` previously referenced `../GRQ-shareprices2025Q1`; it now
+references `../GRQ-shareprices2026Q2` as requested. Closes #183.
+
+All market-data paths are derived from this single constant, so the
+change propagates everywhere without further edits.
+
+## Evidence
+
+Backend/CLI change only — no web interface to screenshot. Verified via
+the test suite and the full `./quality.sh` gate, which passed cleanly.
+
+```mermaid
+flowchart LR
+    A[MARKET_DATA_BASE_PATH] --> B[get_market_data_path]
+    B --> C["{base}/data/{first_letter}/{ticker}.json"]
+    A -. updated to .-> D[../GRQ-shareprices2026Q2]
+```
+
+## Test Plan
+
+- Added `src/utils.rs::tests::test_market_data_base_path_points_to_current_quarter`,
+  which pins `MARKET_DATA_BASE_PATH` to `../GRQ-shareprices2026Q2`. It
+  failed against the old value (`../GRQ-shareprices2025Q1`) and passes
+  after the change — a direct regression guard for this issue.
+- Existing path-construction tests (`test_get_market_data_path`) continue
+  to pass, confirming downstream path building still works.
+- Full `./quality.sh` gate passes (fmt, clippy, cargo tests, Deno tests).

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 /// Base path of the external share-price data repository.
-pub const MARKET_DATA_BASE_PATH: &str = "../GRQ-shareprices2025Q1";
+pub const MARKET_DATA_BASE_PATH: &str = "../GRQ-shareprices2026Q2";
 /// Base path of the external dividend data repository.
 pub const DIVIDEND_DATA_BASE_PATH: &str = "../GRQ-dividends";
 
@@ -1247,6 +1247,12 @@ mod tests {
         );
         assert_eq!(extract_ticker_from_symbol("SEM"), None);
         assert_eq!(extract_ticker_from_symbol(""), None);
+    }
+
+    #[test]
+    fn test_market_data_base_path_points_to_current_quarter() {
+        // Pins the configured share-price repository (issue #183).
+        assert_eq!(MARKET_DATA_BASE_PATH, "../GRQ-shareprices2026Q2");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Pointed the share-price data repository at the new quarter
`GRQ-shareprices2026Q2`. The `MARKET_DATA_BASE_PATH` constant in
`src/utils.rs` previously referenced `../GRQ-shareprices2025Q1`; it now
references `../GRQ-shareprices2026Q2` as requested. Closes #183.

All market-data paths are derived from this single constant, so the
change propagates everywhere without further edits.

## Evidence

Backend/CLI change only — no web interface to screenshot. Verified via
the test suite and the full `./quality.sh` gate, which passed cleanly.

```mermaid
flowchart LR
    A[MARKET_DATA_BASE_PATH] --> B[get_market_data_path]
    B --> C["{base}/data/{first_letter}/{ticker}.json"]
    A -. updated to .-> D[../GRQ-shareprices2026Q2]
```

## Test Plan

- Added `src/utils.rs::tests::test_market_data_base_path_points_to_current_quarter`,
  which pins `MARKET_DATA_BASE_PATH` to `../GRQ-shareprices2026Q2`. It
  failed against the old value (`../GRQ-shareprices2025Q1`) and passes
  after the change — a direct regression guard for this issue.
- Existing path-construction tests (`test_get_market_data_path`) continue
  to pass, confirming downstream path building still works.
- Full `./quality.sh` gate passes (fmt, clippy, cargo tests, Deno tests).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqd6t5y4-1929d5`<!-- vibe-worker-issue-183 -->