### PR TITLE
Add behaviour tests for create_market_data_csv (Issue #265)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -96,9 +102,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -195,6 +201,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -336,10 +374,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -349,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -383,9 +422,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -433,6 +472,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -494,7 +555,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -596,6 +657,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/docs/archive/pr-summaries/pr-summary-265.md
+++ b/docs/archive/pr-summaries/pr-summary-265.md
@@ -1,0 +1,67 @@
+## Summary
+
+Closes #265.
+
+`create_market_data_csv` (`src/utils.rs:406`) and its thin wrapper
+`create_market_data_csv_for_score_file` (`src/utils.rs:391`) were the only
+market-data writers with **no** test exercising them, directly or indirectly —
+an asymmetric gap, since the long-format variant
+(`create_market_data_long_csv_for_score_file`) is already covered by
+`tests/market_data_tests.rs`. A refactor of the date-windowing or CSV-writing
+logic could silently change the produced file with nothing to catch it.
+
+This PR adds `tests/create_market_data_csv_test.rs` with two WHAT-tests that pin
+the public contract — the `date,symbol,close` header and the inclusive 180-day
+window filter — without asserting how the function computes them. No production
+code changed; this is a pure coverage addition.
+
+### Hermetic, not environment-dependent
+
+The existing market-data tests **skip** when the external
+`MARKET_DATA_BASE_PATH` repository is absent, so they provide no safety net in
+CI. To always run and stay deterministic, each new test installs a small,
+fully controlled market-data fixture at the exact location the function reads
+from, then removes exactly what it created on drop (via an RAII guard) — leaving
+no trace whether or not the external data repository pre-exists. The fixture
+uses a clearly-synthetic symbol (`GRQVTEST265`) so it can never collide with a
+real symbol.
+
+```mermaid
+flowchart LR
+    A[Install fixture<br/>GRQVTEST265.json] --> B[create_market_data_csv]
+    B --> C[md.csv]
+    C --> D{Assertions}
+    D --> E[header = date,symbol,close]
+    D --> F[in-window row present]
+    D --> G[before/after-window rows excluded]
+    C --> H[RAII drop removes fixture]
+```
+
+## Evidence
+
+Backend/CLI change with no web interface — no screenshot applicable. Verified
+via the test suite:
+
+- `cargo test --test create_market_data_csv_test` → `2 passed; 0 failed`.
+- Full suite `cargo test --all-targets --all-features` → all green (lib 50
+  passed, integration targets all passed).
+- `./quality.sh` completes with `✅ Quality checks completed successfully!`
+  (fmt, clippy `-D warnings`, type checks, tests, coverage, Deno checks).
+
+The fixture leaves no residue: `../GRQ-shareprices2026Q2` does not exist after
+the run when it was absent beforehand.
+
+## Test Plan
+
+Added `tests/create_market_data_csv_test.rs`:
+
+- `create_market_data_csv_writes_windowed_rows` — asserts the `date,symbol,close`
+  header, that the window-start row (`2025-04-15`) is present with its close
+  price, and that rows before (`2024-01-01`) and after (`2025-12-01`) the
+  180-day window are excluded.
+- `create_market_data_csv_for_score_file_writes_derived_csv` — asserts the
+  wrapper writes the CSV at the derived `<stem>.csv` path with the same header
+  and in-window row.
+
+A regression in the window filter (leaking out-of-window rows) or the header
+contract would now fail these assertions.

--- a/tests/create_market_data_csv_test.rs
+++ b/tests/create_market_data_csv_test.rs
@@ -16,15 +16,19 @@ use grq_validation::utils::{
 };
 use std::path::{Path, PathBuf};
 
-/// A unique, clearly-synthetic symbol so the fixture can never collide with a
-/// real symbol in an existing `MARKET_DATA_BASE_PATH` data repository.
-const FIXTURE_SYMBOL: &str = "GRQVTEST265";
+/// Clearly-synthetic symbols so a fixture can never collide with a real symbol
+/// in an existing `MARKET_DATA_BASE_PATH` data repository. Each test uses a
+/// distinct symbol so the fixtures live at distinct paths and never race when
+/// the test harness runs them in parallel (one test's `Drop` must not delete a
+/// fixture another test is still reading).
+const FIXTURE_SYMBOL_DIRECT: &str = "GRQVTEST265A";
+const FIXTURE_SYMBOL_WRAPPER: &str = "GRQVTEST265B";
 
 /// Score-file date used by every test; the 180-day window therefore runs from
 /// `2025-04-15` to `2025-10-12` inclusive.
 const SCORE_DATE: &str = "2025-04-15";
 
-/// RAII guard that installs a market-data fixture for [`FIXTURE_SYMBOL`] under
+/// RAII guard that installs a market-data fixture for a given symbol under
 /// `MARKET_DATA_BASE_PATH` and removes exactly what it created on drop, so the
 /// test leaves no trace whether or not the external data repository pre-exists.
 struct MarketDataFixture {
@@ -35,12 +39,12 @@ struct MarketDataFixture {
 }
 
 impl MarketDataFixture {
-    /// Writes a fixture whose daily series contains one row inside the 180-day
-    /// window, one row before it, and one row after it, so a test can assert
-    /// both inclusion and exclusion.
-    fn install() -> Result<Self> {
+    /// Writes a fixture for `symbol` whose daily series contains one row inside
+    /// the 180-day window, one row before it, and one row after it, so a test
+    /// can assert both inclusion and exclusion.
+    fn install(symbol: &str) -> Result<Self> {
         let base = Path::new(MARKET_DATA_BASE_PATH);
-        let first_letter = FIXTURE_SYMBOL.chars().next().unwrap().to_string();
+        let first_letter = symbol.chars().next().unwrap().to_string();
         let symbol_dir = base.join("data").join(&first_letter);
 
         // Track the outermost component we create so cleanup removes no more
@@ -48,8 +52,8 @@ impl MarketDataFixture {
         let created_root = first_missing_ancestor(&symbol_dir);
         std::fs::create_dir_all(&symbol_dir)?;
 
-        let json_path = symbol_dir.join(format!("{FIXTURE_SYMBOL}.json"));
-        std::fs::write(&json_path, fixture_json())?;
+        let json_path = symbol_dir.join(format!("{symbol}.json"));
+        std::fs::write(&json_path, fixture_json(symbol))?;
 
         Ok(Self {
             json_path,
@@ -61,8 +65,22 @@ impl MarketDataFixture {
 impl Drop for MarketDataFixture {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.json_path);
+
+        // Prune the directories we created, bottom-up, removing each only when
+        // it is empty. `remove_dir` (not `remove_dir_all`) means a directory
+        // shared with a concurrently-running test's fixture is left intact
+        // until that test has cleaned up too, so cleanup never races.
         if let Some(root) = &self.created_root {
-            let _ = std::fs::remove_dir_all(root);
+            let mut dir = self.json_path.parent().map(Path::to_path_buf);
+            while let Some(current) = dir {
+                if std::fs::remove_dir(&current).is_err() {
+                    break; // non-empty (another fixture present) or already gone
+                }
+                if current == *root {
+                    break;
+                }
+                dir = current.parent().map(Path::to_path_buf);
+            }
         }
     }
 }
@@ -86,7 +104,7 @@ fn first_missing_ancestor(dir: &Path) -> Option<PathBuf> {
 
 /// Builds an Alpha Vantage-shaped market-data JSON document with three dated
 /// rows: before, inside, and after the 180-day window from [`SCORE_DATE`].
-fn fixture_json() -> String {
+fn fixture_json(symbol: &str) -> String {
     fn daily(close: &str) -> serde_json::Value {
         serde_json::json!({
             "1. open": close,
@@ -103,7 +121,7 @@ fn fixture_json() -> String {
     serde_json::json!({
         "Meta Data": {
             "1. Information": "Daily Prices (fixture)",
-            "2. Symbol": FIXTURE_SYMBOL,
+            "2. Symbol": symbol,
             "3. Last Refreshed": "2025-10-12",
             "4. Output Size": "Full size",
             "5. Time Zone": "US/Eastern",
@@ -119,13 +137,13 @@ fn fixture_json() -> String {
 
 #[test]
 fn create_market_data_csv_writes_windowed_rows() -> Result<()> {
-    let _fixture = MarketDataFixture::install()?;
+    let _fixture = MarketDataFixture::install(FIXTURE_SYMBOL_DIRECT)?;
 
     let out_dir = tempfile::tempdir()?;
     let out_path = out_dir.path().join("md.csv");
     let out = out_path.to_str().expect("temp path is valid UTF-8");
 
-    create_market_data_csv(&[FIXTURE_SYMBOL.to_string()], SCORE_DATE, out)?;
+    create_market_data_csv(&[FIXTURE_SYMBOL_DIRECT.to_string()], SCORE_DATE, out)?;
 
     let csv = std::fs::read_to_string(&out_path)?;
 
@@ -138,7 +156,7 @@ fn create_market_data_csv_writes_windowed_rows() -> Result<()> {
 
     // In-window row present with its close price.
     assert!(
-        csv.contains(&format!("2025-04-15,{FIXTURE_SYMBOL},100.5")),
+        csv.contains(&format!("2025-04-15,{FIXTURE_SYMBOL_DIRECT},100.5")),
         "expected the window-start row in:\n{csv}"
     );
 
@@ -157,7 +175,7 @@ fn create_market_data_csv_writes_windowed_rows() -> Result<()> {
 
 #[test]
 fn create_market_data_csv_for_score_file_writes_derived_csv() -> Result<()> {
-    let _fixture = MarketDataFixture::install()?;
+    let _fixture = MarketDataFixture::install(FIXTURE_SYMBOL_WRAPPER)?;
 
     // The wrapper derives the output path by swapping the score file's
     // extension to `.csv` in the same directory.
@@ -168,7 +186,7 @@ fn create_market_data_csv_for_score_file_writes_derived_csv() -> Result<()> {
 
     create_market_data_csv_for_score_file(
         score_file_str,
-        &[FIXTURE_SYMBOL.to_string()],
+        &[FIXTURE_SYMBOL_WRAPPER.to_string()],
         SCORE_DATE,
     )?;
 
@@ -180,7 +198,7 @@ fn create_market_data_csv_for_score_file_writes_derived_csv() -> Result<()> {
 
     let csv = std::fs::read_to_string(&derived)?;
     assert_eq!(csv.lines().next().unwrap(), "date,symbol,close");
-    assert!(csv.contains(&format!("2025-04-15,{FIXTURE_SYMBOL},100.5")));
+    assert!(csv.contains(&format!("2025-04-15,{FIXTURE_SYMBOL_WRAPPER},100.5")));
 
     Ok(())
 }

--- a/tests/create_market_data_csv_test.rs
+++ b/tests/create_market_data_csv_test.rs
@@ -1,0 +1,186 @@
+//! Behaviour tests for `create_market_data_csv` and its wrapper
+//! `create_market_data_csv_for_score_file` (issue #265).
+//!
+//! These were previously the only market-data writers with no test exercising
+//! them, directly or indirectly. Rather than depend on the external
+//! `MARKET_DATA_BASE_PATH` data repository (which is absent in CI and makes the
+//! sibling long-format test skip), each test drops a small, fully controlled
+//! market-data fixture at the location the function reads from, asserts the
+//! observable CSV output, then removes the fixture again. The assertions pin
+//! the public contract — the `date,symbol,close` header and the inclusive
+//! 180-day window filter — without caring how the function computes them.
+
+use anyhow::Result;
+use grq_validation::utils::{
+    create_market_data_csv, create_market_data_csv_for_score_file, MARKET_DATA_BASE_PATH,
+};
+use std::path::{Path, PathBuf};
+
+/// A unique, clearly-synthetic symbol so the fixture can never collide with a
+/// real symbol in an existing `MARKET_DATA_BASE_PATH` data repository.
+const FIXTURE_SYMBOL: &str = "GRQVTEST265";
+
+/// Score-file date used by every test; the 180-day window therefore runs from
+/// `2025-04-15` to `2025-10-12` inclusive.
+const SCORE_DATE: &str = "2025-04-15";
+
+/// RAII guard that installs a market-data fixture for [`FIXTURE_SYMBOL`] under
+/// `MARKET_DATA_BASE_PATH` and removes exactly what it created on drop, so the
+/// test leaves no trace whether or not the external data repository pre-exists.
+struct MarketDataFixture {
+    json_path: PathBuf,
+    /// The outermost directory this guard created (and must remove on drop), or
+    /// `None` when the whole tree already existed.
+    created_root: Option<PathBuf>,
+}
+
+impl MarketDataFixture {
+    /// Writes a fixture whose daily series contains one row inside the 180-day
+    /// window, one row before it, and one row after it, so a test can assert
+    /// both inclusion and exclusion.
+    fn install() -> Result<Self> {
+        let base = Path::new(MARKET_DATA_BASE_PATH);
+        let first_letter = FIXTURE_SYMBOL.chars().next().unwrap().to_string();
+        let symbol_dir = base.join("data").join(&first_letter);
+
+        // Track the outermost component we create so cleanup removes no more
+        // than the test added.
+        let created_root = first_missing_ancestor(&symbol_dir);
+        std::fs::create_dir_all(&symbol_dir)?;
+
+        let json_path = symbol_dir.join(format!("{FIXTURE_SYMBOL}.json"));
+        std::fs::write(&json_path, fixture_json())?;
+
+        Ok(Self {
+            json_path,
+            created_root,
+        })
+    }
+}
+
+impl Drop for MarketDataFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.json_path);
+        if let Some(root) = &self.created_root {
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+}
+
+/// Returns the shallowest ancestor of `dir` (including `dir` itself) that does
+/// not yet exist, i.e. the outermost directory `create_dir_all` would create.
+/// Returns `None` when `dir` already exists.
+fn first_missing_ancestor(dir: &Path) -> Option<PathBuf> {
+    if dir.exists() {
+        return None;
+    }
+    let mut candidate = dir.to_path_buf();
+    while let Some(parent) = candidate.parent() {
+        if parent.exists() {
+            return Some(candidate);
+        }
+        candidate = parent.to_path_buf();
+    }
+    Some(candidate)
+}
+
+/// Builds an Alpha Vantage-shaped market-data JSON document with three dated
+/// rows: before, inside, and after the 180-day window from [`SCORE_DATE`].
+fn fixture_json() -> String {
+    fn daily(close: &str) -> serde_json::Value {
+        serde_json::json!({
+            "1. open": close,
+            "2. high": close,
+            "3. low": close,
+            "4. close": close,
+            "5. adjusted close": close,
+            "6. volume": "1000",
+            "7. dividend amount": "0.0",
+            "8. split coefficient": "1.0",
+        })
+    }
+
+    serde_json::json!({
+        "Meta Data": {
+            "1. Information": "Daily Prices (fixture)",
+            "2. Symbol": FIXTURE_SYMBOL,
+            "3. Last Refreshed": "2025-10-12",
+            "4. Output Size": "Full size",
+            "5. Time Zone": "US/Eastern",
+        },
+        "Time Series (Daily)": {
+            "2024-01-01": daily("11.11"), // before the window -> excluded
+            "2025-04-15": daily("100.5"), // window start (inclusive) -> included
+            "2025-12-01": daily("99.99"), // after the window -> excluded
+        },
+    })
+    .to_string()
+}
+
+#[test]
+fn create_market_data_csv_writes_windowed_rows() -> Result<()> {
+    let _fixture = MarketDataFixture::install()?;
+
+    let out_dir = tempfile::tempdir()?;
+    let out_path = out_dir.path().join("md.csv");
+    let out = out_path.to_str().expect("temp path is valid UTF-8");
+
+    create_market_data_csv(&[FIXTURE_SYMBOL.to_string()], SCORE_DATE, out)?;
+
+    let csv = std::fs::read_to_string(&out_path)?;
+
+    // Header contract.
+    assert_eq!(
+        csv.lines().next().unwrap(),
+        "date,symbol,close",
+        "unexpected CSV header in:\n{csv}"
+    );
+
+    // In-window row present with its close price.
+    assert!(
+        csv.contains(&format!("2025-04-15,{FIXTURE_SYMBOL},100.5")),
+        "expected the window-start row in:\n{csv}"
+    );
+
+    // Out-of-window rows excluded (both before and after the 180-day window).
+    assert!(
+        !csv.contains("2024-01-01"),
+        "row before the window must be excluded in:\n{csv}"
+    );
+    assert!(
+        !csv.contains("2025-12-01"),
+        "row after the window must be excluded in:\n{csv}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn create_market_data_csv_for_score_file_writes_derived_csv() -> Result<()> {
+    let _fixture = MarketDataFixture::install()?;
+
+    // The wrapper derives the output path by swapping the score file's
+    // extension to `.csv` in the same directory.
+    let dir = tempfile::tempdir()?;
+    let score_file = dir.path().join("scores.tsv");
+    std::fs::write(&score_file, "stock\n")?; // contents are irrelevant here
+    let score_file_str = score_file.to_str().expect("temp path is valid UTF-8");
+
+    create_market_data_csv_for_score_file(
+        score_file_str,
+        &[FIXTURE_SYMBOL.to_string()],
+        SCORE_DATE,
+    )?;
+
+    let derived = dir.path().join("scores.csv");
+    assert!(
+        derived.exists(),
+        "wrapper should write the derived CSV at {derived:?}"
+    );
+
+    let csv = std::fs::read_to_string(&derived)?;
+    assert_eq!(csv.lines().next().unwrap(), "date,symbol,close");
+    assert!(csv.contains(&format!("2025-04-15,{FIXTURE_SYMBOL},100.5")));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #265.

`create_market_data_csv` (`src/utils.rs:406`) and its thin wrapper
`create_market_data_csv_for_score_file` (`src/utils.rs:391`) were the only
market-data writers with **no** test exercising them, directly or indirectly —
an asymmetric gap, since the long-format variant
(`create_market_data_long_csv_for_score_file`) is already covered by
`tests/market_data_tests.rs`. A refactor of the date-windowing or CSV-writing
logic could silently change the produced file with nothing to catch it.

This PR adds `tests/create_market_data_csv_test.rs` with two WHAT-tests that pin
the public contract — the `date,symbol,close` header and the inclusive 180-day
window filter — without asserting how the function computes them. No production
code changed; this is a pure coverage addition.

### Hermetic, not environment-dependent

The existing market-data tests **skip** when the external
`MARKET_DATA_BASE_PATH` repository is absent, so they provide no safety net in
CI. To always run and stay deterministic, each new test installs a small,
fully controlled market-data fixture at the exact location the function reads
from, then removes exactly what it created on drop (via an RAII guard) — leaving
no trace whether or not the external data repository pre-exists. The fixture
uses a clearly-synthetic symbol (`GRQVTEST265`) so it can never collide with a
real symbol.

```mermaid
flowchart LR
    A[Install fixture<br/>GRQVTEST265.json] --> B[create_market_data_csv]
    B --> C[md.csv]
    C --> D{Assertions}
    D --> E[header = date,symbol,close]
    D --> F[in-window row present]
    D --> G[before/after-window rows excluded]
    C --> H[RAII drop removes fixture]
```

## Evidence

Backend/CLI change with no web interface — no screenshot applicable. Verified
via the test suite:

- `cargo test --test create_market_data_csv_test` → `2 passed; 0 failed`.
- Full suite `cargo test --all-targets --all-features` → all green (lib 50
  passed, integration targets all passed).
- `./quality.sh` completes with `✅ Quality checks completed successfully!`
  (fmt, clippy `-D warnings`, type checks, tests, coverage, Deno checks).

The fixture leaves no residue: `../GRQ-shareprices2026Q2` does not exist after
the run when it was absent beforehand.

## Test Plan

Added `tests/create_market_data_csv_test.rs`:

- `create_market_data_csv_writes_windowed_rows` — asserts the `date,symbol,close`
  header, that the window-start row (`2025-04-15`) is present with its close
  price, and that rows before (`2024-01-01`) and after (`2025-12-01`) the
  180-day window are excluded.
- `create_market_data_csv_for_score_file_writes_derived_csv` — asserts the
  wrapper writes the CSV at the derived `<stem>.csv` path with the same header
  and in-window row.

A regression in the window filter (leaking out-of-window rows) or the header
contract would now fail these assertions.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqo2ca56-7d52e8`<!-- vibe-worker-issue-265 -->