### PR TITLE
Add freshness guard so benchmark indices can't silently lag the actuals (#239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ sequenceDiagram
     Note over Repo: scores + USDAUD + indices in one commit
 ```
 
+### Freshness guard (issue #239)
+
+Keeping the refresh job running is not enough on its own: when the indices last
+drifted (issue #234) the roughly eight-day staleness went **undetected**. A
+freshness assertion in `tests/market_indices_test.ts` now compares the newest
+date in `docs/market-indices.json` against the newest date in the actuals
+(`docs/USDAUD.json`) and fails when the indices lag by more than
+`FRESHNESS_TOLERANCE_TRADING_DAYS` (3) trading days. The gap is measured in
+trading days (weekends skipped), so the acceptable one-trading-day end-of-day
+publishing lag — and an intervening public holiday — never raises a false
+alarm. When the guard trips it names both newest dates and the gap, e.g.
+`benchmark indices are stale: newest index date 2026-06-08 lags the newest
+actuals date 2026-06-18 by 7 trading days (tolerance is 3 trading days)`.
+
 ## Quick Start
 
 ### Prerequisites

--- a/docs/archive/pr-summaries/pr-summary-239.md
+++ b/docs/archive/pr-summaries/pr-summary-239.md
@@ -1,0 +1,65 @@
+## Summary
+
+Adds an automated **freshness guard** so the benchmark indices can't silently
+lag the actuals again (the undetected ~8-day staleness behind #234). A new
+assertion in `tests/market_indices_test.ts` compares the newest date in
+`docs/market-indices.json` against the newest date in the actuals
+(`docs/USDAUD.json`) and fails when the indices lag by more than
+`FRESHNESS_TOLERANCE_TRADING_DAYS` (3) trading days. The gap is counted in
+**trading days** (weekends skipped), so the acceptable one-trading-day
+end-of-day publishing lag — and an intervening public holiday — never raises a
+false alarm. When the guard trips it emits an actionable message naming **both**
+newest dates and the gap. Closes #239.
+
+Part of milestone #234; sequenced after #237 (data refreshed) and #238 (daily
+refresh sustained). The committed data is currently fresh (indices to
+`2026-06-18`, actuals to `2026-06-19` → 1 trading-day gap), so the new check
+passes today.
+
+New pure, unit-tested helpers in `scripts/fetch_market_indices.ts`:
+
+- `tradingDayGap(from, to)` — trading days (Mon–Fri) elapsed after `from` up to
+  and including `to`; non-positive ranges are 0.
+- `datasetNewestDate(dataset)` — newest date across every index in the file.
+- `checkIndexFreshness(indicesNewest, actualsNewest, tolerance?)` — the guard;
+  returns `{ ok, gap, indicesNewest, actualsNewest, reason? }`.
+- `FRESHNESS_TOLERANCE_TRADING_DAYS = 3`.
+
+## Evidence
+
+Backend/CLI-only change — no web interface to screenshot. Verified via the Deno
+test suite and the full `./quality.sh` gate (all green).
+
+```
+deno test --allow-read tests/market_indices_test.ts
+ok | 31 passed | 0 failed
+
+deno test --allow-read tests/*.ts
+ok | 423 passed (55 steps) | 0 failed
+```
+
+```mermaid
+flowchart LR
+    A[docs/market-indices.json] -->|datasetNewestDate| C{checkIndexFreshness}
+    B[docs/USDAUD.json actuals] -->|newestDate| C
+    C -->|gap &le; 3 trading days| P[pass]
+    C -->|gap &gt; 3 trading days| F["fail: names both dates + gap"]
+```
+
+## Test Plan
+
+Added to `tests/market_indices_test.ts`:
+
+- `datasetNewestDate - newest date across every index` — max across indices;
+  empty dataset and empty series yield `""`.
+- `tradingDayGap - identical or backwards dates are zero` — level/ahead/empty.
+- `tradingDayGap - one trading day end-of-day lag` — Thu→Fri = 1.
+- `tradingDayGap - skips weekends` — Fri→Mon = 1; Fri→Fri = 5.
+- `checkIndexFreshness - one-day lag passes within tolerance`.
+- `checkIndexFreshness - indices level with the actuals pass`.
+- `checkIndexFreshness - a weekend gap does not false-alarm`.
+- `checkIndexFreshness - stale indices fail with an actionable message` —
+  asserts the message names both dates and the gap (acceptance criterion 1).
+- `checkIndexFreshness - tolerance boundary` — 3 trading days passes, 4 fails.
+- `committed indices are fresh against the committed actuals` — the real guard
+  over the committed data files (acceptance criterion 2: fresh data passes).

--- a/scripts/fetch_market_indices.ts
+++ b/scripts/fetch_market_indices.ts
@@ -124,6 +124,73 @@ interface SafetyResult {
   reason?: string;
 }
 
+// The newest date across every index in a dataset (the freshest closing price
+// anywhere in the file). ISO dates sort lexically, so this is just the lexical
+// maximum over all indices' date keys. Returns "" for an empty dataset.
+function datasetNewestDate(data: IndexDataset): string {
+  let newest = "";
+  for (const series of Object.values(data)) {
+    const candidate = newestDate(Object.keys(series));
+    if (candidate > newest) newest = candidate;
+  }
+  return newest;
+}
+
+// Count the trading days (Mon–Fri) that elapse strictly after `from` up to and
+// including `to`. Weekends are skipped. Public holidays are not modelled, so
+// this slightly over-estimates true trading days — acceptable because it only
+// ever makes the freshness check more lenient, never falsely strict.
+function tradingDayGap(from: string, to: string): number {
+  if (!from || !to || to <= from) return 0;
+  const cursor = new Date(`${from}T00:00:00Z`);
+  const end = new Date(`${to}T00:00:00Z`);
+  let gap = 0;
+  while (cursor < end) {
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+    const day = cursor.getUTCDay();
+    if (day !== 0 && day !== 6) gap++; // 0 = Sunday, 6 = Saturday
+  }
+  return gap;
+}
+
+// Default freshness tolerance: the benchmark indices may lag the actuals by up
+// to this many trading days before the guard fails. This covers the acceptable
+// one-trading-day end-of-day publishing lag plus a margin for a public holiday,
+// while still catching the multi-day silent staleness that motivated #234/#239.
+const FRESHNESS_TOLERANCE_TRADING_DAYS = 3;
+
+interface FreshnessResult {
+  ok: boolean;
+  gap: number;
+  indicesNewest: string;
+  actualsNewest: string;
+  reason?: string;
+}
+
+// Freshness guard (#239): fail when the benchmark indices lag the actuals by
+// more than `toleranceTradingDays` trading days. Indices level with — or ahead
+// of — the actuals always pass (a non-positive gap is zero trading days).
+function checkIndexFreshness(
+  indicesNewest: string,
+  actualsNewest: string,
+  toleranceTradingDays = FRESHNESS_TOLERANCE_TRADING_DAYS,
+): FreshnessResult {
+  const gap = tradingDayGap(indicesNewest, actualsNewest);
+  const result: FreshnessResult = {
+    ok: gap <= toleranceTradingDays,
+    gap,
+    indicesNewest,
+    actualsNewest,
+  };
+  if (!result.ok) {
+    result.reason =
+      `benchmark indices are stale: newest index date ${indicesNewest} lags ` +
+      `the newest actuals date ${actualsNewest} by ${gap} trading days ` +
+      `(tolerance is ${toleranceTradingDays} trading days)`;
+  }
+  return result;
+}
+
 // Guard against overwriting good committed history with a regressed payload.
 // A fresh dataset is unsafe when, relative to the committed one, it drops an
 // index key, materially truncates an index's history, or lets an index's newest
@@ -223,10 +290,14 @@ if (import.meta.main) {
 
 export {
   checkDatasetSafety,
+  checkIndexFreshness,
+  datasetNewestDate,
+  FRESHNESS_TOLERANCE_TRADING_DAYS,
   newestDate,
   refreshMarketIndices,
   serialiseDataset,
   toPriceMap,
   toUnixSeconds,
+  tradingDayGap,
 };
-export type { IndexDataset, SafetyResult };
+export type { FreshnessResult, IndexDataset, SafetyResult };

--- a/tests/market_indices_test.ts
+++ b/tests/market_indices_test.ts
@@ -11,11 +11,15 @@ import { assert, assertEquals } from "@std/assert";
 import "../docs/projection.js";
 import {
   checkDatasetSafety,
+  checkIndexFreshness,
+  datasetNewestDate,
+  FRESHNESS_TOLERANCE_TRADING_DAYS,
   type IndexDataset,
   newestDate,
   serialiseDataset,
   toPriceMap,
   toUnixSeconds,
+  tradingDayGap,
 } from "../scripts/fetch_market_indices.ts";
 
 interface IndexSeries {
@@ -252,4 +256,94 @@ Deno.test("committed benchmark data flows through the dashboard kernel", async (
   assert(series.data.length > 0);
   assert(typeof series.initialPrice === "number");
   assert(typeof series.currentPrice === "number");
+});
+
+// --- Freshness guard: indices must not silently lag the actuals (issue #239) ---
+
+Deno.test("datasetNewestDate - newest date across every index", () => {
+  const data: IndexDataset = {
+    sp500: { "2024-01-02": 1, "2024-01-05": 2 },
+    nasdaq: { "2024-01-02": 1, "2024-01-04": 2 },
+    russell2000: { "2024-01-03": 1 },
+  };
+  assertEquals(datasetNewestDate(data), "2024-01-05");
+  assertEquals(datasetNewestDate({}), "");
+  assertEquals(datasetNewestDate({ sp500: {} }), "");
+});
+
+Deno.test("tradingDayGap - identical or backwards dates are zero", () => {
+  assertEquals(tradingDayGap("2026-06-18", "2026-06-18"), 0);
+  // Indices ahead of the actuals: no lag.
+  assertEquals(tradingDayGap("2026-06-19", "2026-06-18"), 0);
+  assertEquals(tradingDayGap("", "2026-06-18"), 0);
+});
+
+Deno.test("tradingDayGap - one trading day end-of-day lag", () => {
+  // Thursday -> Friday is a single trading day.
+  assertEquals(tradingDayGap("2026-06-18", "2026-06-19"), 1);
+});
+
+Deno.test("tradingDayGap - skips weekends", () => {
+  // Friday -> Monday is one trading day (the weekend does not count).
+  assertEquals(tradingDayGap("2026-06-19", "2026-06-22"), 1);
+  // Friday -> following Friday spans only five trading days.
+  assertEquals(tradingDayGap("2026-06-19", "2026-06-26"), 5);
+});
+
+Deno.test("checkIndexFreshness - one-day lag passes within tolerance", () => {
+  const result = checkIndexFreshness("2026-06-18", "2026-06-19");
+  assertEquals(result.ok, true);
+  assertEquals(result.gap, 1);
+  assertEquals(result.reason, undefined);
+});
+
+Deno.test("checkIndexFreshness - indices level with the actuals pass", () => {
+  const result = checkIndexFreshness("2026-06-19", "2026-06-19");
+  assertEquals(result.ok, true);
+  assertEquals(result.gap, 0);
+});
+
+Deno.test("checkIndexFreshness - a weekend gap does not false-alarm", () => {
+  // Indices to Friday, actuals to the following Monday: one trading day.
+  const result = checkIndexFreshness("2026-06-19", "2026-06-22");
+  assertEquals(result.ok, true);
+  assertEquals(result.gap, 1);
+});
+
+Deno.test("checkIndexFreshness - stale indices fail with an actionable message", () => {
+  // Indices roughly eight calendar days behind the actuals (the #234 symptom).
+  const result = checkIndexFreshness("2026-06-08", "2026-06-18");
+  assertEquals(result.ok, false);
+  assert(result.gap > FRESHNESS_TOLERANCE_TRADING_DAYS);
+  // The failure message names both dates and the gap.
+  assert(result.reason);
+  assert(result.reason.includes("2026-06-08"), "names the indices date");
+  assert(result.reason.includes("2026-06-18"), "names the actuals date");
+  assert(result.reason.includes(String(result.gap)), "names the gap");
+});
+
+Deno.test("checkIndexFreshness - tolerance boundary", () => {
+  // Exactly three trading days behind is still acceptable; four is not.
+  assertEquals(checkIndexFreshness("2026-06-15", "2026-06-18").gap, 3);
+  assertEquals(checkIndexFreshness("2026-06-15", "2026-06-18").ok, true);
+  assertEquals(checkIndexFreshness("2026-06-12", "2026-06-18").gap, 4);
+  assertEquals(checkIndexFreshness("2026-06-12", "2026-06-18").ok, false);
+});
+
+Deno.test("committed indices are fresh against the committed actuals", async () => {
+  const indices = JSON.parse(
+    await Deno.readTextFile("docs/market-indices.json"),
+  ) as IndexDataset;
+  const actuals = JSON.parse(
+    await Deno.readTextFile("docs/USDAUD.json"),
+  ) as Record<string, number>;
+
+  const indicesNewest = datasetNewestDate(indices);
+  const actualsNewest = newestDate(Object.keys(actuals));
+
+  const result = checkIndexFreshness(indicesNewest, actualsNewest);
+  assert(
+    result.ok,
+    result.reason ?? "committed benchmark indices lag the committed actuals",
+  );
 });


### PR DESCRIPTION
## Summary

Adds an automated **freshness guard** so the benchmark indices can't silently
lag the actuals again (the undetected ~8-day staleness behind #234). A new
assertion in `tests/market_indices_test.ts` compares the newest date in
`docs/market-indices.json` against the newest date in the actuals
(`docs/USDAUD.json`) and fails when the indices lag by more than
`FRESHNESS_TOLERANCE_TRADING_DAYS` (3) trading days. The gap is counted in
**trading days** (weekends skipped), so the acceptable one-trading-day
end-of-day publishing lag — and an intervening public holiday — never raises a
false alarm. When the guard trips it emits an actionable message naming **both**
newest dates and the gap. Closes #239.

Part of milestone #234; sequenced after #237 (data refreshed) and #238 (daily
refresh sustained). The committed data is currently fresh (indices to
`2026-06-18`, actuals to `2026-06-19` → 1 trading-day gap), so the new check
passes today.

New pure, unit-tested helpers in `scripts/fetch_market_indices.ts`:

- `tradingDayGap(from, to)` — trading days (Mon–Fri) elapsed after `from` up to
  and including `to`; non-positive ranges are 0.
- `datasetNewestDate(dataset)` — newest date across every index in the file.
- `checkIndexFreshness(indicesNewest, actualsNewest, tolerance?)` — the guard;
  returns `{ ok, gap, indicesNewest, actualsNewest, reason? }`.
- `FRESHNESS_TOLERANCE_TRADING_DAYS = 3`.

## Evidence

Backend/CLI-only change — no web interface to screenshot. Verified via the Deno
test suite and the full `./quality.sh` gate (all green).

```
deno test --allow-read tests/market_indices_test.ts
ok | 31 passed | 0 failed

deno test --allow-read tests/*.ts
ok | 423 passed (55 steps) | 0 failed
```

```mermaid
flowchart LR
    A[docs/market-indices.json] -->|datasetNewestDate| C{checkIndexFreshness}
    B[docs/USDAUD.json actuals] -->|newestDate| C
    C -->|gap &le; 3 trading days| P[pass]
    C -->|gap &gt; 3 trading days| F["fail: names both dates + gap"]
```

## Test Plan

Added to `tests/market_indices_test.ts`:

- `datasetNewestDate - newest date across every index` — max across indices;
  empty dataset and empty series yield `""`.
- `tradingDayGap - identical or backwards dates are zero` — level/ahead/empty.
- `tradingDayGap - one trading day end-of-day lag` — Thu→Fri = 1.
- `tradingDayGap - skips weekends` — Fri→Mon = 1; Fri→Fri = 5.
- `checkIndexFreshness - one-day lag passes within tolerance`.
- `checkIndexFreshness - indices level with the actuals pass`.
- `checkIndexFreshness - a weekend gap does not false-alarm`.
- `checkIndexFreshness - stale indices fail with an actionable message` —
  asserts the message names both dates and the gap (acceptance criterion 1).
- `checkIndexFreshness - tolerance boundary` — 3 trading days passes, 4 fails.
- `committed indices are fresh against the committed actuals` — the real guard
  over the committed data files (acceptance criterion 2: fresh data passes).



## Milestone
This PR is part of the **#234 bug: dashboard benchmark index lines lag the actual data by several days** milestone and targets the `milestone/234-bug-dashboard-benchmark-index-lines-lag-the-ac` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqnizd9x-840cda`<!-- vibe-worker-issue-239 -->