### PR TITLE
fix: positive projected return no longer shown as red "Declining" (#297)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-297.md
+++ b/docs/archive/pr-summaries/pr-summary-297.md
@@ -1,0 +1,68 @@
+# Fix computeJudgement sign-flip — positive return no longer reads as "Declining"
+
+## Summary
+On the scores view, stocks with clear gains showed a red **"Declining"** status
+badge: NASDAQ:STLD (realised **+33.5%**) read `Declining (45.5%)` and NYSE:GE
+(**+14.7%**) the same.
+
+Root cause was in `computeJudgement` (`docs/projection.js`). `target` is the
+**target return %**, not a price. When a stock's model 90-Day Target *price*
+sits below its buy price, the target return % is **negative**. The old
+`pctOfTarget = predicted / target` then flipped the sign of a healthy positive
+projection, so `predicted < 0 || pctOfTarget < 0.2` was true and the kernel
+returned `"Declining"`. `getJudgementClass` maps `"Declining"` → red, so fixing
+the kernel corrects STLD, GE, and every stock in the status column at once.
+
+The fix judges direction by the **sign** of the predicted return first (only a
+negative projection is `"Declining"`) and guards the ratio against a
+non-positive `target`. A positive projection is now `"On Track"` or
+`"Below Target"`, never `"Declining"`.
+
+Closes #297.
+
+## Evidence
+This is a pure scoring-kernel (non-UI) change, verified by behavioural tests
+that drive the real exported `GRQProjection.computeJudgement` and assert on the
+shipped judgement strings. The new tests fail before the fix and pass after.
+
+Before → after for the reported cases:
+
+| Case | target % | predicted % | Before | After |
+|------|----------|-------------|--------|-------|
+| STLD | −2 | +45.5 | `Declining (45.5%)` | not `Declining` |
+| GE   | −1.5 | +12.3 | `Declining (12.3%)` | not `Declining` |
+
+```mermaid
+flowchart TD
+    A[predicted return] --> B{predicted &lt; 0?}
+    B -- yes --> D[Declining]
+    B -- no --> C{target &le; 0?}
+    C -- yes --> E[On Track]
+    C -- no --> F[pctOfTarget = predicted / target]
+    F --> G{&ge; 0.95?}
+    G -- yes --> E
+    G -- no --> H[Below Target]
+```
+
+Test run:
+
+```
+ok | 3 passed (9 steps) | 0 failed
+```
+
+`./quality.sh` passes cleanly.
+
+## Test Plan
+Added to `tests/judgement_tests.ts` (new test
+`computeJudgement - positive projection with a non-positive target (issue #297)`):
+- **STLD-like** — confident projection `+45.5`, `targetPercentage = -2`; asserts
+  the result does not start with `"Declining"`.
+- **GE-like** — smaller positive projection `+12.3`, `targetPercentage = -1.5`;
+  asserts not `"Declining"`.
+- **Negative projection** — `-8.0` with a negative target still returns
+  `"Declining"` (no regression in the genuine-decline path).
+- **Small positive vs positive target** — `+2.0` against target `20` is
+  `"Below Target"`, not `"Declining"`.
+
+Existing `computeJudgement` realised-outcome and early-stage tests continue to
+pass unchanged.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -636,15 +636,27 @@ function computeJudgement(
     if (daysElapsed < 90) {
         if (projection && projection.confidence > 0.2) {
             const predicted = projection.projected90DayPerformance;
-            const pctOfTarget = target === 0 ? 0 : predicted / target;
-            if (predicted < 0 || pctOfTarget < 0.2) {
+            // Judge by the sign of the predicted return first: only a negative
+            // projection is "Declining". A positive projection must never read
+            // as declining (issue #297).
+            if (predicted < 0) {
                 return `Declining (${predicted.toFixed(1)}%)`;
-            } else if (pctOfTarget >= 0.95) {
-                return `On Track (${predicted.toFixed(1)}%)`;
-            } else if (pctOfTarget >= 0.2) {
-                return `Below Target (${predicted.toFixed(1)}%)`;
             }
-            return `Declining (${predicted.toFixed(1)}%)`;
+            // predicted >= 0 here. Guard the ratio against a non-positive
+            // target: when the model 90-Day Target price sits below the buy
+            // price the target return % is negative, and `predicted / target`
+            // would flip a healthy positive projection's sign and mislabel it
+            // as "Declining". Fall back to the sign of the projection instead.
+            if (target <= 0) {
+                return `On Track (${predicted.toFixed(1)}%)`;
+            }
+            const pctOfTarget = predicted / target;
+            if (pctOfTarget >= 0.95) {
+                return `On Track (${predicted.toFixed(1)}%)`;
+            }
+            // A positive projection short of target is below target, not
+            // declining.
+            return `Below Target (${predicted.toFixed(1)}%)`;
         }
 
         // Not enough data for a reliable projection: judge current performance.

--- a/tests/judgement_tests.ts
+++ b/tests/judgement_tests.ts
@@ -100,3 +100,94 @@ Deno.test("computeJudgement - pending and early-stage reporting", async (t) => {
     },
   );
 });
+
+Deno.test(
+  "computeJudgement - positive projection with a non-positive target (issue #297)",
+  async (t) => {
+    // Regression for the computeJudgement sign-flip. When a stock's model
+    // 90-Day Target price sits below its buy price the target return % is
+    // negative, so the old `predicted / target` ratio flipped the sign of a
+    // healthy positive projection and mislabelled it as a red "Declining".
+    // A positive projected return must never read as "Declining".
+
+    await t.step(
+      "STLD-like: strong positive projection, negative target",
+      () => {
+        const result = GRQProjection.computeJudgement({
+          performance: 33.5,
+          daysElapsed: 60,
+          targetPercentage: -2, // target price below buy price
+          projection: {
+            projected90DayPerformance: 45.5,
+            projectionMethod: "dampened_trend",
+            confidence: 0.6,
+          },
+        });
+        assert(
+          !result.startsWith("Declining"),
+          `expected not declining, got "${result}"`,
+        );
+      },
+    );
+
+    await t.step(
+      "GE-like: smaller positive projection, negative target",
+      () => {
+        const result = GRQProjection.computeJudgement({
+          performance: 14.7,
+          daysElapsed: 60,
+          targetPercentage: -1.5,
+          projection: {
+            projected90DayPerformance: 12.3,
+            projectionMethod: "dampened_trend",
+            confidence: 0.5,
+          },
+        });
+        assert(
+          !result.startsWith("Declining"),
+          `expected not declining, got "${result}"`,
+        );
+      },
+    );
+
+    await t.step(
+      "a negative projection still declines regardless of target sign",
+      () => {
+        const result = GRQProjection.computeJudgement({
+          performance: -8.0,
+          daysElapsed: 60,
+          targetPercentage: -2,
+          projection: {
+            projected90DayPerformance: -8.0,
+            projectionMethod: "dampened_trend",
+            confidence: 0.6,
+          },
+        });
+        assert(
+          result.startsWith("Declining"),
+          `expected declining, got "${result}"`,
+        );
+      },
+    );
+
+    await t.step(
+      "a small positive projection short of a positive target is below target, not declining",
+      () => {
+        const result = GRQProjection.computeJudgement({
+          performance: 2.0,
+          daysElapsed: 60,
+          targetPercentage: 20, // predicted 2% is < 0.2 * target
+          projection: {
+            projected90DayPerformance: 2.0,
+            projectionMethod: "dampened_trend",
+            confidence: 0.6,
+          },
+        });
+        assert(
+          !result.startsWith("Declining"),
+          `expected not declining, got "${result}"`,
+        );
+      },
+    );
+  },
+);


### PR DESCRIPTION
# Fix computeJudgement sign-flip — positive return no longer reads as "Declining"

## Summary
On the scores view, stocks with clear gains showed a red **"Declining"** status
badge: NASDAQ:STLD (realised **+33.5%**) read `Declining (45.5%)` and NYSE:GE
(**+14.7%**) the same.

Root cause was in `computeJudgement` (`docs/projection.js`). `target` is the
**target return %**, not a price. When a stock's model 90-Day Target *price*
sits below its buy price, the target return % is **negative**. The old
`pctOfTarget = predicted / target` then flipped the sign of a healthy positive
projection, so `predicted < 0 || pctOfTarget < 0.2` was true and the kernel
returned `"Declining"`. `getJudgementClass` maps `"Declining"` → red, so fixing
the kernel corrects STLD, GE, and every stock in the status column at once.

The fix judges direction by the **sign** of the predicted return first (only a
negative projection is `"Declining"`) and guards the ratio against a
non-positive `target`. A positive projection is now `"On Track"` or
`"Below Target"`, never `"Declining"`.

Closes #297.

## Evidence
This is a pure scoring-kernel (non-UI) change, verified by behavioural tests
that drive the real exported `GRQProjection.computeJudgement` and assert on the
shipped judgement strings. The new tests fail before the fix and pass after.

Before → after for the reported cases:

| Case | target % | predicted % | Before | After |
|------|----------|-------------|--------|-------|
| STLD | −2 | +45.5 | `Declining (45.5%)` | not `Declining` |
| GE   | −1.5 | +12.3 | `Declining (12.3%)` | not `Declining` |

```mermaid
flowchart TD
    A[predicted return] --> B{predicted &lt; 0?}
    B -- yes --> D[Declining]
    B -- no --> C{target &le; 0?}
    C -- yes --> E[On Track]
    C -- no --> F[pctOfTarget = predicted / target]
    F --> G{&ge; 0.95?}
    G -- yes --> E
    G -- no --> H[Below Target]
```

Test run:

```
ok | 3 passed (9 steps) | 0 failed
```

`./quality.sh` passes cleanly.

## Test Plan
Added to `tests/judgement_tests.ts` (new test
`computeJudgement - positive projection with a non-positive target (issue #297)`):
- **STLD-like** — confident projection `+45.5`, `targetPercentage = -2`; asserts
  the result does not start with `"Declining"`.
- **GE-like** — smaller positive projection `+12.3`, `targetPercentage = -1.5`;
  asserts not `"Declining"`.
- **Negative projection** — `-8.0` with a negative target still returns
  `"Declining"` (no regression in the genuine-decline path).
- **Small positive vs positive target** — `+2.0` against target `20` is
  `"Below Target"`, not `"Declining"`.

Existing `computeJudgement` realised-outcome and early-stage tests continue to
pass unchanged.



## Milestone
This PR is part of the **#274 bug: 34% gain shown as red "Declining" status on 2026-04-09 scores** milestone and targets the `milestone/274-bug-34-gain-shown-as-red-declining-status-on-2` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqoqmnel-94f691`<!-- vibe-worker-issue-297 -->