### PR TITLE
Refresh docs/market-indices.json from the daily scorer job, in lockstep with scores (#238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Pages.
   Refresh it with `deno task fetch-indices`; the write is safe for unattended
   daily runs (fails fast on an empty response, refuses to overwrite committed
   history with a regressed payload, and skips the write when nothing changed).
+  The external daily scorer job refreshes it in lockstep with the scores via
+  the non-blocking `deno task refresh-indices` wrapper (see _Daily benchmark
+  refresh_ below).
 - **Dividend Tracking** — calculate dividend income and total returns.
 - **Web Dashboard** — interactive charts and tables for performance analysis,
   served as a static site from `docs/`.
@@ -42,6 +45,46 @@ The dashboard reads every input from its own origin: per-score market CSVs, the
 score index, and the benchmark-index file. Benchmark data is fetched
 server-side and committed, so a visitor's browser never calls an untrusted
 third-party relay (issue #93).
+
+### Daily benchmark refresh (in lockstep with the scores)
+
+The actuals stay current because an external daily **scorer** job
+(`stSoftwareAU/GRQ`, `worker/score.sh`) checks out this repo and commits new
+`docs/scores/...` and `docs/USDAUD.json` with a message like
+`Add scores for 2026-06-20`. To stop the benchmark indices drifting behind the
+actuals (issue #238), that same job now refreshes `docs/market-indices.json`
+immediately before the daily commit, by invoking the stable wrapper entry point:
+
+```bash
+deno task refresh-indices
+# (raw form: deno run --allow-net --allow-read --allow-write \
+#   scripts/refresh_market_indices.ts)
+```
+
+The wrapper runs the first-party fetcher but **never blocks the scores/USDAUD
+commit**: a Yahoo Finance outage or partial fetch is logged and swallowed (it
+still exits 0), and the safe-write guard in `scripts/fetch_market_indices.ts`
+leaves the committed file at its last-good content rather than a stale/partial
+payload. The scorer's check-in then stages whatever changed (the scores, the
+USDAUD file, and the refreshed indices) into the **same** daily commit, so the
+indices reach the last trading day in lockstep with the actuals.
+
+```mermaid
+sequenceDiagram
+    participant Scorer as Scorer job (GRQ/worker/score.sh)
+    participant Repo as GRQ-validation checkout
+    participant Yahoo as Yahoo Finance
+    Scorer->>Repo: write docs/scores/... + docs/USDAUD.json
+    Scorer->>Repo: deno task refresh-indices
+    Repo->>Yahoo: fetch S&P 500 / NASDAQ / Russell 2000
+    alt fetch succeeds
+        Repo->>Repo: safe-write docs/market-indices.json
+    else fetch fails
+        Repo-->>Repo: log + exit 0, keep last-good file
+    end
+    Scorer->>Repo: model_checkin.sh "Add scores for YYYY-MM-DD"
+    Note over Repo: scores + USDAUD + indices in one commit
+```
 
 ## Quick Start
 
@@ -194,7 +237,8 @@ GRQ-validation/
 ├── tests/                  # Rust and Deno tests
 ├── helpers/                # Local development helpers (e.g. static server)
 ├── scripts/                # Git hooks and utility scripts
-│   └── fetch_market_indices.ts  # Server-side benchmark-index fetcher
+│   ├── fetch_market_indices.ts    # Server-side benchmark-index fetcher
+│   └── refresh_market_indices.ts  # Non-blocking daily-scorer wrapper (#238)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
-    "fetch-indices": "deno run --allow-net --allow-read --allow-write scripts/fetch_market_indices.ts"
+    "fetch-indices": "deno run --allow-net --allow-read --allow-write scripts/fetch_market_indices.ts",
+    "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/docs/archive/pr-summaries/pr-summary-238.md
+++ b/docs/archive/pr-summaries/pr-summary-238.md
@@ -1,0 +1,93 @@
+# PR Summary — Fetch & commit docs/market-indices.json from the daily scorer job (#238)
+
+## Summary
+
+The benchmark index lines on the dashboard lagged the actuals by several days
+because the external daily **scorer** job (`stSoftwareAU/GRQ`, `worker/score.sh`
+— commits authored by `scorer 3`, messages like `Add scores for 2026-06-20`)
+committed new `docs/scores/...` and `docs/USDAUD.json` but never refreshed
+`docs/market-indices.json`. This change makes the indices refresh in **lockstep**
+with the scores, on the same daily cadence and in the **same commit**, while
+keeping the committed same-origin file from #93 (no return to in-browser
+CORS-proxy fetching). `Closes #238.`
+
+It has two parts:
+
+1. **This repo (the stable entry point).** A new non-blocking wrapper,
+   `scripts/refresh_market_indices.ts`, runs the first-party fetcher and, by
+   contract, **never blocks the scores/USDAUD commit**. A Yahoo Finance outage
+   or partial fetch is logged and swallowed (the process still exits 0), and the
+   safe-write guard in `scripts/fetch_market_indices.ts` (#237) leaves the
+   committed file at its last-good content rather than a stale/partial payload.
+   Exposed as `deno task refresh-indices`.
+
+2. **The scorer job (root-cause fix, cross-repo — Issue #2942).** A companion PR
+   against `stSoftwareAU/GRQ` invokes `deno task refresh-indices` inside the
+   existing GRQ-validation checkout immediately before the daily
+   `model_checkin.sh GRQ-validation "Add scores for YYYY-MM-DD"`. Because
+   `model_checkin.sh` stages all local changes, the refreshed
+   `docs/market-indices.json` lands in the **same** daily commit as the scores
+   and `USDAUD.json`.
+
+`scripts/fetch_market_indices.ts` was refactored to export its fetch+safe-write
+routine as `refreshMarketIndices()` so the wrapper can call it in-process (no
+subprocess), which keeps the wrapper unit-testable under the existing
+`deno test --allow-read` quality gate.
+
+## Evidence
+
+This is a backend/CLI change with no web interface to screenshot. It is verified
+by unit tests that exercise the real `refreshIndicesGraceful` function with an
+injected stub refresh + log capturer (no network, no subprocess), asserting the
+non-blocking contract directly.
+
+Data-flow of the daily lockstep refresh:
+
+```mermaid
+sequenceDiagram
+    participant Scorer as Scorer job (GRQ/worker/score.sh)
+    participant Repo as GRQ-validation checkout
+    participant Yahoo as Yahoo Finance
+    Scorer->>Repo: write docs/scores/... + docs/USDAUD.json
+    Scorer->>Repo: deno task refresh-indices
+    Repo->>Yahoo: fetch S&P 500 / NASDAQ / Russell 2000
+    alt fetch succeeds
+        Repo->>Repo: safe-write docs/market-indices.json
+    else fetch fails
+        Repo-->>Repo: log + exit 0, keep last-good file
+    end
+    Scorer->>Repo: model_checkin.sh "Add scores for YYYY-MM-DD"
+    Note over Repo: scores + USDAUD + indices in one commit
+```
+
+Acceptance criteria coverage:
+
+- **Indices reach the actuals' newest trading day** — the refresh runs in the
+  same job, immediately before the same commit, so the indices keep pace (a
+  one-trading-day end-of-day lag is acceptable).
+- **Runs every day automatically** — it is part of the daily scorer job, not a
+  one-off.
+- **Yahoo failure degrades gracefully** — the wrapper exits 0 on failure so the
+  scores/USDAUD commit still happens, and the safe-write guard leaves the indices
+  file at its last-good content (not corrupted).
+
+## Test Plan
+
+Added `tests/refresh_market_indices_test.ts` covering the wrapper's contract:
+
+- `success path returns 0 and logs success` — happy path.
+- `a fetch failure still returns 0 (never blocks the commit)` — failure path;
+  asserts exit code 0 and the "leaving docs/market-indices.json unchanged" log.
+- `surfaces the underlying failure reason in the log` — safe-write guard reason
+  is propagated for diagnostics.
+- `tolerates a non-Error rejection` — edge case (non-Error thrown value).
+
+All 413 Deno tests pass (`deno test --allow-read tests/*.ts`), plus `deno fmt`,
+`deno lint`, and `deno check`. The existing `tests/market_indices_test.ts`
+safe-write guard tests continue to pass against the refactored fetcher.
+
+## Cross-repo change
+
+The companion root-cause fix in `stSoftwareAU/GRQ` (`worker/score.sh`) is raised
+as a separate PR in that repo and is **not** auto-merged (Issue #2944); it is a
+two-line, non-blocking invocation of the stable entry point added here.

--- a/scripts/fetch_market_indices.ts
+++ b/scripts/fetch_market_indices.ts
@@ -188,7 +188,11 @@ async function readExistingDataset(
   }
 }
 
-async function main(): Promise<void> {
+// Fetch every index, apply the safe-write guard, and refresh the committed
+// docs/market-indices.json. Throws on any failure (an empty Yahoo response or a
+// regressed payload) and leaves the committed file untouched in that case, so a
+// graceful caller can swallow the error and keep the last-good file (#238).
+async function refreshMarketIndices(): Promise<void> {
   const fresh: IndexDataset = {};
   for (const [key, symbol] of Object.entries(INDICES)) {
     console.log(`Fetching ${symbol} (${key})...`);
@@ -214,12 +218,13 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  await main();
+  await refreshMarketIndices();
 }
 
 export {
   checkDatasetSafety,
   newestDate,
+  refreshMarketIndices,
   serialiseDataset,
   toPriceMap,
   toUnixSeconds,

--- a/scripts/refresh_market_indices.ts
+++ b/scripts/refresh_market_indices.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S deno run --allow-net --allow-read --allow-write
+//
+// Daily lockstep wrapper for the benchmark indices (issue #238).
+//
+// The external "scorer" job (stSoftwareAU/GRQ, worker/score.sh) checks out this
+// repo and, once a day, commits new docs/scores/... and docs/USDAUD.json with a
+// message like "Add scores for 2026-06-20". Before #238 the benchmark indices
+// (docs/market-indices.json) were not part of that job, so they drifted days
+// behind the actuals.
+//
+// This wrapper is the stable entry point the scorer invokes immediately before
+// that commit, so the indices reach the last trading day in lockstep with the
+// scores + USDAUD:
+//
+//   deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts
+//   (or the deno task form: deno task refresh-indices)
+//
+// Contract: it MUST NOT block the scores/USDAUD commit. A Yahoo Finance outage
+// or partial fetch is logged and swallowed — the process still exits 0, and the
+// safe-write guard in fetch_market_indices.ts guarantees the committed file is
+// left at its last-good content rather than a stale/partial payload. The
+// scorer's checkin then stages whatever (if anything) changed into the SAME
+// daily commit.
+
+import { refreshMarketIndices } from "./fetch_market_indices.ts";
+
+// Run the index refresh, swallowing any failure so the caller's scores/USDAUD
+// commit is never blocked. `refresh` and `log` are injectable for testing.
+// Always resolves to 0 — a non-fatal exit code by contract (#238).
+async function refreshIndicesGraceful(
+  refresh: () => Promise<void> = refreshMarketIndices,
+  log: (msg: string) => void = console.error,
+): Promise<number> {
+  try {
+    await refresh();
+    log("refresh_market_indices: index refresh succeeded");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(
+      "refresh_market_indices: index refresh failed " +
+        `(${message}); leaving docs/market-indices.json unchanged and continuing`,
+    );
+  }
+  // Always succeed: the scores/USDAUD commit must never be blocked (#238).
+  return 0;
+}
+
+if (import.meta.main) {
+  Deno.exit(await refreshIndicesGraceful());
+}
+
+export { refreshIndicesGraceful };

--- a/tests/refresh_market_indices_test.ts
+++ b/tests/refresh_market_indices_test.ts
@@ -1,0 +1,77 @@
+// Daily lockstep wrapper tests (issue #238).
+//
+// The scorer job invokes scripts/refresh_market_indices.ts immediately before
+// its daily scores/USDAUD commit. Its one hard guarantee is that it must NEVER
+// block that commit: whether the underlying Yahoo fetch succeeds or fails, the
+// wrapper logs the outcome and resolves to exit code 0. These tests inject a
+// stub refresh + log capturer (no network, no subprocess) and assert that
+// contract directly against the REAL refreshIndicesGraceful function.
+
+import { assert, assertEquals } from "@std/assert";
+import { refreshIndicesGraceful } from "../scripts/refresh_market_indices.ts";
+
+Deno.test("refreshIndicesGraceful - success path returns 0 and logs success", async () => {
+  const logs: string[] = [];
+  let called = 0;
+  const code = await refreshIndicesGraceful(
+    () => {
+      called++;
+      return Promise.resolve();
+    },
+    (msg) => logs.push(msg),
+  );
+
+  assertEquals(code, 0);
+  assertEquals(called, 1);
+  assert(
+    logs.some((l) => l.includes("succeeded")),
+    "expected a success log line",
+  );
+});
+
+Deno.test("refreshIndicesGraceful - a fetch failure still returns 0 (never blocks the commit)", async () => {
+  const logs: string[] = [];
+  const code = await refreshIndicesGraceful(
+    () => Promise.reject(new Error("Yahoo Finance returned no usable closes")),
+    (msg) => logs.push(msg),
+  );
+
+  // The contract: a failed/partial fetch must not block the scores/USDAUD commit.
+  assertEquals(code, 0);
+  assert(
+    logs.some((l) => l.includes("failed")),
+    "expected a failure log line",
+  );
+  assert(
+    logs.some((l) => l.includes("leaving docs/market-indices.json unchanged")),
+    "failure log must state the committed file is left untouched",
+  );
+});
+
+Deno.test("refreshIndicesGraceful - surfaces the underlying failure reason in the log", async () => {
+  const logs: string[] = [];
+  const code = await refreshIndicesGraceful(
+    () =>
+      Promise.reject(
+        new Error("Refusing to overwrite docs/market-indices.json: regressed"),
+      ),
+    (msg) => logs.push(msg),
+  );
+
+  assertEquals(code, 0);
+  assert(
+    logs.some((l) => l.includes("Refusing to overwrite")),
+    "the safe-write guard's reason should be surfaced for diagnostics",
+  );
+});
+
+Deno.test("refreshIndicesGraceful - tolerates a non-Error rejection", async () => {
+  const logs: string[] = [];
+  const code = await refreshIndicesGraceful(
+    () => Promise.reject("string failure"),
+    (msg) => logs.push(msg),
+  );
+
+  assertEquals(code, 0);
+  assert(logs.some((l) => l.includes("string failure")));
+});


### PR DESCRIPTION
# PR Summary — Fetch & commit docs/market-indices.json from the daily scorer job (#238)

## Summary

The benchmark index lines on the dashboard lagged the actuals by several days
because the external daily **scorer** job (`stSoftwareAU/GRQ`, `worker/score.sh`
— commits authored by `scorer 3`, messages like `Add scores for 2026-06-20`)
committed new `docs/scores/...` and `docs/USDAUD.json` but never refreshed
`docs/market-indices.json`. This change makes the indices refresh in **lockstep**
with the scores, on the same daily cadence and in the **same commit**, while
keeping the committed same-origin file from #93 (no return to in-browser
CORS-proxy fetching). `Closes #238.`

It has two parts:

1. **This repo (the stable entry point).** A new non-blocking wrapper,
   `scripts/refresh_market_indices.ts`, runs the first-party fetcher and, by
   contract, **never blocks the scores/USDAUD commit**. A Yahoo Finance outage
   or partial fetch is logged and swallowed (the process still exits 0), and the
   safe-write guard in `scripts/fetch_market_indices.ts` (#237) leaves the
   committed file at its last-good content rather than a stale/partial payload.
   Exposed as `deno task refresh-indices`.

2. **The scorer job (root-cause fix, cross-repo — Issue #2942).** A companion PR
   against `stSoftwareAU/GRQ` invokes `deno task refresh-indices` inside the
   existing GRQ-validation checkout immediately before the daily
   `model_checkin.sh GRQ-validation "Add scores for YYYY-MM-DD"`. Because
   `model_checkin.sh` stages all local changes, the refreshed
   `docs/market-indices.json` lands in the **same** daily commit as the scores
   and `USDAUD.json`.

`scripts/fetch_market_indices.ts` was refactored to export its fetch+safe-write
routine as `refreshMarketIndices()` so the wrapper can call it in-process (no
subprocess), which keeps the wrapper unit-testable under the existing
`deno test --allow-read` quality gate.

## Evidence

This is a backend/CLI change with no web interface to screenshot. It is verified
by unit tests that exercise the real `refreshIndicesGraceful` function with an
injected stub refresh + log capturer (no network, no subprocess), asserting the
non-blocking contract directly.

Data-flow of the daily lockstep refresh:

```mermaid
sequenceDiagram
    participant Scorer as Scorer job (GRQ/worker/score.sh)
    participant Repo as GRQ-validation checkout
    participant Yahoo as Yahoo Finance
    Scorer->>Repo: write docs/scores/... + docs/USDAUD.json
    Scorer->>Repo: deno task refresh-indices
    Repo->>Yahoo: fetch S&P 500 / NASDAQ / Russell 2000
    alt fetch succeeds
        Repo->>Repo: safe-write docs/market-indices.json
    else fetch fails
        Repo-->>Repo: log + exit 0, keep last-good file
    end
    Scorer->>Repo: model_checkin.sh "Add scores for YYYY-MM-DD"
    Note over Repo: scores + USDAUD + indices in one commit
```

Acceptance criteria coverage:

- **Indices reach the actuals' newest trading day** — the refresh runs in the
  same job, immediately before the same commit, so the indices keep pace (a
  one-trading-day end-of-day lag is acceptable).
- **Runs every day automatically** — it is part of the daily scorer job, not a
  one-off.
- **Yahoo failure degrades gracefully** — the wrapper exits 0 on failure so the
  scores/USDAUD commit still happens, and the safe-write guard leaves the indices
  file at its last-good content (not corrupted).

## Test Plan

Added `tests/refresh_market_indices_test.ts` covering the wrapper's contract:

- `success path returns 0 and logs success` — happy path.
- `a fetch failure still returns 0 (never blocks the commit)` — failure path;
  asserts exit code 0 and the "leaving docs/market-indices.json unchanged" log.
- `surfaces the underlying failure reason in the log` — safe-write guard reason
  is propagated for diagnostics.
- `tolerates a non-Error rejection` — edge case (non-Error thrown value).

All 413 Deno tests pass (`deno test --allow-read tests/*.ts`), plus `deno fmt`,
`deno lint`, and `deno check`. The existing `tests/market_indices_test.ts`
safe-write guard tests continue to pass against the refactored fetcher.

## Cross-repo change

The companion root-cause fix in `stSoftwareAU/GRQ` (`worker/score.sh`) is raised
as a separate PR in that repo and is **not** auto-merged (Issue #2944); it is a
two-line, non-blocking invocation of the stable entry point added here.



## Milestone
This PR is part of the **#234 bug: dashboard benchmark index lines lag the actual data by several days** milestone and targets the `milestone/234-bug-dashboard-benchmark-index-lines-lag-the-ac` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqnizd9x-840cda`<!-- vibe-worker-issue-238 -->