### PR TITLE
Skip Gitleaks job for Dependabot PRs (Issue #219)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -25,6 +25,12 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Skip Dependabot PRs (Issue #219). Dependabot runs against the separate
+    # Dependabot secrets store and cannot read the org-level GITLEAKS_LICENSE,
+    # so gitleaks-action exits with ErrLicense and the check fails on every
+    # dependency-bump PR (e.g. PR #217). Such PRs only bump versions and carry
+    # no secrets to scan, so skipping the job is safe.
+    if: github.actor != 'dependabot[bot]'
     steps:
       # actions/checkout@v4.2.2
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10

--- a/docs/archive/pr-summaries/pr-summary-219.md
+++ b/docs/archive/pr-summaries/pr-summary-219.md
@@ -1,0 +1,61 @@
+# Resolve PR #217 CI issues — skip Gitleaks for Dependabot PRs
+
+## Summary
+
+PR #217 (a Dependabot bump of `actions/checkout` 6.0.3 → 7.0.0) failed CI on the
+`gitleaks` check only. The root cause is unrelated to the checkout bump:
+`gitleaks/gitleaks-action` requires an org-level Gitleaks Pro licence, but
+Dependabot-triggered runs execute against the separate **Dependabot secrets**
+store and cannot read the `GITLEAKS_LICENSE` secret. The action therefore exits
+with `ErrLicense` ("missing gitleaks license") before scanning, failing the
+check on every Dependabot PR.
+
+A dependency-bump PR introduces no secrets to scan, so the fix guards the
+`gitleaks` job with `if: github.actor != 'dependabot[bot]'`, skipping it for
+Dependabot-authored PRs while leaving full secret scanning intact for all human
+PRs. Branch protection on `main` lists no required status checks, so a skipped
+job does not block merges.
+
+Closes #219.
+
+## Evidence
+
+This is a CI/workflow configuration change with no web interface to screenshot.
+
+Failing run log for PR #217's `gitleaks` check:
+
+```text
+[stSoftwareAU] is an organization. License key is required.
+##[error]🛑 missing gitleaks license. Go grab one at gitleaks.io and store it
+as a GitHub Secret named GITLEAKS_LICENSE.
+```
+
+The empty `GITLEAKS_LICENSE:` env and `Secret source: Dependabot` line in the
+same log confirm the secret was unavailable because the run was triggered by
+Dependabot.
+
+```mermaid
+flowchart TD
+    A[PR opened] --> B{github.actor == dependabot[bot]?}
+    B -- yes --> C[gitleaks job skipped<br/>no licence needed, no secrets to scan]
+    B -- no --> D[gitleaks job runs<br/>org licence available, full scan]
+```
+
+Verified locally:
+
+```text
+deno test --allow-read tests/*.ts
+ok | 338 passed (55 steps) | 0 failed
+```
+
+## Test Plan
+
+- Added `tests/gitleaks_workflow_test.ts::"Gitleaks job is skipped for Dependabot-authored PRs"`,
+  which parses `.github/workflows/gitleaks.yml` and asserts the `gitleaks` job
+  declares an `if` condition referencing `github.actor`, `!=`, and
+  `dependabot[bot]`. It fails against the unfixed workflow and passes after the
+  fix.
+- Existing Gitleaks workflow tests (exists, valid YAML, `pull_request` trigger,
+  read-only `contents` permission, concurrency cancellation) continue to pass.
+- Full Deno suite: 338 passed, 0 failed (`deno test --allow-read tests/*.ts`).
+- `deno fmt`, `deno lint`, and `deno check` clean on the modified test file.

--- a/tests/gitleaks_workflow_test.ts
+++ b/tests/gitleaks_workflow_test.ts
@@ -60,3 +60,31 @@ Deno.test("Gitleaks workflow declares a concurrency group that cancels supersede
     "concurrency must cancel superseded in-progress runs",
   );
 });
+
+// Issue #219: gitleaks-action requires an org-level Gitleaks Pro licence, but
+// Dependabot-triggered runs execute against the separate Dependabot secrets
+// store and cannot read GITLEAKS_LICENSE. The action therefore exits with
+// ErrLicense and the check fails on every Dependabot PR (e.g. PR #217). A
+// dependency-bump PR introduces no secrets to scan, so the gitleaks job must
+// be skipped when the actor is Dependabot.
+Deno.test("Gitleaks job is skipped for Dependabot-authored PRs", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as {
+    jobs?: Record<string, { if?: string }>;
+  };
+  const job = doc.jobs?.gitleaks;
+  assert(job, "workflow must declare a gitleaks job");
+  assert(
+    typeof job.if === "string",
+    "gitleaks job must declare an 'if' condition guarding the Dependabot actor",
+  );
+  const condition = job.if as string;
+  assert(
+    condition.includes("dependabot[bot]"),
+    `gitleaks job 'if' must reference the dependabot[bot] actor: ${condition}`,
+  );
+  assert(
+    condition.includes("github.actor") && condition.includes("!="),
+    `gitleaks job 'if' must skip runs where github.actor is Dependabot: ${condition}`,
+  );
+});


### PR DESCRIPTION
# Resolve PR #217 CI issues — skip Gitleaks for Dependabot PRs

## Summary

PR #217 (a Dependabot bump of `actions/checkout` 6.0.3 → 7.0.0) failed CI on the
`gitleaks` check only. The root cause is unrelated to the checkout bump:
`gitleaks/gitleaks-action` requires an org-level Gitleaks Pro licence, but
Dependabot-triggered runs execute against the separate **Dependabot secrets**
store and cannot read the `GITLEAKS_LICENSE` secret. The action therefore exits
with `ErrLicense` ("missing gitleaks license") before scanning, failing the
check on every Dependabot PR.

A dependency-bump PR introduces no secrets to scan, so the fix guards the
`gitleaks` job with `if: github.actor != 'dependabot[bot]'`, skipping it for
Dependabot-authored PRs while leaving full secret scanning intact for all human
PRs. Branch protection on `main` lists no required status checks, so a skipped
job does not block merges.

Closes #219.

## Evidence

This is a CI/workflow configuration change with no web interface to screenshot.

Failing run log for PR #217's `gitleaks` check:

```text
[stSoftwareAU] is an organization. License key is required.
##[error]🛑 missing gitleaks license. Go grab one at gitleaks.io and store it
as a GitHub Secret named GITLEAKS_LICENSE.
```

The empty `GITLEAKS_LICENSE:` env and `Secret source: Dependabot` line in the
same log confirm the secret was unavailable because the run was triggered by
Dependabot.

```mermaid
flowchart TD
    A[PR opened] --> B{github.actor == dependabot[bot]?}
    B -- yes --> C[gitleaks job skipped<br/>no licence needed, no secrets to scan]
    B -- no --> D[gitleaks job runs<br/>org licence available, full scan]
```

Verified locally:

```text
deno test --allow-read tests/*.ts
ok | 338 passed (55 steps) | 0 failed
```

## Test Plan

- Added `tests/gitleaks_workflow_test.ts::"Gitleaks job is skipped for Dependabot-authored PRs"`,
  which parses `.github/workflows/gitleaks.yml` and asserts the `gitleaks` job
  declares an `if` condition referencing `github.actor`, `!=`, and
  `dependabot[bot]`. It fails against the unfixed workflow and passes after the
  fix.
- Existing Gitleaks workflow tests (exists, valid YAML, `pull_request` trigger,
  read-only `contents` permission, concurrency cancellation) continue to pass.
- Full Deno suite: 338 passed, 0 failed (`deno test --allow-read tests/*.ts`).
- `deno fmt`, `deno lint`, and `deno check` clean on the modified test file.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqn15gpl-7274f0`<!-- vibe-worker-issue-219 -->