### PR TITLE
Replace workflow command-text greps with structured assertions (#202)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-202.md
+++ b/docs/archive/pr-summaries/pr-summary-202.md
@@ -1,0 +1,87 @@
+# Replace source-text command greps in workflow tests with structured assertions
+
+## Summary
+
+The GitHub Actions workflow tests asserted behaviour by regex-matching the
+command **text** inside `.github/workflows/*.yml` — e.g.
+`/\bdeno\s+fmt\s+--check\b/` against a joined blob of every step's `run`
+script. That is the grep-as-assertion anti-pattern (a HOW-test): a
+behaviour-preserving edit — reordering flags, splitting a step, continuing a
+line with `\`, or appending a flag like `--minimum-dependency-age` — breaks the
+test even though CI does exactly the same thing.
+
+This PR introduces a shared helper module, `tests/workflow_assertions.ts`, and
+rewrites the command greps to assert the **parsed, structured invariant**
+instead: load the YAML once, look at steps as data, and decide whether a step
+*invokes a tool/subcommand* by tokenising the command rather than matching its
+exact spelling. The duplicated SHA-pinning check — repeated verbatim across nine
+test files — is deduplicated into a single `assertActionsPinnedToSha` helper, so
+the supply-chain guard now lands in one place.
+
+SHA pinning is the one genuine source-text invariant (the literal `uses:` ref is
+what runs), so it is kept as a parsed-line check; everything else moves to
+token-level matching that tolerates the behaviour-preserving changes the issue
+calls out.
+
+Closes #202.
+
+## Evidence
+
+Backend/test-only change — no UI. Verified by the Deno test suite (337 tests
+pass) and the new unit tests for the helper, which prove the matcher tolerates
+flag reordering, line continuation, extra flags, and `npx` prefixes while still
+failing when a tool is genuinely absent.
+
+```mermaid
+flowchart LR
+    A["Workflow test"] --> B["loadWorkflow / workflowSteps"]
+    B --> C["invokesTool tool + subcommand + args"]
+    C --> D["tokenise commands<br/>(join \\-continuations,<br/>split separators)"]
+    D --> E["semantic invariant:<br/>which tool/subcommand runs"]
+    A --> F["assertActionsPinnedToSha"]
+    F --> G["literal uses: ref<br/>= 40-char SHA"]
+```
+
+Before — couples to exact source text (breaks on flag reorder / line split):
+
+```ts
+const runs = job.steps.map((s) => s.run ?? "").join("\n");
+assert(/\bdeno\s+fmt\s+--check\b/.test(runs), "job must run `deno fmt --check`");
+```
+
+After — asserts the parsed invariant (tolerates behaviour-preserving edits):
+
+```ts
+assert(
+  invokesTool(job.steps, "deno", { subcommand: "fmt", args: ["--check"] }),
+  "job must run `deno fmt --check`",
+);
+```
+
+## Test Plan
+
+- **New** `tests/workflow_assertions.ts` — shared helpers: `loadWorkflow`,
+  `workflowTriggers`, `workflowSteps`, `commandSegments`, `invokesTool`,
+  `stepIndexInvoking`, `stepIndexUsing`, `assertActionsPinnedToSha`.
+- **New** `tests/workflow_assertions_test.ts` — 18 unit tests exercising the
+  helpers with synthetic inputs: happy paths, flag reordering, `name=value`
+  flags, line continuation, `npx`-prefixed tools, absent tool / subcommand
+  mismatch / missing arg, per-step isolation, and the SHA-pin pass/throw cases.
+- **Rewritten** command-grep assertions to `invokesTool` in
+  `deno_quality_workflow_test.ts`, `cargo_audit_workflow_test.ts`,
+  `deno_outdated_workflow_test.ts`, `semgrep_workflow_test.ts`,
+  `bump_quarantine_gate_workflow_test.ts`, `a11y_workflow_test.ts`, and
+  `sbom_workflow_test.ts` (the SBOM ordering test now uses parsed step indices
+  via `stepIndexInvoking`/`stepIndexUsing`).
+- The `bump_quarantine_gate` test now also asserts the referenced gate script
+  exists on disk (a derived relationship) rather than grepping the run text.
+- **Deduplicated** the SHA-pin check to `assertActionsPinnedToSha` across all
+  nine workflow test files (`ci`, `markdown_lint`, `dependency_review`, plus the
+  seven above).
+- No existing tests were removed or commented out; all assertions retain their
+  original intent. Full suite: `deno test --allow-read tests/*.ts` → 337 passed.
+
+### Deno regression avoided
+
+This is a Deno repo; all new code uses Deno-native APIs (`Deno.readTextFile`,
+`@std/yaml`, `@std/assert`) and `deno test` — no Node tooling introduced.

--- a/tests/a11y_workflow_test.ts
+++ b/tests/a11y_workflow_test.ts
@@ -14,6 +14,10 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import {
+  assertActionsPinnedToSha,
+  invokesTool,
+} from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/a11y.yml";
 
@@ -110,8 +114,9 @@ Deno.test("a11y workflow defines a job with a sane timeout", async () => {
 
 Deno.test("a11y workflow runs pa11y-ci against the dashboard pages", async () => {
   const doc = await loadWorkflow();
-  const runs = allSteps(doc).map((s) => s.run ?? "").join("\n");
-  assert(/pa11y-ci/.test(runs), "a job must run pa11y-ci");
+  // Structured invariant (Issue #202): a step invokes pa11y-ci (here via npx),
+  // matched on tokens rather than grepping the run-step source text.
+  assert(invokesTool(allSteps(doc), "pa11y-ci"), "a job must run pa11y-ci");
   // The target URLs live in pa11yci.json (passed via --config), not in the
   // workflow run command. Both published dashboard pages must be exercised.
   const config = await loadPa11yConfig();
@@ -133,11 +138,11 @@ Deno.test("a11y workflow enforces the WCAG2AA standard", async () => {
 
 Deno.test("a11y workflow serves the docs/ directory before checking", async () => {
   const doc = await loadWorkflow();
-  const runs = allSteps(doc).map((s) => s.run ?? "").join("\n");
   // The dashboard is a static site; a local server must back the a11y check
-  // because pa11y loads pages over HTTP.
+  // because pa11y loads pages over HTTP. Assert the http-server tool is
+  // invoked (Issue #202) rather than grepping the run-step source text.
   assert(
-    /http-server|http:\/\/localhost/.test(runs),
+    invokesTool(allSteps(doc), "http-server"),
     "workflow must serve docs/ over a local HTTP server",
   );
 });
@@ -168,12 +173,5 @@ Deno.test("a11y multi-line bash run blocks begin with set -euo pipefail", async 
 
 Deno.test("a11y workflow pins actions to 40-character commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
-  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
-  assert(usesLines.length > 0, "workflow must use at least one action");
-  for (const line of usesLines) {
-    assert(
-      /@[0-9a-f]{40}\s*$/.test(line.trim()),
-      `action not pinned to 40-char SHA: ${line.trim()}`,
-    );
-  }
+  assertActionsPinnedToSha(text);
 });

--- a/tests/bump_quarantine_gate_workflow_test.ts
+++ b/tests/bump_quarantine_gate_workflow_test.ts
@@ -7,8 +7,13 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import {
+  assertActionsPinnedToSha,
+  invokesTool,
+} from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/bump-quarantine-gate.yml";
+const GATE_SCRIPT = "helpers/bump_quarantine_gate.ts";
 
 interface Step {
   run?: string;
@@ -46,10 +51,17 @@ Deno.test("quarantine gate runs the gate script with a 24h window", async () => 
   const job = jobs.quarantine;
   assert(job, "workflow must define a quarantine job");
 
-  const runs = (job.steps ?? []).map((s) => s.run ?? "").join("\n");
+  // Derived-relationship invariant (Issue #202): the referenced gate script
+  // actually exists on disk, and the job invokes it via `deno run` — matched
+  // on tokenised commands rather than the exact run-step source text.
+  const stat = await Deno.stat(GATE_SCRIPT);
+  assert(stat.isFile, `${GATE_SCRIPT} must exist on disk`);
   assert(
-    /deno\s+run[\s\S]*helpers\/bump_quarantine_gate\.ts/.test(runs),
-    "job must invoke helpers/bump_quarantine_gate.ts",
+    invokesTool(job.steps ?? [], "deno", {
+      subcommand: "run",
+      args: [GATE_SCRIPT],
+    }),
+    "job must invoke helpers/bump_quarantine_gate.ts via deno run",
   );
 
   // The 24h window must be configured (env value or VIBE_BUMP_QUARANTINE_HOURS).
@@ -64,22 +76,18 @@ Deno.test("quarantine gate runs the gate script with a 24h window", async () => 
 Deno.test("quarantine gate grants the script the permissions it needs", async () => {
   const { doc } = await loadWorkflow();
   const jobs = doc.jobs as Record<string, { steps?: Step[] }>;
-  const runs = (jobs.quarantine.steps ?? []).map((s) => s.run ?? "").join("\n");
-  for (
-    const flag of ["--allow-read", "--allow-net", "--allow-run", "--allow-env"]
-  ) {
-    assert(runs.includes(flag), `gate run step must pass ${flag}`);
-  }
+  const steps = jobs.quarantine.steps ?? [];
+  // The gate `deno run` invocation must carry every permission the script
+  // needs. Asserting them as args on the tokenised command (Issue #202)
+  // tolerates flag reordering and `\`-continued lines.
+  const flags = ["--allow-read", "--allow-net", "--allow-run", "--allow-env"];
+  assert(
+    invokesTool(steps, "deno", { subcommand: "run", args: flags }),
+    `gate run step must pass ${flags.join(", ")}`,
+  );
 });
 
 Deno.test("quarantine gate workflow pins actions to commit SHAs", async () => {
   const { text } = await loadWorkflow();
-  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
-  assert(usesLines.length > 0, "workflow must use at least one action");
-  for (const line of usesLines) {
-    assert(
-      /@[0-9a-f]{40}\s*$/.test(line.trim()),
-      `action not pinned to 40-char SHA: ${line.trim()}`,
-    );
-  }
+  assertActionsPinnedToSha(text);
 });

--- a/tests/cargo_audit_workflow_test.ts
+++ b/tests/cargo_audit_workflow_test.ts
@@ -7,6 +7,10 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import {
+  assertActionsPinnedToSha,
+  invokesTool,
+} from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/cargo-audit.yml";
 
@@ -61,26 +65,25 @@ Deno.test("Cargo Audit workflow defines audit job that installs and runs cargo-a
   };
   assertEquals(job["runs-on"], "ubuntu-latest");
   assert(Array.isArray(job.steps) && job.steps.length > 0, "job needs steps");
-  const runs = job.steps.map((s) => s.run ?? "").join("\n");
+  // Structured invariant (Issue #202): the job installs and runs cargo-audit,
+  // matched on tokenised commands so the pinned `--version`/`--locked` flags
+  // or a split step do not break the test.
   assert(
-    /cargo\s+install\s+cargo-audit/.test(runs),
+    invokesTool(job.steps, "cargo", {
+      subcommand: "install",
+      args: ["cargo-audit"],
+    }),
     "audit job must install cargo-audit",
   );
-  assert(/cargo\s+audit/.test(runs), "audit job must run `cargo audit`");
+  assert(
+    invokesTool(job.steps, "cargo", { subcommand: "audit" }),
+    "audit job must run `cargo audit`",
+  );
 });
 
 Deno.test("Cargo Audit workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
-  // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a
-  // floating tag like @stable or @v4.
-  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
-  assert(usesLines.length > 0, "workflow must use at least one action");
-  for (const line of usesLines) {
-    assert(
-      /@[0-9a-f]{40}\s*$/.test(line.trim()),
-      `action not pinned to 40-char SHA: ${line.trim()}`,
-    );
-  }
+  assertActionsPinnedToSha(text);
 });
 
 // Concurrency cancellation (Issue #139). Without a concurrency group, rapid

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -9,6 +9,7 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import { assertActionsPinnedToSha } from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/ci.yml";
 
@@ -25,14 +26,7 @@ Deno.test("CI workflow parses as valid YAML", async () => {
 
 Deno.test("CI workflow pins every action to a 40-char commit SHA", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
-  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
-  assert(usesLines.length > 0, "workflow must use at least one action");
-  for (const line of usesLines) {
-    assert(
-      /@[0-9a-f]{40}\s*$/.test(line.trim()),
-      `action not pinned to 40-char SHA: ${line.trim()}`,
-    );
-  }
+  assertActionsPinnedToSha(text);
 });
 
 Deno.test("CI workflow no longer references the mutable rust-toolchain stable branch", async () => {

--- a/tests/deno_outdated_workflow_test.ts
+++ b/tests/deno_outdated_workflow_test.ts
@@ -8,6 +8,10 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import {
+  assertActionsPinnedToSha,
+  invokesTool,
+} from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/deno-outdated.yml";
 
@@ -66,9 +70,14 @@ Deno.test("Deno Outdated workflow runs deno outdated and creates a PR", async ()
   assertEquals(job["runs-on"], "ubuntu-latest");
   assert(Array.isArray(job.steps) && job.steps.length > 0, "job needs steps");
 
-  const runs = job.steps.map((s) => s.run ?? "").join("\n");
+  // Structured invariant (Issue #202): the job runs `deno outdated` with the
+  // --update and --latest flags, matched on tokens so flag order and the
+  // appended --minimum-dependency-age do not break the test.
   assert(
-    /deno\s+outdated\s+--update\s+--latest/.test(runs),
+    invokesTool(job.steps, "deno", {
+      subcommand: "outdated",
+      args: ["--update", "--latest"],
+    }),
     "job must run `deno outdated --update --latest`",
   );
 
@@ -142,14 +151,5 @@ Deno.test("deno.json declares a minimumDependencyAge quarantine with internal ex
 
 Deno.test("Deno Outdated workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
-  // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a
-  // floating tag like @v2 or @v7.
-  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
-  assert(usesLines.length > 0, "workflow must use at least one action");
-  for (const line of usesLines) {
-    assert(
-      /@[0-9a-f]{40}\s*$/.test(line.trim()),
-      `action not pinned to 40-char SHA: ${line.trim()}`,
-    );
-  }
+  assertActionsPinnedToSha(text);
 });

--- a/tests/deno_quality_workflow_test.ts
+++ b/tests/deno_quality_workflow_test.ts
@@ -8,6 +8,10 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import {
+  assertActionsPinnedToSha,
+  invokesTool,
+} from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/deno-quality.yml";
 
@@ -55,19 +59,25 @@ Deno.test("Deno Quality workflow runs lint, fmt --check, check and test", async 
   assertEquals(job["runs-on"], "ubuntu-latest");
   assert(Array.isArray(job.steps) && job.steps.length > 0, "job needs steps");
 
-  const runs = job.steps.map((s) => s.run ?? "").join("\n");
-  assert(/\bdeno\s+lint\b/.test(runs), "job must run `deno lint`");
+  // Structured invariant (Issue #202): the job *invokes* each deno subcommand,
+  // matched by tokenising the step commands rather than grepping their exact
+  // source text — so reordering flags or splitting a step keeps passing.
+  const steps = job.steps;
+  assert(invokesTool(steps, "deno", { subcommand: "lint" }), "must run lint");
   assert(
-    /\bdeno\s+fmt\s+--check\b/.test(runs),
+    invokesTool(steps, "deno", { subcommand: "fmt", args: ["--check"] }),
     "job must run `deno fmt --check`",
   );
-  assert(/\bdeno\s+check\b/.test(runs), "job must run `deno check`");
   assert(
-    /\bdeno\s+test\b[^\n]*--coverage/.test(runs),
+    invokesTool(steps, "deno", { subcommand: "check" }),
+    "job must run `deno check`",
+  );
+  assert(
+    invokesTool(steps, "deno", { subcommand: "test", args: ["--coverage"] }),
     "job must run `deno test` with coverage",
   );
   assert(
-    /deno\s+coverage[^\n]*--lcov/.test(runs),
+    invokesTool(steps, "deno", { subcommand: "coverage", args: ["--lcov"] }),
     "job must export lcov coverage",
   );
 
@@ -94,9 +104,8 @@ Deno.test("Deno Quality workflow runs deno audit (SCR-VULN-SCAN, Issue #59)", as
   const job = doc.jobs.quality as {
     steps: Array<{ run?: string }>;
   };
-  const runs = job.steps.map((s) => s.run ?? "").join("\n");
   assert(
-    /\bdeno\s+audit\b/.test(runs),
+    invokesTool(job.steps, "deno", { subcommand: "audit" }),
     "quality job must run `deno audit` to scan JSR dependencies",
   );
 });
@@ -125,16 +134,7 @@ Deno.test("Deno Quality workflow triggers on a weekly schedule (Issue #59)", asy
 
 Deno.test("Deno Quality workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
-  // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a
-  // floating tag like @v2 or @v4.
-  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
-  assert(usesLines.length > 0, "workflow must use at least one action");
-  for (const line of usesLines) {
-    assert(
-      /@[0-9a-f]{40}\s*$/.test(line.trim()),
-      `action not pinned to 40-char SHA: ${line.trim()}`,
-    );
-  }
+  assertActionsPinnedToSha(text);
 });
 
 // Concurrency cancellation (Issue #139). Without a concurrency group, rapid

--- a/tests/dependency_review_workflow_test.ts
+++ b/tests/dependency_review_workflow_test.ts
@@ -6,6 +6,7 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import { assertActionsPinnedToSha } from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/dependency-review.yml";
 
@@ -22,14 +23,7 @@ Deno.test("Dependency Review workflow parses as valid YAML", async () => {
 
 Deno.test("Dependency Review workflow pins every action to a 40-char commit SHA", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
-  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
-  assert(usesLines.length > 0, "workflow must use at least one action");
-  for (const line of usesLines) {
-    assert(
-      /@[0-9a-f]{40}\s*$/.test(line.trim()),
-      `action not pinned to 40-char SHA: ${line.trim()}`,
-    );
-  }
+  assertActionsPinnedToSha(text);
 });
 
 // Note: the "readable version comment above each pinned action" convention is

--- a/tests/markdown_lint_workflow_test.ts
+++ b/tests/markdown_lint_workflow_test.ts
@@ -7,6 +7,7 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
 import { parse as parseJsonc } from "@std/jsonc";
+import { assertActionsPinnedToSha } from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/markdown-lint.yml";
 const CONFIG_PATH = ".markdownlint-cli2.jsonc";
@@ -71,16 +72,7 @@ Deno.test("Markdown Lint workflow runs markdownlint-cli2 in its job", async () =
 
 Deno.test("Markdown Lint workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
-  // Each `uses:` line in the workflow must reference a 40-char SHA, not a
-  // floating tag like @v4. This matches the supply-chain rule in the guide.
-  const usesLines = text.split("\n").filter((l) => /^\s*-\s*uses:/.test(l));
-  assert(usesLines.length > 0, "workflow must use at least one action");
-  for (const line of usesLines) {
-    assert(
-      /@[0-9a-f]{40}\s*$/.test(line.trim()),
-      `action not pinned to 40-char SHA: ${line.trim()}`,
-    );
-  }
+  assertActionsPinnedToSha(text);
 });
 
 Deno.test("markdownlint-cli2 config exists and parses as JSONC", async () => {

--- a/tests/sbom_workflow_test.ts
+++ b/tests/sbom_workflow_test.ts
@@ -9,6 +9,11 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import {
+  invokesTool,
+  stepIndexInvoking,
+  stepIndexUsing,
+} from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/ci.yml";
 const SBOM_FILE = "grq-validation.cdx.json";
@@ -35,15 +40,23 @@ async function buildSteps(): Promise<Step[]> {
 
 Deno.test("build job generates a CycloneDX SBOM from the Rust lockfile", async () => {
   const steps = await buildSteps();
-  const runs = steps.map((s) => s.run ?? "").join("\n");
+  // Structured invariant (Issue #202): the job installs and invokes
+  // cargo-cyclonedx, matched on tokenised commands so the pinned
+  // `--version`/`--locked` flags or a split step do not break the test.
   assert(
-    /cargo\s+(install\s+cargo-cyclonedx|cyclonedx)/.test(runs),
-    "build job must install/run cargo-cyclonedx",
+    invokesTool(steps, "cargo", {
+      subcommand: "install",
+      args: ["cargo-cyclonedx"],
+    }),
+    "build job must install cargo-cyclonedx",
   );
   assert(
-    /cargo\s+cyclonedx/.test(runs),
+    invokesTool(steps, "cargo", { subcommand: "cyclonedx" }),
     "build job must invoke `cargo cyclonedx` to generate the SBOM",
   );
+  // The normalised SBOM artefact filename must appear in the step (a produced
+  // artefact name, not command syntax).
+  const runs = steps.map((s) => s.run ?? "").join("\n");
   assert(
     runs.includes(SBOM_FILE),
     `SBOM step must produce ${SBOM_FILE}`,
@@ -52,10 +65,12 @@ Deno.test("build job generates a CycloneDX SBOM from the Rust lockfile", async (
 
 Deno.test("SBOM is generated before the artefact upload", async () => {
   const steps = await buildSteps();
-  const sbomIdx = steps.findIndex((s) => /cargo\s+cyclonedx/.test(s.run ?? ""));
-  const uploadIdx = steps.findIndex((s) =>
-    typeof s.uses === "string" && s.uses.includes("actions/upload-artifact")
-  );
+  // Genuine ordering invariant asserted on parsed step indices (Issue #202),
+  // not on substring positions within a joined source blob.
+  const sbomIdx = stepIndexInvoking(steps, "cargo", {
+    subcommand: "cyclonedx",
+  });
+  const uploadIdx = stepIndexUsing(steps, "actions/upload-artifact");
   assert(sbomIdx >= 0, "an SBOM-generation step must exist");
   assert(uploadIdx >= 0, "an upload-artifact step must exist");
   assert(

--- a/tests/semgrep_workflow_test.ts
+++ b/tests/semgrep_workflow_test.ts
@@ -8,6 +8,10 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import {
+  assertActionsPinnedToSha,
+  invokesTool,
+} from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/semgrep.yml";
 
@@ -61,8 +65,12 @@ Deno.test("Semgrep workflow defines semgrep job that runs `semgrep ci`", async (
     "job must run in the semgrep/semgrep container",
   );
   assert(Array.isArray(job.steps) && job.steps.length > 0, "job needs steps");
-  const runs = job.steps.map((s) => s.run ?? "").join("\n");
-  assert(/semgrep\s+ci/.test(runs), "semgrep job must run `semgrep ci`");
+  // Structured invariant (Issue #202): the job invokes `semgrep ci`, matched
+  // on tokens so the `--config p/default` flag or a reordering keeps passing.
+  assert(
+    invokesTool(job.steps, "semgrep", { subcommand: "ci" }),
+    "semgrep job must run `semgrep ci`",
+  );
 });
 
 Deno.test("Semgrep workflow pins the container image to a sha256 digest", async () => {
@@ -88,16 +96,7 @@ Deno.test("Semgrep workflow pins the container image to a sha256 digest", async 
 
 Deno.test("Semgrep workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
-  // Supply-chain rule: every `uses:` must reference a 40-char SHA, not a
-  // floating tag like @stable or @v4.
-  const usesLines = text.split("\n").filter((l) => /^\s*-?\s*uses:/.test(l));
-  assert(usesLines.length > 0, "workflow must use at least one action");
-  for (const line of usesLines) {
-    assert(
-      /@[0-9a-f]{40}\s*$/.test(line.trim()),
-      `action not pinned to 40-char SHA: ${line.trim()}`,
-    );
-  }
+  assertActionsPinnedToSha(text);
 });
 
 // Concurrency cancellation (Issue #139). Without a concurrency group, rapid

--- a/tests/workflow_assertions.ts
+++ b/tests/workflow_assertions.ts
@@ -1,0 +1,178 @@
+// Shared assertions and parsing helpers for the GitHub Actions workflow tests
+// (Issue #202).
+//
+// The workflow tests used to assert behaviour by regex-matching the command
+// *text* inside `.github/workflows/*.yml` — e.g. `/\bdeno\s+fmt\s+--check\b/`
+// on a joined blob of every step's `run` script. That is the
+// grep-as-assertion anti-pattern: a behaviour-preserving edit (reordering
+// flags, splitting a step, continuing a line with `\`) breaks the test even
+// though CI does the same thing.
+//
+// These helpers replace the source-text greps with structured assertions on
+// the parsed workflow: load the YAML once, look at steps as data, and decide
+// whether a step *invokes a tool/subcommand* by tokenising the command rather
+// than matching its exact spelling. The SHA-pinning supply-chain guard — the
+// one genuine source-text invariant, since it is about the literal `uses:`
+// ref — is deduplicated here so the fix lands in a single place.
+
+import { assert } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+export interface WorkflowStep {
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  env?: Record<string, string>;
+}
+
+export interface WorkflowJob {
+  "runs-on"?: string;
+  "timeout-minutes"?: number;
+  container?: { image?: string } | string;
+  env?: Record<string, string>;
+  permissions?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+export interface Workflow {
+  name?: string;
+  permissions?: Record<string, string>;
+  concurrency?: Record<string, unknown>;
+  jobs?: Record<string, WorkflowJob>;
+}
+
+/** Read and parse a workflow file, returning both the raw text and the doc. */
+export async function loadWorkflow(
+  path: string,
+): Promise<{ text: string; doc: Workflow }> {
+  const text = await Deno.readTextFile(path);
+  return { text, doc: parseYaml(text) as Workflow };
+}
+
+/**
+ * Return the workflow's `on` trigger map. YAML 1.1 parses a bare `on:` key as
+ * the boolean `true`, so accept either spelling.
+ */
+export function workflowTriggers(
+  doc: Workflow,
+): Record<string, unknown> | undefined {
+  const raw = doc as Record<string, unknown>;
+  return (raw.on ?? raw["true"] ??
+    raw[true as unknown as string]) as Record<string, unknown> | undefined;
+}
+
+/**
+ * Every step across every job, or just the named job's steps when `jobName`
+ * is given (empty array when the job or its steps are absent).
+ */
+export function workflowSteps(
+  doc: Workflow,
+  jobName?: string,
+): WorkflowStep[] {
+  const jobs = doc.jobs ?? {};
+  if (jobName !== undefined) return jobs[jobName]?.steps ?? [];
+  return Object.values(jobs).flatMap((job) => job.steps ?? []);
+}
+
+/**
+ * Split a shell script into individual command segments. Line continuations
+ * (`\` at end-of-line) are joined first, then the script is split on newlines
+ * and the common shell separators so each segment is a single invocation.
+ */
+export function commandSegments(script: string): string[] {
+  return script
+    .replace(/\s*\\\r?\n\s*/g, " ")
+    .split(/\r?\n|&&|\|\||[;|&]/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+export interface ToolInvocation {
+  /** Expected first non-flag token after the tool (its subcommand). */
+  subcommand?: string;
+  /**
+   * Tokens (flags or operands) that must all appear after the tool token. A
+   * required arg matches a token exactly or as the name part of `name=value`,
+   * so `--coverage` matches `--coverage=cov_profile`.
+   */
+  args?: string[];
+}
+
+function segmentInvokes(
+  segment: string,
+  tool: string,
+  opts: ToolInvocation,
+): boolean {
+  const tokens = segment.split(/\s+/).filter(Boolean);
+  const toolIdx = tokens.indexOf(tool);
+  if (toolIdx === -1) return false;
+  const after = tokens.slice(toolIdx + 1);
+  if (opts.subcommand !== undefined) {
+    const firstOperand = after.find((token) => !token.startsWith("-"));
+    if (firstOperand !== opts.subcommand) return false;
+  }
+  if (opts.args) {
+    const matchesArg = (arg: string) =>
+      after.some((token) => token === arg || token.startsWith(`${arg}=`));
+    if (!opts.args.every(matchesArg)) return false;
+  }
+  return true;
+}
+
+/**
+ * True when any step's `run` invokes `tool` with the optional `subcommand`
+ * and all required `args`. Operates on the parsed steps and tokenises each
+ * command, so flag reordering, extra flags, and `\`-continued lines are all
+ * tolerated — only the semantic invariant (which tool/subcommand runs) is
+ * asserted, never the exact source-text spelling.
+ */
+export function invokesTool(
+  steps: WorkflowStep[],
+  tool: string,
+  opts: ToolInvocation = {},
+): boolean {
+  return steps.some((step) =>
+    commandSegments(step.run ?? "").some((segment) =>
+      segmentInvokes(segment, tool, opts)
+    )
+  );
+}
+
+/** Index of the first step whose `run` invokes `tool` (or -1 if none). */
+export function stepIndexInvoking(
+  steps: WorkflowStep[],
+  tool: string,
+  opts: ToolInvocation = {},
+): number {
+  return steps.findIndex((step) => invokesTool([step], tool, opts));
+}
+
+/** Index of the first step that uses an action whose ref starts with `prefix`. */
+export function stepIndexUsing(
+  steps: WorkflowStep[],
+  prefix: string,
+): number {
+  return steps.findIndex((step) =>
+    typeof step.uses === "string" && step.uses.startsWith(prefix)
+  );
+}
+
+/**
+ * Assert every `uses:` action in the workflow source is pinned to a 40-char
+ * commit SHA, not a mutable tag/branch. SHA pinning is a genuine source-text
+ * invariant (the literal ref is what runs), so this is the one grep we keep —
+ * deduplicated here per Issue #202 so the supply-chain guard lands once.
+ */
+export function assertActionsPinnedToSha(text: string): void {
+  const usesLines = text.split("\n").filter((line) =>
+    /^\s*-?\s*uses:/.test(line)
+  );
+  assert(usesLines.length > 0, "workflow must use at least one action");
+  for (const line of usesLines) {
+    assert(
+      /@[0-9a-f]{40}\s*$/.test(line.trim()),
+      `action not pinned to 40-char SHA: ${line.trim()}`,
+    );
+  }
+}

--- a/tests/workflow_assertions_test.ts
+++ b/tests/workflow_assertions_test.ts
@@ -1,0 +1,159 @@
+// Unit tests for the shared workflow assertions helper (Issue #202).
+//
+// These exercise the real helper functions with synthetic inputs to prove the
+// structured matchers behave as intended — in particular that `invokesTool`
+// tolerates the behaviour-preserving edits (flag reordering, line
+// continuation, extra flags) that previously broke the source-text greps,
+// while still failing when the tool is genuinely absent.
+
+import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
+import {
+  assertActionsPinnedToSha,
+  commandSegments,
+  invokesTool,
+  stepIndexInvoking,
+  stepIndexUsing,
+  type Workflow,
+  workflowSteps,
+  workflowTriggers,
+} from "./workflow_assertions.ts";
+
+Deno.test("commandSegments joins line continuations and splits separators", () => {
+  const script = "deno run --allow-read \\\n  helpers/gate.ts; echo done && ls";
+  assertEquals(commandSegments(script), [
+    "deno run --allow-read helpers/gate.ts",
+    "echo done",
+    "ls",
+  ]);
+});
+
+Deno.test("commandSegments drops blank lines", () => {
+  assertEquals(commandSegments("\n\n  \n"), []);
+});
+
+Deno.test("invokesTool matches a bare tool invocation", () => {
+  const steps = [{ run: "deno lint" }];
+  assert(invokesTool(steps, "deno", { subcommand: "lint" }));
+});
+
+Deno.test("invokesTool tolerates flag reordering and extra flags", () => {
+  // `--check` before the subcommand operand still counts; a source-text grep
+  // for `deno fmt --check` would have failed here.
+  const steps = [{ run: "deno fmt --config deno.json --check src/" }];
+  assert(invokesTool(steps, "deno", { subcommand: "fmt", args: ["--check"] }));
+});
+
+Deno.test("invokesTool matches name=value flags by name", () => {
+  const steps = [{
+    run: "deno test --allow-read --coverage=cov_profile tests/*.ts",
+  }];
+  assert(
+    invokesTool(steps, "deno", { subcommand: "test", args: ["--coverage"] }),
+  );
+});
+
+Deno.test("invokesTool follows line continuations across a step", () => {
+  const steps = [{
+    run:
+      "deno run --allow-read --allow-net \\\n  helpers/bump_quarantine_gate.ts origin/main",
+  }];
+  assert(
+    invokesTool(steps, "deno", {
+      subcommand: "run",
+      args: ["helpers/bump_quarantine_gate.ts", "--allow-net"],
+    }),
+  );
+});
+
+Deno.test("invokesTool detects a tool invoked via npx", () => {
+  const steps = [{ run: "npx pa11y-ci --config pa11yci.json" }];
+  assert(invokesTool(steps, "pa11y-ci"));
+});
+
+Deno.test("invokesTool returns false when the tool is absent", () => {
+  const steps = [{ run: "deno lint" }];
+  assertFalse(invokesTool(steps, "cargo"));
+});
+
+Deno.test("invokesTool returns false on subcommand mismatch", () => {
+  const steps = [{ run: "deno fmt --check" }];
+  assertFalse(invokesTool(steps, "deno", { subcommand: "lint" }));
+});
+
+Deno.test("invokesTool returns false when a required arg is missing", () => {
+  const steps = [{ run: "deno test tests/*.ts" }];
+  assertFalse(
+    invokesTool(steps, "deno", { subcommand: "test", args: ["--coverage"] }),
+  );
+});
+
+Deno.test("invokesTool checks each step independently", () => {
+  // A tool in one step and its subcommand in another must not cross-match.
+  const steps = [{ run: "cargo build" }, { run: "audit something" }];
+  assertFalse(invokesTool(steps, "cargo", { subcommand: "audit" }));
+});
+
+Deno.test("stepIndexInvoking returns the matching step index", () => {
+  const steps = [
+    { run: "echo hi" },
+    { run: "cargo cyclonedx --format json" },
+    { run: "echo bye" },
+  ];
+  assertEquals(
+    stepIndexInvoking(steps, "cargo", { subcommand: "cyclonedx" }),
+    1,
+  );
+  assertEquals(stepIndexInvoking(steps, "cargo", { subcommand: "audit" }), -1);
+});
+
+Deno.test("stepIndexUsing finds an action by ref prefix", () => {
+  const steps = [
+    { uses: "actions/checkout@abc" },
+    { uses: "actions/upload-artifact@def" },
+  ];
+  assertEquals(stepIndexUsing(steps, "actions/upload-artifact@"), 1);
+  assertEquals(stepIndexUsing(steps, "codecov/"), -1);
+});
+
+Deno.test("workflowSteps collects all steps or a single job's steps", () => {
+  const doc: Workflow = {
+    jobs: {
+      a: { steps: [{ run: "one" }] },
+      b: { steps: [{ run: "two" }, { run: "three" }] },
+    },
+  };
+  assertEquals(workflowSteps(doc).length, 3);
+  assertEquals(workflowSteps(doc, "b").length, 2);
+  assertEquals(workflowSteps(doc, "missing"), []);
+});
+
+Deno.test("workflowTriggers accepts the YAML boolean-true `on` key", () => {
+  const truthy = { true: { pull_request: {} } } as unknown as Workflow;
+  const triggers = workflowTriggers(truthy);
+  assert(triggers && "pull_request" in triggers);
+});
+
+Deno.test("assertActionsPinnedToSha passes for 40-char SHAs", () => {
+  const text = [
+    "      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+    "      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282",
+  ].join("\n");
+  assertActionsPinnedToSha(text);
+});
+
+Deno.test("assertActionsPinnedToSha throws on a floating tag", () => {
+  const text = "      - uses: actions/checkout@v4";
+  assertThrows(
+    () => assertActionsPinnedToSha(text),
+    Error,
+    "not pinned",
+  );
+});
+
+Deno.test("assertActionsPinnedToSha throws when no actions are present", () => {
+  assertThrows(
+    () => assertActionsPinnedToSha("name: no actions here\n"),
+    Error,
+    "at least one action",
+  );
+});


### PR DESCRIPTION
# Replace source-text command greps in workflow tests with structured assertions

## Summary

The GitHub Actions workflow tests asserted behaviour by regex-matching the
command **text** inside `.github/workflows/*.yml` — e.g.
`/\bdeno\s+fmt\s+--check\b/` against a joined blob of every step's `run`
script. That is the grep-as-assertion anti-pattern (a HOW-test): a
behaviour-preserving edit — reordering flags, splitting a step, continuing a
line with `\`, or appending a flag like `--minimum-dependency-age` — breaks the
test even though CI does exactly the same thing.

This PR introduces a shared helper module, `tests/workflow_assertions.ts`, and
rewrites the command greps to assert the **parsed, structured invariant**
instead: load the YAML once, look at steps as data, and decide whether a step
*invokes a tool/subcommand* by tokenising the command rather than matching its
exact spelling. The duplicated SHA-pinning check — repeated verbatim across nine
test files — is deduplicated into a single `assertActionsPinnedToSha` helper, so
the supply-chain guard now lands in one place.

SHA pinning is the one genuine source-text invariant (the literal `uses:` ref is
what runs), so it is kept as a parsed-line check; everything else moves to
token-level matching that tolerates the behaviour-preserving changes the issue
calls out.

Closes #202.

## Evidence

Backend/test-only change — no UI. Verified by the Deno test suite (337 tests
pass) and the new unit tests for the helper, which prove the matcher tolerates
flag reordering, line continuation, extra flags, and `npx` prefixes while still
failing when a tool is genuinely absent.

```mermaid
flowchart LR
    A["Workflow test"] --> B["loadWorkflow / workflowSteps"]
    B --> C["invokesTool tool + subcommand + args"]
    C --> D["tokenise commands<br/>(join \\-continuations,<br/>split separators)"]
    D --> E["semantic invariant:<br/>which tool/subcommand runs"]
    A --> F["assertActionsPinnedToSha"]
    F --> G["literal uses: ref<br/>= 40-char SHA"]
```

Before — couples to exact source text (breaks on flag reorder / line split):

```ts
const runs = job.steps.map((s) => s.run ?? "").join("\n");
assert(/\bdeno\s+fmt\s+--check\b/.test(runs), "job must run `deno fmt --check`");
```

After — asserts the parsed invariant (tolerates behaviour-preserving edits):

```ts
assert(
  invokesTool(job.steps, "deno", { subcommand: "fmt", args: ["--check"] }),
  "job must run `deno fmt --check`",
);
```

## Test Plan

- **New** `tests/workflow_assertions.ts` — shared helpers: `loadWorkflow`,
  `workflowTriggers`, `workflowSteps`, `commandSegments`, `invokesTool`,
  `stepIndexInvoking`, `stepIndexUsing`, `assertActionsPinnedToSha`.
- **New** `tests/workflow_assertions_test.ts` — 18 unit tests exercising the
  helpers with synthetic inputs: happy paths, flag reordering, `name=value`
  flags, line continuation, `npx`-prefixed tools, absent tool / subcommand
  mismatch / missing arg, per-step isolation, and the SHA-pin pass/throw cases.
- **Rewritten** command-grep assertions to `invokesTool` in
  `deno_quality_workflow_test.ts`, `cargo_audit_workflow_test.ts`,
  `deno_outdated_workflow_test.ts`, `semgrep_workflow_test.ts`,
  `bump_quarantine_gate_workflow_test.ts`, `a11y_workflow_test.ts`, and
  `sbom_workflow_test.ts` (the SBOM ordering test now uses parsed step indices
  via `stepIndexInvoking`/`stepIndexUsing`).
- The `bump_quarantine_gate` test now also asserts the referenced gate script
  exists on disk (a derived relationship) rather than grepping the run text.
- **Deduplicated** the SHA-pin check to `assertActionsPinnedToSha` across all
  nine workflow test files (`ci`, `markdown_lint`, `dependency_review`, plus the
  seven above).
- No existing tests were removed or commented out; all assertions retain their
  original intent. Full suite: `deno test --allow-read tests/*.ts` → 337 passed.

### Deno regression avoided

This is a Deno repo; all new code uses Deno-native APIs (`Deno.readTextFile`,
`@std/yaml`, `@std/assert`) and `deno test` — no Node tooling introduced.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqkce2j8-abb955`<!-- vibe-worker-issue-202 -->