### PR TITLE
Add behaviour test for update_index_with_performance (Issue #203)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-203.md
+++ b/docs/archive/pr-summaries/pr-summary-203.md
@@ -54,8 +54,8 @@ test update_index_with_performance_writes_settled_and_open_entries ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 ```
 
-`./quality.sh` passes cleanly (cargo fmt/clippy/check/test + tarpaulin coverage
-+ release build + Deno test/lint/check: `337 passed | 0 failed`).
+`./quality.sh` passes cleanly (cargo fmt/clippy/check/test + tarpaulin
+coverage + release build + Deno test/lint/check: `337 passed | 0 failed`).
 
 ## Test Plan
 

--- a/docs/archive/pr-summaries/pr-summary-203.md
+++ b/docs/archive/pr-summaries/pr-summary-203.md
@@ -1,0 +1,74 @@
+## Summary
+
+Closes #203.
+
+The public function `update_index_with_performance` (`src/utils.rs:1155`) is
+the write path that persists every performance and projection figure into
+`docs/scores/index.json`, yet no test referenced it — a coverage gap
+(anti-pattern 7). A refactor that mis-mapped an entry, dropped a field, or
+mis-handled a still-open (null 90-day) score could silently corrupt the
+published index while the suite stayed green.
+
+This PR adds a behaviour ("WHAT") test that runs the real function against a
+temporary `docs` fixture and asserts on the **persisted output** (the rewritten
+index JSON), never on internals — so it keeps working when the orchestration is
+refactored. No production code was changed; the function already behaves
+correctly, it simply had no safety net.
+
+Expected values are derived from the spec:
+
+- A **settled** entry (`2025-01-15`, well over 90 days old) takes the regular
+  performance branch. Its single stock buys at `100.0` on the score date and
+  closes at `110.0` on the exact 90-day end date (`2025-04-15`) — a clean 10%
+  price gain, no dividends for the synthetic ticker — so the persisted
+  `performance_90_day` is `10.0`, `total_stocks` is `1`, and the annualised
+  figure compounds above the 90-day return.
+- A **still-open** entry (dated 10 days ago, so always under 90 days) takes the
+  hybrid-projection branch. Its source files are deliberately absent, so no
+  projection can be computed and the persisted `performance_90_day` must remain
+  `null` rather than fabricating a figure.
+
+```mermaid
+flowchart TD
+    A[update_index_with_performance] --> B[read_index_json]
+    B --> C{score >= 90 days old?}
+    C -->|yes| D[calculate_portfolio_performance<br/>reads co-located TSV + CSV]
+    C -->|no| E[calculate_hybrid_projection<br/>reads TSV + market CSV]
+    D --> F[write performance_90_day,<br/>annualized, total_stocks]
+    E --> F
+    D -. data missing .-> G[leave fields null]
+    E -. data missing .-> G
+    F --> H[write rewritten index.json]
+    G --> H
+```
+
+## Evidence
+
+Backend/CLI change with no web interface to screenshot. Verified via the new
+Rust integration test and the full quality gate.
+
+```
+running 1 test
+test update_index_with_performance_writes_settled_and_open_entries ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+`./quality.sh` passes cleanly (cargo fmt/clippy/check/test + tarpaulin coverage
++ release build + Deno test/lint/check: `337 passed | 0 failed`).
+
+## Test Plan
+
+- Added `tests/update_index_with_performance_test.rs::update_index_with_performance_writes_settled_and_open_entries`,
+  which:
+  - builds a temp `docs/scores` fixture (index JSON + score TSV + long-format
+    market CSV);
+  - calls the real `update_index_with_performance`;
+  - re-reads the rewritten `index.json` via `read_index_json` and locates
+    entries by `file` (not position);
+  - asserts the settled entry persists `performance_90_day == 10.0`,
+    `total_stocks == Some(1)`, and an annualised return greater than the 90-day
+    return;
+  - asserts the still-open entry keeps `performance_90_day` and
+    `performance_annualized` as `null`.
+- No existing tests were modified or removed.

--- a/tests/update_index_with_performance_test.rs
+++ b/tests/update_index_with_performance_test.rs
@@ -1,0 +1,136 @@
+//! Behaviour ("WHAT") tests for `update_index_with_performance` (issue #203).
+//!
+//! `update_index_with_performance` is the write path that persists every
+//! performance and projection figure into `docs/scores/index.json`. These
+//! tests run the real function against a temporary `docs` fixture and assert
+//! on the **persisted output** (the rewritten index JSON), not on internals,
+//! so they keep working when the orchestration is refactored.
+//!
+//! Expected values are derived from the spec:
+//!   * a settled (>= 90 day old) score with a single stock that closes 10%
+//!     above its buy price persists `performance_90_day == 10.0` (no dividends
+//!     for the synthetic ticker, so total return equals the price gain), and
+//!   * a still-open (< 90 day old) score whose source data is absent keeps
+//!     `performance_90_day == null` rather than fabricating a figure.
+
+use chrono::{Duration, Utc};
+use grq_validation::utils::{read_index_json, update_index_with_performance};
+use std::fs;
+use std::path::Path;
+
+/// Writes `contents` to `path`, creating parent directories as needed.
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent directories");
+    }
+    fs::write(path, contents).expect("write fixture file");
+}
+
+/// A `YYYY-MM-DD` date string `days` before today (UTC).
+fn date_days_ago(days: i64) -> String {
+    let date = Utc::now().naive_utc().date() - Duration::days(days);
+    date.format("%Y-%m-%d").to_string()
+}
+
+#[test]
+fn update_index_with_performance_writes_settled_and_open_entries() {
+    let dir = tempfile::tempdir().expect("create temp docs dir");
+    let docs = dir.path();
+    let scores = docs.join("scores");
+
+    // --- Settled entry: 2025-01-15 is far more than 90 days old, so it takes
+    // the regular performance branch which reads the co-located TSV + CSV. ---
+    let settled_file = "2025/January/15.tsv";
+    write_file(
+        &scores.join(settled_file),
+        "Stock\tScore\tTarget\tExDividendDate\tDividendPerShare\tNotes\t\
+         intrinsicValuePerShareBasic\tintrinsicValuePerShareAdjusted\n\
+         NYSE:TEST\t1.0\t150.00\t\t\t\t\t\n",
+    );
+    // Long-format market CSV (date,ticker,high,low,open,close) read by the
+    // performance calculation. Buy on the score date at 100, sell on the exact
+    // 90-day end date (2025-04-15) at 110 => a clean 10% price gain.
+    write_file(
+        &scores.join("2025/January/15.csv"),
+        "date,ticker,high,low,open,close\n\
+         2025-01-15,NYSE:TEST,0,0,0,100.0\n\
+         2025-04-15,NYSE:TEST,0,0,0,110.0\n",
+    );
+
+    // --- Still-open entry: dated 10 days ago, so it always takes the hybrid
+    // branch. Its source files are deliberately absent, so no projection can
+    // be computed and the persisted figure must stay null. ---
+    let open_date = date_days_ago(10);
+    let open_file = "open/score.tsv";
+
+    let index_json = format!(
+        r#"{{
+  "scores": [
+    {{
+      "year": "2025",
+      "month": "January",
+      "day": "15",
+      "file": "{settled_file}",
+      "date": "2025-01-15"
+    }},
+    {{
+      "year": "2026",
+      "month": "Open",
+      "day": "01",
+      "file": "{open_file}",
+      "date": "{open_date}"
+    }}
+  ]
+}}"#
+    );
+    write_file(&scores.join("index.json"), &index_json);
+
+    // Act: run the real write path against the fixture.
+    update_index_with_performance(docs.to_str().unwrap())
+        .expect("update_index_with_performance should succeed");
+
+    // Assert on the persisted output, located by `file` rather than position.
+    let updated = read_index_json(docs.to_str().unwrap()).expect("re-read rewritten index");
+
+    let settled = updated
+        .scores
+        .iter()
+        .find(|e| e.file == settled_file)
+        .expect("settled entry persisted");
+    let perf = settled
+        .performance_90_day
+        .expect("settled entry carries a 90-day performance figure");
+    assert!(
+        (perf - 10.0).abs() < 1e-6,
+        "expected spec-derived 10.0% 90-day performance, got {perf}"
+    );
+    assert_eq!(
+        settled.total_stocks,
+        Some(1),
+        "settled entry records the single contributing stock"
+    );
+    // Annualised return compounds the 10% over the full 90-day window and so
+    // must be a positive figure larger than the 90-day return.
+    let annualised = settled
+        .performance_annualized
+        .expect("settled entry carries an annualised figure");
+    assert!(
+        annualised > perf,
+        "annualised return {annualised} should exceed the 90-day return {perf}"
+    );
+
+    let open = updated
+        .scores
+        .iter()
+        .find(|e| e.file == open_file)
+        .expect("still-open entry persisted");
+    assert!(
+        open.performance_90_day.is_none(),
+        "still-open score with no source data must keep performance_90_day = null, got {:?}",
+        open.performance_90_day
+    );
+    assert!(
+        open.performance_annualized.is_none(),
+        "still-open score must keep performance_annualized = null"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #203.

The public function `update_index_with_performance` (`src/utils.rs:1155`) is
the write path that persists every performance and projection figure into
`docs/scores/index.json`, yet no test referenced it — a coverage gap
(anti-pattern 7). A refactor that mis-mapped an entry, dropped a field, or
mis-handled a still-open (null 90-day) score could silently corrupt the
published index while the suite stayed green.

This PR adds a behaviour ("WHAT") test that runs the real function against a
temporary `docs` fixture and asserts on the **persisted output** (the rewritten
index JSON), never on internals — so it keeps working when the orchestration is
refactored. No production code was changed; the function already behaves
correctly, it simply had no safety net.

Expected values are derived from the spec:

- A **settled** entry (`2025-01-15`, well over 90 days old) takes the regular
  performance branch. Its single stock buys at `100.0` on the score date and
  closes at `110.0` on the exact 90-day end date (`2025-04-15`) — a clean 10%
  price gain, no dividends for the synthetic ticker — so the persisted
  `performance_90_day` is `10.0`, `total_stocks` is `1`, and the annualised
  figure compounds above the 90-day return.
- A **still-open** entry (dated 10 days ago, so always under 90 days) takes the
  hybrid-projection branch. Its source files are deliberately absent, so no
  projection can be computed and the persisted `performance_90_day` must remain
  `null` rather than fabricating a figure.

```mermaid
flowchart TD
    A[update_index_with_performance] --> B[read_index_json]
    B --> C{score >= 90 days old?}
    C -->|yes| D[calculate_portfolio_performance<br/>reads co-located TSV + CSV]
    C -->|no| E[calculate_hybrid_projection<br/>reads TSV + market CSV]
    D --> F[write performance_90_day,<br/>annualized, total_stocks]
    E --> F
    D -. data missing .-> G[leave fields null]
    E -. data missing .-> G
    F --> H[write rewritten index.json]
    G --> H
```

## Evidence

Backend/CLI change with no web interface to screenshot. Verified via the new
Rust integration test and the full quality gate.

```
running 1 test
test update_index_with_performance_writes_settled_and_open_entries ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`./quality.sh` passes cleanly (cargo fmt/clippy/check/test + tarpaulin
coverage + release build + Deno test/lint/check: `337 passed | 0 failed`).

## Test Plan

- Added `tests/update_index_with_performance_test.rs::update_index_with_performance_writes_settled_and_open_entries`,
  which:
  - builds a temp `docs/scores` fixture (index JSON + score TSV + long-format
    market CSV);
  - calls the real `update_index_with_performance`;
  - re-reads the rewritten `index.json` via `read_index_json` and locates
    entries by `file` (not position);
  - asserts the settled entry persists `performance_90_day == 10.0`,
    `total_stocks == Some(1)`, and an annualised return greater than the 90-day
    return;
  - asserts the still-open entry keeps `performance_90_day` and
    `performance_annualized` as `null`.
- No existing tests were modified or removed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqkce2j8-abb955`<!-- vibe-worker-issue-203 -->