### PR TITLE
PWA: add service worker + registration (Issue #223)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-223.md
+++ b/docs/archive/pr-summaries/pr-summary-223.md
@@ -1,0 +1,74 @@
+# PWA: service worker + registration (Issue #223)
+
+## Summary
+
+Adds the service worker and its registration script so the GRQ Validation
+Dashboard can work offline as an installable PWA, mirroring
+`stSoftwareAU/GRQ-FX-validation` adapted to this dashboard's file layout.
+**Closes #223.**
+
+- **`docs/sw.js`** — versioned caches (`grq-validation-v1.0.186`, plus
+  `…-static-…` / `…-dynamic-…`) aligned with the `app-version` meta in
+  `index.html` / `docs/version.js`; old `grq-validation-*` caches are cleaned
+  up on `activate`. Mirrors FX's install/activate/fetch/message structure:
+  - **App shell (precache)** — the static dashboard assets (`./`,
+    `index.html`, `list.html`, `app.js`, `list.js`, `projection.js`,
+    `escape.js`, `version.js`, `dashboard_boot.js`, `list_render.js`,
+    `list_stats.js`, `styles.css`, `list.css`, `manifest.json`, `logo.png`,
+    `sw-register.js`) plus the SRI-pinned CDN assets enumerated from the
+    `<head>` (Bootstrap 5.3.0 CSS, Bootstrap 5.1.3 JS, Chart.js 4.5.1,
+    `chartjs-adapter-date-fns` 3.0.0, `chartjs-plugin-annotation` 3.1.0).
+    Precaching is resilient (each asset cached individually), so an entry a
+    sibling sub-issue has not landed yet (e.g. `manifest.json`) is simply
+    skipped rather than failing the whole install.
+  - **Cache-on-demand (dynamic)** for per-day score data, matched by
+    `URL.pathname` regexes: `/\/scores\/.*\.(csv|tsv)$/`, plus the on-demand
+    data JSON (`market-indices.json`, `USDAUD.json`).
+  - **Network-first** for the score index `/\/scores\/index\.json$/` — the
+    file `docs/list.js` loads to build the date/score list — so the list never
+    goes stale while online, falling back to cache when offline.
+- **`docs/sw-register.js`** — an **external** (CSP-safe) registration script:
+  registers `./sw.js?v=1.0.186`, forces an update check on load, polls
+  `registration.update()` every 30s, forces a reload when a new SW activates,
+  and handles SW→page messages. External because the CSP uses
+  `script-src 'self'` with no `'unsafe-inline'`.
+
+Wiring `sw-register.js` into `index.html` / `list.html` is intentionally **out
+of scope** here — it lands with the paired `<head>`-wiring sub-issue. The
+unrelated `Cargo.lock` churn that `quality.sh`'s `cargo update` produces was
+reverted to keep this PR focused.
+
+## Evidence
+
+No web UI changes ship in this sub-issue (the service worker is not registered
+until the `<head>`-wiring sub-issue loads `sw-register.js`), so there is
+nothing new to screenshot. Correctness is verified by the new pathname-guard
+tests and the full quality gate (`./quality.sh` passes, 346 Deno tests + Rust
+suite green).
+
+Caching-strategy decision flow implemented in `docs/sw.js`:
+
+```mermaid
+flowchart TD
+    A[fetch GET request] --> B{scores/index.json?}
+    B -- yes --> N[Network-first<br/>fall back to cache]
+    B -- no --> C{scores/*.csv|tsv<br/>or data JSON?}
+    C -- yes --> D[Cache-on-demand<br/>network-first, warn header offline]
+    C -- no --> E{static shell asset?<br/>.js/.css/.html/.json}
+    E -- yes --> F[Cache-first<br/>fall back to ./index.html for docs]
+    E -- no --> G[Cache-first]
+```
+
+## Test Plan
+
+- Added `tests/sw_pathname_guards_test.ts` (mirrors FX
+  `tests/sw-pathname-guards.test.ts`), asserting that `docs/sw.js`:
+  - includes the `URL.pathname` regex `/\/scores\/.*\.(csv|tsv)$/` for per-day
+    score data;
+  - includes the network-first regex `/\/scores\/index\.json$/`;
+  - does **not** contain a `./scores/` string literal (which would never match
+    `URL.pathname`);
+  - excludes data JSON from the generic cache-first `.json` static matcher
+    (`endsWith(".json") && !isNetworkFirst && !isDataFile`).
+- Full suite: `./quality.sh` passes (Rust + 346 Deno tests, lint, fmt, type
+  checks).

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -1,0 +1,92 @@
+// Service worker registration for the GRQ Validation Dashboard (issue #223).
+//
+// Australian English: an external registration script (not an inline
+// <script>) so docs/index.html and docs/list.html can keep a strict
+// Content-Security-Policy with script-src 'self' and no 'unsafe-inline'.
+// Behaviour mirrors the FX dashboard: register ./sw.js, force an update check
+// on load, poll registration.update() every 30 seconds, force a reload when a
+// new service worker activates, and handle service-worker → page messages.
+//
+// Keep the ?v= query aligned with the app-version meta in index.html so a new
+// version always re-registers a fresh service worker.
+
+(function registerServiceWorker() {
+  "use strict";
+
+  if (!("serviceWorker" in navigator)) {
+    return;
+  }
+
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("./sw.js?v=1.0.186")
+      .then((registration) => {
+        console.log("SW registered: ", registration);
+
+        // Force an update check on every page load.
+        registration.update();
+
+        // Check for updates.
+        registration.addEventListener("updatefound", () => {
+          const newWorker = registration.installing;
+          newWorker.addEventListener("statechange", () => {
+            if (newWorker.state === "installed") {
+              if (navigator.serviceWorker.controller) {
+                // New content is available, force an immediate refresh.
+                console.log("New version available, forcing refresh...");
+
+                navigator.serviceWorker.controller.postMessage({
+                  type: "FORCE_UPDATE",
+                });
+                window.location.reload();
+              } else {
+                // First-time installation.
+                console.log("Service worker installed for the first time");
+              }
+            }
+          });
+        });
+
+        // Listen for messages from the service worker.
+        navigator.serviceWorker.addEventListener("message", (event) => {
+          if (event.data && event.data.type === "FORCE_RELOAD") {
+            console.log("Service worker requested force reload");
+            window.location.reload();
+          }
+          if (event.data && event.data.type === "SW_UPDATED") {
+            console.log(
+              "Service worker updated to version:",
+              event.data.version,
+            );
+            window.location.reload();
+          }
+        });
+
+        // Listen for messages from the active service-worker controller.
+        if (navigator.serviceWorker.controller) {
+          navigator.serviceWorker.controller.addEventListener(
+            "message",
+            (event) => {
+              if (
+                event.data && event.data.type === "SW_UPDATED" &&
+                event.data.forceReload
+              ) {
+                console.log("Force reload requested due to version update");
+                window.location.reload();
+              }
+            },
+          );
+        }
+
+        // Check for updates every 30 seconds.
+        setInterval(() => {
+          registration.update();
+        }, 30000);
+      })
+      .catch((registrationError) => {
+        console.log("SW registration failed: ", registrationError);
+      });
+  });
+
+  // PWA install prompt handling omitted for iPhone compatibility.
+  // Users can install via Safari's "Add to Home Screen" option.
+})();

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,0 +1,406 @@
+// Service Worker for the GRQ Validation Dashboard (issue #223).
+//
+// Mirrors the GRQ FX Validation Dashboard's service worker, adapted to this
+// dashboard's file layout. Versioned caches are aligned with the app-version
+// meta in docs/index.html (and docs/version.js). Bump APP_VERSION whenever the
+// app version or the SRI-pinned CDN assets below change so the service worker
+// re-fetches and re-validates everything.
+
+const APP_VERSION = "1.0.186";
+const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
+const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
+const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;
+
+// App shell — static dashboard assets precached on install. Enumerated from
+// the <head> of docs/index.html and docs/list.html so the list stays in sync;
+// bump APP_VERSION when the SRI pins below change. Entries that do not yet
+// exist (e.g. manifest.json added by a sibling sub-issue) are simply skipped
+// during precache rather than failing the whole install.
+const STATIC_ASSETS = [
+  "./",
+  "./index.html",
+  "./list.html",
+  "./app.js",
+  "./list.js",
+  "./projection.js",
+  "./escape.js",
+  "./version.js",
+  "./dashboard_boot.js",
+  "./list_render.js",
+  "./list_stats.js",
+  "./styles.css",
+  "./list.css",
+  "./manifest.json",
+  "./logo.png",
+  "./sw-register.js",
+  // SRI-pinned CDN assets from docs/index.html / docs/list.html (issue #79).
+  // Bump APP_VERSION whenever these pins change so the integrity hashes are
+  // re-validated.
+  "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css",
+  "https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js",
+  "https://cdn.jsdelivr.net/npm/chart.js@4.5.1",
+  "https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js",
+  "https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3.1.0",
+];
+
+// Per-day score data cached on demand. Matched against URL.pathname (not a
+// string literal) so the regexes work regardless of the page's base path.
+const DYNAMIC_PATTERNS = [
+  /\/scores\/.*\.(csv|tsv)$/,
+  /\/market-indices\.json$/,
+  /\/USDAUD\.json$/,
+];
+
+// The score index uses a Network First strategy so the date/score list never
+// goes stale while online (docs/list.js fetches scores/index.json).
+const NETWORK_FIRST_PATTERNS = [
+  /\/scores\/index\.json$/,
+];
+
+/**
+ * Add diagnostic headers to a response.
+ *
+ * Note: Response headers are immutable; we must create a new Response.
+ */
+function withHeaders(response, extraHeaders) {
+  const cloned = response.clone();
+  const headers = new Headers(cloned.headers);
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    headers.set(key, value);
+  }
+
+  return new Response(cloned.body, {
+    status: cloned.status,
+    statusText: cloned.statusText,
+    headers,
+  });
+}
+
+/**
+ * Precache the app shell resiliently: cache each asset individually so a
+ * single missing entry (e.g. a manifest.json a sibling sub-issue has not
+ * landed yet) does not reject the whole install.
+ */
+async function precacheStaticAssets() {
+  const cache = await caches.open(STATIC_CACHE_NAME);
+  await Promise.all(
+    STATIC_ASSETS.map(async (asset) => {
+      try {
+        await cache.add(asset);
+      } catch (error) {
+        console.warn("Service Worker: Skipping uncacheable asset", asset, error);
+      }
+    }),
+  );
+}
+
+/**
+ * Network-first for the score index so the date/score list stays current.
+ *
+ * If the network fails, fall back to the cached index with a warning header.
+ */
+async function networkFirstScoreIndex(originalRequest) {
+  const request = new Request(originalRequest, { cache: "no-store" });
+  const cache = await caches.open(DYNAMIC_CACHE_NAME);
+
+  try {
+    const response = await fetch(request);
+    if (response && response.status === 200 && response.type === "basic") {
+      await cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    console.warn(
+      "Service Worker: Network failed for scores index, using cache",
+      request.url,
+      error,
+    );
+    const cached = await cache.match(request);
+    if (cached) {
+      return withHeaders(cached, {
+        "X-Served-From-Cache": "true",
+        "X-Validation-Warning": "STALE-INDEX",
+        "X-Cache-Timestamp": new Date().toISOString(),
+      });
+    }
+    throw error;
+  }
+}
+
+// Install event - aggressively cache static assets
+self.addEventListener("install", (event) => {
+  console.log("Service Worker: Installing version", CACHE_NAME);
+
+  event.waitUntil(
+    precacheStaticAssets()
+      .then(() => {
+        console.log("Service Worker: Static assets cached successfully");
+        // Force immediate activation to ensure new version takes over.
+        return self.skipWaiting();
+      })
+      .catch((error) => {
+        console.error("Service Worker: Failed to cache static assets", error);
+        // Still skip waiting even if caching fails.
+        return self.skipWaiting();
+      }),
+  );
+});
+
+// Activate event - clean up old caches and force version update
+self.addEventListener("activate", (event) => {
+  console.log("Service Worker: Activating version", CACHE_NAME);
+
+  event.waitUntil(
+    caches.keys()
+      .then((cacheNames) => {
+        return Promise.all(
+          cacheNames.map((cacheName) => {
+            // Delete ALL old GRQ Validation caches to force fresh downloads.
+            if (
+              cacheName.startsWith("grq-validation-") &&
+              cacheName !== CACHE_NAME &&
+              cacheName !== STATIC_CACHE_NAME &&
+              cacheName !== DYNAMIC_CACHE_NAME
+            ) {
+              console.log("Service Worker: Deleting old cache", cacheName);
+              return caches.delete(cacheName);
+            }
+          }),
+        );
+      })
+      .then(() => {
+        console.log("Service Worker: Old caches deleted, claiming clients");
+        // Force claim all clients immediately.
+        return self.clients.claim();
+      })
+      .then(() => {
+        // Notify all clients about the update and force reload.
+        return self.clients.matchAll();
+      })
+      .then((clients) => {
+        clients.forEach((client) => {
+          client.postMessage({
+            type: "SW_UPDATED",
+            version: CACHE_NAME,
+            timestamp: Date.now(),
+            forceReload: true,
+          });
+        });
+      }),
+  );
+});
+
+// Fetch event - cache-first for the app shell, network-first for the score
+// index, cache-on-demand for per-day score data.
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests.
+  if (request.method !== "GET") {
+    return;
+  }
+
+  // Skip external requests other than the SRI-pinned CDN.
+  if (
+    url.origin !== location.origin &&
+    !url.hostname.includes("cdn.jsdelivr.net")
+  ) {
+    return;
+  }
+
+  // Per-day score data (CSV/TSV) and on-demand data JSON.
+  const isDataFile = DYNAMIC_PATTERNS.some((pattern) =>
+    pattern.test(url.pathname)
+  );
+
+  // The score index uses Network First.
+  const isNetworkFirst = NETWORK_FIRST_PATTERNS.some((pattern) =>
+    pattern.test(url.pathname)
+  );
+
+  // Static app-shell assets (JS, CSS, HTML, manifest.json, the root).
+  const isStaticAsset = url.pathname.endsWith(".js") ||
+    url.pathname.endsWith(".css") ||
+    url.pathname.endsWith(".html") ||
+    url.pathname === "./" ||
+    (url.pathname.endsWith(".json") && !isNetworkFirst && !isDataFile);
+
+  if (isStaticAsset) {
+    // App shell: cache first with version-based invalidation. Aggressive
+    // caching is safe because a version change invalidates every cache.
+    event.respondWith(
+      caches.match(request)
+        .then((cachedResponse) => {
+          if (cachedResponse) {
+            return cachedResponse;
+          }
+
+          return fetch(request)
+            .then((response) => {
+              if (
+                response && response.status === 200 && response.type === "basic"
+              ) {
+                const responseToCache = response.clone();
+                caches.open(STATIC_CACHE_NAME)
+                  .then((cache) => {
+                    cache.put(request, responseToCache);
+                  });
+              }
+              return response;
+            })
+            .catch((error) => {
+              // No cache and offline: fall back to the dashboard for
+              // navigation requests.
+              if (request.destination === "document") {
+                return caches.match("./index.html");
+              }
+              throw error;
+            });
+        }),
+    );
+  } else if (isNetworkFirst) {
+    // Score index: network first so the date/score list stays current online.
+    event.respondWith(
+      networkFirstScoreIndex(request),
+    );
+  } else if (isDataFile) {
+    // Per-day score data: network first, falling back to cache with a warning
+    // header when offline so the validation banner can flag stale data.
+    event.respondWith(
+      fetch(new Request(request, { cache: "no-store" }))
+        .then((response) => {
+          if (
+            response && response.status === 200 && response.type === "basic"
+          ) {
+            const responseToCache = response.clone();
+            caches.open(DYNAMIC_CACHE_NAME)
+              .then((cache) => {
+                cache.put(request, responseToCache);
+              });
+          }
+          return response;
+        })
+        .catch((_error) => {
+          console.warn(
+            "Service Worker: Network failed for score data - VALIDATION MAY BE STALE",
+            request.url,
+          );
+          return caches.match(request)
+            .then((cachedResponse) => {
+              if (cachedResponse) {
+                return withHeaders(cachedResponse, {
+                  "X-Served-From-Cache": "true",
+                  "X-Validation-Warning": "CACHED-DATA",
+                  "X-Cache-Timestamp": new Date().toISOString(),
+                });
+              }
+              throw new Error(
+                "No network connection and no cached data available. Cannot validate scores.",
+              );
+            });
+        }),
+    );
+  } else {
+    // Everything else: cache first with version-based invalidation.
+    event.respondWith(
+      caches.match(request)
+        .then((cachedResponse) => {
+          if (cachedResponse) {
+            return cachedResponse;
+          }
+
+          return fetch(request)
+            .then((response) => {
+              if (
+                response && response.status === 200 && response.type === "basic"
+              ) {
+                const responseToCache = response.clone();
+                caches.open(STATIC_CACHE_NAME)
+                  .then((cache) => {
+                    cache.put(request, responseToCache);
+                  });
+              }
+              return response;
+            });
+        }),
+    );
+  }
+});
+
+// Background sync (if supported).
+self.addEventListener("sync", (event) => {
+  console.log("Service Worker: Background sync", event.tag);
+
+  if (event.tag === "background-sync") {
+    event.waitUntil(Promise.resolve());
+  }
+});
+
+// Push notifications (reserved for future use).
+self.addEventListener("push", (event) => {
+  console.log("Service Worker: Push notification received");
+
+  const options = {
+    body: event.data ? event.data.text() : "New validation data available",
+    icon: "./icons/icon-192x192.png",
+    badge: "./icons/icon-72x72.png",
+    vibrate: [100, 50, 100],
+    data: {
+      dateOfArrival: Date.now(),
+      primaryKey: 1,
+    },
+    actions: [
+      {
+        action: "explore",
+        title: "View Dashboard",
+        icon: "./icons/icon-96x96.png",
+      },
+      {
+        action: "close",
+        title: "Close",
+        icon: "./icons/icon-96x96.png",
+      },
+    ],
+  };
+
+  event.waitUntil(
+    self.registration.showNotification("GRQ Validation Dashboard", options),
+  );
+});
+
+// Notification clicks.
+self.addEventListener("notificationclick", (event) => {
+  console.log("Service Worker: Notification clicked");
+
+  event.notification.close();
+
+  if (event.action === "explore") {
+    event.waitUntil(
+      clients.openWindow("./"),
+    );
+  }
+});
+
+// Messages from the main thread.
+self.addEventListener("message", (event) => {
+  console.log("Service Worker: Message received", event.data);
+
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
+
+  if (event.data && event.data.type === "GET_VERSION") {
+    event.ports[0].postMessage({ version: CACHE_NAME });
+  }
+
+  if (event.data && event.data.type === "FORCE_UPDATE") {
+    console.log("Service Worker: Force update requested");
+    self.skipWaiting();
+    self.clients.matchAll().then((clients) => {
+      clients.forEach((client) => {
+        client.postMessage({ type: "FORCE_RELOAD" });
+      });
+    });
+  }
+});

--- a/tests/sw_pathname_guards_test.ts
+++ b/tests/sw_pathname_guards_test.ts
@@ -1,0 +1,45 @@
+// Service worker pathname guards for the GRQ Validation Dashboard (issue #223).
+//
+// Australian English: these tests prevent regressions where per-day score
+// data (CSV/TSV) or the score index becomes stale due to incorrect
+// URL.pathname matching. They mirror the FX dashboard's
+// tests/sw-pathname-guards.test.ts, adapted to GRQ Validation's file layout
+// (scores live under ./scores/<year>/<month>/<day>.tsv plus *-analysis.csv
+// and *-dividends.csv, and the index is ./scores/index.json).
+
+const sw = await Deno.readTextFile(new URL("../docs/sw.js", import.meta.url));
+
+Deno.test("sw.js caches per-day score data using a pathname-based CSV/TSV regex", () => {
+  if (!sw.includes("/\\/scores\\/.*\\.(csv|tsv)$/")) {
+    throw new Error(
+      "Expected sw.js to include pathname regex /\\/scores\\/.*\\.(csv|tsv)$/",
+    );
+  }
+});
+
+Deno.test("sw.js treats scores/index.json as network-first via a pathname regex", () => {
+  if (!sw.includes("/\\/scores\\/index\\.json$/")) {
+    throw new Error(
+      "Expected sw.js to include network-first pathname regex /\\/scores\\/index\\.json$/",
+    );
+  }
+});
+
+Deno.test("sw.js does not use a './scores/' string literal that never matches URL.pathname", () => {
+  if (sw.includes("./scores/")) {
+    throw new Error(
+      "sw.js still appears to contain './scores/' which does not match URL.pathname",
+    );
+  }
+});
+
+Deno.test("sw.js does not treat data JSON as a cache-first static JSON asset", () => {
+  // sw.js writes the guard with double-quoted ".json" — match that exactly so
+  // score/index and on-demand data JSON (market-indices.json, USDAUD.json)
+  // are excluded from the generic cache-first static .json matcher.
+  if (!sw.includes('endsWith(".json") && !isNetworkFirst && !isDataFile')) {
+    throw new Error(
+      "Expected sw.js to exclude data JSON from the static asset .json matcher",
+    );
+  }
+});


### PR DESCRIPTION
# PWA: service worker + registration (Issue #223)

## Summary

Adds the service worker and its registration script so the GRQ Validation
Dashboard can work offline as an installable PWA, mirroring
`stSoftwareAU/GRQ-FX-validation` adapted to this dashboard's file layout.
**Closes #223.**

- **`docs/sw.js`** — versioned caches (`grq-validation-v1.0.186`, plus
  `…-static-…` / `…-dynamic-…`) aligned with the `app-version` meta in
  `index.html` / `docs/version.js`; old `grq-validation-*` caches are cleaned
  up on `activate`. Mirrors FX's install/activate/fetch/message structure:
  - **App shell (precache)** — the static dashboard assets (`./`,
    `index.html`, `list.html`, `app.js`, `list.js`, `projection.js`,
    `escape.js`, `version.js`, `dashboard_boot.js`, `list_render.js`,
    `list_stats.js`, `styles.css`, `list.css`, `manifest.json`, `logo.png`,
    `sw-register.js`) plus the SRI-pinned CDN assets enumerated from the
    `<head>` (Bootstrap 5.3.0 CSS, Bootstrap 5.1.3 JS, Chart.js 4.5.1,
    `chartjs-adapter-date-fns` 3.0.0, `chartjs-plugin-annotation` 3.1.0).
    Precaching is resilient (each asset cached individually), so an entry a
    sibling sub-issue has not landed yet (e.g. `manifest.json`) is simply
    skipped rather than failing the whole install.
  - **Cache-on-demand (dynamic)** for per-day score data, matched by
    `URL.pathname` regexes: `/\/scores\/.*\.(csv|tsv)$/`, plus the on-demand
    data JSON (`market-indices.json`, `USDAUD.json`).
  - **Network-first** for the score index `/\/scores\/index\.json$/` — the
    file `docs/list.js` loads to build the date/score list — so the list never
    goes stale while online, falling back to cache when offline.
- **`docs/sw-register.js`** — an **external** (CSP-safe) registration script:
  registers `./sw.js?v=1.0.186`, forces an update check on load, polls
  `registration.update()` every 30s, forces a reload when a new SW activates,
  and handles SW→page messages. External because the CSP uses
  `script-src 'self'` with no `'unsafe-inline'`.

Wiring `sw-register.js` into `index.html` / `list.html` is intentionally **out
of scope** here — it lands with the paired `<head>`-wiring sub-issue. The
unrelated `Cargo.lock` churn that `quality.sh`'s `cargo update` produces was
reverted to keep this PR focused.

## Evidence

No web UI changes ship in this sub-issue (the service worker is not registered
until the `<head>`-wiring sub-issue loads `sw-register.js`), so there is
nothing new to screenshot. Correctness is verified by the new pathname-guard
tests and the full quality gate (`./quality.sh` passes, 346 Deno tests + Rust
suite green).

Caching-strategy decision flow implemented in `docs/sw.js`:

```mermaid
flowchart TD
    A[fetch GET request] --> B{scores/index.json?}
    B -- yes --> N[Network-first<br/>fall back to cache]
    B -- no --> C{scores/*.csv|tsv<br/>or data JSON?}
    C -- yes --> D[Cache-on-demand<br/>network-first, warn header offline]
    C -- no --> E{static shell asset?<br/>.js/.css/.html/.json}
    E -- yes --> F[Cache-first<br/>fall back to ./index.html for docs]
    E -- no --> G[Cache-first]
```

## Test Plan

- Added `tests/sw_pathname_guards_test.ts` (mirrors FX
  `tests/sw-pathname-guards.test.ts`), asserting that `docs/sw.js`:
  - includes the `URL.pathname` regex `/\/scores\/.*\.(csv|tsv)$/` for per-day
    score data;
  - includes the network-first regex `/\/scores\/index\.json$/`;
  - does **not** contain a `./scores/` string literal (which would never match
    `URL.pathname`);
  - excludes data JSON from the generic cache-first `.json` static matcher
    (`endsWith(".json") && !isNetworkFirst && !isDataFile`).
- Full suite: `./quality.sh` passes (Rust + 346 Deno tests, lint, fmt, type
  checks).
