### PR TITLE
Strike out excluded stock rows on the dashboard (#290)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -2823,6 +2823,14 @@ class GRQValidator {
                 }">${judgement}</span></span></td>
             <td><span class="clickable-value" data-bs-toggle="popover" data-bs-trigger="click" data-bs-content="" data-bs-title="Dividends - ${safeStock}" data-field="dividend-info" data-stock="${safeStock}">${dividendInfo}</span></td>
           `;
+                // Strike out excluded stocks (issue #290): a stock dropped from
+                // every portfolio calculation (per the shared inclusion
+                // predicate) gets the `excluded-stock` class so its row renders
+                // with a theme-safe line-through, signalling it is out of all
+                // calculations.
+                if (!this.isStockPriceable(stock.stock, scoreDate)) {
+                    row.classList.add("excluded-stock");
+                }
                 // Add highlighting for selected stock in aggregate view
                 if (this.selectedStock === stock.stock) {
                     row.classList.add("table-primary");

--- a/docs/archive/pr-summaries/pr-summary-290.md
+++ b/docs/archive/pr-summaries/pr-summary-290.md
@@ -1,0 +1,68 @@
+## Summary
+
+Excluded stocks are now signalled on the dashboard aggregate table by striking
+out their row, indicating they are out of **all** portfolio calculations.
+Closes #290.
+
+A stock is *excluded* when it fails the shared inclusion predicate
+`GRQProjection.isStockIncluded` (missing or non-positive buy **or** current
+price — delisted, merged for cash, renamed). The aggregate row builder in
+`docs/app.js` now adds an `excluded-stock` class to that stock's `<tr>`
+(reusing the existing `isStockPriceable` helper, so the strikethrough cannot
+drift from the maths that drops the stock from the portfolio totals).
+
+`docs/styles.css` renders `.excluded-stock td` with
+`text-decoration: line-through`. The line is drawn on the cell text in
+`currentColor`, so the row keeps its inherited theme text colour at **full
+strength — no opacity dimming**. That preserves the same WCAG 2 AA contrast as a
+normal row in **both** the light and dark themes (coordinates with #281). The
+ticker cell, which sets its own `text-decoration: underline`, is given
+`underline line-through` so it stays an underlined link *and* is struck through.
+
+Per the explicit issue requirement, **no "N of M excluded" summary line** was
+added.
+
+```mermaid
+flowchart LR
+    A[stock row] --> B{isStockPriceable?}
+    B -- yes --> C[normal row]
+    B -- no --> D["row gets .excluded-stock<br/>(theme-safe line-through)"]
+```
+
+## Evidence
+
+Browser screenshot capture was unavailable in this run — the headless Chrome
+compositor in the sandbox never produced a frame (`Page.captureScreenshot`
+timed out across `--headless`, `--headless=new`, CDP-attach, swiftshader and
+sandbox-disabled attempts). Per the Error-Recovery guidance, verification is
+documented via automated tests and the CI accessibility gate instead.
+
+- **Automated tests** (`tests/excluded_stock_strikethrough_test.ts`) — full
+  suite: `deno test --allow-read tests/*.ts` → **521 passed, 0 failed**.
+  - The row-exclusion decision is exercised through the **real** shipped
+    `isStockIncluded` predicate (included → no class; missing/zero buy or
+    current price → `excluded-stock`).
+  - The CSS deliverable is pinned: `.excluded-stock` is struck through and is
+    theme-safe (asserts the rule does **not** dim the text with a
+    contrast-reducing `opacity`).
+- **Contrast in both themes** is gated by the repo's pa11y-ci check
+  (`pa11yci.json` runs `index.html` and `index.html?theme=dark` against
+  `WCAG2AA`). Because the strikethrough preserves the row's normal theme text
+  colour, contrast is identical to an unmodified row in each theme.
+- **Expected visual result**: an excluded stock's entire aggregate row (ticker
+  through dividends) shows a strikethrough line in the current theme text
+  colour; the ticker remains an underlined link with the strikethrough applied;
+  included rows are unchanged.
+
+## Test Plan
+
+- Added `tests/excluded_stock_strikethrough_test.ts`:
+  - `excluded row - included stock is NOT struck through`
+  - `excluded row - missing buy price is struck through`
+  - `excluded row - missing current price is struck through`
+  - `excluded row - non-positive prices are struck through`
+  - `styles.css: excluded rows are struck through`
+  - `styles.css: strikethrough is theme-safe (no contrast-reducing dim)`
+- Ran `deno test --allow-read tests/*.ts` (521 passed), `deno lint`,
+  `deno check`, `deno fmt`, and `cargo check --all-targets` (clean — Rust
+  untouched).

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -168,6 +168,24 @@
   font-weight: bold;
 }
 
+/* Excluded stock rows (issue #290): a stock that fails the shared inclusion
+ * predicate (missing/non-positive buy OR current price) is dropped from every
+ * portfolio calculation, so its aggregate row is struck through to signal it is
+ * out of all calculations. The strikethrough is drawn on the cell text in
+ * `currentColor`, so it keeps the row's inherited theme text colour at full
+ * strength — no opacity dimming — and therefore preserves the same WCAG 2 AA
+ * contrast as a normal row in BOTH the light and dark themes (issue #281). */
+.excluded-stock td {
+  text-decoration: line-through;
+}
+
+/* The ticker cell sets its own `text-decoration: underline` (link styling),
+ * which would otherwise block the row's line-through on that cell. Combine both
+ * line types so the ticker stays an underlined link AND is struck through. */
+.excluded-stock .clickable-stock {
+  text-decoration: underline line-through;
+}
+
 /* Clickable stock names */
 .clickable-stock {
   cursor: pointer;

--- a/tests/excluded_stock_strikethrough_test.ts
+++ b/tests/excluded_stock_strikethrough_test.ts
@@ -1,0 +1,113 @@
+// Tests for striking out excluded stock rows on the dashboard (issue #290,
+// part of the exclusion milestone #270).
+//
+// An excluded stock — one that fails the shared inclusion predicate
+// `isStockIncluded` (missing/non-positive buy OR current price) — is dropped
+// from EVERY portfolio calculation. Issue #290 signals this on the aggregate
+// table by adding an `excluded-stock` class to the stock's <tr>, which the
+// stylesheet renders with `text-decoration: line-through`.
+//
+// Two things are pinned here:
+//   1. The row-exclusion DECISION mirrors the production predicate
+//      (isStockIncluded), exercised through the REAL shipped helper so the
+//      strikethrough cannot drift from what the portfolio maths excludes.
+//   2. The CSS DELIVERABLE: `.excluded-stock` strikes the row through and is
+//      theme-safe — it must NOT dim the text (no contrast-reducing opacity),
+//      so the row keeps the same WCAG 2 AA contrast as a normal row in both
+//      the light and dark themes (coordinates with issue #281).
+//
+// Pure-CSS assertions read docs/styles.css and inspect the relevant rule body,
+// the same approach used by section_title_centring_test.ts and
+// chart_color_key_test.ts.
+
+import { assert, assertEquals, assertMatch } from "@std/assert";
+import "../docs/projection.js";
+
+const STYLES = "docs/styles.css";
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    isStockIncluded: (
+      buyPrice: number | null | undefined,
+      currentPrice: number | null | undefined,
+    ) => boolean;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+/**
+ * The class list the aggregate row receives for a given (buyPrice, currentPrice)
+ * pair, mirroring docs/app.js: an excluded stock (per the shared predicate)
+ * gets the `excluded-stock` strikethrough class; an included one does not.
+ */
+function rowClassesFor(
+  buyPrice: number | null,
+  currentPrice: number | null,
+): string[] {
+  return GRQProjection.isStockIncluded(buyPrice, currentPrice)
+    ? []
+    : ["excluded-stock"];
+}
+
+/**
+ * Return the body of the FIRST top-level CSS rule for `selector`, or null.
+ * Brace-aware so a later/nested rule is not mistaken for the block.
+ */
+function ruleBody(css: string, selector: string): string | null {
+  const head = css.indexOf(selector + " {");
+  if (head === -1) return null;
+  const open = css.indexOf("{", head);
+  const close = css.indexOf("}", open);
+  if (open === -1 || close === -1) return null;
+  return css.slice(open + 1, close);
+}
+
+// --- Row-exclusion decision -------------------------------------------------
+
+Deno.test("excluded row - included stock is NOT struck through", () => {
+  assertEquals(rowClassesFor(10.5, 12.0), []);
+});
+
+Deno.test("excluded row - missing buy price is struck through", () => {
+  assertEquals(rowClassesFor(null, 12.0), ["excluded-stock"]);
+});
+
+Deno.test("excluded row - missing current price is struck through", () => {
+  assertEquals(rowClassesFor(10.5, null), ["excluded-stock"]);
+});
+
+Deno.test("excluded row - non-positive prices are struck through", () => {
+  assertEquals(rowClassesFor(0, 12.0), ["excluded-stock"]);
+  assertEquals(rowClassesFor(10.5, 0), ["excluded-stock"]);
+});
+
+// --- CSS deliverable --------------------------------------------------------
+
+Deno.test("styles.css: excluded rows are struck through", async () => {
+  const css = await Deno.readTextFile(STYLES);
+  const body = ruleBody(css, ".excluded-stock td") ??
+    ruleBody(css, ".excluded-stock");
+  assert(body, ".excluded-stock rule must exist");
+  assertMatch(
+    body,
+    /text-decoration:\s*line-through/i,
+    "excluded rows must be struck through",
+  );
+});
+
+Deno.test("styles.css: strikethrough is theme-safe (no contrast-reducing dim)", async () => {
+  const css = await Deno.readTextFile(STYLES);
+  const body = (ruleBody(css, ".excluded-stock td") ?? "") +
+    (ruleBody(css, ".excluded-stock") ?? "");
+  assert(body.length > 0, ".excluded-stock rule must exist");
+  // Dimming the text (opacity < 1) would lower the contrast ratio and risk
+  // failing WCAG 2 AA in one or both themes. The strikethrough must keep the
+  // inherited theme text colour at full strength.
+  const opacityMatch = body.match(/opacity:\s*([0-9.]+)/i);
+  if (opacityMatch) {
+    assert(
+      parseFloat(opacityMatch[1]) >= 1,
+      "excluded-stock must not dim text (opacity < 1) — it would break AA contrast",
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Excluded stocks are now signalled on the dashboard aggregate table by striking
out their row, indicating they are out of **all** portfolio calculations.
Closes #290.

A stock is *excluded* when it fails the shared inclusion predicate
`GRQProjection.isStockIncluded` (missing or non-positive buy **or** current
price — delisted, merged for cash, renamed). The aggregate row builder in
`docs/app.js` now adds an `excluded-stock` class to that stock's `<tr>`
(reusing the existing `isStockPriceable` helper, so the strikethrough cannot
drift from the maths that drops the stock from the portfolio totals).

`docs/styles.css` renders `.excluded-stock td` with
`text-decoration: line-through`. The line is drawn on the cell text in
`currentColor`, so the row keeps its inherited theme text colour at **full
strength — no opacity dimming**. That preserves the same WCAG 2 AA contrast as a
normal row in **both** the light and dark themes (coordinates with #281). The
ticker cell, which sets its own `text-decoration: underline`, is given
`underline line-through` so it stays an underlined link *and* is struck through.

Per the explicit issue requirement, **no "N of M excluded" summary line** was
added.

```mermaid
flowchart LR
    A[stock row] --> B{isStockPriceable?}
    B -- yes --> C[normal row]
    B -- no --> D["row gets .excluded-stock<br/>(theme-safe line-through)"]
```

## Evidence

Browser screenshot capture was unavailable in this run — the headless Chrome
compositor in the sandbox never produced a frame (`Page.captureScreenshot`
timed out across `--headless`, `--headless=new`, CDP-attach, swiftshader and
sandbox-disabled attempts). Per the Error-Recovery guidance, verification is
documented via automated tests and the CI accessibility gate instead.

- **Automated tests** (`tests/excluded_stock_strikethrough_test.ts`) — full
  suite: `deno test --allow-read tests/*.ts` → **521 passed, 0 failed**.
  - The row-exclusion decision is exercised through the **real** shipped
    `isStockIncluded` predicate (included → no class; missing/zero buy or
    current price → `excluded-stock`).
  - The CSS deliverable is pinned: `.excluded-stock` is struck through and is
    theme-safe (asserts the rule does **not** dim the text with a
    contrast-reducing `opacity`).
- **Contrast in both themes** is gated by the repo's pa11y-ci check
  (`pa11yci.json` runs `index.html` and `index.html?theme=dark` against
  `WCAG2AA`). Because the strikethrough preserves the row's normal theme text
  colour, contrast is identical to an unmodified row in each theme.
- **Expected visual result**: an excluded stock's entire aggregate row (ticker
  through dividends) shows a strikethrough line in the current theme text
  colour; the ticker remains an underlined link with the strikethrough applied;
  included rows are unchanged.

## Test Plan

- Added `tests/excluded_stock_strikethrough_test.ts`:
  - `excluded row - included stock is NOT struck through`
  - `excluded row - missing buy price is struck through`
  - `excluded row - missing current price is struck through`
  - `excluded row - non-positive prices are struck through`
  - `styles.css: excluded rows are struck through`
  - `styles.css: strikethrough is theme-safe (no contrast-reducing dim)`
- Ran `deno test --allow-read tests/*.ts` (521 passed), `deno lint`,
  `deno check`, `deno fmt`, and `cargo check --all-targets` (clean — Rust
  untouched).
