### PR TITLE
Backend: read split_coefficient, correct-or-exclude split-distorted stocks (Issue #294)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Pages.
   The external daily scorer job refreshes it in lockstep with the scores via
   the non-blocking `deno task refresh-indices` wrapper (see _Daily benchmark
   refresh_ below).
+- **Split-Aware Returns** — the backend reads each day's `split_coefficient` and
+  reconciles any stock split inside the 90-day window. A trustworthy split
+  series is corrected (the buy price is restated into current, post-split
+  terms); a series that cannot be reconciled (implausible or duplicated
+  coefficients, or a coefficient that does not match the observed price drop)
+  excludes the stock through the single `is_priceable` gate, dropping it from
+  the average, the included count and into `excluded_tickers`. The thresholds
+  mirror the frontend so backend and dashboard agree.
 - **Dividend Tracking** — calculate dividend income and total returns.
 - **Web Dashboard** — interactive charts and tables for performance analysis,
   served as a static site from `docs/`.

--- a/docs/archive/pr-summaries/pr-summary-294.md
+++ b/docs/archive/pr-summaries/pr-summary-294.md
@@ -1,0 +1,79 @@
+## Summary
+
+The Rust backend previously ignored stock splits entirely: `read_market_data_from_csv`
+parsed only the `close` column, and `calculate_portfolio_performance` used the raw
+close for both buy and current price, so a split inside the 90-day window distorted
+the return. This PR mirrors the frontend correct-or-exclude rule in the backend and
+reuses #286's exclusion plumbing rather than building a parallel one. **Closes #294.**
+
+What changed:
+
+- **`read_market_data_from_csv`** now parses the `split_coefficient` (and `high`/`low`)
+  columns and returns a `MarketDataCsv { closes, points }`. `closes` preserves the
+  original `ticker → date → close` shape consumed by existing callers; `points`
+  carries the split-relevant daily figures. A missing/invalid coefficient is treated
+  as `1.0` (no split).
+- **`compute_split_adjustment`** is a Rust mirror of the frontend
+  `computeSplitAdjustment`, using the same agreed thresholds: de-duplicate split
+  events within 5 days, flag any single coefficient above 10, cap the cumulative
+  factor at 50, and cross-check each split against the observed pre/post price drop
+  within ±15%. It returns `{ factor, reliable }`.
+- **`calculate_portfolio_performance`** computes the buy date, then reconciles any
+  split between the buy date and the current-price date. A **reliable** series
+  restates the buy price into post-split terms (`buy / factor`) so the return is
+  correct; an **unreliable** series excludes the stock.
+- **`is_priceable`** gains a third `split_reliable` argument (mirroring the frontend
+  `isStockIncluded`), so split-unreliable stocks drop through the single gate — out of
+  the average, out of the included `total_stocks` count, and into `excluded_tickers`.
+  With no split, the factor is `1.0` and behaviour is identical to before.
+
+Backend and frontend share the same thresholds, so their exclusion outcomes stay
+consistent.
+
+### Deno regression avoided
+
+This is a Deno + Rust repo; the work was done entirely in Rust (`cargo test`,
+`cargo clippy`) and verified against the existing Deno consistency suite — no
+Node tooling was introduced.
+
+## Evidence
+
+Backend/CLI change with no web interface to screenshot. Verified via `cargo test`
+and the full `./quality.sh` gate (Rust tests + clippy + coverage, plus 544 Deno
+tests including the split/consistency suites), all green.
+
+Data flow:
+
+```mermaid
+flowchart LR
+    A[scores/*.csv<br/>date,ticker,high,low,open,close,split_coefficient] --> B[read_market_data_from_csv]
+    B --> C[MarketDataCsv: closes + points]
+    C --> D[compute_split_adjustment<br/>factor + reliable]
+    D -->|reliable| E[restate buy price<br/>buy / factor → corrected return]
+    D -->|unreliable| F[is_priceable gate = false]
+    E --> G[included: average + count]
+    F --> H[excluded_tickers]
+```
+
+## Test Plan
+
+New tests in the `#[cfg(test)]` module of `src/utils.rs`:
+
+- `test_compute_split_adjustment_no_splits_is_reliable_unity` — no splits → factor 1.0, reliable.
+- `test_compute_split_adjustment_clean_single_split` — reconcilable 2:1 → factor 2.0, reliable.
+- `test_compute_split_adjustment_deduplicates_repeated_event` — duplicate within 5 days applied once (factor 2.0, not 4.0).
+- `test_compute_split_adjustment_implausible_coefficient_unreliable` — coefficient > 10 → unreliable.
+- `test_compute_split_adjustment_price_ratio_mismatch_unreliable` — coefficient that does not match the price drop → unreliable.
+- `test_compute_split_adjustment_ignores_splits_before_buy_date` — splits before the buy date do not adjust.
+- `test_portfolio_performance_corrects_clean_split` — clean split corrected to +10% and included (buy basis restated to 50).
+- `test_portfolio_performance_excludes_implausible_split` — implausible split excluded: not in the average, not in the count, present in `excluded_tickers`; clean stock still counted.
+- `test_portfolio_performance_no_split_unchanged` — no-split stock behaves exactly as before.
+- `test_is_priceable_split_unreliable_excludes_otherwise_priceable_stock` — split-unreliable stock dropped through the single gate.
+
+Modified existing tests (required by the `is_priceable` signature change and the
+`MarketDataCsv` return type; behaviour-preserving, documented inline):
+
+- The `test_is_priceable_*` cases and the two `test_portfolio_performance_excludes_*`
+  sanity tests pass `true` for the new `split_reliable` argument.
+- `test_read_market_data_from_csv_skips_unparseable_close` reads `.closes` from the
+  new `MarketDataCsv` return value.

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,8 @@ fn main() -> Result<()> {
             let market_data_csv = grq_validation::utils::read_market_data_from_csv(
                 &grq_validation::utils::derive_csv_output_path(&score_file_path),
             )
-            .context("reading market data CSV")?;
+            .context("reading market data CSV")?
+            .closes;
             let performance = grq_validation::utils::calculate_hybrid_projection(
                 &stock_records,
                 score_file_date,

--- a/src/models.rs
+++ b/src/models.rs
@@ -177,6 +177,35 @@ pub struct DailyData {
     pub split_coefficient: String,
 }
 
+/// Split-relevant daily figures parsed from the derived market-data CSV.
+///
+/// `high`/`low` feed the price-ratio reconciliation cross-check used to judge
+/// whether a split series can be trusted (issue #294). The close price is held
+/// separately in [`MarketDataCsv::closes`] and is not duplicated here.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DailyMarketPoint {
+    /// Highest traded price for the day.
+    pub high: f64,
+    /// Lowest traded price for the day.
+    pub low: f64,
+    /// Split coefficient applied on this date (`1.0` means no split).
+    pub split_coefficient: f64,
+}
+
+/// Result of parsing a derived market-data CSV.
+///
+/// `closes` preserves the original `ticker -> date -> close` shape consumed by
+/// existing callers; `points` carries the split-relevant figures used to
+/// correct-or-exclude split-distorted stocks (issue #294).
+#[derive(Debug, Default)]
+pub struct MarketDataCsv {
+    /// `ticker -> date -> close price`.
+    pub closes: std::collections::HashMap<String, std::collections::HashMap<String, f64>>,
+    /// `ticker -> date -> split-relevant daily figures`.
+    pub points:
+        std::collections::HashMap<String, std::collections::HashMap<String, DailyMarketPoint>>,
+}
+
 /// A full market-data file: metadata plus the daily time series keyed by date.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarketData {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use crate::models::{
-    DividendData, IndexData, MarketData, PortfolioPerformance, StockPerformance, StockRecord,
+    DailyMarketPoint, DividendData, IndexData, MarketData, MarketDataCsv, PortfolioPerformance,
+    StockPerformance, StockRecord,
 };
 use anyhow::{anyhow, Result};
 use chrono::{Duration, NaiveDate};
@@ -45,13 +46,129 @@ pub fn validate_stock_symbol(symbol: &str) -> bool {
 /// ```
 /// use grq_validation::utils::is_priceable;
 ///
-/// assert!(is_priceable(10.5, 12.0));
-/// assert!(!is_priceable(0.0, 12.0));  // missing buy price
-/// assert!(!is_priceable(10.5, 0.0));  // missing current price
-/// assert!(!is_priceable(0.0, 0.0));   // both missing
+/// assert!(is_priceable(10.5, 12.0, true));
+/// assert!(!is_priceable(0.0, 12.0, true));  // missing buy price
+/// assert!(!is_priceable(10.5, 0.0, true));  // missing current price
+/// assert!(!is_priceable(0.0, 0.0, true));   // both missing
+/// assert!(!is_priceable(10.5, 12.0, false)); // split series unreliable
 /// ```
-pub fn is_priceable(buy_price: f64, current_price: f64) -> bool {
-    buy_price > 0.0 && current_price > 0.0
+///
+/// `split_reliable` mirrors the frontend `isStockIncluded` predicate (issue
+/// #293): a stock whose split series cannot be trustworthily reconciled is
+/// excluded through this single gate rather than via a parallel path.
+pub fn is_priceable(buy_price: f64, current_price: f64, split_reliable: bool) -> bool {
+    buy_price > 0.0 && current_price > 0.0 && split_reliable
+}
+
+/// Trustworthy split-adjustment thresholds, mirroring `docs/projection.js`
+/// (issues #291/#292, parent #272). Agreed in the #291 investigation — see
+/// `docs/fixes/klac-split-distortion-investigation.md`.
+const MAX_PLAUSIBLE_COEFFICIENT: f64 = 10.0; // a single split of <= 10:1 is plausible
+const DUPLICATE_WINDOW_DAYS: i64 = 5; // splits within 5 days = the same event twice
+const MAX_CUMULATIVE_FACTOR: f64 = 50.0; // cumulative factor cap over the window
+const RECONCILE_TOLERANCE: f64 = 0.15; // +/-15% price-ratio cross-check
+
+/// Cumulative split adjustment for a window plus whether it can be trusted.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SplitAdjustment {
+    /// De-duplicated, plausibility-checked cumulative split factor (kept for
+    /// diagnostics even when `reliable` is `false`).
+    pub factor: f64,
+    /// `false` when the series cannot be reconciled; callers must then exclude
+    /// the stock rather than silently apply `factor`.
+    pub reliable: bool,
+}
+
+impl SplitAdjustment {
+    /// A no-split, trivially-reliable adjustment (factor `1.0`).
+    pub const NONE: SplitAdjustment = SplitAdjustment {
+        factor: 1.0,
+        reliable: true,
+    };
+}
+
+/// Computes the cumulative split adjustment for splits strictly after
+/// `from_date`, judging whether the series can be trusted — the Rust mirror of
+/// the frontend `computeSplitAdjustment` (issue #294, parent #272).
+///
+/// Rules: de-duplicate split events recorded within [`DUPLICATE_WINDOW_DAYS`];
+/// flag any single coefficient above [`MAX_PLAUSIBLE_COEFFICIENT`]; cap the
+/// cumulative factor at [`MAX_CUMULATIVE_FACTOR`]; and cross-check each split
+/// against the observed pre/post price drop (a real N:1 split divides the price
+/// ~N-fold) within [`RECONCILE_TOLERANCE`]. A missing or empty series means no
+/// known splits, so the factor is `1.0` and the series is reliable.
+pub fn compute_split_adjustment(
+    series: &HashMap<String, DailyMarketPoint>,
+    from_date: NaiveDate,
+) -> SplitAdjustment {
+    // Sort by date so "the price immediately before a split" is well-defined
+    // regardless of map iteration order.
+    let mut points: Vec<(NaiveDate, &DailyMarketPoint)> = series
+        .iter()
+        .filter_map(|(date_str, point)| {
+            NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+                .ok()
+                .map(|date| (date, point))
+        })
+        .collect();
+    points.sort_by_key(|(date, _)| *date);
+
+    let mut factor = 1.0;
+    let mut reliable = true;
+    let mut last_event: Option<NaiveDate> = None;
+
+    for (i, (date, point)) in points.iter().enumerate() {
+        let date = *date;
+        let c = point.split_coefficient;
+
+        // Only splits strictly after the buy date adjust the buy price.
+        if date <= from_date {
+            continue;
+        }
+        // Invalid / non-split coefficients mean "no adjustment" (treat as 1.0)
+        // and are not, by themselves, a reliability failure.
+        if !c.is_finite() || c <= 1.0 {
+            continue;
+        }
+        // De-duplicate: a split within DUPLICATE_WINDOW_DAYS of the last kept
+        // one is the same corporate event recorded twice — apply it once.
+        if let Some(prev_event) = last_event {
+            if (date - prev_event).num_days() <= DUPLICATE_WINDOW_DAYS {
+                continue;
+            }
+        }
+        last_event = Some(date);
+
+        // Implausibly large single coefficient: cannot trust unguarded.
+        if c > MAX_PLAUSIBLE_COEFFICIENT {
+            reliable = false;
+        }
+
+        // Price-ratio cross-check: compare the midpoint just before the split
+        // with the split point's own (post-split) midpoint. Only checkable when
+        // a prior point exists; absent one we keep the data-feed invariant.
+        if i > 0 {
+            let prev = points[i - 1].1;
+            let prev_mid = (prev.high + prev.low) / 2.0;
+            let split_mid = (point.high + point.low) / 2.0;
+            if prev_mid.is_finite() && split_mid.is_finite() && split_mid > 0.0 {
+                let observed_ratio = prev_mid / split_mid;
+                if (observed_ratio / c - 1.0).abs() > RECONCILE_TOLERANCE {
+                    reliable = false;
+                }
+            }
+        }
+
+        factor *= c;
+    }
+
+    // Cumulative-factor plausibility bound: a larger factor almost certainly
+    // means duplicated or spurious coefficients.
+    if factor > MAX_CUMULATIVE_FACTOR {
+        reliable = false;
+    }
+
+    SplitAdjustment { factor, reliable }
 }
 
 /// Returns the arithmetic mean of `scores`, or `0.0` for an empty slice.
@@ -301,25 +418,28 @@ fn parse_financial_value(field: &str, context: &str, raw: &str) -> Option<f64> {
     }
 }
 
-/// Reads a derived market-data CSV into a map of `ticker → (date → close)`.
+/// Reads a derived market-data CSV into a [`MarketDataCsv`].
 ///
-/// Rows with a non-numeric or non-positive close price are skipped (and a
-/// warning is written to stderr).
+/// The long-format columns are `date,ticker,high,low,open,close,
+/// split_coefficient`. `closes` keeps the original `ticker → (date → close)`
+/// shape; `points` additionally carries the `high`/`low`/`split_coefficient`
+/// figures the backend needs to correct-or-exclude split-distorted stocks
+/// (issue #294). Rows with a non-numeric or non-positive close price are
+/// skipped (and a warning is written to stderr). A missing or unparseable
+/// `split_coefficient` is treated as `1.0` (no split).
 ///
 /// # Errors
 ///
 /// Returns an error if the CSV file cannot be opened or a record cannot be
 /// read.
-pub fn read_market_data_from_csv(
-    csv_file_path: &str,
-) -> Result<HashMap<String, HashMap<String, f64>>> {
+pub fn read_market_data_from_csv(csv_file_path: &str) -> Result<MarketDataCsv> {
     use csv::ReaderBuilder;
     use std::fs::File;
 
     let file = File::open(csv_file_path)?;
     let mut reader = ReaderBuilder::new().has_headers(true).from_reader(file);
 
-    let mut market_data: HashMap<String, HashMap<String, f64>> = HashMap::new();
+    let mut market_data = MarketDataCsv::default();
 
     for result in reader.records() {
         let record = result?;
@@ -336,13 +456,42 @@ pub fn read_market_data_from_csv(
                 None => continue,
             };
 
-            if close_price > 0.0 {
-                // Store data using the full ticker (e.g., "NYSE:MBC")
-                market_data
-                    .entry(full_ticker)
-                    .or_default()
-                    .insert(date, close_price);
+            if close_price <= 0.0 {
+                continue;
             }
+
+            // high/low (columns 2/3) drive the split reconciliation cross-check;
+            // fall back to the close so a missing pair simply no-ops the check.
+            let high = record
+                .get(2)
+                .and_then(|v| v.parse::<f64>().ok())
+                .unwrap_or(close_price);
+            let low = record
+                .get(3)
+                .and_then(|v| v.parse::<f64>().ok())
+                .unwrap_or(close_price);
+            // split_coefficient (column 6) is optional; absent or invalid means
+            // "no split" (1.0) rather than a parse failure.
+            let split_coefficient = record
+                .get(6)
+                .and_then(|v| v.parse::<f64>().ok())
+                .filter(|c| c.is_finite() && *c > 0.0)
+                .unwrap_or(1.0);
+
+            // Store data using the full ticker (e.g., "NYSE:MBC").
+            market_data
+                .closes
+                .entry(full_ticker.clone())
+                .or_default()
+                .insert(date.clone(), close_price);
+            market_data.points.entry(full_ticker).or_default().insert(
+                date,
+                DailyMarketPoint {
+                    high,
+                    low,
+                    split_coefficient,
+                },
+            );
         }
     }
 
@@ -840,7 +989,8 @@ pub fn calculate_portfolio_performance(
 
     // Read market data from the CSV file that was created by the program
     let csv_file_path = derive_csv_output_path(score_file_path);
-    let market_data_csv = read_market_data_from_csv(&csv_file_path)?;
+    let market = read_market_data_from_csv(&csv_file_path)?;
+    let market_data_csv = &market.closes;
 
     let mut individual_performances = Vec::new();
     let mut excluded_tickers = Vec::new();
@@ -850,28 +1000,31 @@ pub fn calculate_portfolio_performance(
         // Use the full ticker (e.g., "NYSE:SEM") to match CSV data
         let full_ticker = &record.stock;
 
-        // Get the buy price (first day close) from CSV data
-        let buy_price = if let Some(first_day_data) = market_data_csv.get(full_ticker) {
+        // Get the buy price (first day close) from CSV data, and the date it
+        // came from (needed to know which splits fall inside the window).
+        let (buy_price, buy_date) = if let Some(first_day_data) = market_data_csv.get(full_ticker) {
             if let Some(first_day) = first_day_data.get(score_file_date) {
-                *first_day
+                (*first_day, score_date)
             } else {
                 // Find the next available trading day
                 let mut next_trading_day_price = 0.0;
-                let mut next_trading_day_date = None;
+                let mut next_trading_day_date = score_date;
+                let mut found: Option<NaiveDate> = None;
 
                 for (date_str, price) in first_day_data {
                     if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
-                        if date >= score_date && next_trading_day_date.is_none_or(|d| date < d) {
-                            next_trading_day_date = Some(date);
+                        if date >= score_date && found.is_none_or(|d| date < d) {
+                            found = Some(date);
+                            next_trading_day_date = date;
                             next_trading_day_price = *price;
                         }
                     }
                 }
 
-                next_trading_day_price
+                (next_trading_day_price, next_trading_day_date)
             }
         } else {
-            0.0
+            (0.0, score_date)
         };
 
         // Get the current price (90-day end date or latest available)
@@ -909,22 +1062,38 @@ pub fn calculate_portfolio_performance(
             0.0
         };
 
-        // Use the priceable predicate to determine inclusion
-        if is_priceable(buy_price, current_price) {
-            // Calculate price gain/loss
-            let gain_loss_percent = ((current_price - buy_price) / buy_price) * 100.0;
+        // Reconcile any split between the buy date and the current-price date.
+        // A reliable series is corrected (buy price restated to current terms);
+        // an unreliable one drops the stock through the single is_priceable gate.
+        let split = market
+            .points
+            .get(full_ticker)
+            .map(|series| compute_split_adjustment(series, buy_date))
+            .unwrap_or(SplitAdjustment::NONE);
+
+        // Use the priceable predicate (now split-aware) to determine inclusion.
+        if is_priceable(buy_price, current_price, split.reliable) {
+            // Restate the buy price into current (post-split) terms so the
+            // return is not distorted by a split inside the window. With no
+            // split the factor is 1.0 and the cost basis is unchanged.
+            let adjusted_buy_price = buy_price / split.factor;
+
+            // Calculate price gain/loss against the corrected cost basis.
+            let gain_loss_percent =
+                ((current_price - adjusted_buy_price) / adjusted_buy_price) * 100.0;
 
             // Calculate dividends for the 90-day period
             let dividends_total =
                 calculate_dividends_for_period(full_ticker, score_file_date, &end_date_str)
                     .unwrap_or(0.0);
 
-            // Calculate total return (price + dividends)
-            let total_return_percent = gain_loss_percent + (dividends_total / buy_price * 100.0);
+            // Calculate total return (price + dividends) on the same basis.
+            let total_return_percent =
+                gain_loss_percent + (dividends_total / adjusted_buy_price * 100.0);
 
             individual_performances.push(StockPerformance {
                 ticker: record.stock.clone(),
-                buy_price,
+                buy_price: adjusted_buy_price,
                 target_price: record.target,
                 current_price,
                 gain_loss_percent,
@@ -1043,8 +1212,11 @@ pub fn calculate_hybrid_projection(
                 0.0
             };
 
-            // Use the priceable predicate to determine inclusion
-            if is_priceable(buy_price, latest_price) {
+            // Use the priceable predicate to determine inclusion. The hybrid
+            // projection does not yet apply split correction (out of scope for
+            // issue #294), so split reliability is left at `true` to preserve
+            // its existing behaviour.
+            if is_priceable(buy_price, latest_price, true) {
                 let gain_loss_percent = ((latest_price - buy_price) / buy_price) * 100.0;
                 // Use market data days elapsed instead of calendar days
                 let market_days_elapsed = (latest_date - score_date).num_days();
@@ -1222,11 +1394,11 @@ pub fn update_index_with_performance(docs_path: &str) -> Result<()> {
             match read_tsv_score_file(&score_file_path) {
                 Ok(stock_records) => {
                     match read_market_data_from_csv(&derive_csv_output_path(&score_file_path)) {
-                        Ok(market_data_csv) => {
+                        Ok(market) => {
                             match calculate_hybrid_projection(
                                 &stock_records,
                                 &score_entry.date,
-                                &market_data_csv,
+                                &market.closes,
                             ) {
                                 Ok(performance) => {
                                     score_entry.performance_90_day =
@@ -2224,7 +2396,10 @@ mod tests {
         tmp.write_all(csv.as_bytes()).unwrap();
         let path = tmp.path().to_string_lossy().to_string();
 
-        let market_data = read_market_data_from_csv(&path).unwrap();
+        // `read_market_data_from_csv` now returns a `MarketDataCsv`; the close
+        // map lives under `.closes` (issue #294). Behaviour for close parsing is
+        // otherwise unchanged.
+        let market_data = read_market_data_from_csv(&path).unwrap().closes;
 
         // Previously the bad close became 0.0 and was dropped by the > 0.0
         // guard; now it is explicitly skipped with a warning. Either way only
@@ -2575,33 +2750,45 @@ mod tests {
 
     // --- Tests for stock priceable predicate (issue #286) ---
 
+    // The third `split_reliable` argument was added in issue #294 so the single
+    // predicate also drops split-unreliable stocks (mirroring the frontend
+    // `isStockIncluded`). These existing cases pass `true` to preserve their
+    // original price-only intent; a dedicated case below covers `false`.
     #[test]
     fn test_is_priceable_both_prices_present() {
-        assert!(is_priceable(10.5, 12.0));
-        assert!(is_priceable(0.01, 0.01));
-        assert!(is_priceable(100.0, 1.0));
+        assert!(is_priceable(10.5, 12.0, true));
+        assert!(is_priceable(0.01, 0.01, true));
+        assert!(is_priceable(100.0, 1.0, true));
     }
 
     #[test]
     fn test_is_priceable_buy_price_missing() {
-        assert!(!is_priceable(0.0, 12.0));
+        assert!(!is_priceable(0.0, 12.0, true));
     }
 
     #[test]
     fn test_is_priceable_current_price_missing() {
-        assert!(!is_priceable(10.5, 0.0));
+        assert!(!is_priceable(10.5, 0.0, true));
     }
 
     #[test]
     fn test_is_priceable_both_prices_missing() {
-        assert!(!is_priceable(0.0, 0.0));
+        assert!(!is_priceable(0.0, 0.0, true));
     }
 
     #[test]
     fn test_is_priceable_negative_prices() {
-        assert!(!is_priceable(-10.5, 12.0));
-        assert!(!is_priceable(10.5, -12.0));
-        assert!(!is_priceable(-10.5, -12.0));
+        assert!(!is_priceable(-10.5, 12.0, true));
+        assert!(!is_priceable(10.5, -12.0, true));
+        assert!(!is_priceable(-10.5, -12.0, true));
+    }
+
+    #[test]
+    fn test_is_priceable_split_unreliable_excludes_otherwise_priceable_stock() {
+        // Both prices usable, but an unreliable split series drops the stock
+        // through the single gate (issue #294).
+        assert!(!is_priceable(10.5, 12.0, false));
+        assert!(!is_priceable(100.0, 1.0, false));
     }
 
     #[test]
@@ -2633,18 +2820,18 @@ mod tests {
 
         // Simulate that GOOD1 and GOOD2 are priceable but MISSING_BUY is not
         // This is tested implicitly via the count and excluded list
-        assert!(is_priceable(20.0, 25.0)); // GOOD1 is priceable
-        assert!(is_priceable(20.0, 22.0)); // GOOD2 is priceable
-        assert!(!is_priceable(0.0, 0.0)); // MISSING_BUY is not priceable
+        assert!(is_priceable(20.0, 25.0, true)); // GOOD1 is priceable
+        assert!(is_priceable(20.0, 22.0, true)); // GOOD2 is priceable
+        assert!(!is_priceable(0.0, 0.0, true)); // MISSING_BUY is not priceable
     }
 
     #[test]
     fn test_portfolio_performance_excludes_missing_current_price() {
         // When a stock has a missing current price within the 90-day window,
         // it should be excluded from both the average and the count.
-        assert!(is_priceable(20.0, 25.0)); // priceable
-        assert!(!is_priceable(20.0, 0.0)); // missing current price is not priceable
-        assert!(!is_priceable(0.0, 25.0)); // missing buy price is not priceable
+        assert!(is_priceable(20.0, 25.0, true)); // priceable
+        assert!(!is_priceable(20.0, 0.0, true)); // missing current price is not priceable
+        assert!(!is_priceable(0.0, 25.0, true)); // missing buy price is not priceable
     }
 
     #[test]
@@ -2691,5 +2878,226 @@ mod tests {
         let wrong_average = good_returns.iter().sum::<f64>() / wrong_denominator as f64;
         assert_eq!(wrong_average, 20.0 / 3.0);
         assert_ne!(correct_average, wrong_average);
+    }
+
+    // --- Split-coefficient guard and correct-or-exclude (issue #294) ---
+
+    /// Builds a split-relevant series for one ticker from
+    /// `(date, high, low, close_unused, split_coefficient)` points. `close` is
+    /// not stored in `DailyMarketPoint`, so only high/low/coefficient matter.
+    fn split_series(points: &[(&str, f64, f64, f64)]) -> HashMap<String, DailyMarketPoint> {
+        let mut series = HashMap::new();
+        for (date, high, low, split_coefficient) in points {
+            series.insert(
+                (*date).to_string(),
+                DailyMarketPoint {
+                    high: *high,
+                    low: *low,
+                    split_coefficient: *split_coefficient,
+                },
+            );
+        }
+        series
+    }
+
+    fn date(s: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(s, "%Y-%m-%d").unwrap()
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_no_splits_is_reliable_unity() {
+        let series = split_series(&[
+            ("2024-11-15", 100.0, 100.0, 1.0),
+            ("2024-12-15", 105.0, 105.0, 1.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert_eq!(adj, SplitAdjustment::NONE);
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_clean_single_split() {
+        // A real 2:1 split: the day before trades ~110, the split day ~55.
+        let series = split_series(&[
+            ("2024-12-14", 110.0, 110.0, 1.0),
+            ("2024-12-15", 55.0, 55.0, 2.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert!(adj.reliable, "a reconcilable 2:1 split must be reliable");
+        assert!((adj.factor - 2.0).abs() < 1e-9, "factor should be 2.0");
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_deduplicates_repeated_event() {
+        // The same 2:1 event recorded twice within five days applies once.
+        let series = split_series(&[
+            ("2024-12-14", 110.0, 110.0, 1.0),
+            ("2024-12-15", 55.0, 55.0, 2.0),
+            ("2024-12-17", 55.0, 55.0, 2.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert!(adj.reliable);
+        assert!(
+            (adj.factor - 2.0).abs() < 1e-9,
+            "duplicate within window must not compound to 4.0, got {}",
+            adj.factor
+        );
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_implausible_coefficient_unreliable() {
+        let series = split_series(&[
+            ("2024-12-14", 110.0, 110.0, 1.0),
+            ("2024-12-15", 2.0, 2.0, 50.0), // single coefficient far above 10
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert!(
+            !adj.reliable,
+            "an implausibly large single coefficient must be flagged unreliable"
+        );
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_price_ratio_mismatch_unreliable() {
+        // Coefficient claims 2:1 but the price barely moves: cannot reconcile.
+        let series = split_series(&[
+            ("2024-12-14", 100.0, 100.0, 1.0),
+            ("2024-12-15", 98.0, 98.0, 2.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert!(
+            !adj.reliable,
+            "a coefficient that does not match the observed price drop is unreliable"
+        );
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_ignores_splits_before_buy_date() {
+        // A split that predates the buy date does not adjust the buy price.
+        let series = split_series(&[
+            ("2024-12-14", 110.0, 110.0, 1.0),
+            ("2024-12-15", 55.0, 55.0, 2.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-12-31"));
+        assert_eq!(adj, SplitAdjustment::NONE);
+    }
+
+    /// Writes a score TSV and its derived market-data CSV into a temp dir, then
+    /// returns the temp dir (kept alive) and the score-file path.
+    fn write_portfolio_fixture(tsv: &str, csv: &str) -> (tempfile::TempDir, String) {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let tsv_path = dir.path().join("score.tsv");
+        let csv_path = dir.path().join("score.csv");
+        std::fs::File::create(&tsv_path)
+            .unwrap()
+            .write_all(tsv.as_bytes())
+            .unwrap();
+        std::fs::File::create(&csv_path)
+            .unwrap()
+            .write_all(csv.as_bytes())
+            .unwrap();
+        (dir, tsv_path.to_string_lossy().to_string())
+    }
+
+    const PERF_CSV_HEADER: &str = "date,ticker,high,low,open,close,split_coefficient\n";
+
+    /// Score-TSV header carrying every column `StockRecord` deserialises.
+    const PERF_TSV_HEADER: &str = "Stock\tScore\tTarget\tExDividendDate\tDividendPerShare\tNotes\tintrinsicValuePerShareBasic\tintrinsicValuePerShareAdjusted\n";
+
+    #[test]
+    fn test_portfolio_performance_corrects_clean_split() {
+        // A clean 2:1 split inside the window must be corrected, not excluded:
+        // raw close 100 -> 55 looks like -45%, but the split-adjusted return is
+        // +10% (buy basis restated to 50).
+        let tsv = format!("{PERF_TSV_HEADER}NYSE:CLEAN\t1.0\t$120.00\t\t\t\t\t\n");
+        let csv = format!(
+            "{PERF_CSV_HEADER}\
+             2024-11-15,NYSE:CLEAN,100,100,100,100,1.0\n\
+             2024-12-14,NYSE:CLEAN,110,110,110,110,1.0\n\
+             2024-12-15,NYSE:CLEAN,55,55,55,55,2.0\n\
+             2025-02-13,NYSE:CLEAN,55,55,55,55,1.0\n"
+        );
+        let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
+
+        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+
+        assert_eq!(result.total_stocks, 1, "a clean split stock stays included");
+        assert!(result.excluded_tickers.is_empty());
+        let stock = &result.individual_performances[0];
+        assert!(
+            (stock.buy_price - 50.0).abs() < 1e-6,
+            "buy basis must be restated to 50, got {}",
+            stock.buy_price
+        );
+        assert!(
+            (stock.gain_loss_percent - 10.0).abs() < 1e-6,
+            "corrected return must be +10%, got {}",
+            stock.gain_loss_percent
+        );
+        assert!((result.performance_90_day - 10.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_portfolio_performance_excludes_implausible_split() {
+        // Two stocks: one clean (+10%), one with an implausible coefficient that
+        // cannot be reconciled. The bad one must drop from the average, from the
+        // count, and appear in excluded_tickers (issue #294 + #286 plumbing).
+        let tsv = format!(
+            "{PERF_TSV_HEADER}\
+             NYSE:GOODSPLIT\t1.0\t$120.00\t\t\t\t\t\n\
+             NYSE:BADSPLIT\t1.0\t$120.00\t\t\t\t\t\n"
+        );
+        let csv = format!(
+            "{PERF_CSV_HEADER}\
+             2024-11-15,NYSE:GOODSPLIT,100,100,100,100,1.0\n\
+             2024-12-14,NYSE:GOODSPLIT,110,110,110,110,1.0\n\
+             2024-12-15,NYSE:GOODSPLIT,55,55,55,55,2.0\n\
+             2025-02-13,NYSE:GOODSPLIT,55,55,55,55,1.0\n\
+             2024-11-15,NYSE:BADSPLIT,100,100,100,100,1.0\n\
+             2024-12-15,NYSE:BADSPLIT,2,2,2,2,50.0\n\
+             2025-02-13,NYSE:BADSPLIT,2,2,2,2,1.0\n"
+        );
+        let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
+
+        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+
+        assert_eq!(
+            result.total_stocks, 1,
+            "only the reconcilable stock is counted"
+        );
+        assert_eq!(result.individual_performances.len(), 1);
+        assert_eq!(result.individual_performances[0].ticker, "NYSE:GOODSPLIT");
+        assert!(
+            result
+                .excluded_tickers
+                .contains(&"NYSE:BADSPLIT".to_string()),
+            "the unreconcilable split stock must be excluded"
+        );
+        // Average is over the single included stock only.
+        assert!((result.performance_90_day - 10.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_portfolio_performance_no_split_unchanged() {
+        // A stock with no split (coefficient 1.0 throughout) behaves exactly as
+        // before: 100 -> 110 is a straight +10%, buy basis unchanged.
+        let tsv = format!("{PERF_TSV_HEADER}NYSE:NOSPLIT\t1.0\t$120.00\t\t\t\t\t\n");
+        let csv = format!(
+            "{PERF_CSV_HEADER}\
+             2024-11-15,NYSE:NOSPLIT,100,100,100,100,1.0\n\
+             2025-02-13,NYSE:NOSPLIT,110,110,110,110,1.0\n"
+        );
+        let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
+
+        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+
+        assert_eq!(result.total_stocks, 1);
+        assert!(result.excluded_tickers.is_empty());
+        let stock = &result.individual_performances[0];
+        assert!(
+            (stock.buy_price - 100.0).abs() < 1e-6,
+            "no-split buy basis is unchanged"
+        );
+        assert!((stock.gain_loss_percent - 10.0).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
## Summary

The Rust backend previously ignored stock splits entirely: `read_market_data_from_csv`
parsed only the `close` column, and `calculate_portfolio_performance` used the raw
close for both buy and current price, so a split inside the 90-day window distorted
the return. This PR mirrors the frontend correct-or-exclude rule in the backend and
reuses #286's exclusion plumbing rather than building a parallel one. **Closes #294.**

What changed:

- **`read_market_data_from_csv`** now parses the `split_coefficient` (and `high`/`low`)
  columns and returns a `MarketDataCsv { closes, points }`. `closes` preserves the
  original `ticker → date → close` shape consumed by existing callers; `points`
  carries the split-relevant daily figures. A missing/invalid coefficient is treated
  as `1.0` (no split).
- **`compute_split_adjustment`** is a Rust mirror of the frontend
  `computeSplitAdjustment`, using the same agreed thresholds: de-duplicate split
  events within 5 days, flag any single coefficient above 10, cap the cumulative
  factor at 50, and cross-check each split against the observed pre/post price drop
  within ±15%. It returns `{ factor, reliable }`.
- **`calculate_portfolio_performance`** computes the buy date, then reconciles any
  split between the buy date and the current-price date. A **reliable** series
  restates the buy price into post-split terms (`buy / factor`) so the return is
  correct; an **unreliable** series excludes the stock.
- **`is_priceable`** gains a third `split_reliable` argument (mirroring the frontend
  `isStockIncluded`), so split-unreliable stocks drop through the single gate — out of
  the average, out of the included `total_stocks` count, and into `excluded_tickers`.
  With no split, the factor is `1.0` and behaviour is identical to before.

Backend and frontend share the same thresholds, so their exclusion outcomes stay
consistent.

### Deno regression avoided

This is a Deno + Rust repo; the work was done entirely in Rust (`cargo test`,
`cargo clippy`) and verified against the existing Deno consistency suite — no
Node tooling was introduced.

## Evidence

Backend/CLI change with no web interface to screenshot. Verified via `cargo test`
and the full `./quality.sh` gate (Rust tests + clippy + coverage, plus 544 Deno
tests including the split/consistency suites), all green.

Data flow:

```mermaid
flowchart LR
    A[scores/*.csv<br/>date,ticker,high,low,open,close,split_coefficient] --> B[read_market_data_from_csv]
    B --> C[MarketDataCsv: closes + points]
    C --> D[compute_split_adjustment<br/>factor + reliable]
    D -->|reliable| E[restate buy price<br/>buy / factor → corrected return]
    D -->|unreliable| F[is_priceable gate = false]
    E --> G[included: average + count]
    F --> H[excluded_tickers]
```

## Test Plan

New tests in the `#[cfg(test)]` module of `src/utils.rs`:

- `test_compute_split_adjustment_no_splits_is_reliable_unity` — no splits → factor 1.0, reliable.
- `test_compute_split_adjustment_clean_single_split` — reconcilable 2:1 → factor 2.0, reliable.
- `test_compute_split_adjustment_deduplicates_repeated_event` — duplicate within 5 days applied once (factor 2.0, not 4.0).
- `test_compute_split_adjustment_implausible_coefficient_unreliable` — coefficient > 10 → unreliable.
- `test_compute_split_adjustment_price_ratio_mismatch_unreliable` — coefficient that does not match the price drop → unreliable.
- `test_compute_split_adjustment_ignores_splits_before_buy_date` — splits before the buy date do not adjust.
- `test_portfolio_performance_corrects_clean_split` — clean split corrected to +10% and included (buy basis restated to 50).
- `test_portfolio_performance_excludes_implausible_split` — implausible split excluded: not in the average, not in the count, present in `excluded_tickers`; clean stock still counted.
- `test_portfolio_performance_no_split_unchanged` — no-split stock behaves exactly as before.
- `test_is_priceable_split_unreliable_excludes_otherwise_priceable_stock` — split-unreliable stock dropped through the single gate.

Modified existing tests (required by the `is_priceable` signature change and the
`MarketDataCsv` return type; behaviour-preserving, documented inline):

- The `test_is_priceable_*` cases and the two `test_portfolio_performance_excludes_*`
  sanity tests pass `true` for the new `split_reliable` argument.
- `test_read_market_data_from_csv_skips_unparseable_close` reads `.closes` from the
  new `MarketDataCsv` return value.
