### PR TITLE
Replace magic projection thresholds with spec-derived assertion (#205)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-205.md
+++ b/docs/archive/pr-summaries/pr-summary-205.md
@@ -1,0 +1,64 @@
+## Summary
+
+`tests/schw_projection_test.ts` asserted the 90-day projection against two
+undocumented magic lower bounds — `projected90DayPerformance > 17` (line 305)
+and `> 19` (line 311). The first was strictly redundant with the second, and
+both read as empirical numbers copied from a run against the frozen SCHW
+fixture rather than a spec-derived expectation (magic-value anti-pattern).
+
+Replaced both with a single documented `assertAlmostEquals` whose expected
+value is computed from the documented projection formula over the fixture.
+The SCHW snapshot spans ~77 days, so `computeHybridProjection` takes the
+long-term (`daysElapsed >= 60`) `realistic_trajectory` branch; with a known
+target and the stock already trading above it (current ~17.2% > target ~7.8%),
+the kernel trusts the realised trajectory and extrapolates the current daily
+rate to the full 90-day horizon:
+
+```
+projected = currentPerformance * 90 / daysElapsed   ≈ 20.1%
+```
+
+A comment in the test shows this derivation. The assertion now also confirms
+the `realistic_trajectory` branch is taken, so if the projection maths is
+retuned the test fails with a meaningful expected-vs-actual diff instead of a
+stale threshold.
+
+Closes #205.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+Derivation of the expected figure, confirmed against the committed fixture:
+
+```mermaid
+flowchart LR
+    A["daysElapsed ≈ 77 (>= 60)"] --> B["realistic_trajectory branch"]
+    B --> C{"current 17.2% > target 7.8%?"}
+    C -- "yes" --> D["trust trajectory:\ncurrentPerformance * 90 / daysElapsed"]
+    D --> E["projected ≈ 20.1%"]
+```
+
+Test run after the change:
+
+```
+running 1 test from ./tests/schw_projection_test.ts
+NYSE:SCHW Projection Test - Using Real App Functions ...
+  should calculate correct current performance ... ok
+  should calculate correct 90-day projection ... ok
+  should have strong trend line fit ... ok
+ok | 1 passed (3 steps) | 0 failed
+```
+
+`./quality.sh` passes cleanly.
+
+## Test Plan
+
+- Modified `tests/schw_projection_test.ts` —
+  `NYSE:SCHW Projection Test › should calculate correct 90-day projection`:
+  removed the redundant `> 17`/`> 19` magic bounds and added an
+  `assertAlmostEquals` against the spec-derived expectation plus a
+  `projectionMethod === "realistic_trajectory"` branch check.
+- Verified the step still passes against the frozen fixture via
+  `deno test --allow-read tests/schw_projection_test.ts`.
+- Ran the full `./quality.sh` gate; all Rust and Deno checks pass.

--- a/tests/schw_projection_test.ts
+++ b/tests/schw_projection_test.ts
@@ -11,7 +11,7 @@
 // currentPriceFromLatest, calculatePerformanceReturn, computeTrendLine,
 // calculateTargetPercentage, computeHybridProjection) — the same code the
 // dashboard's GRQValidator uses.
-import { assert } from "@std/assert";
+import { assert, assertAlmostEquals } from "@std/assert";
 import "../docs/projection.js";
 
 interface StockData {
@@ -301,17 +301,37 @@ Deno.test("NYSE:SCHW Projection Test - Using Real App Functions", async (t) => {
   await t.step("should calculate correct 90-day projection", () => {
     const projection = validator.calculateHybridProjection(stock!, scoreDate);
     assert(projection, "Should have projection");
+
+    // Spec-derived expectation (issue #205) — replaces two undocumented magic
+    // lower bounds (`> 17` and `> 19`) that asserted on the number the code
+    // happened to emit against this fixture.
+    //
+    // Derivation: the frozen SCHW snapshot spans ~77 days, so
+    // computeHybridProjection takes the long-term (daysElapsed >= 60)
+    // "realistic_trajectory" branch. There, with a known target and the stock
+    // already trading above that target (current ~17.2% > target ~7.8%), the
+    // kernel trusts the realised trajectory and extrapolates the current daily
+    // rate out to the full 90-day horizon:
+    //
+    //     projected = currentPerformance * 90 / daysElapsed
+    //
+    // So the expected figure is the documented formula applied to the fixture
+    // (~20.1%), not an empirical bound. If the projection maths is retuned,
+    // this assertion fails with a meaningful expected-vs-actual diff rather
+    // than a stale threshold.
     assert(
-      projection!.projected90DayPerformance > 17,
-      `Projection should be > 17%, got ${
-        projection!.projected90DayPerformance.toFixed(1)
-      }%`,
+      projection!.projectionMethod === "realistic_trajectory",
+      `Expected realistic_trajectory branch, got ${
+        projection!.projectionMethod
+      }`,
     );
-    assert(
-      projection!.projected90DayPerformance > 19,
-      `Projection should be > 19%, got ${
-        projection!.projected90DayPerformance.toFixed(1)
-      }%`,
+    const expected = (projection!.currentPerformance * 90) /
+      projection!.daysElapsed;
+    assertAlmostEquals(
+      projection!.projected90DayPerformance,
+      expected,
+      1e-9,
+      "Above-target SCHW should project its current daily rate to 90 days",
     );
   });
 


### PR DESCRIPTION
## Summary

`tests/schw_projection_test.ts` asserted the 90-day projection against two
undocumented magic lower bounds — `projected90DayPerformance > 17` (line 305)
and `> 19` (line 311). The first was strictly redundant with the second, and
both read as empirical numbers copied from a run against the frozen SCHW
fixture rather than a spec-derived expectation (magic-value anti-pattern).

Replaced both with a single documented `assertAlmostEquals` whose expected
value is computed from the documented projection formula over the fixture.
The SCHW snapshot spans ~77 days, so `computeHybridProjection` takes the
long-term (`daysElapsed >= 60`) `realistic_trajectory` branch; with a known
target and the stock already trading above it (current ~17.2% > target ~7.8%),
the kernel trusts the realised trajectory and extrapolates the current daily
rate to the full 90-day horizon:

```
projected = currentPerformance * 90 / daysElapsed   ≈ 20.1%
```

A comment in the test shows this derivation. The assertion now also confirms
the `realistic_trajectory` branch is taken, so if the projection maths is
retuned the test fails with a meaningful expected-vs-actual diff instead of a
stale threshold.

Closes #205.

## Evidence

Backend/test-only change — no web interface to screenshot.

Derivation of the expected figure, confirmed against the committed fixture:

```mermaid
flowchart LR
    A["daysElapsed ≈ 77 (>= 60)"] --> B["realistic_trajectory branch"]
    B --> C{"current 17.2% > target 7.8%?"}
    C -- "yes" --> D["trust trajectory:\ncurrentPerformance * 90 / daysElapsed"]
    D --> E["projected ≈ 20.1%"]
```

Test run after the change:

```
running 1 test from ./tests/schw_projection_test.ts
NYSE:SCHW Projection Test - Using Real App Functions ...
  should calculate correct current performance ... ok
  should calculate correct 90-day projection ... ok
  should have strong trend line fit ... ok
ok | 1 passed (3 steps) | 0 failed
```

`./quality.sh` passes cleanly.

## Test Plan

- Modified `tests/schw_projection_test.ts` —
  `NYSE:SCHW Projection Test › should calculate correct 90-day projection`:
  removed the redundant `> 17`/`> 19` magic bounds and added an
  `assertAlmostEquals` against the spec-derived expectation plus a
  `projectionMethod === "realistic_trajectory"` branch check.
- Verified the step still passes against the frozen fixture via
  `deno test --allow-read tests/schw_projection_test.ts`.
- Ran the full `./quality.sh` gate; all Rust and Deno checks pass.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqkepykj-a258d5`<!-- vibe-worker-issue-205 -->