### PR TITLE
Document branch-protection and commit-signing posture for main (Issue #180)

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,31 @@
+{
+  "comment": "Declared branch-protection and commit-signing policy for the default branch (Issue #180). This is the static, machine-readable record of the governance decisions described in CONTRIBUTING.md and SECURITY.md. GitHub does NOT apply this file automatically: a repository administrator enforces the intended controls via Settings -> Branches or a repository ruleset. The file exists so static scans can confirm the intended controls AND the deliberately relaxed ones, rather than treating the posture as an undocumented gap (finding BP-c6a4162e1eed).",
+  "default_branch": "main",
+  "intended_controls": {
+    "require_pull_request": true,
+    "require_code_owner_reviews": true,
+    "block_force_pushes": true,
+    "block_deletions": true,
+    "require_linear_history": true,
+    "require_signed_commits": true
+  },
+  "required_approving_review_count": 1,
+  "enforcement": "Requires a repository administrator to enable on `main` via Settings -> Branches or a repository ruleset; the controls are not applied automatically from this file. The committed `.github/CODEOWNERS` rules become enforced (not merely advisory) once 'Require review from Code Owners' is turned on.",
+  "accepted_relaxations": [
+    {
+      "control": "require_pull_request",
+      "identities": ["scorer 3 <scorer-3@lecklogic.com>"],
+      "scope": "Generated data only: daily score files and auto-committed models under docs/. Never source, workflows, or actions, which CODEOWNERS guards.",
+      "reason": "The autonomous scorer identity pushes daily score data straight to `main`. Requiring a human-reviewed pull request for each day's generated data is operationally infeasible, so direct pushes by this identity for data-only commits are a deliberate, documented choice. A ruleset bypass actor scoped to this identity is the recommended way to encode the exception."
+    },
+    {
+      "control": "require_signed_commits",
+      "identities": [
+        "scorer 3 <scorer-3@lecklogic.com>",
+        "Vibe Coder <nigel+VibeCoder@stsoftware.com.au>",
+        "service @ ST <service@stsoftware.com.au>"
+      ],
+      "reason": "Per-identity GPG/SSH signing keys for the automated committers are not yet provisioned, so `git log --show-signature` does not yet report 'Good signature' on `main`. Until keys are issued and `commit.gpgsign` is configured for each agent identity, unsigned commits from these automation identities are an accepted, documented posture rather than an undetected gap. Tracked as future work."
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CONTRIBUTING.md` documenting the build, test, lint, and pull-request
   workflow.
 - `CHANGELOG.md` (this file) tracking notable changes between releases.
+- `.github/branch-protection.json`: a machine-readable record of the intended
+  branch-protection and commit-signing controls for `main`, and the controls
+  deliberately relaxed for the autonomous committers, so static scans treat the
+  posture as documented rather than a gap (Issue #180). Documented in
+  `CONTRIBUTING.md` and `SECURITY.md`.
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,45 @@ redirect stdin to avoid hangs: `./quality.sh < /dev/null`.
 6. **Open a pull request** with a clear description of what changed and why,
    referencing any related issue.
 
+## Branch protection, review, and commit signing
+
+The repository's governance posture for the default branch (`main`) is recorded
+as machine-readable static evidence in
+[`.github/branch-protection.json`](.github/branch-protection.json), so security
+scans can confirm the intended controls — and the deliberately relaxed ones —
+rather than treating them as an undocumented gap. GitHub does **not** apply that
+file automatically; a repository administrator enforces the controls via
+Settings → Branches or a repository ruleset. The intended controls are:
+
+- **Require a pull request before merging** with at least one approving review.
+- **Require review from Code Owners** so the committed
+  [`.github/CODEOWNERS`](.github/CODEOWNERS) rules are enforced rather than
+  advisory.
+- **Block force-pushes and deletions** on `main`.
+- **Require linear history** (the rebase/squash workflow above).
+- **Require signed commits.**
+
+### Controls intentionally relaxed for automation
+
+Two controls are deliberately relaxed for the autonomous committer identities,
+and this is a recorded operational choice — not an oversight:
+
+- **Direct pushes for daily data.** The automated `scorer 3` identity pushes
+  daily score files and auto-committed models under `docs/` straight to `main`.
+  These commits touch generated data only — never source, workflows, or actions
+  (which CODEOWNERS guards) — and a human-reviewed pull request per day is
+  operationally infeasible. A ruleset bypass actor scoped to this identity is
+  the recommended way to encode the exception.
+- **Unsigned automation commits.** Per-identity GPG/SSH signing keys for the
+  automated committers (`scorer 3`, `Vibe Coder`, `service @ ST`) are not yet
+  provisioned, so commits from these identities are currently unsigned. This is
+  an accepted, documented posture and tracked as future work; once keys are
+  issued and `commit.gpgsign` is configured per identity, `main` will show the
+  **Verified** badge.
+
+See [SECURITY.md](SECURITY.md) for the rationale linking these controls to the
+supply-chain attack shape they defend against.
+
 ## Conventions
 
 - **Australian English** — use Australian spelling in code, comments, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,15 +32,26 @@ supply-chain attack shape.
 
 `CODEOWNERS` only requests reviews on its own; enforcement comes from
 branch-protection settings, which a repository administrator must enable on the
-default branch (they are not stored in the tree). The recommended settings are:
+default branch (they are not stored in the tree). The intended controls — and
+the controls deliberately relaxed for the autonomous committers — are recorded
+as machine-readable static evidence in
+[`.github/branch-protection.json`](.github/branch-protection.json) and described
+for contributors in [CONTRIBUTING.md](CONTRIBUTING.md). The intended settings
+are:
 
 - Require at least one approving pull-request review.
 - **Require review from Code Owners.**
 - Block direct pushes and force-pushes to the default branch.
 - Require linear history (to suit the rebase/squash workflow).
+- **Require signed commits**, so `git log --show-signature` reports a good
+  signature on `main` and GitHub shows a **Verified** badge.
 
-Note: commit-signature verification is a separate, optional control and is not
-asserted here.
+Two controls are deliberately relaxed for automation and recorded as such: the
+`scorer 3` identity pushes daily data-only commits under `docs/` directly to
+`main`, and the automated committers (`scorer 3`, `Vibe Coder`, `service @ ST`)
+currently commit unsigned because per-identity signing keys are not yet
+provisioned. Both are accepted, documented postures tracked as future work — see
+`.github/branch-protection.json` for the per-control rationale.
 
 ## Emergency dependency-bump procedure
 

--- a/docs/archive/pr-summaries/pr-summary-180.md
+++ b/docs/archive/pr-summaries/pr-summary-180.md
@@ -1,0 +1,77 @@
+# Document branch-protection and commit-signing posture for `main`
+
+## Summary
+
+Branch-protection rules and commit-signature requirements are repository
+settings that do not live in the committed tree, so a static scan cannot confirm
+them and flags them as a gap (finding `BP-c6a4162e1eed`). This repository also
+pushes daily score data straight to `main` under the automated `scorer 3`
+identity, so a blanket "require a reviewed pull request for every commit" rule
+is a **deliberately relaxed** control rather than an oversight.
+
+Enabling required-review protection and per-identity commit signing are
+administrator/infrastructure actions that cannot be performed through committed
+files — and enabling required reviews unconditionally would break the autonomous
+daily-score automation. Following the route the issue itself offers, this PR
+**records the governance decision** as static, machine-readable evidence so
+future scans treat the posture as documented:
+
+- Adds `.github/branch-protection.json` — a machine-readable declaration of the
+  intended controls for `main` (require PR + at least one approving review,
+  require review from Code Owners, block force-pushes/deletions, require linear
+  history, require signed commits) **and** the deliberately relaxed controls
+  (direct data-only pushes by `scorer 3`; unsigned automation commits pending
+  signing-key provisioning), each with a rationale. The file documents that an
+  administrator must enforce the controls via Settings → Branches or a ruleset;
+  it is not auto-applied.
+- Documents the decision in `CONTRIBUTING.md` (the file named in the issue) and
+  `SECURITY.md`, including which controls are intentionally relaxed and why.
+- Records the change in `CHANGELOG.md`.
+
+Closes #180.
+
+## Evidence
+
+This is a governance/documentation change with no web interface to screenshot.
+It is verified by the new Deno test suite, the full existing suite, and
+markdownlint.
+
+```text
+deno test --allow-read tests/*.ts
+ok | 267 passed (55 steps) | 0 failed (3s)
+
+npx markdownlint-cli2 CONTRIBUTING.md SECURITY.md CHANGELOG.md
+Summary: 0 error(s)
+```
+
+How the pieces relate:
+
+```mermaid
+flowchart LR
+    A[Static scan<br/>BP-c6a4162e1eed] -->|controls not evidenced| B[.github/branch-protection.json<br/>declared policy]
+    B --> C[CONTRIBUTING.md]
+    B --> D[SECURITY.md]
+    B --> E[branch_protection_governance_test.ts<br/>parse + assert]
+    B -. admin enforces .-> F[(GitHub branch<br/>protection / ruleset)]
+    G[scorer 3 daily data pushes] -.->|documented relaxation| B
+```
+
+## Test Plan
+
+Added `tests/branch_protection_governance_test.ts`, which parses
+`.github/branch-protection.json` and asserts on its structure (the
+parse-and-assert pattern used by `codeowners_test.ts`, not the prose greps
+removed under Issues #81/#149):
+
+- descriptor exists and is valid JSON.
+- descriptor targets the `main` default branch.
+- every required control is declared enabled (require PR, code-owner review,
+  block force-pushes, block deletions, linear history, signed commits).
+- at least one approving review is required.
+- the enforcement note is present.
+- the deliberately relaxed controls are documented with identities and reasons.
+- every relaxation references a declared control (consistency check).
+- the direct-push relaxation names the automated scorer identity.
+
+All eight tests fail against the unfixed tree (no descriptor) and pass after it
+is added. The full Deno suite (267 tests) and markdownlint pass.

--- a/tests/branch_protection_governance_test.ts
+++ b/tests/branch_protection_governance_test.ts
@@ -1,0 +1,149 @@
+// Tests for the declared branch-protection and commit-signing governance
+// descriptor (Issue #180).
+//
+// Branch-protection rules and commit-signature requirements are repository
+// settings that do not live in the committed tree, so a static scan cannot
+// confirm them and flags them as a gap (finding BP-c6a4162e1eed). This repo
+// also pushes daily score data straight to `main` under the automated
+// `scorer 3` identity, so a blanket "require a reviewed PR for every commit"
+// rule is a deliberately relaxed control rather than an oversight.
+//
+// `.github/branch-protection.json` is the static, machine-readable record of
+// the intended controls AND the deliberately relaxed ones, so future scans can
+// treat the posture as documented. These tests parse that descriptor and
+// assert on its structure — the same parse-and-assert pattern used by
+// codeowners_test.ts and dependabot_config_test.ts, not the fragile prose
+// greps removed under Issues #81 and #149.
+
+import { assert, assertEquals } from "@std/assert";
+
+const DESCRIPTOR_PATH = ".github/branch-protection.json";
+
+// Controls the descriptor must declare as the intended posture for `main`.
+const REQUIRED_CONTROLS = [
+  "require_pull_request",
+  "require_code_owner_reviews",
+  "block_force_pushes",
+  "block_deletions",
+  "require_linear_history",
+  "require_signed_commits",
+] as const;
+
+interface Relaxation {
+  control: string;
+  identities: string[];
+  reason: string;
+  scope?: string;
+}
+
+interface Descriptor {
+  default_branch: string;
+  intended_controls: Record<string, boolean>;
+  required_approving_review_count: number;
+  enforcement: string;
+  accepted_relaxations: Relaxation[];
+}
+
+async function loadDescriptor(): Promise<Descriptor> {
+  const text = await Deno.readTextFile(DESCRIPTOR_PATH);
+  return JSON.parse(text) as Descriptor;
+}
+
+Deno.test("branch-protection descriptor exists and is valid JSON", async () => {
+  const stat = await Deno.stat(DESCRIPTOR_PATH);
+  assert(stat.isFile, `${DESCRIPTOR_PATH} should be a file`);
+  const descriptor = await loadDescriptor();
+  assert(
+    typeof descriptor === "object" && descriptor !== null,
+    "descriptor must parse to an object",
+  );
+});
+
+Deno.test("descriptor targets the default branch", async () => {
+  const descriptor = await loadDescriptor();
+  assertEquals(
+    descriptor.default_branch,
+    "main",
+    "descriptor must target the `main` default branch",
+  );
+});
+
+Deno.test("descriptor declares every required control as enabled", async () => {
+  const descriptor = await loadDescriptor();
+  for (const control of REQUIRED_CONTROLS) {
+    assertEquals(
+      descriptor.intended_controls[control],
+      true,
+      `intended_controls.${control} must be declared true`,
+    );
+  }
+});
+
+Deno.test("descriptor requires at least one approving review", async () => {
+  const descriptor = await loadDescriptor();
+  assert(
+    typeof descriptor.required_approving_review_count === "number" &&
+      descriptor.required_approving_review_count >= 1,
+    "required_approving_review_count must be a number >= 1",
+  );
+});
+
+Deno.test("descriptor records how the controls are enforced", async () => {
+  const descriptor = await loadDescriptor();
+  assert(
+    typeof descriptor.enforcement === "string" &&
+      descriptor.enforcement.trim().length > 0,
+    "enforcement must be a non-empty string explaining who applies the rules",
+  );
+});
+
+Deno.test("descriptor documents the deliberately relaxed controls", async () => {
+  const descriptor = await loadDescriptor();
+  assert(
+    Array.isArray(descriptor.accepted_relaxations) &&
+      descriptor.accepted_relaxations.length > 0,
+    "accepted_relaxations must list at least one documented exception",
+  );
+  for (const relaxation of descriptor.accepted_relaxations) {
+    assert(
+      typeof relaxation.control === "string" &&
+        relaxation.control.length > 0,
+      "each relaxation must name the control it relaxes",
+    );
+    assert(
+      Array.isArray(relaxation.identities) && relaxation.identities.length > 0,
+      `relaxation of ${relaxation.control} must name at least one identity`,
+    );
+    assert(
+      typeof relaxation.reason === "string" &&
+        relaxation.reason.trim().length > 0,
+      `relaxation of ${relaxation.control} must give a non-empty reason`,
+    );
+  }
+});
+
+Deno.test("every relaxation references a declared control", async () => {
+  const descriptor = await loadDescriptor();
+  const known = new Set(Object.keys(descriptor.intended_controls));
+  for (const relaxation of descriptor.accepted_relaxations) {
+    assert(
+      known.has(relaxation.control),
+      `relaxation control "${relaxation.control}" must match a key in intended_controls`,
+    );
+  }
+});
+
+Deno.test("the direct-push relaxation covers the automated score committer", async () => {
+  const descriptor = await loadDescriptor();
+  const prRelaxation = descriptor.accepted_relaxations.find(
+    (r) => r.control === "require_pull_request",
+  );
+  assert(
+    prRelaxation !== undefined,
+    "the require_pull_request relaxation for direct data pushes must be recorded",
+  );
+  assert(
+    prRelaxation.identities.some((id) => id.includes("scorer")),
+    "the direct-push relaxation must name the automated scorer identity",
+  );
+});


### PR DESCRIPTION
# Document branch-protection and commit-signing posture for `main`

## Summary

Branch-protection rules and commit-signature requirements are repository
settings that do not live in the committed tree, so a static scan cannot confirm
them and flags them as a gap (finding `BP-c6a4162e1eed`). This repository also
pushes daily score data straight to `main` under the automated `scorer 3`
identity, so a blanket "require a reviewed pull request for every commit" rule
is a **deliberately relaxed** control rather than an oversight.

Enabling required-review protection and per-identity commit signing are
administrator/infrastructure actions that cannot be performed through committed
files — and enabling required reviews unconditionally would break the autonomous
daily-score automation. Following the route the issue itself offers, this PR
**records the governance decision** as static, machine-readable evidence so
future scans treat the posture as documented:

- Adds `.github/branch-protection.json` — a machine-readable declaration of the
  intended controls for `main` (require PR + at least one approving review,
  require review from Code Owners, block force-pushes/deletions, require linear
  history, require signed commits) **and** the deliberately relaxed controls
  (direct data-only pushes by `scorer 3`; unsigned automation commits pending
  signing-key provisioning), each with a rationale. The file documents that an
  administrator must enforce the controls via Settings → Branches or a ruleset;
  it is not auto-applied.
- Documents the decision in `CONTRIBUTING.md` (the file named in the issue) and
  `SECURITY.md`, including which controls are intentionally relaxed and why.
- Records the change in `CHANGELOG.md`.

Closes #180.

## Evidence

This is a governance/documentation change with no web interface to screenshot.
It is verified by the new Deno test suite, the full existing suite, and
markdownlint.

```text
deno test --allow-read tests/*.ts
ok | 267 passed (55 steps) | 0 failed (3s)

npx markdownlint-cli2 CONTRIBUTING.md SECURITY.md CHANGELOG.md
Summary: 0 error(s)
```

How the pieces relate:

```mermaid
flowchart LR
    A[Static scan<br/>BP-c6a4162e1eed] -->|controls not evidenced| B[.github/branch-protection.json<br/>declared policy]
    B --> C[CONTRIBUTING.md]
    B --> D[SECURITY.md]
    B --> E[branch_protection_governance_test.ts<br/>parse + assert]
    B -. admin enforces .-> F[(GitHub branch<br/>protection / ruleset)]
    G[scorer 3 daily data pushes] -.->|documented relaxation| B
```

## Test Plan

Added `tests/branch_protection_governance_test.ts`, which parses
`.github/branch-protection.json` and asserts on its structure (the
parse-and-assert pattern used by `codeowners_test.ts`, not the prose greps
removed under Issues #81/#149):

- descriptor exists and is valid JSON.
- descriptor targets the `main` default branch.
- every required control is declared enabled (require PR, code-owner review,
  block force-pushes, block deletions, linear history, signed commits).
- at least one approving review is required.
- the enforcement note is present.
- the deliberately relaxed controls are documented with identities and reasons.
- every relaxation references a declared control (consistency check).
- the direct-push relaxation names the automated scorer identity.

All eight tests fail against the unfixed tree (no descriptor) and pass after it
is added. The full Deno suite (267 tests) and markdownlint pass.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqde4idl-e1981d`<!-- vibe-worker-issue-180 -->