### PR TITLE
Add WHAT-tests for calculate_hybrid_projection (Issue #200)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,12 +221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,12 +241,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -280,15 +268,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -305,21 +291,6 @@ dependencies = [
  "serde_json",
  "tempfile",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -349,24 +320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -415,12 +368,6 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -486,16 +433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -575,12 +512,6 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -674,34 +605,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -746,40 +653,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -848,100 +721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]

--- a/docs/archive/pr-summaries/pr-summary-200.md
+++ b/docs/archive/pr-summaries/pr-summary-200.md
@@ -1,0 +1,68 @@
+## Summary
+
+Added WHAT-tests for the previously untested public function
+`calculate_hybrid_projection` (`src/utils.rs`). This is a load-bearing
+projection routine — it produces the headline projected-90-day-performance
+figure for scores under 90 days old — yet no Rust test referenced it, so a
+refactor of its dampening factors, slope maths, or clamping bounds could
+silently change every projection with no test failure. The new tests pin the
+function's observable behaviour against controlled, spec-derived inputs.
+
+No production logic changed — this is a coverage-gap fix only. Closes #200.
+
+## Evidence
+
+This is a backend/CLI change with no web interface, so no screenshot applies.
+Verification is via the new unit tests and the full quality gate.
+
+All six new tests pass and `./quality.sh` completes cleanly (cargo
+fmt/clippy/check/test/tarpaulin + Deno tests/lint/check: `307 passed | 0
+failed`):
+
+```
+running 6 tests
+test utils::tests::test_calculate_hybrid_projection_no_market_data_yields_zero ... ok
+test utils::tests::test_calculate_hybrid_projection_rejects_old_score ... ok
+test utils::tests::test_calculate_hybrid_projection_clamps_to_upper_bound ... ok
+test utils::tests::test_calculate_hybrid_projection_clamps_to_lower_bound ... ok
+test utils::tests::test_calculate_hybrid_projection_dampens_moderate_trend ... ok
+test utils::tests::test_calculate_hybrid_projection_uses_next_trading_day_buy_price ... ok
+```
+
+Each expected value is derived by hand from the documented formula
+(`daily_rate * 90 * dampening_factor`, then clamped to the per-bucket bounds),
+not copied from current output. A deliberately fake ticker is used so no
+dividend file exists, keeping `dividends_total` at `0.0` and the total return
+equal to the projected 90-day figure. Dates are built relative to "today" so
+each score stays within the function's under-90-days window.
+
+```mermaid
+flowchart TD
+    A[StockRecord + market_data] --> B{days_elapsed >= 90?}
+    B -- yes --> E[Err: use regular calc]
+    B -- no --> C[gain_loss over market days]
+    C --> D[daily_rate * 90 * dampening_factor]
+    D --> F[clamp to per-bucket bounds]
+    F --> G[average -> PortfolioPerformance]
+```
+
+## Test Plan
+
+Added to the inline `#[cfg(test)]` module in `src/utils.rs`:
+
+- `test_calculate_hybrid_projection_dampens_moderate_trend` — 10% gain over 40
+  market days dampens to the spec value 11.25% and annualises to ~53.18%
+  (quarterly compounding).
+- `test_calculate_hybrid_projection_uses_next_trading_day_buy_price` — weak-fit
+  fallback: no price on the score date, so the buy price uses the next trading
+  day (50.0) and the projection is 18%.
+- `test_calculate_hybrid_projection_clamps_to_upper_bound` — a steep doubling
+  clamps to the 7–14-day upper bound of +20%.
+- `test_calculate_hybrid_projection_clamps_to_lower_bound` — a steep crash
+  clamps to the 7–14-day lower bound of -10%.
+- `test_calculate_hybrid_projection_rejects_old_score` — a 100-day-old score is
+  rejected with an error.
+- `test_calculate_hybrid_projection_no_market_data_yields_zero` — no market data
+  yields a zero projection with `total_stocks = 1` and no per-stock entries.
+
+No existing tests were modified or removed.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2204,4 +2204,180 @@ mod tests {
         assert_eq!(ticker.get("2025-06-18"), Some(&12.00));
         assert!(ticker.get("2025-06-17").is_none());
     }
+
+    // --- WHAT-tests for calculate_hybrid_projection (issue #200) ---
+    //
+    // These exercise the public projection behaviour against controlled,
+    // spec-derived inputs and assert on the returned PortfolioPerformance,
+    // never on internals. Each expected value is derived by hand from the
+    // documented formula (daily_rate * 90 * dampening_factor, then clamped),
+    // not copied from current output. A deliberately fake ticker is used so
+    // no dividend file exists, keeping dividends_total at 0.0 and the total
+    // return equal to the projected 90-day figure.
+
+    /// Builds a market-data map for a single ticker from `(date, price)` points.
+    fn hybrid_market_data(
+        ticker: &str,
+        points: &[(NaiveDate, f64)],
+    ) -> HashMap<String, HashMap<String, f64>> {
+        let mut inner = HashMap::new();
+        for (date, price) in points {
+            inner.insert(date.format("%Y-%m-%d").to_string(), *price);
+        }
+        let mut outer = HashMap::new();
+        outer.insert(ticker.to_string(), inner);
+        outer
+    }
+
+    #[test]
+    fn test_calculate_hybrid_projection_dampens_moderate_trend() {
+        let ticker = "TEST:HYBRIDA";
+        let today = chrono::Utc::now().naive_utc().date();
+        // Score 41 days ago; 40 market days of price history (30..60 bucket).
+        let score_date = today - Duration::days(41);
+        let latest_date = score_date + Duration::days(40); // = today - 1
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        // Buy price keyed exactly on the score date: 100 -> 110 over 40 days.
+        let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 110.0)]);
+        let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+
+        // gain = 10% over 40 market days -> daily_rate = 0.25%/day.
+        // raw = 0.25 * 90 = 22.5; dampening (30..60) = 0.5 -> 11.25; within [-40, 80].
+        let expected = 11.25;
+        assert!(
+            (result.performance_90_day - expected).abs() < 1e-6,
+            "expected projected 90-day ~{expected}, got {}",
+            result.performance_90_day
+        );
+        assert_eq!(result.total_stocks, 1);
+        assert_eq!(result.individual_performances.len(), 1);
+        assert!(
+            (result.individual_performances[0].gain_loss_percent - expected).abs() < 1e-6,
+            "per-stock projection should match portfolio figure for a single stock"
+        );
+
+        // Annualisation uses quarterly compounding: ((1 + p/100)^4 - 1) * 100.
+        // For p = 11.25 this is ~53.179%.
+        assert!(
+            (result.performance_annualized - 53.1793).abs() < 1e-2,
+            "expected annualised ~53.18%, got {}",
+            result.performance_annualized
+        );
+    }
+
+    #[test]
+    fn test_calculate_hybrid_projection_uses_next_trading_day_buy_price() {
+        let ticker = "TEST:HYBRIDB";
+        let today = chrono::Utc::now().naive_utc().date();
+        // Score 20 days ago, but no price on the score date itself: the buy
+        // price must fall back to the earliest available trading day.
+        let score_date = today - Duration::days(20);
+        let buy_date = score_date + Duration::days(2); // first available day
+        let latest_date = score_date + Duration::days(10); // 10 market days
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        let market = hybrid_market_data(ticker, &[(buy_date, 50.0), (latest_date, 55.0)]);
+        let records = vec![StockRecord::new(ticker.to_string(), 5.0, 60.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+
+        // Fallback buy price = 50 (next trading day). gain = 10% over 10 market
+        // days -> daily_rate = 1.0%/day; raw = 90; dampening (7..14) = 0.2 -> 18;
+        // within [-10, 20].
+        let expected = 18.0;
+        assert!(
+            (result.performance_90_day - expected).abs() < 1e-6,
+            "expected projected 90-day ~{expected}, got {}",
+            result.performance_90_day
+        );
+        assert_eq!(result.individual_performances[0].buy_price, 50.0);
+    }
+
+    #[test]
+    fn test_calculate_hybrid_projection_clamps_to_upper_bound() {
+        let ticker = "TEST:HYBRIDC";
+        let today = chrono::Utc::now().naive_utc().date();
+        // Score 9 days ago; 8 market days (7..14 bucket -> max gain 20%).
+        let score_date = today - Duration::days(9);
+        let latest_date = score_date + Duration::days(8);
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        // Steep doubling: 100 -> 200 over 8 days.
+        let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 200.0)]);
+        let records = vec![StockRecord::new(ticker.to_string(), 5.0, 250.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+
+        // gain = 100% over 8 days -> daily_rate = 12.5; raw = 1125; dampened
+        // (0.2) = 225; clamped to the 7..14 upper bound of 20%.
+        let expected = 20.0;
+        assert!(
+            (result.performance_90_day - expected).abs() < 1e-6,
+            "steep trend should clamp to upper bound {expected}, got {}",
+            result.performance_90_day
+        );
+    }
+
+    #[test]
+    fn test_calculate_hybrid_projection_clamps_to_lower_bound() {
+        let ticker = "TEST:HYBRIDD";
+        let today = chrono::Utc::now().naive_utc().date();
+        // Score 9 days ago; 8 market days (7..14 bucket -> max loss -10%).
+        let score_date = today - Duration::days(9);
+        let latest_date = score_date + Duration::days(8);
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        // Steep crash: 100 -> 10 over 8 days.
+        let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 10.0)]);
+        let records = vec![StockRecord::new(ticker.to_string(), 5.0, 90.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+
+        // gain = -90% over 8 days -> daily_rate = -11.25; raw = -1012.5; dampened
+        // (0.2) = -202.5; clamped to the 7..14 lower bound of -10%.
+        let expected = -10.0;
+        assert!(
+            (result.performance_90_day - expected).abs() < 1e-6,
+            "steep crash should clamp to lower bound {expected}, got {}",
+            result.performance_90_day
+        );
+    }
+
+    #[test]
+    fn test_calculate_hybrid_projection_rejects_old_score() {
+        let ticker = "TEST:HYBRIDE";
+        let today = chrono::Utc::now().naive_utc().date();
+        // 100 days old: must fall back to the regular performance calculation.
+        let score_date = today - Duration::days(100);
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        let market = hybrid_market_data(ticker, &[(score_date, 100.0)]);
+        let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market);
+        assert!(
+            result.is_err(),
+            "scores >= 90 days old must be rejected by the hybrid projection"
+        );
+    }
+
+    #[test]
+    fn test_calculate_hybrid_projection_no_market_data_yields_zero() {
+        let today = chrono::Utc::now().naive_utc().date();
+        let score_date = today - Duration::days(10);
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        // No market data for the requested ticker -> no valid projections.
+        let market: HashMap<String, HashMap<String, f64>> = HashMap::new();
+        let records = vec![StockRecord::new("TEST:HYBRIDF".to_string(), 5.0, 50.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        assert_eq!(result.performance_90_day, 0.0);
+        assert_eq!(result.performance_annualized, 0.0);
+        assert_eq!(result.total_stocks, 1);
+        assert!(result.individual_performances.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

Added WHAT-tests for the previously untested public function
`calculate_hybrid_projection` (`src/utils.rs`). This is a load-bearing
projection routine — it produces the headline projected-90-day-performance
figure for scores under 90 days old — yet no Rust test referenced it, so a
refactor of its dampening factors, slope maths, or clamping bounds could
silently change every projection with no test failure. The new tests pin the
function's observable behaviour against controlled, spec-derived inputs.

No production logic changed — this is a coverage-gap fix only. Closes #200.

## Evidence

This is a backend/CLI change with no web interface, so no screenshot applies.
Verification is via the new unit tests and the full quality gate.

All six new tests pass and `./quality.sh` completes cleanly (cargo
fmt/clippy/check/test/tarpaulin + Deno tests/lint/check: `307 passed | 0
failed`):

```
running 6 tests
test utils::tests::test_calculate_hybrid_projection_no_market_data_yields_zero ... ok
test utils::tests::test_calculate_hybrid_projection_rejects_old_score ... ok
test utils::tests::test_calculate_hybrid_projection_clamps_to_upper_bound ... ok
test utils::tests::test_calculate_hybrid_projection_clamps_to_lower_bound ... ok
test utils::tests::test_calculate_hybrid_projection_dampens_moderate_trend ... ok
test utils::tests::test_calculate_hybrid_projection_uses_next_trading_day_buy_price ... ok
```

Each expected value is derived by hand from the documented formula
(`daily_rate * 90 * dampening_factor`, then clamped to the per-bucket bounds),
not copied from current output. A deliberately fake ticker is used so no
dividend file exists, keeping `dividends_total` at `0.0` and the total return
equal to the projected 90-day figure. Dates are built relative to "today" so
each score stays within the function's under-90-days window.

```mermaid
flowchart TD
    A[StockRecord + market_data] --> B{days_elapsed >= 90?}
    B -- yes --> E[Err: use regular calc]
    B -- no --> C[gain_loss over market days]
    C --> D[daily_rate * 90 * dampening_factor]
    D --> F[clamp to per-bucket bounds]
    F --> G[average -> PortfolioPerformance]
```

## Test Plan

Added to the inline `#[cfg(test)]` module in `src/utils.rs`:

- `test_calculate_hybrid_projection_dampens_moderate_trend` — 10% gain over 40
  market days dampens to the spec value 11.25% and annualises to ~53.18%
  (quarterly compounding).
- `test_calculate_hybrid_projection_uses_next_trading_day_buy_price` — weak-fit
  fallback: no price on the score date, so the buy price uses the next trading
  day (50.0) and the projection is 18%.
- `test_calculate_hybrid_projection_clamps_to_upper_bound` — a steep doubling
  clamps to the 7–14-day upper bound of +20%.
- `test_calculate_hybrid_projection_clamps_to_lower_bound` — a steep crash
  clamps to the 7–14-day lower bound of -10%.
- `test_calculate_hybrid_projection_rejects_old_score` — a 100-day-old score is
  rejected with an error.
- `test_calculate_hybrid_projection_no_market_data_yields_zero` — no market data
  yields a zero projection with `total_stocks = 1` and no per-stock entries.

No existing tests were modified or removed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqk7c2fl-5ee23d`<!-- vibe-worker-issue-200 -->