### PR TITLE
Retire list.* from PWA precache + bump cache version (#253)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-253.md
+++ b/docs/archive/pr-summaries/pr-summary-253.md
@@ -1,0 +1,54 @@
+# Retire `list.*` from the PWA service-worker precache + bump cache version
+
+## Summary
+The `list.*` pages were retired from the dashboard, but the PWA service worker
+(`docs/sw.js`) still precached them and its comments still named `list.html`.
+This change removes the dead precache entries and bumps the aligned app/cache
+version so existing visitors drop any stale cached `list.html`.
+
+- `docs/sw.js` — dropped `./list.html`, `./list.js`, `./list_render.js`,
+  `./list_stats.js`, `./list.css` from `STATIC_ASSETS`; updated the two
+  comments that named `list.html`.
+- Bumped the aligned version **1.0.189 → 1.0.190** across `docs/sw.js`
+  (`APP_VERSION`, drives the cache names), `docs/sw-register.js`
+  (`./sw.js?v=`, forces a fresh `sw.js` fetch) and `docs/index.html`
+  (`app-version` meta + `sw-register.js?v=` script tag).
+- Fixed the `docs/sw-register.js` header comment that named `list.html`.
+
+The cache version was already `1.0.189` on the milestone branch (the issue
+referenced `1.0.187`), so the bump moves the three files together to the next
+patch, `1.0.190`.
+
+Closes #253
+
+## Evidence
+Backend/PWA config change — no web UI to screenshot. Verified via Deno tests.
+
+```mermaid
+flowchart LR
+    A[Bump APP_VERSION 1.0.189 -> 1.0.190] --> B[New cache names grq-validation-v1.0.190]
+    B --> C[activate handler deletes non-matching caches]
+    C --> D[Stale cached list.html purged]
+```
+
+Test run:
+
+```
+running 4 tests from ./tests/sw_precache_list_test.ts
+sw.js STATIC_ASSETS no longer precaches any list.* file ... ok
+sw.js contains no remaining list.html reference (comments included) ... ok
+sw-register.js contains no remaining list.html reference ... ok
+app/cache version is aligned across sw.js, sw-register.js and index.html ... ok
+running 4 tests from ./tests/sw_pathname_guards_test.ts
+... ok | 8 passed | 0 failed
+```
+
+## Test Plan
+- Added `tests/sw_precache_list_test.ts`:
+  - `STATIC_ASSETS` no longer precaches any `list.*` file (reproduces the issue).
+  - No remaining `list.html` reference in `docs/sw.js` (comments included).
+  - No remaining `list.html` reference in `docs/sw-register.js`.
+  - App/cache version aligned across `docs/sw.js`, `docs/sw-register.js`,
+    `docs/index.html` (meta + script tag).
+- `tests/sw_pathname_guards_test.ts` still passes — fetch-routing regexes unchanged.
+- `./quality.sh` passes cleanly.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.189">
+    <meta name="app-version" content="1.0.190">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -316,6 +316,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.189"></script>
+    <script src="sw-register.js?v=1.0.190"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -1,8 +1,8 @@
 // Service worker registration for the GRQ Validation Dashboard (issue #223).
 //
 // Australian English: an external registration script (not an inline
-// <script>) so docs/index.html and docs/list.html can keep a strict
-// Content-Security-Policy with script-src 'self' and no 'unsafe-inline'.
+// <script>) so docs/index.html can keep a strict Content-Security-Policy
+// with script-src 'self' and no 'unsafe-inline'.
 // Behaviour mirrors the FX dashboard: register ./sw.js, force an update check
 // on load, poll registration.update() every 30 seconds, force a reload when a
 // new service worker activates, and handle service-worker → page messages.
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.189")
+    navigator.serviceWorker.register("./sw.js?v=1.0.190")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,36 +6,31 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.189";
+const APP_VERSION = "1.0.190";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;
 
 // App shell — static dashboard assets precached on install. Enumerated from
-// the <head> of docs/index.html and docs/list.html so the list stays in sync;
-// bump APP_VERSION when the SRI pins below change. Entries that do not yet
-// exist (e.g. manifest.json added by a sibling sub-issue) are simply skipped
-// during precache rather than failing the whole install.
+// the <head> of docs/index.html so the list stays in sync; bump APP_VERSION
+// when the SRI pins below change. Entries that do not yet exist (e.g.
+// manifest.json added by a sibling sub-issue) are simply skipped during
+// precache rather than failing the whole install.
 const STATIC_ASSETS = [
   "./",
   "./index.html",
-  "./list.html",
   "./app.js",
-  "./list.js",
   "./projection.js",
   "./color_key.js",
   "./escape.js",
   "./version.js",
   "./theme.js",
   "./dashboard_boot.js",
-  "./list_render.js",
-  "./list_stats.js",
   "./styles.css",
-  "./list.css",
   "./manifest.json",
   "./logo.png",
   "./sw-register.js",
-  // SRI-pinned CDN assets from docs/index.html / docs/list.html (issue #79).
+  // SRI-pinned CDN assets from docs/index.html (issue #79).
   // Bump APP_VERSION whenever these pins change so the integrity hashes are
   // re-validated.
   "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css",

--- a/tests/sw_precache_list_test.ts
+++ b/tests/sw_precache_list_test.ts
@@ -1,0 +1,77 @@
+// Service worker precache + version-alignment guards (issue #253).
+//
+// Australian English: after the list.* pages were retired from the dashboard,
+// the PWA service worker must no longer precache them, and must not reference
+// list.html in code or comments. The app/cache version is intentionally
+// aligned across docs/sw.js, docs/sw-register.js and docs/index.html so that
+// bumping it purges stale caches (including any cached list.html).
+
+const sw = await Deno.readTextFile(new URL("../docs/sw.js", import.meta.url));
+const swRegister = await Deno.readTextFile(
+  new URL("../docs/sw-register.js", import.meta.url),
+);
+const indexHtml = await Deno.readTextFile(
+  new URL("../docs/index.html", import.meta.url),
+);
+
+const LIST_ASSETS = [
+  "./list.html",
+  "./list.js",
+  "./list_render.js",
+  "./list_stats.js",
+  "./list.css",
+];
+
+Deno.test("sw.js STATIC_ASSETS no longer precaches any list.* file", () => {
+  for (const asset of LIST_ASSETS) {
+    if (sw.includes(`"${asset}"`)) {
+      throw new Error(
+        `Expected sw.js STATIC_ASSETS to drop ${asset}, but it is still listed`,
+      );
+    }
+  }
+});
+
+Deno.test("sw.js contains no remaining list.html reference (comments included)", () => {
+  if (sw.includes("list.html")) {
+    throw new Error("sw.js still references list.html");
+  }
+});
+
+Deno.test("sw-register.js contains no remaining list.html reference", () => {
+  if (swRegister.includes("list.html")) {
+    throw new Error("sw-register.js still references list.html");
+  }
+});
+
+Deno.test("app/cache version is aligned across sw.js, sw-register.js and index.html", () => {
+  const appVersion = sw.match(/const APP_VERSION = "([^"]+)";/)?.[1];
+  if (!appVersion) {
+    throw new Error("Could not find APP_VERSION in sw.js");
+  }
+
+  const registerVersion = swRegister.match(/\.\/sw\.js\?v=([0-9.]+)/)?.[1];
+  if (registerVersion !== appVersion) {
+    throw new Error(
+      `sw-register.js registers v=${registerVersion}, expected ${appVersion}`,
+    );
+  }
+
+  const metaVersion = indexHtml.match(
+    /<meta name="app-version" content="([^"]+)">/,
+  )?.[1];
+  if (metaVersion !== appVersion) {
+    throw new Error(
+      `index.html app-version meta is ${metaVersion}, expected ${appVersion}`,
+    );
+  }
+
+  const registerScriptVersion = indexHtml.match(
+    /sw-register\.js\?v=([0-9.]+)/,
+  )?.[1];
+  if (registerScriptVersion !== appVersion) {
+    throw new Error(
+      `index.html sw-register.js script tag is v=${registerScriptVersion}, expected ${appVersion}`,
+    );
+  }
+});


### PR DESCRIPTION
# Retire `list.*` from the PWA service-worker precache + bump cache version

## Summary
The `list.*` pages were retired from the dashboard, but the PWA service worker
(`docs/sw.js`) still precached them and its comments still named `list.html`.
This change removes the dead precache entries and bumps the aligned app/cache
version so existing visitors drop any stale cached `list.html`.

- `docs/sw.js` — dropped `./list.html`, `./list.js`, `./list_render.js`,
  `./list_stats.js`, `./list.css` from `STATIC_ASSETS`; updated the two
  comments that named `list.html`.
- Bumped the aligned version **1.0.189 → 1.0.190** across `docs/sw.js`
  (`APP_VERSION`, drives the cache names), `docs/sw-register.js`
  (`./sw.js?v=`, forces a fresh `sw.js` fetch) and `docs/index.html`
  (`app-version` meta + `sw-register.js?v=` script tag).
- Fixed the `docs/sw-register.js` header comment that named `list.html`.

The cache version was already `1.0.189` on the milestone branch (the issue
referenced `1.0.187`), so the bump moves the three files together to the next
patch, `1.0.190`.

Closes #253

## Evidence
Backend/PWA config change — no web UI to screenshot. Verified via Deno tests.

```mermaid
flowchart LR
    A[Bump APP_VERSION 1.0.189 -> 1.0.190] --> B[New cache names grq-validation-v1.0.190]
    B --> C[activate handler deletes non-matching caches]
    C --> D[Stale cached list.html purged]
```

Test run:

```
running 4 tests from ./tests/sw_precache_list_test.ts
sw.js STATIC_ASSETS no longer precaches any list.* file ... ok
sw.js contains no remaining list.html reference (comments included) ... ok
sw-register.js contains no remaining list.html reference ... ok
app/cache version is aligned across sw.js, sw-register.js and index.html ... ok
running 4 tests from ./tests/sw_pathname_guards_test.ts
... ok | 8 passed | 0 failed
```

## Test Plan
- Added `tests/sw_precache_list_test.ts`:
  - `STATIC_ASSETS` no longer precaches any `list.*` file (reproduces the issue).
  - No remaining `list.html` reference in `docs/sw.js` (comments included).
  - No remaining `list.html` reference in `docs/sw-register.js`.
  - App/cache version aligned across `docs/sw.js`, `docs/sw-register.js`,
    `docs/index.html` (meta + script tag).
- `tests/sw_pathname_guards_test.ts` still passes — fetch-routing regexes unchanged.
- `./quality.sh` passes cleanly.