### PR TITLE
Document emergency quarantine-window override in SECURITY.md (Issue #197)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,6 +92,49 @@ merging. Land the fix straight to the default branch as an out-of-band update.
    cargo test --all-targets --all-features
    ```
 
+### Overriding the quarantine window
+
+The procedure above assumes the known-safe version has already cleared the
+repository's 24-hour dependency-age quarantine. That same quarantine — the
+`VIBE_BUMP_QUARANTINE_HOURS` window enforced by the **Dependency Quarantine
+Gate** workflow for Cargo/Action bumps, and the `minimumDependencyAge`
+(`age: "P1D"`, i.e. 24 hours) policy enforced for the Deno channel — also
+blocks a *legitimate* emergency patch when the only fix for an
+actively-exploited CVE ships as a release younger than 24 hours. The gate is
+deliberately fail-closed and has no env-var escape hatch, so use the explicit,
+reviewable override below rather than an ad-hoc bypass. Treat this as a
+last resort for an active incident, not a routine fast-lane.
+
+**Cargo / GitHub Actions channel — Code-Owner check override.** The gate runs
+as a required status check; there is intentionally no `emergency_bypass` input
+to keep it attacker-unbypassable. To land a sub-24h patch:
+
+1. Open the emergency bump PR exactly as in the procedure above, pinning the
+   single vetted dependency and version.
+2. Re-run `cargo audit` first and confirm the advisory is cleared by the
+   pinned version — the override is only justified once the fix is proven.
+3. Record the justification on the PR: the CVE/advisory ID, the dependency and
+   version, and why waiting out the window is riskier than merging early.
+4. A **Code Owner** (see [`CODEOWNERS`](.github/CODEOWNERS)) — and only a Code
+   Owner — then dismisses/overrides the failing **Dependency Quarantine Gate**
+   required check on that one PR via branch-protection's "require status
+   checks" override, leaving the audit gate and review in force. The override
+   is per-PR, logged in the PR timeline, and never widens the window for other
+   PRs.
+
+**Deno (JSR / `@std`) channel — explicit pin.** `minimumDependencyAge`
+(`age: "P1D"`) gates resolution of *new* versions, but it does not block an
+explicit pin already written into the tree. To override:
+
+1. Pin the patched, vetted version directly in the `imports` map of
+   `deno.json` (an explicit pin is honoured even when younger than the window).
+2. Refresh `deno.lock` so the safe version is locked, then re-run
+   `deno test --allow-read tests/*.ts` before merging.
+
+In both channels the override is a documented, rehearsed path that keeps the
+audit and Code-Owner review in force — it relaxes only the age window, only for
+the single named dependency, and only for the duration of the incident PR.
+
 A few minutes of this rehearsed procedure is enough — the goal is that a
 reporter knows who to tell and the team has an agreed steer for the
 out-of-band update, not an exhaustive runbook.

--- a/docs/archive/pr-summaries/pr-summary-197.md
+++ b/docs/archive/pr-summaries/pr-summary-197.md
@@ -1,0 +1,87 @@
+## Summary
+
+`SCR-QUARANTINE-OVERRIDE` posture finding (`severity:low`): the repository
+enforces a deliberate 24-hour dependency-age quarantine across its
+external-dependency channels but documented **no emergency override** for the
+case where the only known-safe version of an actively-exploited dependency is
+itself younger than that window. Under incident pressure a responder was left
+either waiting out the quarantine while exposed, or improvising an undocumented
+bypass — exactly the ad-hoc change the posture is meant to avoid.
+
+This PR adds an **"Overriding the quarantine window"** subsection to
+`SECURITY.md`, under the existing *Emergency dependency-bump procedure*, that
+documents a single concrete, reviewable path per channel:
+
+- **Cargo / GitHub Actions** — a **Code-Owner** dismisses/overrides the failing
+  **Dependency Quarantine Gate** required check on the single emergency PR,
+  after re-running `cargo audit` and recording the advisory ID, dependency,
+  version, and justification. The gate stays deliberately fail-closed with no
+  `emergency_bypass` input — the override is per-PR, logged, and Code-Owner
+  gated, not a new control.
+- **Deno (JSR / `@std`)** — pin the patched version explicitly in the
+  `deno.json` `imports` map (an explicit pin is honoured even when younger than
+  `minimumDependencyAge`), refresh `deno.lock`, and re-run the Deno tests.
+
+No production gate behaviour changed — the gate workflow, `helpers/`, and
+`deno.json` are untouched. This is the *missing override path* only, not a
+change to the 24h window itself.
+
+Closes #197.
+
+## Evidence
+
+This is a documentation + test change with no web interface to screenshot.
+Verification is by the Deno test suite below.
+
+The new tests assert *derivable relationships* (per the Issue #81
+anti-brittleness lesson) rather than brittle prose greps: the override steer
+must reference the same `VIBE_BUMP_QUARANTINE_HOURS` window configured in the
+gate workflow and the same `minimumDependencyAge.age` token configured in
+`deno.json`, so the runbook cannot silently drift from the controls it
+describes.
+
+```mermaid
+flowchart TD
+    A[Active CVE; only safe version &lt; 24h old] --> B{Channel?}
+    B -->|Cargo / Actions| C[Open emergency PR, pin vetted version]
+    C --> D[Re-run cargo audit: advisory cleared]
+    D --> E[Record CVE / dep / version / justification on PR]
+    E --> F[Code Owner overrides required Dependency Quarantine Gate check]
+    F --> G[Merge: audit + review still enforced]
+    B -->|Deno / JSR| H[Pin version explicitly in deno.json imports]
+    H --> I[Refresh deno.lock, re-run deno test]
+    I --> G
+```
+
+Test run:
+
+```text
+deno test --allow-read tests/security_md_quarantine_override_test.ts
+SECURITY.md documents overriding the quarantine window ... ok
+quarantine override references the configured Cargo/Action window ... ok
+quarantine override addresses the Deno minimumDependencyAge channel ... ok
+ok | 3 passed | 0 failed
+
+deno test --allow-read tests/*.ts
+ok | 307 passed (55 steps) | 0 failed
+```
+
+`deno fmt`, `deno lint`, `deno check`, and `markdownlint-cli2` all pass clean.
+
+## Test Plan
+
+Added `tests/security_md_quarantine_override_test.ts`:
+
+- `SECURITY.md documents overriding the quarantine window` — asserts the
+  "Overriding the quarantine window" subsection exists under the emergency
+  dependency-bump procedure.
+- `quarantine override references the configured Cargo/Action window` — parses
+  `VIBE_BUMP_QUARANTINE_HOURS` from `.github/workflows/bump-quarantine-gate.yml`
+  and asserts the override subsection references that window value.
+- `quarantine override addresses the Deno minimumDependencyAge channel` —
+  parses `minimumDependencyAge.age` from `deno.json` and asserts the subsection
+  names the `minimumDependencyAge` control and references the configured age
+  token.
+
+These fail against the pre-change `SECURITY.md` (no subsection) and pass after
+the documentation is added.

--- a/tests/security_md_quarantine_override_test.ts
+++ b/tests/security_md_quarantine_override_test.ts
@@ -1,0 +1,109 @@
+// Tests for the SECURITY.md emergency quarantine-override steer (Issue #197).
+//
+// The repository enforces a deliberate 24h dependency-age quarantine across
+// its external-dependency channels (the Cargo/Action "Dependency Quarantine
+// Gate" workflow and the Deno `minimumDependencyAge` policy). SECURITY.md
+// documents an emergency dependency-bump procedure but, before this change,
+// never addressed how to land a patched version that is itself *younger* than
+// the quarantine window during an actively-exploited CVE.
+//
+// Following the anti-brittleness lessons of Issue #81, these tests assert
+// *derivable relationships* rather than hand-copied prose: the override steer
+// in SECURITY.md must reference the same quarantine-window hours configured in
+// the gate workflow and the same `minimumDependencyAge` age token configured
+// in deno.json, so editing either control and the runbook together keeps the
+// test green while a silent drift between them fails. Exact wording remains
+// policed by the Markdown linter and human review.
+
+import { assert } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const SECURITY_PATH = "SECURITY.md";
+const WORKFLOW_PATH = ".github/workflows/bump-quarantine-gate.yml";
+const DENO_JSON_PATH = "deno.json";
+
+async function readText(path: string): Promise<string> {
+  return await Deno.readTextFile(path);
+}
+
+// Source of truth for the Cargo/Action quarantine window: the gate workflow's
+// VIBE_BUMP_QUARANTINE_HOURS env value.
+async function quarantineHoursFromWorkflow(): Promise<string> {
+  const doc = parseYaml(await readText(WORKFLOW_PATH)) as Record<
+    string,
+    unknown
+  >;
+  const jobs = doc.jobs as Record<string, { env?: Record<string, string> }>;
+  const hours = jobs.quarantine?.env?.["VIBE_BUMP_QUARANTINE_HOURS"];
+  assert(hours, "workflow must configure VIBE_BUMP_QUARANTINE_HOURS");
+  return String(hours);
+}
+
+// Source of truth for the Deno channel quarantine: deno.json
+// minimumDependencyAge.age (an ISO-8601 duration, e.g. "P1D").
+async function denoMinimumAgeToken(): Promise<string> {
+  const doc = JSON.parse(await readText(DENO_JSON_PATH)) as {
+    minimumDependencyAge?: { age?: string };
+  };
+  const age = doc.minimumDependencyAge?.age;
+  assert(age, "deno.json must configure minimumDependencyAge.age");
+  return age;
+}
+
+// Locate the emergency-bump section and the override subsection within it.
+function overrideSubsection(text: string): string {
+  const emergencyIdx = text.indexOf("## Emergency dependency-bump procedure");
+  assert(
+    emergencyIdx >= 0,
+    "SECURITY.md must keep the emergency dependency-bump procedure",
+  );
+  const section = text.slice(emergencyIdx);
+  const match = section.match(/###\s+Overriding the quarantine window/);
+  assert(
+    match,
+    "SECURITY.md must document an 'Overriding the quarantine window' " +
+      "subsection under the emergency dependency-bump procedure",
+  );
+  return section.slice(match.index!);
+}
+
+Deno.test(
+  "SECURITY.md documents overriding the quarantine window",
+  async () => {
+    const text = await readText(SECURITY_PATH);
+    // Asserts the subsection exists in the right place.
+    overrideSubsection(text);
+  },
+);
+
+Deno.test(
+  "quarantine override references the configured Cargo/Action window",
+  async () => {
+    const subsection = overrideSubsection(await readText(SECURITY_PATH));
+    const hours = await quarantineHoursFromWorkflow();
+    assert(
+      subsection.includes(hours),
+      `override steer must reference the ${hours}h quarantine window from ` +
+        "the gate workflow so the runbook cannot drift from the control",
+    );
+  },
+);
+
+Deno.test(
+  "quarantine override addresses the Deno minimumDependencyAge channel",
+  async () => {
+    const subsection = overrideSubsection(await readText(SECURITY_PATH));
+    const age = await denoMinimumAgeToken();
+    // The Deno steer must name both the control and its configured age token
+    // so the explicit-pin escape hatch stays tied to deno.json.
+    assert(
+      subsection.includes("minimumDependencyAge"),
+      "override steer must name the deno.json minimumDependencyAge control",
+    );
+    assert(
+      subsection.includes(age),
+      `override steer must reference the configured age token '${age}' ` +
+        "from deno.json",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

`SCR-QUARANTINE-OVERRIDE` posture finding (`severity:low`): the repository
enforces a deliberate 24-hour dependency-age quarantine across its
external-dependency channels but documented **no emergency override** for the
case where the only known-safe version of an actively-exploited dependency is
itself younger than that window. Under incident pressure a responder was left
either waiting out the quarantine while exposed, or improvising an undocumented
bypass — exactly the ad-hoc change the posture is meant to avoid.

This PR adds an **"Overriding the quarantine window"** subsection to
`SECURITY.md`, under the existing *Emergency dependency-bump procedure*, that
documents a single concrete, reviewable path per channel:

- **Cargo / GitHub Actions** — a **Code-Owner** dismisses/overrides the failing
  **Dependency Quarantine Gate** required check on the single emergency PR,
  after re-running `cargo audit` and recording the advisory ID, dependency,
  version, and justification. The gate stays deliberately fail-closed with no
  `emergency_bypass` input — the override is per-PR, logged, and Code-Owner
  gated, not a new control.
- **Deno (JSR / `@std`)** — pin the patched version explicitly in the
  `deno.json` `imports` map (an explicit pin is honoured even when younger than
  `minimumDependencyAge`), refresh `deno.lock`, and re-run the Deno tests.

No production gate behaviour changed — the gate workflow, `helpers/`, and
`deno.json` are untouched. This is the *missing override path* only, not a
change to the 24h window itself.

Closes #197.

## Evidence

This is a documentation + test change with no web interface to screenshot.
Verification is by the Deno test suite below.

The new tests assert *derivable relationships* (per the Issue #81
anti-brittleness lesson) rather than brittle prose greps: the override steer
must reference the same `VIBE_BUMP_QUARANTINE_HOURS` window configured in the
gate workflow and the same `minimumDependencyAge.age` token configured in
`deno.json`, so the runbook cannot silently drift from the controls it
describes.

```mermaid
flowchart TD
    A[Active CVE; only safe version &lt; 24h old] --> B{Channel?}
    B -->|Cargo / Actions| C[Open emergency PR, pin vetted version]
    C --> D[Re-run cargo audit: advisory cleared]
    D --> E[Record CVE / dep / version / justification on PR]
    E --> F[Code Owner overrides required Dependency Quarantine Gate check]
    F --> G[Merge: audit + review still enforced]
    B -->|Deno / JSR| H[Pin version explicitly in deno.json imports]
    H --> I[Refresh deno.lock, re-run deno test]
    I --> G
```

Test run:

```text
deno test --allow-read tests/security_md_quarantine_override_test.ts
SECURITY.md documents overriding the quarantine window ... ok
quarantine override references the configured Cargo/Action window ... ok
quarantine override addresses the Deno minimumDependencyAge channel ... ok
ok | 3 passed | 0 failed

deno test --allow-read tests/*.ts
ok | 307 passed (55 steps) | 0 failed
```

`deno fmt`, `deno lint`, `deno check`, and `markdownlint-cli2` all pass clean.

## Test Plan

Added `tests/security_md_quarantine_override_test.ts`:

- `SECURITY.md documents overriding the quarantine window` — asserts the
  "Overriding the quarantine window" subsection exists under the emergency
  dependency-bump procedure.
- `quarantine override references the configured Cargo/Action window` — parses
  `VIBE_BUMP_QUARANTINE_HOURS` from `.github/workflows/bump-quarantine-gate.yml`
  and asserts the override subsection references that window value.
- `quarantine override addresses the Deno minimumDependencyAge channel` —
  parses `minimumDependencyAge.age` from `deno.json` and asserts the subsection
  names the `minimumDependencyAge` control and references the configured age
  token.

These fail against the pre-change `SECURITY.md` (no subsection) and pass after
the documentation is added.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqj253fp-6e0708`<!-- vibe-worker-issue-197 -->