### PR TITLE
Trustworthy split-adjustment in projection.js (correct-or-flag) — #292

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-292.md
+++ b/docs/archive/pr-summaries/pr-summary-292.md
@@ -1,0 +1,82 @@
+# Frontend: trustworthy split-adjustment in `projection.js`
+
+## Summary
+
+Replaced the unguarded cumulative split multiply in `docs/projection.js` with a
+single validated "correct-or-flag" computation, fixing the KLAC split distortion
+(parent #272). **Closes #292.**
+
+A new pure helper `computeSplitAdjustment(marketData, historicalDate) → { factor,
+reliable }` decides split-truth in one tested place:
+
+- **De-duplicates** split events recorded within five days of each other (the
+  same corporate event written twice) — prevents the factor-100 duplicate case.
+- **Rejects implausible coefficients**: a single `splitCoefficient` above `10:1`,
+  or a cumulative factor above `50`, flips `reliable: false`. Invalid
+  coefficients (`NaN`, `≤ 0`) are treated as `1.0` (no adjustment).
+- **Cross-checks** each split against the observed pre/post price drop: a real
+  `N:1` split divides the price ~`N`-fold (±15%). When the price never dropped
+  (the KLAC distortion — the latest price was never split-adjusted), the series
+  is flagged unreliable.
+
+`getSplitAdjustment` and `adjustHistoricalPriceToCurrent` now consume the helper
+and **refuse to apply a factor they cannot reconcile** — returning `1.0` instead
+of silently inflating the return. `getBuyPrice` surfaces the same `reliable`
+flag in its return object so buy and current price stay on one consistent
+post-split basis, and the inclusion predicate (`isStockIncluded`, #288) can reuse
+it. The helper is exported via `globalThis.GRQProjection`, so every `app.js` call
+site is corrected at once.
+
+Thresholds match the agreed spike values in
+`docs/fixes/klac-split-distortion-investigation.md` (updated with an
+implementation note).
+
+## Evidence
+
+Backend/CLI + frontend-helper change with no new UI surface to screenshot — the
+helpers are pure functions verified by the Deno test suite against the frozen
+KLAC fixtures. Key behavioural proof:
+
+| Fixture | Before #292 | After #292 |
+| --- | --- | --- |
+| `klac_split_distorted.csv` | factor 10 applied → **+1302.5%** | `reliable: false`, factor suppressed to 1.0 → **no inflation (< +300%)** |
+| Duplicate split row | compounded to **factor 100** (buy 14.745) | de-duplicated to **factor 10** (buy 147.45) |
+| `klac_split_reconciled.csv` | +74% | **+74%** (unchanged, reliable) |
+| `control_clean_no_split.csv` | +15% | **+15%** (unchanged, reliable) |
+
+```mermaid
+flowchart TD
+    A[marketData + historicalDate] --> B[computeSplitAdjustment]
+    B --> C{De-dup, plausible,<br/>price-ratio reconciles?}
+    C -->|yes| D["reliable: true<br/>apply corrected factor"]
+    C -->|no| E["reliable: false<br/>factor suppressed to 1.0"]
+    D --> F[getSplitAdjustment / getBuyPrice]
+    E --> F
+    F --> G[Buy + current price on one split basis]
+```
+
+## Test Plan
+
+New tests in `tests/projection_kernels_test.ts` (added alongside the existing
+kernels):
+
+- `computeSplitAdjustment: clean single split -> corrected, reliable`
+- `computeSplitAdjustment: no-split series -> factor 1.0, reliable`
+- `computeSplitAdjustment: duplicate split rows are de-duplicated`
+- `computeSplitAdjustment: distinct splits beyond the window compound`
+- `computeSplitAdjustment: implausible coefficient -> unreliable`
+- `computeSplitAdjustment: price-ratio mismatch -> unreliable`
+- `computeSplitAdjustment: invalid coefficient treated as no split`
+- `getSplitAdjustment suppresses an unreliable factor (no inflation)`
+- `getBuyPrice surfaces the reliability flag`
+
+Updated (documented business-logic change) in
+`tests/klac_split_distortion_test.ts` — two reproduction tests that asserted the
+**defective** numbers now assert the **corrected** behaviour:
+
+- `KLAC split distortion - corrected: flagged unreliable, no inflation (#292)`
+- `Duplicate split coefficient is de-duplicated, not compounded (#292)`
+- The reconciled (+74%) and clean (+15%) controls are unchanged.
+
+All 507 Deno tests pass; `deno lint`, `deno check`, and `./quality.sh` (Rust
+build/tests/clippy + Deno) green.

--- a/docs/fixes/klac-split-distortion-investigation.md
+++ b/docs/fixes/klac-split-distortion-investigation.md
@@ -6,6 +6,16 @@ agreeing the "implausible split coefficient" thresholds. **No production code
 is changed by this issue** — the follow-up `projection.js` helper and backend
 guard consume the fixture and thresholds documented here.
 
+> **Update (issue #292):** the frontend helper is now implemented.
+> `computeSplitAdjustment(marketData, historicalDate) → { factor, reliable }`
+> in `docs/projection.js` applies the thresholds in §3 (de-dup within five
+> days, plausible single coefficient `≤ 10:1`, cumulative cap `≤ 50`, and the
+> ±15% price-ratio cross-check). `getSplitAdjustment`/`getBuyPrice` consume it
+> and refuse to apply an unreconcilable factor (return `1.0` / surface
+> `reliable: false`) instead of silently inflating the return. The inclusion
+> predicate (`isStockIncluded`, #288) consumes the same `reliable` flag, keeping
+> this the single source of split-truth.
+
 ## 1. Root cause confirmed (with numbers)
 
 KLAC's inflated "Capital" figure traces to the frontend split adjustment in

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -217,31 +217,125 @@ function formatCurrency(value) {
     }).format(value);
 }
 
-// Cumulative split adjustment from a historical date to "now". Walks the stock's
-// market data and multiplies every split (splitCoefficient > 1.0) recorded after
-// `historicalDate`. A missing series means no known splits, so the factor is 1.0.
-function getSplitAdjustment(marketData, historicalDate) {
-    if (!marketData) return 1.0;
-    let cumulativeSplit = 1.0;
-    for (const point of marketData) {
-        if (point.date > historicalDate && point.splitCoefficient > 1.0) {
-            cumulativeSplit *= point.splitCoefficient;
-        }
+// Trustworthy split-adjustment thresholds (issue #292, parent #272). Agreed in
+// the #291 investigation — see docs/fixes/klac-split-distortion-investigation.md.
+const MAX_PLAUSIBLE_COEFFICIENT = 10.0; // a single split of <= 10:1 is plausible
+const DUPLICATE_WINDOW_DAYS = 5; // splits within 5 days = the same event twice
+const MAX_CUMULATIVE_FACTOR = 50.0; // cumulative factor cap over the window
+const RECONCILE_TOLERANCE = 0.15; // +/-15% price-ratio cross-check
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Compute the cumulative split adjustment from `historicalDate` to "now" AND
+// judge whether it can be trusted — the single "correct-or-flag" place (issue
+// #292). Pure: no DOM or class state. Returns `{ factor, reliable }` where:
+//   - `factor` is the de-duplicated, plausibility-checked cumulative factor
+//     (kept for diagnostics);
+//   - `reliable` is false when the series cannot be reconciled, so callers must
+//     NOT silently apply `factor` — treat an unreliable series as no split.
+// Rules: de-duplicate split events recorded within DUPLICATE_WINDOW_DAYS; flag
+// any single coefficient above MAX_PLAUSIBLE_COEFFICIENT; cap the cumulative
+// factor at MAX_CUMULATIVE_FACTOR; and cross-check each split against the
+// observed pre/post price drop (a real N:1 split divides the price ~N-fold).
+function computeSplitAdjustment(marketData, historicalDate) {
+    if (!marketData || marketData.length === 0) {
+        return { factor: 1.0, reliable: true };
     }
-    return cumulativeSplit;
+
+    // Sorted copy so "the price immediately before a split" is well-defined
+    // regardless of input order (the cumulative product is order-independent).
+    const sorted = marketData
+        .filter((p) => p && p.date instanceof Date && !isNaN(p.date.getTime()))
+        .slice()
+        .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    let factor = 1.0;
+    let reliable = true;
+    let lastEventTime = null; // ms of the last *kept* split, for de-duplication
+
+    for (let i = 0; i < sorted.length; i++) {
+        const point = sorted[i];
+        const c = point.splitCoefficient;
+
+        // Only splits strictly after the historical date adjust the buy price.
+        if (!(point.date > historicalDate)) continue;
+
+        // Invalid / non-split coefficients mean "no adjustment" (treat as 1.0)
+        // and are not, by themselves, a reliability failure.
+        if (typeof c !== "number" || !isFinite(c) || c <= 1.0) continue;
+
+        // De-duplicate: a split within DUPLICATE_WINDOW_DAYS of the last kept
+        // one is the same corporate event recorded twice — apply it once.
+        if (
+            lastEventTime !== null &&
+            (point.date.getTime() - lastEventTime) <=
+                DUPLICATE_WINDOW_DAYS * MS_PER_DAY
+        ) {
+            continue;
+        }
+        lastEventTime = point.date.getTime();
+
+        // Implausibly large single coefficient: cannot trust unguarded.
+        if (c > MAX_PLAUSIBLE_COEFFICIENT) {
+            reliable = false;
+        }
+
+        // Price-ratio cross-check: compare the midpoint just before the split
+        // with the split point's own (post-split) midpoint. Only checkable when
+        // a prior point exists; absent one we keep the data-feed invariant.
+        const prev = sorted[i - 1];
+        if (prev) {
+            const prevMid = (prev.high + prev.low) / 2;
+            const splitMid = (point.high + point.low) / 2;
+            if (isFinite(prevMid) && isFinite(splitMid) && splitMid > 0) {
+                const observedRatio = prevMid / splitMid;
+                if (Math.abs(observedRatio / c - 1) > RECONCILE_TOLERANCE) {
+                    reliable = false;
+                }
+            }
+        }
+
+        factor *= c;
+    }
+
+    // Cumulative-factor plausibility bound: a larger factor almost certainly
+    // means duplicated or spurious coefficients.
+    if (factor > MAX_CUMULATIVE_FACTOR) {
+        reliable = false;
+    }
+
+    return { factor, reliable };
+}
+
+// Cumulative split adjustment from a historical date to "now". Delegates to the
+// validated `computeSplitAdjustment` and refuses to apply a factor it cannot
+// reconcile — an unreliable series yields 1.0 (no adjustment) rather than a
+// silently wrong, inflated factor (issue #292). A missing series means no known
+// splits, so the factor is 1.0.
+function getSplitAdjustment(marketData, historicalDate) {
+    const { factor, reliable } = computeSplitAdjustment(
+        marketData,
+        historicalDate,
+    );
+    return reliable ? factor : 1.0;
 }
 
 // Restate a historical price in current (post-split) terms by dividing out the
-// cumulative split adjustment.
+// cumulative split adjustment. Uses the reliable factor only, so an
+// unreconcilable split never over-divides the price (issue #292).
 function adjustHistoricalPriceToCurrent(price, marketData, historicalDate) {
     return price / getSplitAdjustment(marketData, historicalDate);
 }
 
 // Resolve the buy price for a stock: the split-adjusted midpoint of the first
 // trading day on or within five days after the score date. Returns
-// `{ price, dateUsed }`, or null when no market data falls in that window.
+// `{ price, dateUsed, reliable }`, or null when no market data falls in that
+// window. `reliable` mirrors `computeSplitAdjustment` so callers (and the
+// inclusion predicate, #288) can surface — rather than silently apply — a split
+// series that cannot be reconciled (issue #292).
 function getBuyPrice(marketData, scoreDate) {
     if (!marketData) return null;
+
+    const { reliable } = computeSplitAdjustment(marketData, scoreDate);
 
     for (let offset = 0; offset <= 5; offset++) {
         const candidateDate = new Date(scoreDate.getTime());
@@ -260,7 +354,7 @@ function getBuyPrice(marketData, scoreDate) {
                 marketData,
                 scoreDate,
             );
-            return { price: adjustedPrice, dateUsed: candidateDate };
+            return { price: adjustedPrice, dateUsed: candidateDate, reliable };
         }
     }
     return null;
@@ -667,6 +761,7 @@ globalThis.GRQProjection = {
     sumDividends,
     buildHybridProjectionData,
     formatCurrency,
+    computeSplitAdjustment,
     getSplitAdjustment,
     adjustHistoricalPriceToCurrent,
     getBuyPrice,

--- a/tests/klac_split_distortion_test.ts
+++ b/tests/klac_split_distortion_test.ts
@@ -1,26 +1,28 @@
-// KLAC split-distortion reproduction (issue #291, parent #272).
+// KLAC split-distortion regression (issues #291 + #292, parent #272).
 //
-// This is the investigation/spike's deterministic, regression-ready proof. It
-// loads the FROZEN fixtures under tests/fixtures/ and runs the REAL shared
+// This loads the FROZEN fixtures under tests/fixtures/ and runs the REAL shared
 // kernels in docs/projection.js (getBuyPrice, getSplitAdjustment,
-// currentPriceFromLatest, calculatePerformanceReturn) — the same code the
-// dashboard's GRQValidator uses — to pin the root cause with exact numbers:
+// computeSplitAdjustment, currentPriceFromLatest, calculatePerformanceReturn) —
+// the same code the dashboard's GRQValidator uses.
 //
-//   * getSplitAdjustment multiplies EVERY split_coefficient > 1.0 recorded after
-//     the buy date with no de-duplication, no plausibility bound, and no
-//     reconciliation against the observed buy/current price ratio.
-//   * A split applied to the historical buy price while the latest price has NOT
-//     been correspondingly split-adjusted over-divides the buy price and inflates
-//     the % return (klac_split_distorted.csv -> ~+1302.5%).
-//   * Once the same 10:1 split reconciles on BOTH sides the figure collapses to
-//     the correct ~+74% (klac_split_reconciled.csv).
-//   * A duplicate split row (the literal no-de-dup defect) compounds the factor
-//     to 100 and inflates the figure even further (~+1640%).
+// Issue #291 (the spike) pinned the root cause from these fixtures: the old
+// getSplitAdjustment multiplied EVERY split_coefficient > 1.0 with no de-dup,
+// plausibility bound, or price-ratio reconciliation, inflating KLAC to
+// ~+1302.5% (distorted) and ~+1640% (duplicate row).
 //
-// No production code changes are made in this issue; the follow-up projection.js
-// helper and backend guard sub-issues of #272 consume these fixtures + the
-// thresholds documented in docs/fixes/klac-split-distortion-investigation.md.
-import { assertAlmostEquals, assertEquals, assertExists } from "@std/assert";
+// Issue #292 fixes that root cause via computeSplitAdjustment (correct-or-flag).
+// Business-logic change documented here: the two tests that previously asserted
+// the *defective* numbers (distorted return ~+1302.5%, duplicate factor 100)
+// now assert the *corrected* behaviour — the distorted series is flagged
+// `reliable: false` and no longer inflates, and the duplicate row de-duplicates
+// to a factor of 10. The reconciled (+74%) and clean (+15%) controls are
+// unchanged. Thresholds: docs/fixes/klac-split-distortion-investigation.md.
+import {
+  assert,
+  assertAlmostEquals,
+  assertEquals,
+  assertExists,
+} from "@std/assert";
 import { fromFileUrl } from "@std/path";
 import "../docs/projection.js";
 
@@ -38,11 +40,15 @@ const g = globalThis as unknown as {
     getBuyPrice: (
       marketData: MarketDataPoint[] | undefined,
       scoreDate: Date,
-    ) => { price: number; dateUsed: Date } | null;
+    ) => { price: number; dateUsed: Date; reliable: boolean } | null;
     getSplitAdjustment: (
       marketData: MarketDataPoint[] | undefined,
       historicalDate: Date,
     ) => number;
+    computeSplitAdjustment: (
+      marketData: MarketDataPoint[] | undefined,
+      historicalDate: Date,
+    ) => { factor: number; reliable: boolean };
     currentPriceFromLatest: (
       marketData: MarketDataPoint[] | undefined,
     ) => number | null;
@@ -101,23 +107,38 @@ function priceReturn(
   };
 }
 
-Deno.test("KLAC split distortion - inflated return reproduced from fixture", () => {
+Deno.test("KLAC split distortion - corrected: flagged unreliable, no inflation (#292)", () => {
+  // BEFORE #292 this fixture inflated to ~+1302.5% (factor 10 applied while the
+  // latest price was still pre-split). AFTER #292 computeSplitAdjustment's
+  // price-ratio cross-check fails (the price never dropped 10-fold), so the
+  // series is flagged unreliable and the factor is NOT applied.
   const data = loadFixture("klac_split_distorted.csv");
-  const r = priceReturn(data, SCORE_DATE);
 
-  // Single 10:1 coefficient recorded after the buy date.
-  assertEquals(r.factor, 10, "cumulative split factor is 10");
-  // Raw buy midpoint (1495 + 1454) / 2 = 1474.50, divided by the 10:1 factor.
-  assertAlmostEquals(
-    r.buyPrice,
-    147.45,
-    1e-9,
-    "buy price over-divided to 147.45",
+  const split = GRQProjection.computeSplitAdjustment(data, SCORE_DATE);
+  // The suspect cumulative factor is still surfaced for diagnostics...
+  assertEquals(split.factor, 10, "diagnostic cumulative factor is still 10");
+  // ...but the series cannot be reconciled, so it is flagged.
+  assertEquals(split.reliable, false, "distorted series flagged unreliable");
+
+  // getSplitAdjustment refuses to apply the unreliable factor (returns 1.0).
+  assertEquals(
+    GRQProjection.getSplitAdjustment(data, SCORE_DATE),
+    1.0,
+    "unreliable factor suppressed to 1.0",
   );
-  // Latest row is still PRE-split ((2095 + 2041) / 2 = 2068.00): the defect.
-  assertAlmostEquals(r.current, 2068.0, 1e-9, "current price still pre-split");
-  // The over-division inflates the return to the reported ~1302.5%.
-  assertAlmostEquals(r.ret, 1302.5, 0.05, "return inflated to ~+1302.5%");
+
+  const r = priceReturn(data, SCORE_DATE);
+  // getBuyPrice surfaces the same flag.
+  const buy = GRQProjection.getBuyPrice(data, SCORE_DATE);
+  assertExists(buy);
+  assertEquals(buy!.reliable, false, "buy price carries the reliability flag");
+  // Buy price is the raw midpoint (1495 + 1454) / 2 = 1474.50 — no over-division.
+  assertAlmostEquals(r.buyPrice, 1474.5, 1e-9, "buy price not over-divided");
+  // Crucially, the return is no longer the inflated ~+1302.5%.
+  assert(
+    r.ret < 300,
+    `corrected return must not inflate past +300% (was ${r.ret})`,
+  );
 });
 
 Deno.test("KLAC split reconciled - correct return when split applied both sides", () => {
@@ -153,24 +174,34 @@ Deno.test("Clean control - no split, no distortion, modest return", () => {
   assertAlmostEquals(r.ret, 15.0, 1e-9, "return is a plausible +15%");
 });
 
-Deno.test("Duplicate split coefficient compounds the factor (no de-dup defect)", () => {
+Deno.test("Duplicate split coefficient is de-duplicated, not compounded (#292)", () => {
   // Take the reconciled fixture and inject a DUPLICATE of the 2026-06-12 10:1
-  // split row, modelling the same split event recorded twice. getSplitAdjustment
-  // multiplies both, so the factor jumps 10 -> 100 with no de-duplication.
+  // split row, modelling the same split event recorded twice. BEFORE #292 this
+  // compounded the factor to 100 (buy price over-divided to 14.745). AFTER #292
+  // computeSplitAdjustment treats two split rows within five days as one event,
+  // so the factor stays 10 and the buy price is the correct 147.45.
   const data = loadFixture("klac_split_reconciled.csv");
   const splitRow = data.find((p) => p.splitCoefficient === 10.0);
   assertExists(splitRow, "fixture should contain the 10:1 split row");
   data.push({ ...splitRow! });
 
+  const split = GRQProjection.computeSplitAdjustment(data, SCORE_DATE);
+  assertEquals(
+    split.factor,
+    10,
+    "duplicate row de-duplicated to a factor of 10",
+  );
+  assertEquals(split.reliable, true, "de-duplicated series reconciles cleanly");
+
   const factor = GRQProjection.getSplitAdjustment(data, SCORE_DATE);
-  assertEquals(factor, 100, "duplicate split compounds the factor to 100");
+  assertEquals(factor, 10, "applied factor is the de-duplicated 10, not 100");
 
   const buy = GRQProjection.getBuyPrice(data, SCORE_DATE);
   assertExists(buy);
   assertAlmostEquals(
     buy!.price,
-    14.745,
+    147.45,
     1e-9,
-    "buy price over-divided to 14.745",
+    "buy price correctly split-adjusted to 147.45",
   );
 });

--- a/tests/projection_kernels_test.ts
+++ b/tests/projection_kernels_test.ts
@@ -28,6 +28,10 @@ const g = globalThis as unknown as {
       marketData: MarketDataPoint[] | undefined,
       historicalDate: Date,
     ) => number;
+    computeSplitAdjustment: (
+      marketData: MarketDataPoint[] | undefined,
+      historicalDate: Date,
+    ) => { factor: number; reliable: boolean };
     adjustHistoricalPriceToCurrent: (
       price: number,
       marketData: MarketDataPoint[] | undefined,
@@ -36,7 +40,7 @@ const g = globalThis as unknown as {
     getBuyPrice: (
       marketData: MarketDataPoint[] | undefined,
       scoreDate: Date,
-    ) => { price: number; dateUsed: Date } | null;
+    ) => { price: number; dateUsed: Date; reliable: boolean } | null;
     currentPriceFromLatest: (marketData: MarketDataPoint[]) => number | null;
     calculateTargetPercentage: (
       buyPrice: number | null,
@@ -125,6 +129,127 @@ Deno.test("adjustHistoricalPriceToCurrent divides out the split", () => {
     GRQProjection.adjustHistoricalPriceToCurrent(30, md, new Date(2025, 0, 1)),
     15,
   );
+});
+
+// --- computeSplitAdjustment (issue #292) ------------------------------------
+
+Deno.test("computeSplitAdjustment: clean single split -> corrected, reliable", () => {
+  // A real 2:1 split halves the price, so the observed pre/post ratio matches
+  // the coefficient and the factor is trustworthy.
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 50, 49, 2.0),
+  ];
+  const r = GRQProjection.computeSplitAdjustment(md, new Date(2025, 0, 1));
+  assertEquals(r.factor, 2.0);
+  assertEquals(r.reliable, true);
+});
+
+Deno.test("computeSplitAdjustment: no-split series -> factor 1.0, reliable", () => {
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 105, 103, 1.0),
+  ];
+  const r = GRQProjection.computeSplitAdjustment(md, new Date(2025, 0, 1));
+  assertEquals(r.factor, 1.0);
+  assertEquals(r.reliable, true);
+
+  // Missing data is also a reliable no-op.
+  const empty = GRQProjection.computeSplitAdjustment(undefined, new Date());
+  assertEquals(empty.factor, 1.0);
+  assertEquals(empty.reliable, true);
+});
+
+Deno.test("computeSplitAdjustment: duplicate split rows are de-duplicated", () => {
+  // The same 2:1 event recorded twice three days apart must apply once, not
+  // compound to 4.0.
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 50, 49, 2.0),
+    makePoint(new Date(2025, 0, 13), 50, 49, 2.0), // duplicate within 5 days
+  ];
+  const r = GRQProjection.computeSplitAdjustment(md, new Date(2025, 0, 1));
+  assertEquals(r.factor, 2.0, "duplicate within the window applies once");
+  assertEquals(r.reliable, true);
+});
+
+Deno.test("computeSplitAdjustment: distinct splits beyond the window compound", () => {
+  // Two genuine events more than five days apart, each with a matching price
+  // drop, multiply to a 4.0 cumulative factor and stay reliable.
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 50, 49, 2.0),
+    makePoint(new Date(2025, 1, 10), 25, 24.5, 2.0),
+  ];
+  const r = GRQProjection.computeSplitAdjustment(md, new Date(2025, 0, 1));
+  assertEquals(r.factor, 4.0);
+  assertEquals(r.reliable, true);
+});
+
+Deno.test("computeSplitAdjustment: implausible coefficient -> unreliable", () => {
+  // A 50:1 coefficient is above the plausible 10:1 ceiling.
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 2, 1.9, 50.0),
+  ];
+  const r = GRQProjection.computeSplitAdjustment(md, new Date(2025, 0, 1));
+  assertEquals(r.reliable, false);
+});
+
+Deno.test("computeSplitAdjustment: price-ratio mismatch -> unreliable", () => {
+  // Coefficient claims 10:1 but the price barely moved: the cross-check fails,
+  // mirroring the KLAC distortion (current price never split).
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 99, 97, 10.0),
+  ];
+  const r = GRQProjection.computeSplitAdjustment(md, new Date(2025, 0, 1));
+  assertEquals(r.reliable, false);
+});
+
+Deno.test("computeSplitAdjustment: invalid coefficient treated as no split", () => {
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 100, 98, 0),
+  ];
+  const r = GRQProjection.computeSplitAdjustment(md, new Date(2025, 0, 1));
+  assertEquals(r.factor, 1.0);
+  assertEquals(r.reliable, true);
+});
+
+Deno.test("getSplitAdjustment suppresses an unreliable factor (no inflation)", () => {
+  // The unguarded multiply would return 10; the guarded helper refuses to apply
+  // a factor it cannot reconcile and returns 1.0 instead.
+  const md = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 99, 97, 10.0),
+  ];
+  assertEquals(GRQProjection.getSplitAdjustment(md, new Date(2025, 0, 1)), 1.0);
+});
+
+Deno.test("getBuyPrice surfaces the reliability flag", () => {
+  const reliableData = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 50, 49, 2.0),
+  ];
+  const reliable = GRQProjection.getBuyPrice(
+    reliableData,
+    new Date(2025, 0, 1),
+  );
+  assert(reliable !== null);
+  assertEquals(reliable!.reliable, true);
+  // 99 midpoint / 2.0 split = 49.5.
+  assertEquals(reliable!.price, 49.5);
+
+  const distorted = [
+    makePoint(new Date(2025, 0, 1), 100, 98, 1.0),
+    makePoint(new Date(2025, 0, 10), 99, 97, 10.0),
+  ];
+  const flagged = GRQProjection.getBuyPrice(distorted, new Date(2025, 0, 1));
+  assert(flagged !== null);
+  assertEquals(flagged!.reliable, false);
+  // Unreliable -> factor suppressed to 1.0, so the buy price is not over-divided.
+  assertEquals(flagged!.price, 99);
 });
 
 // --- getBuyPrice ------------------------------------------------------------


### PR DESCRIPTION
# Frontend: trustworthy split-adjustment in `projection.js`

## Summary

Replaced the unguarded cumulative split multiply in `docs/projection.js` with a
single validated "correct-or-flag" computation, fixing the KLAC split distortion
(parent #272). **Closes #292.**

A new pure helper `computeSplitAdjustment(marketData, historicalDate) → { factor,
reliable }` decides split-truth in one tested place:

- **De-duplicates** split events recorded within five days of each other (the
  same corporate event written twice) — prevents the factor-100 duplicate case.
- **Rejects implausible coefficients**: a single `splitCoefficient` above `10:1`,
  or a cumulative factor above `50`, flips `reliable: false`. Invalid
  coefficients (`NaN`, `≤ 0`) are treated as `1.0` (no adjustment).
- **Cross-checks** each split against the observed pre/post price drop: a real
  `N:1` split divides the price ~`N`-fold (±15%). When the price never dropped
  (the KLAC distortion — the latest price was never split-adjusted), the series
  is flagged unreliable.

`getSplitAdjustment` and `adjustHistoricalPriceToCurrent` now consume the helper
and **refuse to apply a factor they cannot reconcile** — returning `1.0` instead
of silently inflating the return. `getBuyPrice` surfaces the same `reliable`
flag in its return object so buy and current price stay on one consistent
post-split basis, and the inclusion predicate (`isStockIncluded`, #288) can reuse
it. The helper is exported via `globalThis.GRQProjection`, so every `app.js` call
site is corrected at once.

Thresholds match the agreed spike values in
`docs/fixes/klac-split-distortion-investigation.md` (updated with an
implementation note).

## Evidence

Backend/CLI + frontend-helper change with no new UI surface to screenshot — the
helpers are pure functions verified by the Deno test suite against the frozen
KLAC fixtures. Key behavioural proof:

| Fixture | Before #292 | After #292 |
| --- | --- | --- |
| `klac_split_distorted.csv` | factor 10 applied → **+1302.5%** | `reliable: false`, factor suppressed to 1.0 → **no inflation (< +300%)** |
| Duplicate split row | compounded to **factor 100** (buy 14.745) | de-duplicated to **factor 10** (buy 147.45) |
| `klac_split_reconciled.csv` | +74% | **+74%** (unchanged, reliable) |
| `control_clean_no_split.csv` | +15% | **+15%** (unchanged, reliable) |

```mermaid
flowchart TD
    A[marketData + historicalDate] --> B[computeSplitAdjustment]
    B --> C{De-dup, plausible,<br/>price-ratio reconciles?}
    C -->|yes| D["reliable: true<br/>apply corrected factor"]
    C -->|no| E["reliable: false<br/>factor suppressed to 1.0"]
    D --> F[getSplitAdjustment / getBuyPrice]
    E --> F
    F --> G[Buy + current price on one split basis]
```

## Test Plan

New tests in `tests/projection_kernels_test.ts` (added alongside the existing
kernels):

- `computeSplitAdjustment: clean single split -> corrected, reliable`
- `computeSplitAdjustment: no-split series -> factor 1.0, reliable`
- `computeSplitAdjustment: duplicate split rows are de-duplicated`
- `computeSplitAdjustment: distinct splits beyond the window compound`
- `computeSplitAdjustment: implausible coefficient -> unreliable`
- `computeSplitAdjustment: price-ratio mismatch -> unreliable`
- `computeSplitAdjustment: invalid coefficient treated as no split`
- `getSplitAdjustment suppresses an unreliable factor (no inflation)`
- `getBuyPrice surfaces the reliability flag`

Updated (documented business-logic change) in
`tests/klac_split_distortion_test.ts` — two reproduction tests that asserted the
**defective** numbers now assert the **corrected** behaviour:

- `KLAC split distortion - corrected: flagged unreliable, no inflation (#292)`
- `Duplicate split coefficient is de-duplicated, not compounded (#292)`
- The reconciled (+74%) and clean (+15%) controls are unchanged.

All 507 Deno tests pass; `deno lint`, `deno check`, and `./quality.sh` (Rust
build/tests/clippy + Deno) green.



## Milestone
This PR is part of the **#272 Verify KLAC; exclude or correct split-skewed stocks; clarify Capital column** milestone and targets the `milestone/272-verify-klac-exclude-or-correct-split-skewed-st` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqolu68j-6f42e8`<!-- vibe-worker-issue-292 -->