### PR TITLE
Make cargo install assertions order-independent (Issue #266)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-266.md
+++ b/docs/archive/pr-summaries/pr-summary-266.md
@@ -1,0 +1,44 @@
+## Summary
+
+Made two flag-order-coupled assertions in
+`tests/cargo_supply_chain_quarantine_test.ts` order-independent. The tests
+previously regexed workflow `run:` text and required `--locked` to appear
+*before* `--version`, so a behaviour-preserving flag swap
+(`cargo install <tool> --version 0.x --locked`) would turn them red — a
+HOW-test coupled to YAML source layout rather than the observable contract.
+
+The assertions now locate the `cargo install <tool>` line and check the flag
+set independently: `--locked` present **and** `--version` pinned, in any
+order. The genuine supply-chain property (pinned, locked installs) is still
+enforced; the source-text ordering coupling is gone. Closes #266.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verified via
+`deno test` and the full `./quality.sh` gate (passes cleanly).
+
+The new helper checks the *observable* contract rather than text order:
+
+```ts
+function assertPinnedInstall(runs, tool, source) {
+  const line = installLine(runs, tool);
+  assert(line !== "", `${source} must install ${tool}`);
+  assert(/\s--locked\b/.test(line), `${source}: ${tool} install must pass --locked`);
+  assert(/\s--version\s+\d+\.\d+/.test(line), `${source}: ${tool} install must pin --version`);
+}
+```
+
+Either flag order now passes; dropping a flag still fails. The sibling
+WHAT-tests (`cargo update` absent, `--locked` present) were intentionally left
+untouched as already-robust behaviour assertions.
+
+## Test Plan
+
+- Modified `tests/cargo_supply_chain_quarantine_test.ts`:
+  - `ci.yml pins cargo tool installs to explicit versions with --locked` — now
+    uses order-independent `assertPinnedInstall`.
+  - `cargo-audit.yml pins cargo-audit install to an explicit version with
+    --locked` — now uses order-independent `assertPinnedInstall`.
+- `deno test --allow-read tests/cargo_supply_chain_quarantine_test.ts` →
+  6 passed / 0 failed.
+- `./quality.sh < /dev/null` → passes cleanly.

--- a/tests/cargo_supply_chain_quarantine_test.ts
+++ b/tests/cargo_supply_chain_quarantine_test.ts
@@ -64,25 +64,38 @@ Deno.test("ci.yml release build uses --locked (Issue #124)", async () => {
   );
 });
 
+// Find the `cargo install <tool>` line within the combined run text. Returns
+// "" when no install line is present, so callers fail with a clear message.
+function installLine(runs: string, tool: string): string {
+  const re = new RegExp(`cargo\\s+install\\s+${tool}\\b`);
+  return runs.split("\n").find((l) => re.test(l)) ?? "";
+}
+
+// Assert the observable supply-chain contract for a tool install: both flags
+// present and the version pinned. Order-independent — swapping --locked and
+// --version preserves behaviour and must keep the test green.
+function assertPinnedInstall(runs: string, tool: string, source: string): void {
+  const line = installLine(runs, tool);
+  assert(line !== "", `${source} must install ${tool}`);
+  assert(
+    /\s--locked\b/.test(line),
+    `${source}: ${tool} install must pass --locked`,
+  );
+  assert(
+    /\s--version\s+\d+\.\d+/.test(line),
+    `${source}: ${tool} install must pin --version`,
+  );
+}
+
 Deno.test("ci.yml pins cargo tool installs to explicit versions with --locked (Issue #124)", async () => {
   const runs = runText(await jobSteps(CI_PATH, "test")) + "\n" +
     runText(await jobSteps(CI_PATH, "build"));
   for (const tool of ["cargo-tarpaulin", "cargo-cyclonedx"]) {
-    const installRe = new RegExp(
-      `cargo\\s+install\\s+${tool}\\b[^\\n]*--locked[^\\n]*--version\\s+\\d+\\.\\d+`,
-    );
-    assert(
-      installRe.test(runs),
-      `ci.yml must install ${tool} with --locked and a pinned --version`,
-    );
+    assertPinnedInstall(runs, tool, "ci.yml");
   }
 });
 
 Deno.test("cargo-audit.yml pins cargo-audit install to an explicit version with --locked (Issue #124)", async () => {
   const runs = runText(await jobSteps(AUDIT_PATH, "audit"));
-  assert(
-    /cargo\s+install\s+cargo-audit\b[^\n]*--locked[^\n]*--version\s+\d+\.\d+/
-      .test(runs),
-    "cargo-audit.yml must install cargo-audit with --locked and a pinned --version",
-  );
+  assertPinnedInstall(runs, "cargo-audit", "cargo-audit.yml");
 });


### PR DESCRIPTION
## Summary

Made two flag-order-coupled assertions in
`tests/cargo_supply_chain_quarantine_test.ts` order-independent. The tests
previously regexed workflow `run:` text and required `--locked` to appear
*before* `--version`, so a behaviour-preserving flag swap
(`cargo install <tool> --version 0.x --locked`) would turn them red — a
HOW-test coupled to YAML source layout rather than the observable contract.

The assertions now locate the `cargo install <tool>` line and check the flag
set independently: `--locked` present **and** `--version` pinned, in any
order. The genuine supply-chain property (pinned, locked installs) is still
enforced; the source-text ordering coupling is gone. Closes #266.

## Evidence

Backend/test-only change — no web interface to screenshot. Verified via
`deno test` and the full `./quality.sh` gate (passes cleanly).

The new helper checks the *observable* contract rather than text order:

```ts
function assertPinnedInstall(runs, tool, source) {
  const line = installLine(runs, tool);
  assert(line !== "", `${source} must install ${tool}`);
  assert(/\s--locked\b/.test(line), `${source}: ${tool} install must pass --locked`);
  assert(/\s--version\s+\d+\.\d+/.test(line), `${source}: ${tool} install must pin --version`);
}
```

Either flag order now passes; dropping a flag still fails. The sibling
WHAT-tests (`cargo update` absent, `--locked` present) were intentionally left
untouched as already-robust behaviour assertions.

## Test Plan

- Modified `tests/cargo_supply_chain_quarantine_test.ts`:
  - `ci.yml pins cargo tool installs to explicit versions with --locked` — now
    uses order-independent `assertPinnedInstall`.
  - `cargo-audit.yml pins cargo-audit install to an explicit version with
    --locked` — now uses order-independent `assertPinnedInstall`.
- `deno test --allow-read tests/cargo_supply_chain_quarantine_test.ts` →
  6 passed / 0 failed.
- `./quality.sh < /dev/null` → passes cleanly.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqo4y5od-e0b242`<!-- vibe-worker-issue-266 -->