### PR TITLE
fix: target price not shown red next to a positive return (#299)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-299.md
+++ b/docs/archive/pr-summaries/pr-summary-299.md
@@ -1,0 +1,66 @@
+# Reconsider red 90-Day Target price colour next to a positive return
+
+## Summary
+The **90-Day Target price** rendered red ("danger") whenever the target price
+sat below the buy price — even when the position was in profit. For STLD the
+target ($184.36) is below buy ($188.35), so the price showed red while sitting
+directly next to a large green realised gain, reading as self-contradictory
+(part of #274).
+
+`getTargetPriceColor` (`docs/projection.js`) now reserves red for a genuinely
+bad position: red fires **only when the position is underwater** (current price
+below buy) **and** the target stays below entry. When the position is in profit
+(current >= buy) the target is green (upside still implied) or grey (target
+already met / below entry), **never red**. This mirrors the sibling fix #297,
+which stopped a positive projected return reading as a red "Declining" badge —
+red should never sit next to a positive return.
+
+The target *value* is unchanged (target correctness is out of scope for #274) —
+this is a colour/presentation change only.
+
+Closes #299.
+
+## Evidence
+This is a pure display-kernel change. `getTargetPriceColor` is exported on
+`globalThis.GRQProjection` and the dashboard delegates to it, so the new
+behavioural tests drive the **real production logic**, not a copy. Playwright
+MCP was not available in this environment, so verification is via the exported
+kernel (the same approach as #297).
+
+Before → after, class tokens returned by the real exported function:
+
+| Case | target | current | buy | Before | After |
+|------|--------|---------|-----|--------|-------|
+| STLD-like (in profit, target < buy) | 184.36 | 200.00 | 188.35 | `price-bad` (red) | `price-neutral` (grey) |
+| In profit, target above current | 70 | 60 | 55 | `price-good` (green) | `price-good` (green) |
+| Underwater, target below buy | 40 | 50 | 55 | `price-bad` (red) | `price-bad` (red) |
+| Underwater, target at/above buy | 70 | 50 | 55 | `price-neutral` (grey) | `price-neutral` (grey) |
+
+Only the in-profit / target-below-buy case changes — exactly the contradictory
+case the issue reports. Genuine danger (underwater with a sub-entry target)
+stays red.
+
+```mermaid
+flowchart TD
+    A[target, current, buy] --> N{any null?}
+    N -- yes --> Z[default colour]
+    N -- no --> P{current &ge; buy? in profit}
+    P -- yes --> G{target &gt; current?}
+    G -- yes --> GG[green: upside remains]
+    G -- no --> GR1[grey: already met / below entry]
+    P -- no --> U{target &lt; buy?}
+    U -- yes --> R[red: underwater, target below entry]
+    U -- no --> GR2[grey: recovery implied]
+```
+
+Test run (`deno test --allow-read tests/*.ts`): `539 passed | 0 failed`.
+
+## Test Plan
+Updated `tests/fair_value_color_test.ts`:
+- **Renamed** `…- target below buy price is red (always bad)` →
+  `…- target below buy is red ONLY in loss territory`, asserting `(40, 50, 55)`
+  (underwater) is still red.
+- **Added** `…- target below buy while in profit is NOT red (issue #299)`:
+  the STLD-like case `(40, 60, 55)` now returns grey, not red — the regression
+  guard for #299.
+- Existing green / grey / null / boundary cases are unchanged and still pass.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -364,29 +364,37 @@ function getFairValueRange(analysis) {
 // rules (issue #204). Pure given the three prices so the dashboard and tests
 // share one cascade. Returns a CSS *class* token (not an inline colour) so the
 // colour is theme-aware via the cascade — the dark theme remaps the same class
-// to a higher-contrast colour, meeting WCAG 2 AA in both themes (issue #281):
+// to a higher-contrast colour, meeting WCAG 2 AA in both themes (issue #281).
+//
+// Red ("danger") must signal a genuine problem, never sit next to a positive
+// return (issue #299, part of #274): when the position is in profit
+// (current >= buy) the target is never red — a target below the buy price there
+// is simply already met by the market, not "bad". Red is reserved for a
+// position that is underwater with a target that stays below entry.
 //   - any input null -> '' (default colour, inherited)
-//   - target below buy price -> 'price-bad' (red, always bad)
-//   - target above current AND in profit (current >= buy) -> 'price-good' (green)
+//   - in profit (current >= buy): target above current -> 'price-good' (green),
+//     otherwise -> 'price-neutral' (grey)
+//   - underwater (current < buy) AND target below buy -> 'price-bad' (red)
 //   - otherwise -> 'price-neutral' (grey)
 function getTargetPriceColor(targetPrice, currentPrice, buyPrice) {
     if (targetPrice === null || currentPrice === null || buyPrice === null) {
         return ""; // Default colour (inherits)
     }
 
-    // Red (Danger): Target price is below buy price - this is always bad
+    // In profit (current at or above buy): the realised return is positive, so
+    // the target must never read as danger (issue #299). Green when the target
+    // still implies upside from here, grey when it is already met/below entry.
+    if (currentPrice >= buyPrice) {
+        return targetPrice > currentPrice ? "price-good" : "price-neutral";
+    }
+
+    // Underwater (current below buy): a target below the buy price means the
+    // model expects the price to stay below entry - genuinely bad -> red.
     if (targetPrice < buyPrice) {
         return "price-bad";
     }
 
-    // Green (Good): Target price is above current price AND we're in profit territory
-    if (targetPrice > currentPrice && currentPrice >= buyPrice) {
-        return "price-good";
-    }
-
-    // Grey (Neutral): Target price is above buy price but we're either:
-    // - Below current price (target achieved), or
-    // - Current price is below buy price (we're in loss territory but target is still above buy price)
+    // Underwater but the target is still above entry (recovery implied) -> grey.
     return "price-neutral";
 }
 

--- a/tests/fair_value_color_test.ts
+++ b/tests/fair_value_color_test.ts
@@ -9,8 +9,9 @@
 // output:
 //   - Fair value: both values -> range; one value -> single (with source);
 //     neither / no analysis -> null.
-//   - Colour: any null input -> ''; target < buy -> red; target > current AND
-//     current >= buy -> green; otherwise grey.
+//   - Colour: any null input -> ''; in profit (current >= buy) the target is
+//     never red (issue #299) -> green when target > current, else grey; only
+//     when underwater (current < buy) does a target < buy go red.
 import { assertEquals } from "@std/assert";
 import "../docs/projection.js";
 
@@ -94,9 +95,19 @@ Deno.test("getTargetPriceColor - any null input returns the default colour", () 
   assertEquals(GRQProjection.getTargetPriceColor(50, 60, null), "");
 });
 
-Deno.test("getTargetPriceColor - target below buy price is red (always bad)", () => {
-  // 40 < buy 55 -> red, even though it is also below the current price.
-  assertEquals(GRQProjection.getTargetPriceColor(40, 60, 55), RED);
+Deno.test("getTargetPriceColor - target below buy is red ONLY in loss territory", () => {
+  // Issue #299: red ("danger") must signal a genuine problem, so it only fires
+  // when the position is underwater. current 50 < buy 55 AND target 40 < buy 55
+  // -> the model expects the price to stay below entry -> red.
+  assertEquals(GRQProjection.getTargetPriceColor(40, 50, 55), RED);
+});
+
+Deno.test("getTargetPriceColor - target below buy while in profit is NOT red (issue #299)", () => {
+  // Regression for #299/#274: STLD-like case. The position is in profit
+  // (current 60 >= buy 55) and shows a large green realised gain, so painting a
+  // target below buy red read as self-contradictory. With current >= buy the
+  // target is grey (already met/below entry), never red.
+  assertEquals(GRQProjection.getTargetPriceColor(40, 60, 55), GREY);
 });
 
 Deno.test("getTargetPriceColor - target above current while in profit is green", () => {


### PR DESCRIPTION
# Reconsider red 90-Day Target price colour next to a positive return

## Summary
The **90-Day Target price** rendered red ("danger") whenever the target price
sat below the buy price — even when the position was in profit. For STLD the
target ($184.36) is below buy ($188.35), so the price showed red while sitting
directly next to a large green realised gain, reading as self-contradictory
(part of #274).

`getTargetPriceColor` (`docs/projection.js`) now reserves red for a genuinely
bad position: red fires **only when the position is underwater** (current price
below buy) **and** the target stays below entry. When the position is in profit
(current >= buy) the target is green (upside still implied) or grey (target
already met / below entry), **never red**. This mirrors the sibling fix #297,
which stopped a positive projected return reading as a red "Declining" badge —
red should never sit next to a positive return.

The target *value* is unchanged (target correctness is out of scope for #274) —
this is a colour/presentation change only.

Closes #299.

## Evidence
This is a pure display-kernel change. `getTargetPriceColor` is exported on
`globalThis.GRQProjection` and the dashboard delegates to it, so the new
behavioural tests drive the **real production logic**, not a copy. Playwright
MCP was not available in this environment, so verification is via the exported
kernel (the same approach as #297).

Before → after, class tokens returned by the real exported function:

| Case | target | current | buy | Before | After |
|------|--------|---------|-----|--------|-------|
| STLD-like (in profit, target < buy) | 184.36 | 200.00 | 188.35 | `price-bad` (red) | `price-neutral` (grey) |
| In profit, target above current | 70 | 60 | 55 | `price-good` (green) | `price-good` (green) |
| Underwater, target below buy | 40 | 50 | 55 | `price-bad` (red) | `price-bad` (red) |
| Underwater, target at/above buy | 70 | 50 | 55 | `price-neutral` (grey) | `price-neutral` (grey) |

Only the in-profit / target-below-buy case changes — exactly the contradictory
case the issue reports. Genuine danger (underwater with a sub-entry target)
stays red.

```mermaid
flowchart TD
    A[target, current, buy] --> N{any null?}
    N -- yes --> Z[default colour]
    N -- no --> P{current &ge; buy? in profit}
    P -- yes --> G{target &gt; current?}
    G -- yes --> GG[green: upside remains]
    G -- no --> GR1[grey: already met / below entry]
    P -- no --> U{target &lt; buy?}
    U -- yes --> R[red: underwater, target below entry]
    U -- no --> GR2[grey: recovery implied]
```

Test run (`deno test --allow-read tests/*.ts`): `539 passed | 0 failed`.

## Test Plan
Updated `tests/fair_value_color_test.ts`:
- **Renamed** `…- target below buy price is red (always bad)` →
  `…- target below buy is red ONLY in loss territory`, asserting `(40, 50, 55)`
  (underwater) is still red.
- **Added** `…- target below buy while in profit is NOT red (issue #299)`:
  the STLD-like case `(40, 60, 55)` now returns grey, not red — the regression
  guard for #299.
- Existing green / grey / null / boundary cases are unchanged and still pass.



## Milestone
This PR is part of the **#274 bug: 34% gain shown as red "Declining" status on 2026-04-09 scores** milestone and targets the `milestone/274-bug-34-gain-shown-as-red-declining-status-on-2` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqoy4lls-1214f8`<!-- vibe-worker-issue-299 -->