### PR TITLE
Frontend: pure exclusion + re-weighting helpers in projection.js (#288)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-288.md
+++ b/docs/archive/pr-summaries/pr-summary-288.md
@@ -1,0 +1,61 @@
+# Frontend: pure exclusion + re-weighting helpers in projection.js
+
+## Summary
+
+Adds the JS single source of truth for the "exclude stocks we can't price"
+rule (parent #270) to `docs/projection.js`, mirroring the Rust backend's
+`is_priceable` predicate (`src/utils.rs`). This gives the upcoming app.js
+aggregate and strikethrough sub-issues one tested rule to reuse. Closes #288.
+
+Two pure helpers were added and exported on `globalThis.GRQProjection`:
+
+- **`isStockIncluded(buyPrice, currentPrice)`** — returns `true` only when both
+  prices are present numbers strictly greater than 0 (a stock is included iff it
+  has a usable buy price AND a usable current price). Missing, zero, negative,
+  `NaN`, `null`/`undefined`, or non-numeric inputs all exclude the stock,
+  matching the backend's `buy_price > 0.0 && current_price > 0.0` rule.
+- **`calculateIncludedPortfolioPerformance(stocks)`** — equal-weight mean of the
+  total returns (price + dividend, via the existing `calculatePerformanceReturn`)
+  over **only** the included stocks. Excluded stocks are dropped entirely, so
+  excluding one redistributes weight equally over the remainder (two of three
+  included → ½ each, not ⅓). Returns `null` when no stock is included.
+
+No production wiring changes yet — this is the foundation the app.js aggregate
+and strikethrough sub-issues build on.
+
+```mermaid
+flowchart LR
+    S[Stock buyPrice + currentPrice] --> P{isStockIncluded?}
+    P -- both > 0 --> I[Included: count return]
+    P -- either missing/<=0 --> X[Excluded entirely]
+    I --> R[calculateIncludedPortfolioPerformance:\nequal-weight mean over included only]
+```
+
+## Evidence
+
+Pure-function module change with no visible UI; verified via the Deno unit
+suite rather than a screenshot. The shipped helpers in `docs/projection.js` are
+imported directly by the tests (no mocks), so the tests exercise the exact code
+the dashboard will use.
+
+Test run:
+
+```
+deno test --allow-read tests/exclusion_reweight_test.ts
+ok | 12 passed | 0 failed
+
+deno test --allow-read tests/*.ts
+ok | 506 passed (55 steps) | 0 failed
+```
+
+## Test Plan
+
+New `tests/exclusion_reweight_test.ts` (TDD — written failing first):
+
+- `isStockIncluded` — both prices present → included; missing buy price →
+  excluded; missing current price → excluded; both missing → excluded; negative
+  prices → excluded; non-numeric / `NaN` → excluded.
+- `calculateIncludedPortfolioPerformance` — averages returns over included
+  stocks only; excluding one redistributes weight over the remainder; includes
+  dividend return; all excluded → `null`; empty / invalid input → `null`.
+- Asserts both helpers are published on `globalThis.GRQProjection`.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -103,6 +103,55 @@ function calculatePerformanceReturn(buyPrice, currentPrice, totalDividends) {
     return priceReturn + dividendReturn;
 }
 
+// Single source of truth for the "is this stock included?" rule (issue #288),
+// mirroring the Rust backend's `is_priceable` predicate (src/utils.rs). A stock
+// counts towards portfolio performance ONLY when it has BOTH a usable buy price
+// AND a usable current price — both present and strictly greater than 0. If
+// either is missing/non-positive (delisted, merged for cash, renamed), the
+// stock is excluded entirely from all portfolio calculations. The numeric guard
+// rejects null/undefined/NaN and string inputs so only real positive numbers
+// count as usable.
+function isStockIncluded(buyPrice, currentPrice) {
+    const usable = (price) => typeof price === "number" && price > 0;
+    return usable(buyPrice) && usable(currentPrice);
+}
+
+// Equal-weight portfolio performance over ONLY the included stocks (issue #288).
+// Each stock object provides `buyPrice`, `currentPrice` and optional
+// `totalDividends`. Excluded stocks (per isStockIncluded) are dropped entirely,
+// so excluding one redistributes weight equally over the remainder — e.g. two
+// of three included stocks are weighted 1/2 each, not 1/3. Returns the mean of
+// the included total returns, or null when no stock is included (matching the
+// dashboard's guard before reporting a portfolio figure). Mirrors the backend's
+// equal-weight average of `total_return_percent` over priceable stocks.
+function calculateIncludedPortfolioPerformance(stocks) {
+    if (!Array.isArray(stocks)) {
+        return null;
+    }
+    const includedReturns = [];
+    for (const stock of stocks) {
+        const buyPrice = stock && stock.buyPrice;
+        const currentPrice = stock && stock.currentPrice;
+        if (!isStockIncluded(buyPrice, currentPrice)) {
+            continue;
+        }
+        const totalReturn = calculatePerformanceReturn(
+            buyPrice,
+            currentPrice,
+            stock.totalDividends,
+        );
+        if (totalReturn === null) {
+            continue;
+        }
+        includedReturns.push(totalReturn);
+    }
+    if (includedReturns.length === 0) {
+        return null;
+    }
+    const sum = includedReturns.reduce((total, value) => total + value, 0);
+    return sum / includedReturns.length;
+}
+
 // Dividends whose ex-dividend date falls on or before the 90-day validation
 // window measured from the score date. Pure given the dividend list and score
 // date; the dashboard's GRQValidator looks the list up per stock and delegates
@@ -663,6 +712,8 @@ globalThis.GRQProjection = {
     selectDefaultScore,
     getDaysElapsed,
     calculatePerformanceReturn,
+    isStockIncluded,
+    calculateIncludedPortfolioPerformance,
     filterDividendsWithin90Days,
     sumDividends,
     buildHybridProjectionData,

--- a/tests/exclusion_reweight_test.ts
+++ b/tests/exclusion_reweight_test.ts
@@ -1,0 +1,132 @@
+// Tests for the shared exclusion + re-weighting helpers (issue #288).
+//
+// These import the REAL shipped helpers from docs/projection.js — the single
+// source of truth for the "is this stock included?" rule, mirroring the Rust
+// backend's `is_priceable` predicate (src/utils.rs). The dashboard's app.js
+// aggregate and strikethrough work reuses this same tested rule.
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    isStockIncluded: (
+      buyPrice: number | null | undefined,
+      currentPrice: number | null | undefined,
+    ) => boolean;
+    calculateIncludedPortfolioPerformance: (
+      stocks: Array<{
+        buyPrice?: number | null;
+        currentPrice?: number | null;
+        totalDividends?: number;
+      }>,
+    ) => number | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+Deno.test("projection.js publishes the exclusion helpers on globalThis", () => {
+  assertEquals(typeof GRQProjection.isStockIncluded, "function");
+  assertEquals(
+    typeof GRQProjection.calculateIncludedPortfolioPerformance,
+    "function",
+  );
+});
+
+// --- isStockIncluded: the single inclusion predicate -----------------------
+
+Deno.test("isStockIncluded - both prices present and positive -> included", () => {
+  assert(GRQProjection.isStockIncluded(10.5, 12.0));
+});
+
+Deno.test("isStockIncluded - missing buy price -> excluded", () => {
+  assertEquals(GRQProjection.isStockIncluded(null, 12.0), false);
+  assertEquals(GRQProjection.isStockIncluded(undefined, 12.0), false);
+  assertEquals(GRQProjection.isStockIncluded(0, 12.0), false);
+});
+
+Deno.test("isStockIncluded - missing current price -> excluded", () => {
+  assertEquals(GRQProjection.isStockIncluded(10.5, null), false);
+  assertEquals(GRQProjection.isStockIncluded(10.5, undefined), false);
+  assertEquals(GRQProjection.isStockIncluded(10.5, 0), false);
+});
+
+Deno.test("isStockIncluded - both missing -> excluded", () => {
+  assertEquals(GRQProjection.isStockIncluded(null, null), false);
+  assertEquals(GRQProjection.isStockIncluded(undefined, undefined), false);
+  assertEquals(GRQProjection.isStockIncluded(0, 0), false);
+});
+
+Deno.test("isStockIncluded - negative prices -> excluded", () => {
+  assertEquals(GRQProjection.isStockIncluded(-1, 12.0), false);
+  assertEquals(GRQProjection.isStockIncluded(10.5, -1), false);
+});
+
+Deno.test("isStockIncluded - non-numeric prices -> excluded", () => {
+  assertEquals(
+    GRQProjection.isStockIncluded(
+      "10" as unknown as number,
+      12.0,
+    ),
+    false,
+  );
+  assertEquals(GRQProjection.isStockIncluded(NaN, 12.0), false);
+});
+
+// --- calculateIncludedPortfolioPerformance: equal-weight re-weighting ------
+
+Deno.test("re-weighting - averages returns over included stocks only", () => {
+  // Two included stocks: +10% and +20% -> equal-weight average +15%.
+  const stocks = [
+    { buyPrice: 100, currentPrice: 110 }, // +10%
+    { buyPrice: 100, currentPrice: 120 }, // +20%
+  ];
+  const perf = GRQProjection.calculateIncludedPortfolioPerformance(stocks);
+  assert(perf !== null);
+  assertAlmostEquals(perf as number, 15);
+});
+
+Deno.test("re-weighting - excluding one redistributes weight over the remainder", () => {
+  // Three stocks but the middle one has no current price (delisted/merged).
+  // It must be dropped entirely: the result is the equal-weight average of
+  // the two priceable stocks (1/2 each), NOT 1/3 each over all three.
+  const stocks = [
+    { buyPrice: 100, currentPrice: 110 }, // +10% included
+    { buyPrice: 100, currentPrice: null }, // excluded (no current price)
+    { buyPrice: 100, currentPrice: 130 }, // +30% included
+  ];
+  const perf = GRQProjection.calculateIncludedPortfolioPerformance(stocks);
+  assert(perf !== null);
+  // Average of the two included stocks = (10 + 30) / 2 = 20.
+  assertAlmostEquals(perf as number, 20);
+});
+
+Deno.test("re-weighting - includes dividend return for included stocks", () => {
+  // Single included stock: +10% price return + 5% dividend return = 15%.
+  const stocks = [
+    { buyPrice: 100, currentPrice: 110, totalDividends: 5 },
+  ];
+  const perf = GRQProjection.calculateIncludedPortfolioPerformance(stocks);
+  assert(perf !== null);
+  assertAlmostEquals(perf as number, 15);
+});
+
+Deno.test("re-weighting - all stocks excluded -> null", () => {
+  const stocks = [
+    { buyPrice: 0, currentPrice: 110 },
+    { buyPrice: 100, currentPrice: null },
+  ];
+  assertEquals(
+    GRQProjection.calculateIncludedPortfolioPerformance(stocks),
+    null,
+  );
+});
+
+Deno.test("re-weighting - empty or invalid input -> null", () => {
+  assertEquals(GRQProjection.calculateIncludedPortfolioPerformance([]), null);
+  assertEquals(
+    GRQProjection.calculateIncludedPortfolioPerformance(
+      null as unknown as [],
+    ),
+    null,
+  );
+});


### PR DESCRIPTION
# Frontend: pure exclusion + re-weighting helpers in projection.js

## Summary

Adds the JS single source of truth for the "exclude stocks we can't price"
rule (parent #270) to `docs/projection.js`, mirroring the Rust backend's
`is_priceable` predicate (`src/utils.rs`). This gives the upcoming app.js
aggregate and strikethrough sub-issues one tested rule to reuse. Closes #288.

Two pure helpers were added and exported on `globalThis.GRQProjection`:

- **`isStockIncluded(buyPrice, currentPrice)`** — returns `true` only when both
  prices are present numbers strictly greater than 0 (a stock is included iff it
  has a usable buy price AND a usable current price). Missing, zero, negative,
  `NaN`, `null`/`undefined`, or non-numeric inputs all exclude the stock,
  matching the backend's `buy_price > 0.0 && current_price > 0.0` rule.
- **`calculateIncludedPortfolioPerformance(stocks)`** — equal-weight mean of the
  total returns (price + dividend, via the existing `calculatePerformanceReturn`)
  over **only** the included stocks. Excluded stocks are dropped entirely, so
  excluding one redistributes weight equally over the remainder (two of three
  included → ½ each, not ⅓). Returns `null` when no stock is included.

No production wiring changes yet — this is the foundation the app.js aggregate
and strikethrough sub-issues build on.

```mermaid
flowchart LR
    S[Stock buyPrice + currentPrice] --> P{isStockIncluded?}
    P -- both > 0 --> I[Included: count return]
    P -- either missing/<=0 --> X[Excluded entirely]
    I --> R[calculateIncludedPortfolioPerformance:\nequal-weight mean over included only]
```

## Evidence

Pure-function module change with no visible UI; verified via the Deno unit
suite rather than a screenshot. The shipped helpers in `docs/projection.js` are
imported directly by the tests (no mocks), so the tests exercise the exact code
the dashboard will use.

Test run:

```
deno test --allow-read tests/exclusion_reweight_test.ts
ok | 12 passed | 0 failed

deno test --allow-read tests/*.ts
ok | 506 passed (55 steps) | 0 failed
```

## Test Plan

New `tests/exclusion_reweight_test.ts` (TDD — written failing first):

- `isStockIncluded` — both prices present → included; missing buy price →
  excluded; missing current price → excluded; both missing → excluded; negative
  prices → excluded; non-numeric / `NaN` → excluded.
- `calculateIncludedPortfolioPerformance` — averages returns over included
  stocks only; excluding one redistributes weight over the remainder; includes
  dividend return; all excluded → `null`; empty / invalid input → `null`.
- Asserts both helpers are published on `globalThis.GRQProjection`.



## Milestone
This PR is part of the **#270 Exclude stocks we can't price (delisted/merged) from portfolio performance** milestone and targets the `milestone/270-exclude-stocks-we-can-t-price-delisted-merged` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqoj19aw-77ed63`<!-- vibe-worker-issue-288 -->