### PR TITLE
Backend: apply unpriceable-stock exclusion to hybrid projection (Issue #287)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-287.md
+++ b/docs/archive/pr-summaries/pr-summary-287.md
@@ -1,0 +1,60 @@
+## Summary
+
+Apply the unpriceable-stock exclusion rule to the hybrid projection path
+(`src/utils.rs::calculate_hybrid_projection`) so recent (under-90-day) scores
+and mature scores share identical exclusion semantics. Closes #287.
+
+The shared `is_priceable(buy_price, current_price)` predicate, the
+`excluded_tickers` surfacing, and the included-only count/average correction
+were introduced for `calculate_portfolio_performance` and, in the same change
+(#308), already wired into `calculate_hybrid_projection` — the hybrid path now
+gates inclusion on `is_priceable(buy_price, latest_price)` (requiring BOTH a
+usable buy price AND a usable current/latest price) rather than the old
+`buy_price > 0.0`-only guard, pushes unpriceable tickers onto `excluded_tickers`,
+and reports `total_stocks` over included stocks only.
+
+This PR completes the issue's TDD requirement by adding the parallel exclusion
+cases for the hybrid path, locking in that behaviour and guarding against
+regression to a buy-price-only gate.
+
+```mermaid
+flowchart TD
+    A[StockRecord in hybrid path] --> B{market data exists?}
+    B -- no --> X[excluded_tickers]
+    B -- yes --> C[compute buy_price + latest_price]
+    C --> D{is_priceable buy AND latest > 0?}
+    D -- no --> X
+    D -- yes --> I[included: projection + count + average]
+    X --> R[total_stocks = included only]
+    I --> R
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via the Rust unit
+tests below and the full quality gate.
+
+- `cargo test --lib hybrid_projection` → 11 passed, 0 failed (5 new cases plus
+  the existing hybrid tests).
+- `./quality.sh < /dev/null` → completes with "✅ Quality checks completed
+  successfully!" (fmt, clippy `-D warnings`, `cargo check`, full `cargo test`,
+  tarpaulin coverage, release build, and the Deno test/lint/check suite all
+  green).
+
+The `missing current/latest price → excluded` case is the key regression guard:
+under the previous `buy_price > 0.0`-only gate a stock with a usable buy price
+but no usable latest price would have been wrongly included; the new test
+asserts it is excluded and surfaced in `excluded_tickers`.
+
+## Test Plan
+
+Added to the `src/utils.rs` test module:
+
+- `test_hybrid_projection_includes_when_both_prices_present` — both prices usable → included, not excluded.
+- `test_hybrid_projection_excludes_when_buy_price_missing` — buy price 0.0, latest usable → excluded.
+- `test_hybrid_projection_excludes_when_latest_price_missing` — buy usable, latest 0.0 → excluded (regression guard).
+- `test_hybrid_projection_excludes_when_both_prices_missing` — neither price usable → excluded.
+- `test_hybrid_projection_count_and_average_over_included_only` — two priceable + one unpriceable stock; asserts `total_stocks == 2`, average computed over the two included stocks only (11.25), and the unpriceable ticker surfaced in `excluded_tickers`.
+
+Added a `hybrid_market_data_multi` helper to build multi-ticker market data for
+the count/average case.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2418,6 +2418,161 @@ mod tests {
             .contains(&"TEST:HYBRIDF".to_string()));
     }
 
+    // --- Unpriceable-stock exclusion for the hybrid path (issue #287) ---
+    //
+    // These mirror the exclusion cases proven for the full-period
+    // `calculate_portfolio_performance` so recent (hybrid) and mature scores
+    // apply identical semantics: a stock is included only when BOTH its buy
+    // price and its current/latest price are usable, and counts/averages are
+    // computed over the included stocks alone.
+
+    /// Builds a market-data map covering several tickers, each from its own
+    /// `(date, price)` points.
+    fn hybrid_market_data_multi(
+        entries: &[(&str, &[(NaiveDate, f64)])],
+    ) -> HashMap<String, HashMap<String, f64>> {
+        let mut outer = HashMap::new();
+        for (ticker, points) in entries {
+            let mut inner = HashMap::new();
+            for (date, price) in *points {
+                inner.insert(date.format("%Y-%m-%d").to_string(), *price);
+            }
+            outer.insert((*ticker).to_string(), inner);
+        }
+        outer
+    }
+
+    #[test]
+    fn test_hybrid_projection_includes_when_both_prices_present() {
+        let ticker = "TEST:HYBRIDBOTH";
+        let today = chrono::Utc::now().naive_utc().date();
+        let score_date = today - Duration::days(41);
+        let latest_date = score_date + Duration::days(40);
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        // Usable buy price (on the score date) and usable latest price.
+        let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 110.0)]);
+        let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+
+        assert_eq!(result.total_stocks, 1, "priceable stock must be included");
+        assert_eq!(result.individual_performances.len(), 1);
+        assert!(
+            result.excluded_tickers.is_empty(),
+            "a fully priceable stock must not be excluded"
+        );
+    }
+
+    #[test]
+    fn test_hybrid_projection_excludes_when_buy_price_missing() {
+        let ticker = "TEST:HYBRIDNOBUY";
+        let today = chrono::Utc::now().naive_utc().date();
+        let score_date = today - Duration::days(41);
+        let latest_date = score_date + Duration::days(40);
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        // Buy price unusable (0.0 on the score date) but a usable latest price.
+        let market = hybrid_market_data(ticker, &[(score_date, 0.0), (latest_date, 110.0)]);
+        let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+
+        assert_eq!(
+            result.total_stocks, 0,
+            "stock without a usable buy price must be excluded"
+        );
+        assert!(result.individual_performances.is_empty());
+        assert!(result.excluded_tickers.contains(&ticker.to_string()));
+    }
+
+    #[test]
+    fn test_hybrid_projection_excludes_when_latest_price_missing() {
+        let ticker = "TEST:HYBRIDNOLATEST";
+        let today = chrono::Utc::now().naive_utc().date();
+        let score_date = today - Duration::days(41);
+        let latest_date = score_date + Duration::days(40);
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        // Usable buy price but the latest available price is unusable (0.0).
+        let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 0.0)]);
+        let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+
+        assert_eq!(
+            result.total_stocks, 0,
+            "stock without a usable current/latest price must be excluded"
+        );
+        assert!(result.individual_performances.is_empty());
+        assert!(result.excluded_tickers.contains(&ticker.to_string()));
+    }
+
+    #[test]
+    fn test_hybrid_projection_excludes_when_both_prices_missing() {
+        let ticker = "TEST:HYBRIDNONE";
+        let today = chrono::Utc::now().naive_utc().date();
+        let score_date = today - Duration::days(41);
+        let latest_date = score_date + Duration::days(40);
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        // Neither price is usable.
+        let market = hybrid_market_data(ticker, &[(score_date, 0.0), (latest_date, 0.0)]);
+        let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+
+        assert_eq!(
+            result.total_stocks, 0,
+            "stock with neither price usable must be excluded"
+        );
+        assert!(result.individual_performances.is_empty());
+        assert!(result.excluded_tickers.contains(&ticker.to_string()));
+    }
+
+    #[test]
+    fn test_hybrid_projection_count_and_average_over_included_only() {
+        let today = chrono::Utc::now().naive_utc().date();
+        let score_date = today - Duration::days(41);
+        let latest_date = score_date + Duration::days(40);
+        let score_str = score_date.format("%Y-%m-%d").to_string();
+
+        // Two priceable stocks with identical 100 -> 110 trends (projection
+        // 11.25 each) plus one unpriceable stock (buy price 0.0).
+        let included_a = "TEST:HYBRIDINCA";
+        let included_b = "TEST:HYBRIDINCB";
+        let excluded = "TEST:HYBRIDEXC";
+        let market = hybrid_market_data_multi(&[
+            (included_a, &[(score_date, 100.0), (latest_date, 110.0)]),
+            (included_b, &[(score_date, 100.0), (latest_date, 110.0)]),
+            (excluded, &[(score_date, 0.0), (latest_date, 0.0)]),
+        ]);
+        let records = vec![
+            StockRecord::new(included_a.to_string(), 5.0, 120.0),
+            StockRecord::new(included_b.to_string(), 5.0, 120.0),
+            StockRecord::new(excluded.to_string(), 5.0, 120.0),
+        ];
+
+        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+
+        // Count is over included stocks only.
+        assert_eq!(result.total_stocks, 2);
+        assert_eq!(result.individual_performances.len(), 2);
+
+        // Average is computed over the two included stocks only; the excluded
+        // stock contributes nothing (otherwise the mean would be dragged down).
+        let expected = 11.25;
+        assert!(
+            (result.performance_90_day - expected).abs() < 1e-6,
+            "average must be over included stocks only, got {}",
+            result.performance_90_day
+        );
+
+        // The unpriceable stock is surfaced as excluded.
+        assert_eq!(result.excluded_tickers.len(), 1);
+        assert!(result.excluded_tickers.contains(&excluded.to_string()));
+    }
+
     // --- Tests for stock priceable predicate (issue #286) ---
 
     #[test]


### PR DESCRIPTION
## Summary

Apply the unpriceable-stock exclusion rule to the hybrid projection path
(`src/utils.rs::calculate_hybrid_projection`) so recent (under-90-day) scores
and mature scores share identical exclusion semantics. Closes #287.

The shared `is_priceable(buy_price, current_price)` predicate, the
`excluded_tickers` surfacing, and the included-only count/average correction
were introduced for `calculate_portfolio_performance` and, in the same change
(#308), already wired into `calculate_hybrid_projection` — the hybrid path now
gates inclusion on `is_priceable(buy_price, latest_price)` (requiring BOTH a
usable buy price AND a usable current/latest price) rather than the old
`buy_price > 0.0`-only guard, pushes unpriceable tickers onto `excluded_tickers`,
and reports `total_stocks` over included stocks only.

This PR completes the issue's TDD requirement by adding the parallel exclusion
cases for the hybrid path, locking in that behaviour and guarding against
regression to a buy-price-only gate.

```mermaid
flowchart TD
    A[StockRecord in hybrid path] --> B{market data exists?}
    B -- no --> X[excluded_tickers]
    B -- yes --> C[compute buy_price + latest_price]
    C --> D{is_priceable buy AND latest > 0?}
    D -- no --> X
    D -- yes --> I[included: projection + count + average]
    X --> R[total_stocks = included only]
    I --> R
```

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via the Rust unit
tests below and the full quality gate.

- `cargo test --lib hybrid_projection` → 11 passed, 0 failed (5 new cases plus
  the existing hybrid tests).
- `./quality.sh < /dev/null` → completes with "✅ Quality checks completed
  successfully!" (fmt, clippy `-D warnings`, `cargo check`, full `cargo test`,
  tarpaulin coverage, release build, and the Deno test/lint/check suite all
  green).

The `missing current/latest price → excluded` case is the key regression guard:
under the previous `buy_price > 0.0`-only gate a stock with a usable buy price
but no usable latest price would have been wrongly included; the new test
asserts it is excluded and surfaced in `excluded_tickers`.

## Test Plan

Added to the `src/utils.rs` test module:

- `test_hybrid_projection_includes_when_both_prices_present` — both prices usable → included, not excluded.
- `test_hybrid_projection_excludes_when_buy_price_missing` — buy price 0.0, latest usable → excluded.
- `test_hybrid_projection_excludes_when_latest_price_missing` — buy usable, latest 0.0 → excluded (regression guard).
- `test_hybrid_projection_excludes_when_both_prices_missing` — neither price usable → excluded.
- `test_hybrid_projection_count_and_average_over_included_only` — two priceable + one unpriceable stock; asserts `total_stocks == 2`, average computed over the two included stocks only (11.25), and the unpriceable ticker surfaced in `excluded_tickers`.

Added a `hybrid_market_data_multi` helper to build multi-ticker market data for
the count/average case.



## Milestone
This PR is part of the **#270 Exclude stocks we can't price (delisted/merged) from portfolio performance** milestone and targets the `milestone/270-exclude-stocks-we-can-t-price-delisted-merged` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqoj19aw-77ed63`<!-- vibe-worker-issue-287 -->