### PR TITLE
Guard market-data path against TSV symbol traversal (#195)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +247,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -268,13 +280,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -291,6 +305,21 @@ dependencies = [
  "serde_json",
  "tempfile",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -320,6 +349,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -368,6 +415,12 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -433,6 +486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -512,6 +575,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -605,10 +674,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -653,6 +746,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -721,6 +848,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,12 +221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,12 +241,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -280,15 +268,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -305,21 +291,6 @@ dependencies = [
  "serde_json",
  "tempfile",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -349,24 +320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -415,12 +368,6 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -486,16 +433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -577,12 +514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,9 +576,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -674,34 +605,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -746,40 +653,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -848,100 +721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]

--- a/docs/archive/pr-summaries/pr-summary-195.md
+++ b/docs/archive/pr-summaries/pr-summary-195.md
@@ -1,0 +1,52 @@
+## Summary
+
+Fixed a path-traversal weakness in `src/utils.rs` where a TSV-derived stock
+`symbol` was interpolated straight into a filesystem path with no sanitisation.
+A crafted `symbol` such as `../../../../etc/hosts` could escape the intended
+`MARKET_DATA_BASE_PATH/data/` root when reading market-data JSON. Closes #195.
+
+The fix applies the same `std::path::Component` allow-list guard already used by
+the sibling builders `build_score_file_path` (issue #182) and
+`get_dividend_data_path`:
+
+- `get_market_data_path` now returns `Result<String>` and builds the path with
+  `Path::join` over validated components, rejecting any `ParentDir` (`..`),
+  `RootDir`, or `Prefix` segment.
+- `read_market_data` now delegates to `get_market_data_path(symbol)?` instead of
+  raw `format!` string interpolation, so the guard runs on every production read.
+  The three call sites (`create_market_data_csv`, `create_market_data_long_csv`)
+  already handle the `Result`, logging/skipping on error, so a malicious row is
+  skipped rather than escaping the data root.
+
+Legitimate tickers (including exchange-prefixed ones like `NYSE:SEM`) resolve to
+exactly the same path as before — only traversal attempts are rejected.
+
+## Data flow
+
+```mermaid
+flowchart LR
+    TSV[score TSV stock column] --> ETC[extract_ticker_codes_from_score_file]
+    ETC --> RMD[read_market_data]
+    RMD --> GMP[get_market_data_path<br/>Component allow-list guard]
+    GMP -->|normal segments| OPEN[File::open within data root]
+    GMP -->|`..` / absolute| ERR[Err: rejected, row skipped]
+```
+
+## Evidence
+
+Backend/CLI change with no web interface to screenshot. Verified via `cargo test`
+and the full `./quality.sh` gate (fmt, clippy `-D warnings`, type check, tests,
+coverage, release build, and Deno checks) — all pass cleanly.
+
+## Test Plan
+
+Added regression tests in `src/utils.rs` (mirroring the dividend/score-path
+traversal tests):
+
+- `test_get_market_data_path_rejects_parent_dir_traversal` — `..` segment is rejected.
+- `test_get_market_data_path_rejects_absolute_symbol` — absolute symbol is rejected.
+- `test_get_market_data_path_allows_plain_ticker_with_exchange_prefix` — `NYSE:SEM` still resolves.
+- `test_read_market_data_rejects_traversal_symbol` — `read_market_data` errors on a traversal symbol rather than opening an out-of-tree file.
+
+Updated the existing `test_get_market_data_path` for the new `Result<String>`
+signature (behaviour unchanged for legitimate tickers; documented inline).

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -140,10 +140,57 @@ pub fn extract_ticker_from_symbol(symbol: &str) -> Option<String> {
 }
 
 /// Builds the market-data JSON path for `ticker` under [`MARKET_DATA_BASE_PATH`],
-/// bucketed by uppercased first letter (e.g. `"SEM"` → `.../data/S/SEM.json`).
-pub fn get_market_data_path(ticker: &str) -> String {
-    let first_letter = ticker.chars().next().unwrap_or('X').to_uppercase();
-    format!("{MARKET_DATA_BASE_PATH}/data/{first_letter}/{ticker}.json")
+/// bucketed by uppercased first letter (e.g. `"SEM"` → `.../data/S/SEM.json`),
+/// guarding against path traversal.
+///
+/// The `ticker`/`symbol` originates from the `stock` column of a daily score
+/// TSV, which is attacker-influenceable (a contributor, a compromised upstream
+/// data step, or a malicious pull request against the data set), exactly like
+/// the `file` field guarded by [`build_score_file_path`] and the ticker guarded
+/// by [`get_dividend_data_path`]. To stop a crafted symbol such as
+/// `"../../../../etc/hosts"` escaping the intended `MARKET_DATA_BASE_PATH/data/`
+/// tree, the path is built with `Path::join` over validated components rather
+/// than plain string interpolation: any parent-directory (`..`), root, or
+/// prefix component is a traversal attempt and is rejected (issue #195).
+///
+/// # Errors
+///
+/// Returns an error if `ticker` is absolute or contains a parent-directory
+/// (`..`) segment.
+pub fn get_market_data_path(ticker: &str) -> Result<String> {
+    use std::path::Component;
+
+    let first_letter = ticker
+        .chars()
+        .next()
+        .unwrap_or('X')
+        .to_uppercase()
+        .to_string();
+
+    // Build within the market-data root via join rather than string
+    // concatenation, keeping only normal segments.
+    let mut full_path = Path::new(MARKET_DATA_BASE_PATH)
+        .join("data")
+        .join(&first_letter);
+
+    let file_name = format!("{ticker}.json");
+    for component in Path::new(&file_name).components() {
+        match component {
+            Component::ParentDir => {
+                return Err(anyhow!(
+                    "Refusing market-data ticker with parent-directory segment: {ticker:?}"
+                ));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(anyhow!("Refusing absolute market-data ticker: {ticker:?}"));
+            }
+            // `.` adds nothing; normal segments extend the path.
+            Component::CurDir => {}
+            Component::Normal(segment) => full_path.push(segment),
+        }
+    }
+
+    Ok(full_path.to_string_lossy().into_owned())
 }
 
 /// Reads a tab-separated score file into a vector of [`StockRecord`]s.
@@ -209,8 +256,9 @@ pub fn extract_symbol_from_ticker(ticker: &str) -> String {
 pub fn read_market_data(symbol: &str) -> Result<MarketData> {
     use std::fs::File;
 
-    let first_letter = symbol.chars().next().unwrap_or('X').to_uppercase();
-    let market_data_path = format!("{MARKET_DATA_BASE_PATH}/data/{first_letter}/{symbol}.json");
+    // Build the path through the traversal-guarded helper so an attacker-supplied
+    // symbol such as `"../../../../etc/hosts"` cannot escape the data root (issue #195).
+    let market_data_path = get_market_data_path(symbol)?;
 
     let file = File::open(&market_data_path)?;
     let market_data: MarketData = serde_json::from_reader(file)?;
@@ -1305,17 +1353,70 @@ mod tests {
 
     #[test]
     fn test_get_market_data_path() {
+        // Signature changed to `Result<String>` in issue #195 to guard against
+        // path traversal; legitimate tickers still resolve to the same path.
         assert_eq!(
-            get_market_data_path("SEM"),
-            format!("{MARKET_DATA_BASE_PATH}/data/S/SEM.json")
+            get_market_data_path("SEM").unwrap(),
+            Path::new(MARKET_DATA_BASE_PATH)
+                .join("data/S/SEM.json")
+                .to_string_lossy()
         );
         assert_eq!(
-            get_market_data_path("AAPL"),
-            format!("{MARKET_DATA_BASE_PATH}/data/A/AAPL.json")
+            get_market_data_path("AAPL").unwrap(),
+            Path::new(MARKET_DATA_BASE_PATH)
+                .join("data/A/AAPL.json")
+                .to_string_lossy()
         );
         assert_eq!(
-            get_market_data_path("TSLA"),
-            format!("{MARKET_DATA_BASE_PATH}/data/T/TSLA.json")
+            get_market_data_path("TSLA").unwrap(),
+            Path::new(MARKET_DATA_BASE_PATH)
+                .join("data/T/TSLA.json")
+                .to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn test_get_market_data_path_allows_plain_ticker_with_exchange_prefix() {
+        // A legitimate ticker with an exchange prefix contains no path
+        // separators or traversal segments and must still resolve.
+        let path = get_market_data_path("NYSE:SEM").unwrap();
+        assert_eq!(
+            path,
+            Path::new(MARKET_DATA_BASE_PATH)
+                .join("data/N/NYSE:SEM.json")
+                .to_string_lossy()
+        );
+    }
+
+    // Regression tests for issue #195: a `..` or absolute segment in an
+    // attacker-influenceable symbol must not escape the market-data root.
+    #[test]
+    fn test_get_market_data_path_rejects_parent_dir_traversal() {
+        let result = get_market_data_path("../../../../etc/hosts");
+        assert!(
+            result.is_err(),
+            "expected a symbol containing `..` to be rejected, got {result:?}"
+        );
+        assert!(result.unwrap_err().to_string().contains("parent-directory"));
+    }
+
+    #[test]
+    fn test_get_market_data_path_rejects_absolute_symbol() {
+        let result = get_market_data_path("/etc/hosts");
+        assert!(
+            result.is_err(),
+            "expected an absolute symbol to be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_read_market_data_rejects_traversal_symbol() {
+        // The read must fail at the path-validation stage rather than opening an
+        // out-of-tree file. We assert it errors for a traversal symbol.
+        let result = read_market_data("../../../../etc/hosts");
+        assert!(
+            result.is_err(),
+            "expected read_market_data to reject a traversal symbol, got ok"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixed a path-traversal weakness in `src/utils.rs` where a TSV-derived stock
`symbol` was interpolated straight into a filesystem path with no sanitisation.
A crafted `symbol` such as `../../../../etc/hosts` could escape the intended
`MARKET_DATA_BASE_PATH/data/` root when reading market-data JSON. Closes #195.

The fix applies the same `std::path::Component` allow-list guard already used by
the sibling builders `build_score_file_path` (issue #182) and
`get_dividend_data_path`:

- `get_market_data_path` now returns `Result<String>` and builds the path with
  `Path::join` over validated components, rejecting any `ParentDir` (`..`),
  `RootDir`, or `Prefix` segment.
- `read_market_data` now delegates to `get_market_data_path(symbol)?` instead of
  raw `format!` string interpolation, so the guard runs on every production read.
  The three call sites (`create_market_data_csv`, `create_market_data_long_csv`)
  already handle the `Result`, logging/skipping on error, so a malicious row is
  skipped rather than escaping the data root.

Legitimate tickers (including exchange-prefixed ones like `NYSE:SEM`) resolve to
exactly the same path as before — only traversal attempts are rejected.

## Data flow

```mermaid
flowchart LR
    TSV[score TSV stock column] --> ETC[extract_ticker_codes_from_score_file]
    ETC --> RMD[read_market_data]
    RMD --> GMP[get_market_data_path<br/>Component allow-list guard]
    GMP -->|normal segments| OPEN[File::open within data root]
    GMP -->|`..` / absolute| ERR[Err: rejected, row skipped]
```

## Evidence

Backend/CLI change with no web interface to screenshot. Verified via `cargo test`
and the full `./quality.sh` gate (fmt, clippy `-D warnings`, type check, tests,
coverage, release build, and Deno checks) — all pass cleanly.

## Test Plan

Added regression tests in `src/utils.rs` (mirroring the dividend/score-path
traversal tests):

- `test_get_market_data_path_rejects_parent_dir_traversal` — `..` segment is rejected.
- `test_get_market_data_path_rejects_absolute_symbol` — absolute symbol is rejected.
- `test_get_market_data_path_allows_plain_ticker_with_exchange_prefix` — `NYSE:SEM` still resolves.
- `test_read_market_data_rejects_traversal_symbol` — `read_market_data` errors on a traversal symbol rather than opening an out-of-tree file.

Updated the existing `test_get_market_data_path` for the new `Result<String>`
signature (behaviour unchanged for legitimate tickers; documented inline).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqiznimh-b5574c`<!-- vibe-worker-issue-195 -->