### PR TITLE
Test fair-value band & target-price colour rules (Issue #204)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -644,49 +644,19 @@ class GRQValidator {
     }
 
     getFairValueRange(stockSymbol) {
-        const analysis = this.analysisData[stockSymbol];
-        if (!analysis) {
-            return null;
-        }
-        
-        const { msFairValue, tipsTarget } = analysis;
-        
-        // If we have both values, show range
-        if (msFairValue !== null && tipsTarget !== null) {
-            const low = Math.min(msFairValue, tipsTarget);
-            const high = Math.max(msFairValue, tipsTarget);
-            return { low, high, type: 'range' };
-        }
-        // If we have only one value, show single target
-        else if (msFairValue !== null) {
-            return { value: msFairValue, type: 'single', source: 'MS Fair Value' };
-        }
-        else if (tipsTarget !== null) {
-            return { value: tipsTarget, type: 'single', source: 'Tips Target' };
-        }
-        
-        return null;
+        // Delegate to the shared projection module (issue #204) so the browser
+        // and the Deno tests apply identical fair-value band rules.
+        return GRQProjection.getFairValueRange(this.analysisData[stockSymbol]);
     }
 
     getTargetPriceColor(targetPrice, currentPrice, buyPrice) {
-        if (targetPrice === null || currentPrice === null || buyPrice === null) {
-            return ''; // Default color
-        }
-        
-        // Red (Danger): Target price is below buy price - this is always bad
-        if (targetPrice < buyPrice) {
-            return 'color: #dc3545; font-weight: bold;'; // Red - danger
-        }
-        
-        // Green (Good): Target price is above current price AND we're in profit territory
-        if (targetPrice > currentPrice && currentPrice >= buyPrice) {
-            return 'color: #28a745; font-weight: bold;'; // Green - good
-        }
-        
-        // Gray (Neutral): Target price is above buy price but we're either:
-        // - Below current price (target achieved), or
-        // - Current price is below buy price (we're in loss territory but target is still above buy price)
-        return 'color: #6c757d; font-weight: bold;'; // Gray - neutral
+        // Delegate to the shared projection module (issue #204) so the browser
+        // and the Deno tests apply identical target-price colour rules.
+        return GRQProjection.getTargetPriceColor(
+            targetPrice,
+            currentPrice,
+            buyPrice,
+        );
     }
 
     getStarRatingCalculation(stockSymbol) {

--- a/docs/archive/pr-summaries/pr-summary-204.md
+++ b/docs/archive/pr-summaries/pr-summary-204.md
@@ -1,0 +1,68 @@
+# Test the fair-value band & target-price colour rules (Issue #204)
+
+## Summary
+
+`getFairValueRange` and `getTargetPriceColor` were pure-logic branch trees
+living inside the `GRQValidator` class in `docs/app.js`, with **no test
+references anywhere** — `docs/**` is excluded from the Deno test config and the
+functions could not be imported because `app.js` instantiates the validator and
+touches the DOM at module load.
+
+Rather than copy the logic into a test (a "tautology" the existing
+`docs/projection.js` header explicitly warns against), this PR follows the
+established kernel-extraction pattern used for `formatCurrency`, `getBuyPrice`
+etc.:
+
+- Extracted both functions as pure helpers into `docs/projection.js` and
+  published them on `globalThis.GRQProjection`.
+- `GRQValidator.getFairValueRange` / `getTargetPriceColor` now **delegate** to
+  the shared kernels, so the browser dashboard and the Deno tests exercise the
+  exact same code. Behaviour is unchanged.
+- Added `tests/fair_value_color_test.ts` with WHAT-tests covering every branch.
+
+Expected values were derived from the documented display spec, **not** the
+current output (the issue's example sketch values were intentionally
+illustrative — e.g. `getTargetPriceColor(50, 60, 55)` is actually red because
+`50 < 55`, not green).
+
+Closes #204.
+
+## Display rules under test
+
+```mermaid
+flowchart TD
+    A[getTargetPriceColor] --> B{any input null?}
+    B -- yes --> C["'' default"]
+    B -- no --> D{target < buy?}
+    D -- yes --> E["red #dc3545"]
+    D -- no --> F{"target > current AND current >= buy?"}
+    F -- yes --> G["green #28a745"]
+    F -- no --> H["grey #6c757d"]
+```
+
+## Evidence
+
+Pure-logic / non-UI change (the functions return data and CSS strings; no
+visual rendering changed). Verified via the new unit tests:
+
+```
+running 12 tests from ./tests/fair_value_color_test.ts
+ok | 12 passed | 0 failed
+```
+
+Full Deno suite remains green: `ok | 319 passed | 0 failed`. The
+`js_syntax_test.ts` guard confirms `docs/app.js` still parses cleanly after the
+delegation refactor.
+
+## Test Plan
+
+`tests/fair_value_color_test.ts` — imports `../docs/projection.js` and asserts
+on the real kernels:
+
+- `getFairValueRange`: both values → sorted `range`; sort holds regardless of
+  input order; only MS → single `MS Fair Value`; only Tips → single
+  `Tips Target`; neither → `null`; missing/`undefined`/`null` analysis → `null`.
+- `getTargetPriceColor`: any null input → `''`; target below buy → red; target
+  above current while in profit → green; target at/below current → grey (incl.
+  `target == current` boundary); target above buy but in loss → grey;
+  `target == buy` boundary → grey (not red).

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -220,6 +220,62 @@ function calculateTargetPercentage(buyPrice, adjustedTarget) {
     return null;
 }
 
+// Fair-value display band for a stock's analysis. Pure given the analysis
+// object so the dashboard (via GRQValidator) and the Deno tests share one set
+// of branch rules (issue #204):
+//   - both MS Fair Value and Tips Target present  -> { low, high, type: 'range' }
+//   - only one present -> { value, type: 'single', source } for that source
+//   - neither present, or no analysis -> null
+function getFairValueRange(analysis) {
+    if (!analysis) {
+        return null;
+    }
+
+    const { msFairValue, tipsTarget } = analysis;
+
+    // If we have both values, show range
+    if (msFairValue !== null && tipsTarget !== null) {
+        const low = Math.min(msFairValue, tipsTarget);
+        const high = Math.max(msFairValue, tipsTarget);
+        return { low, high, type: "range" };
+    } // If we have only one value, show single target
+    else if (msFairValue !== null) {
+        return { value: msFairValue, type: "single", source: "MS Fair Value" };
+    } else if (tipsTarget !== null) {
+        return { value: tipsTarget, type: "single", source: "Tips Target" };
+    }
+
+    return null;
+}
+
+// Inline CSS colour for a target-price cell, encoding the user-facing display
+// rules (issue #204). Pure given the three prices so the dashboard and tests
+// share one cascade:
+//   - any input null -> '' (default colour)
+//   - target below buy price -> red (always bad)
+//   - target above current AND in profit (current >= buy) -> green (good)
+//   - otherwise -> grey (neutral)
+function getTargetPriceColor(targetPrice, currentPrice, buyPrice) {
+    if (targetPrice === null || currentPrice === null || buyPrice === null) {
+        return ""; // Default color
+    }
+
+    // Red (Danger): Target price is below buy price - this is always bad
+    if (targetPrice < buyPrice) {
+        return "color: #dc3545; font-weight: bold;"; // Red - danger
+    }
+
+    // Green (Good): Target price is above current price AND we're in profit territory
+    if (targetPrice > currentPrice && currentPrice >= buyPrice) {
+        return "color: #28a745; font-weight: bold;"; // Green - good
+    }
+
+    // Gray (Neutral): Target price is above buy price but we're either:
+    // - Below current price (target achieved), or
+    // - Current price is below buy price (we're in loss territory but target is still above buy price)
+    return "color: #6c757d; font-weight: bold;"; // Gray - neutral
+}
+
 // Coefficient of determination (R²) for a linear fit y = slope·x + intercept over
 // the data points. Returns 0 when the data has no variance.
 function calculateRSquared(dataPoints, slope, intercept) {
@@ -550,6 +606,8 @@ globalThis.GRQProjection = {
     getBuyPrice,
     currentPriceFromLatest,
     calculateTargetPercentage,
+    getFairValueRange,
+    getTargetPriceColor,
     calculateRSquared,
     computeTrendLine,
     buildTrendLineDataPoints,

--- a/tests/fair_value_color_test.ts
+++ b/tests/fair_value_color_test.ts
@@ -1,0 +1,119 @@
+// WHAT-tests for the fair-value band and target-price colour rules (issue #204).
+//
+// getFairValueRange and getTargetPriceColor used to live only inside the
+// GRQValidator class in docs/app.js, where no test could reach them. They are
+// now pure kernels in docs/projection.js (the dashboard delegates to them), so
+// these tests exercise the REAL production logic rather than a copy.
+//
+// Expected values are derived from the documented display spec, not the current
+// output:
+//   - Fair value: both values -> range; one value -> single (with source);
+//     neither / no analysis -> null.
+//   - Colour: any null input -> ''; target < buy -> red; target > current AND
+//     current >= buy -> green; otherwise grey.
+import { assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+interface Analysis {
+  msFairValue: number | null;
+  tipsTarget: number | null;
+}
+
+type FairValueRange =
+  | { low: number; high: number; type: "range" }
+  | { value: number; type: "single"; source: string }
+  | null;
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    getFairValueRange: (
+      analysis: Analysis | undefined | null,
+    ) => FairValueRange;
+    getTargetPriceColor: (
+      targetPrice: number | null,
+      currentPrice: number | null,
+      buyPrice: number | null,
+    ) => string;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+const RED = "color: #dc3545; font-weight: bold;";
+const GREEN = "color: #28a745; font-weight: bold;";
+const GREY = "color: #6c757d; font-weight: bold;";
+
+Deno.test("getFairValueRange - both values present returns a sorted range", () => {
+  assertEquals(
+    GRQProjection.getFairValueRange({ msFairValue: 10, tipsTarget: 20 }),
+    { low: 10, high: 20, type: "range" },
+  );
+});
+
+Deno.test("getFairValueRange - range is sorted regardless of input order", () => {
+  // Tips below MS: low/high must still be ordered ascending.
+  assertEquals(
+    GRQProjection.getFairValueRange({ msFairValue: 30, tipsTarget: 12 }),
+    { low: 12, high: 30, type: "range" },
+  );
+});
+
+Deno.test("getFairValueRange - only MS Fair Value returns a single MS target", () => {
+  assertEquals(
+    GRQProjection.getFairValueRange({ msFairValue: 15, tipsTarget: null }),
+    { value: 15, type: "single", source: "MS Fair Value" },
+  );
+});
+
+Deno.test("getFairValueRange - only Tips Target returns a single Tips target", () => {
+  assertEquals(
+    GRQProjection.getFairValueRange({ msFairValue: null, tipsTarget: 25 }),
+    { value: 25, type: "single", source: "Tips Target" },
+  );
+});
+
+Deno.test("getFairValueRange - neither value present returns null", () => {
+  assertEquals(
+    GRQProjection.getFairValueRange({ msFairValue: null, tipsTarget: null }),
+    null,
+  );
+});
+
+Deno.test("getFairValueRange - missing analysis returns null", () => {
+  assertEquals(GRQProjection.getFairValueRange(undefined), null);
+  assertEquals(GRQProjection.getFairValueRange(null), null);
+});
+
+Deno.test("getTargetPriceColor - any null input returns the default colour", () => {
+  assertEquals(GRQProjection.getTargetPriceColor(null, 60, 55), "");
+  assertEquals(GRQProjection.getTargetPriceColor(50, null, 55), "");
+  assertEquals(GRQProjection.getTargetPriceColor(50, 60, null), "");
+});
+
+Deno.test("getTargetPriceColor - target below buy price is red (always bad)", () => {
+  // 40 < buy 55 -> red, even though it is also below the current price.
+  assertEquals(GRQProjection.getTargetPriceColor(40, 60, 55), RED);
+});
+
+Deno.test("getTargetPriceColor - target above current while in profit is green", () => {
+  // target 70 > current 60, and current 60 >= buy 55 -> green.
+  assertEquals(GRQProjection.getTargetPriceColor(70, 60, 55), GREEN);
+});
+
+Deno.test("getTargetPriceColor - target at or below current is grey (not green)", () => {
+  // target 58 >= buy 55 (not red) but 58 < current 60, so not green -> grey.
+  assertEquals(GRQProjection.getTargetPriceColor(58, 60, 55), GREY);
+  // Boundary: target equals current -> the strict '>' fails, so grey.
+  assertEquals(GRQProjection.getTargetPriceColor(60, 60, 55), GREY);
+});
+
+Deno.test("getTargetPriceColor - target above buy but in loss territory is grey", () => {
+  // target 70 >= buy 55 (not red), target > current 50, but current 50 < buy 55
+  // so the profit condition fails -> grey.
+  assertEquals(GRQProjection.getTargetPriceColor(70, 50, 55), GREY);
+});
+
+Deno.test("getTargetPriceColor - target equal to buy price is not red", () => {
+  // Boundary: target 55 is NOT < buy 55, and 55 > current 50 with current 50 <
+  // buy 55, so it falls through to grey rather than red.
+  assertEquals(GRQProjection.getTargetPriceColor(55, 50, 55), GREY);
+});


### PR DESCRIPTION
# Test the fair-value band & target-price colour rules (Issue #204)

## Summary

`getFairValueRange` and `getTargetPriceColor` were pure-logic branch trees
living inside the `GRQValidator` class in `docs/app.js`, with **no test
references anywhere** — `docs/**` is excluded from the Deno test config and the
functions could not be imported because `app.js` instantiates the validator and
touches the DOM at module load.

Rather than copy the logic into a test (a "tautology" the existing
`docs/projection.js` header explicitly warns against), this PR follows the
established kernel-extraction pattern used for `formatCurrency`, `getBuyPrice`
etc.:

- Extracted both functions as pure helpers into `docs/projection.js` and
  published them on `globalThis.GRQProjection`.
- `GRQValidator.getFairValueRange` / `getTargetPriceColor` now **delegate** to
  the shared kernels, so the browser dashboard and the Deno tests exercise the
  exact same code. Behaviour is unchanged.
- Added `tests/fair_value_color_test.ts` with WHAT-tests covering every branch.

Expected values were derived from the documented display spec, **not** the
current output (the issue's example sketch values were intentionally
illustrative — e.g. `getTargetPriceColor(50, 60, 55)` is actually red because
`50 < 55`, not green).

Closes #204.

## Display rules under test

```mermaid
flowchart TD
    A[getTargetPriceColor] --> B{any input null?}
    B -- yes --> C["'' default"]
    B -- no --> D{target < buy?}
    D -- yes --> E["red #dc3545"]
    D -- no --> F{"target > current AND current >= buy?"}
    F -- yes --> G["green #28a745"]
    F -- no --> H["grey #6c757d"]
```

## Evidence

Pure-logic / non-UI change (the functions return data and CSS strings; no
visual rendering changed). Verified via the new unit tests:

```
running 12 tests from ./tests/fair_value_color_test.ts
ok | 12 passed | 0 failed
```

Full Deno suite remains green: `ok | 319 passed | 0 failed`. The
`js_syntax_test.ts` guard confirms `docs/app.js` still parses cleanly after the
delegation refactor.

## Test Plan

`tests/fair_value_color_test.ts` — imports `../docs/projection.js` and asserts
on the real kernels:

- `getFairValueRange`: both values → sorted `range`; sort holds regardless of
  input order; only MS → single `MS Fair Value`; only Tips → single
  `Tips Target`; neither → `null`; missing/`undefined`/`null` analysis → `null`.
- `getTargetPriceColor`: any null input → `''`; target below buy → red; target
  above current while in profit → green; target at/below current → grey (incl.
  `target == current` boundary); target above buy but in loss → grey;
  `target == buy` boundary → grey (not red).
