### PR TITLE
Drive real production helpers in tautological tests (Issue #201)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-201.md
+++ b/docs/archive/pr-summaries/pr-summary-201.md
@@ -1,0 +1,50 @@
+## Summary
+
+Two `t.step` blocks in `tests/integration_test.ts` were tautological: they
+asserted on values the test itself had just computed inline, never touching the
+production code they claimed to guard. This PR rewrites both steps to drive the
+real shared helpers in `docs/projection.js`, so a regression in the production
+90-day boundary or dividend-window logic now makes the tests fail. Closes #201.
+
+- **"90-day boundary respect"** previously rebuilt `ninetyDayDate` and asserted
+  `testDate > ninetyDayDate` — only its own date arithmetic. It now calls the
+  real `GRQProjection.getDaysElapsed(scoreDate, date)` and asserts a date past
+  the window reports `> 90` elapsed days while a date inside it reports `<= 90`.
+- **"dividend exclusion after 90 days"** previously re-implemented the window
+  predicate with a local `.filter(...)`. It now calls the real
+  `GRQProjection.filterDividendsWithin90Days(testDividends, scoreDate)` and
+  asserts the surviving amounts are `[0.135, 0.32]`.
+
+Both rewrites follow the same pattern as the existing "performance calculation"
+step (issue #80), which already drives the real maths.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+Verified the rewritten "dividend exclusion" step is no longer tautological by
+temporarily flipping the production predicate (`<=` → `>=`) in
+`docs/projection.js`: the step failed as expected, then passed again once the
+production code was restored. This confirms the assertion now exercises the
+function under test rather than the test's own arithmetic.
+
+```
+  dividend exclusion after 90 days ... FAILED   # with production logic broken
+  ...
+ok | 1 passed (4 steps) | 0 failed             # with production logic restored
+```
+
+Pre-existing, unrelated: the Rust `utils::tests::test_read_market_data` fails on
+this machine because it needs a current-quarter market-data file that is not
+present. It fails identically on a clean checkout (verified via `git stash`) and
+is untouched by this TS-only change.
+
+## Test Plan
+
+- Modified `tests/integration_test.ts`:
+  - `Integration Tests › 90-day boundary respect` — now drives
+    `GRQProjection.getDaysElapsed`.
+  - `Integration Tests › dividend exclusion after 90 days` — now drives
+    `GRQProjection.filterDividendsWithin90Days`.
+- `deno test tests/integration_test.ts` — all 4 steps pass.
+- `deno lint`, `deno fmt --check`, `deno check` on the changed file — clean.

--- a/tests/integration_test.ts
+++ b/tests/integration_test.ts
@@ -1,6 +1,11 @@
 import { assertEquals } from "@std/assert";
 import "../docs/projection.js";
 
+interface Dividend {
+  exDivDate: Date;
+  amount: number;
+}
+
 const g = globalThis as unknown as {
   GRQProjection: {
     calculatePerformanceReturn: (
@@ -8,6 +13,11 @@ const g = globalThis as unknown as {
       currentPrice: number,
       totalDividends?: number,
     ) => number | null;
+    getDaysElapsed: (scoreDate: Date, today: Date) => number;
+    filterDividendsWithin90Days: (
+      dividends: Dividend[],
+      scoreDate: Date,
+    ) => Dividend[];
   };
 };
 const GRQProjection = g.GRQProjection;
@@ -21,14 +31,21 @@ Deno.test("Integration Tests", async (t) => {
   );
 
   await t.step("90-day boundary respect", () => {
-    // Test that all calculations respect the 90-day boundary
-    const testDate = new Date("2025-03-14"); // After 90 days
-    const isAfter90Days = testDate > ninetyDayDate;
+    // Drive the REAL elapsed-day maths rather than recomputing the boundary
+    // inline: a date past the window must report > 90 days, one inside it
+    // must report <= 90 (issue #201).
+    const afterWindow = new Date("2025-03-14"); // After 90 days
+    const withinWindow = new Date("2025-01-15"); // Within 90 days
 
     assertEquals(
-      isAfter90Days,
+      GRQProjection.getDaysElapsed(scoreDate, afterWindow) > 90,
       true,
-      "Test date should be after 90-day boundary",
+      "A date past the window should report more than 90 elapsed days",
+    );
+    assertEquals(
+      GRQProjection.getDaysElapsed(scoreDate, withinWindow) <= 90,
+      true,
+      "A date inside the window should report 90 or fewer elapsed days",
     );
   });
 
@@ -38,21 +55,23 @@ Deno.test("Integration Tests", async (t) => {
   // real-function "performance calculation" step below.
 
   await t.step("dividend exclusion after 90 days", () => {
-    // Test that dividends after 90 days are excluded
+    // Drive the REAL production window filter (issue #201) instead of
+    // re-implementing the predicate inline.
     const testDividends = [
       { exDivDate: new Date("2024-12-19"), amount: 0.135 }, // Within 90 days
       { exDivDate: new Date("2024-12-27"), amount: 0.32 }, // Within 90 days
       { exDivDate: new Date("2025-03-14"), amount: 0.32 }, // After 90 days
     ];
 
-    const dividendsWithin90Days = testDividends.filter((d) =>
-      d.exDivDate <= ninetyDayDate
+    const within = GRQProjection.filterDividendsWithin90Days(
+      testDividends,
+      scoreDate,
     );
 
     assertEquals(
-      dividendsWithin90Days.length,
-      2,
-      "Should have 2 dividends within 90 days",
+      within.map((d) => d.amount),
+      [0.135, 0.32],
+      "Only the two dividends inside the 90-day window should remain",
     );
   });
 


### PR DESCRIPTION
## Summary

Two `t.step` blocks in `tests/integration_test.ts` were tautological: they
asserted on values the test itself had just computed inline, never touching the
production code they claimed to guard. This PR rewrites both steps to drive the
real shared helpers in `docs/projection.js`, so a regression in the production
90-day boundary or dividend-window logic now makes the tests fail. Closes #201.

- **"90-day boundary respect"** previously rebuilt `ninetyDayDate` and asserted
  `testDate > ninetyDayDate` — only its own date arithmetic. It now calls the
  real `GRQProjection.getDaysElapsed(scoreDate, date)` and asserts a date past
  the window reports `> 90` elapsed days while a date inside it reports `<= 90`.
- **"dividend exclusion after 90 days"** previously re-implemented the window
  predicate with a local `.filter(...)`. It now calls the real
  `GRQProjection.filterDividendsWithin90Days(testDividends, scoreDate)` and
  asserts the surviving amounts are `[0.135, 0.32]`.

Both rewrites follow the same pattern as the existing "performance calculation"
step (issue #80), which already drives the real maths.

## Evidence

Backend/test-only change — no web interface to screenshot.

Verified the rewritten "dividend exclusion" step is no longer tautological by
temporarily flipping the production predicate (`<=` → `>=`) in
`docs/projection.js`: the step failed as expected, then passed again once the
production code was restored. This confirms the assertion now exercises the
function under test rather than the test's own arithmetic.

```
  dividend exclusion after 90 days ... FAILED   # with production logic broken
  ...
ok | 1 passed (4 steps) | 0 failed             # with production logic restored
```

Pre-existing, unrelated: the Rust `utils::tests::test_read_market_data` fails on
this machine because it needs a current-quarter market-data file that is not
present. It fails identically on a clean checkout (verified via `git stash`) and
is untouched by this TS-only change.

## Test Plan

- Modified `tests/integration_test.ts`:
  - `Integration Tests › 90-day boundary respect` — now drives
    `GRQProjection.getDaysElapsed`.
  - `Integration Tests › dividend exclusion after 90 days` — now drives
    `GRQProjection.filterDividendsWithin90Days`.
- `deno test tests/integration_test.ts` — all 4 steps pass.
- `deno lint`, `deno fmt --check`, `deno check` on the changed file — clean.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqk9x2zm-04cb04`<!-- vibe-worker-issue-201 -->