### PR TITLE
fix: single-stock trend line via regression through origin (Issue #302)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-302.md
+++ b/docs/archive/pr-summaries/pr-summary-302.md
@@ -1,0 +1,45 @@
+# Single-stock trend line: regression through the origin
+
+## Summary
+The single-stock trend line sat **below all** performance points on charts that
+rise fast then plateau. `computeTrendLine()` in `docs/projection.js` fitted a
+**free-intercept** least-squares slope and then pinned the intercept to `0`,
+keeping a slope that only made sense alongside a non-zero start. A slope fitted
+for a non-zero intercept, anchored at `0%` on day 0, drops the whole line below
+the data.
+
+The fix recomputes the slope as a **regression through the origin** (line pinned
+to `(0,0)`), which minimises `Σ(y − m·x)²` and gives `m = Σ(x·y) / Σ(x·x)`. The
+dead free-intercept computation and the now-unused `sumX`/`sumY`/`n` terms were
+removed. Day 0 stays `0%` (anchor unchanged); `predicted90DayPerformance` shifts
+with the corrected slope (accepted consequence per #273); `calculateRSquared`
+continues to measure the line actually drawn.
+
+Closes #302.
+
+## Evidence
+Backend/pure-function change — no web UI to screenshot. Verified via Deno tests
+calling the real exported `computeTrendLine`.
+
+```mermaid
+flowchart LR
+    A["data points<br/>(rises then plateaus)"] --> B{slope}
+    B -->|"old: free-intercept slope,<br/>intercept pinned to 0"| C["line below ALL points"]
+    B -->|"new: m = Σxy / Σx²<br/>through origin"| D["points straddle the line"]
+```
+
+Before the fix the rises-then-plateaus fixture produced slope `3.0` (every
+non-origin point strictly above the line). After the fix the slope is
+`Σxy/Σx² ≈ 4.385` and at least one point lies on/below the line.
+
+## Test Plan
+- Added `tests/trend_line_origin_regression_test.ts`:
+  - `computeTrendLine: rises-then-plateaus line is not below all points` —
+    asserts `slope === Σxy/Σx²`, `intercept === 0`, day-0 value `0%`, and that
+    the line is not strictly below every point. This reproduces #302 (fails
+    against the unfixed code with slope `3.0`).
+  - `computeTrendLine: recovers the exact rate for a linear-from-origin series`
+    — sanity check that a `y = 3x` series recovers slope `3` with `R² = 1`.
+- All existing tests pass, including `tests/projection_kernels_test.ts` and
+  `tests/trend_line_extension_test.ts`.
+- `./quality.sh` passes cleanly.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -510,17 +510,15 @@ function computeTrendLine(dataPoints) {
         return null;
     }
 
-    const n = dataPoints.length;
-    const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
-    const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
     const sumXY = dataPoints.reduce((sum, point) => sum + point.x * point.y, 0);
     const sumXX = dataPoints.reduce((sum, point) => sum + point.x * point.x, 0);
 
-    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-
-    // Force the line through zero on the score date (x = 0 -> y = 0).
+    // Regression through the origin. Day 0 = 0% by definition (performance is
+    // measured against the buy price on the score date), so the line must pass
+    // through (0,0); the slope is the least-squares slope subject to that
+    // anchor, minimising Σ(y − m·x)² which gives m = Σ(x·y) / Σ(x·x).
     const adjustedIntercept = 0;
-    const adjustedSlope = slope;
+    const adjustedSlope = sumXX !== 0 ? sumXY / sumXX : 0;
 
     const predicted90DayPerformance = adjustedSlope * 90 + adjustedIntercept;
     // Cannot lose more than 100% of the investment.

--- a/tests/trend_line_origin_regression_test.ts
+++ b/tests/trend_line_origin_regression_test.ts
@@ -1,0 +1,76 @@
+// Regression-through-the-origin tests for computeTrendLine (issue #302).
+//
+// The single-stock trend line must be a least-squares regression pinned to
+// (0, 0) — day 0 reads 0% by definition (performance is measured against the
+// buy price on the score date). The previous code fitted a *free-intercept*
+// slope and then pinned the intercept to 0, which dropped the whole line below
+// data that rises fast then plateaus. These tests import the REAL shipped
+// helper from docs/projection.js and assert on its observable output.
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    computeTrendLine: (
+      dataPoints: { x: number; y: number }[],
+    ) => {
+      slope: number;
+      intercept: number;
+      predicted90DayPerformance: number;
+      rSquared: number;
+    } | null;
+  };
+};
+
+const GRQProjection = g.GRQProjection;
+
+Deno.test("computeTrendLine: rises-then-plateaus line is not below all points", () => {
+  // Performance rises fast off the score date then plateaus around 20%.
+  const points = [
+    { x: 0, y: 0 },
+    { x: 1, y: 10 },
+    { x: 2, y: 16 },
+    { x: 3, y: 19 },
+    { x: 4, y: 20 },
+    { x: 5, y: 20 },
+    { x: 6, y: 20 },
+  ];
+
+  const trend = GRQProjection.computeTrendLine(points);
+  assert(trend !== null);
+
+  // Regression through the origin: slope = Σ(x·y) / Σ(x·x), intercept = 0.
+  const sumXY = points.reduce((s, p) => s + p.x * p.y, 0);
+  const sumXX = points.reduce((s, p) => s + p.x * p.x, 0);
+  const expectedSlope = sumXY / sumXX;
+
+  assertEquals(trend!.intercept, 0, "line must pass through the origin");
+  assertAlmostEquals(trend!.slope, expectedSlope, 1e-9);
+
+  // Day 0 reads exactly 0%.
+  assertEquals(trend!.slope * 0 + trend!.intercept, 0);
+
+  // The line must NOT sit below every data point: at least one actual point
+  // lies on or below the line (points straddle the line).
+  const someOnOrBelow = points.some((p) => p.y <= trend!.slope * p.x + 1e-9);
+  assert(
+    someOnOrBelow,
+    "trend line must not be strictly below all data points",
+  );
+});
+
+Deno.test("computeTrendLine: recovers the exact rate for a linear-from-origin series", () => {
+  // y = 3x exactly — through-origin regression must recover slope 3.
+  const points = [
+    { x: 0, y: 0 },
+    { x: 5, y: 15 },
+    { x: 10, y: 30 },
+    { x: 20, y: 60 },
+  ];
+
+  const trend = GRQProjection.computeTrendLine(points);
+  assert(trend !== null);
+  assertEquals(trend!.intercept, 0);
+  assertAlmostEquals(trend!.slope, 3, 1e-9);
+  assertAlmostEquals(trend!.rSquared, 1, 1e-9);
+});


### PR DESCRIPTION
# Single-stock trend line: regression through the origin

## Summary
The single-stock trend line sat **below all** performance points on charts that
rise fast then plateau. `computeTrendLine()` in `docs/projection.js` fitted a
**free-intercept** least-squares slope and then pinned the intercept to `0`,
keeping a slope that only made sense alongside a non-zero start. A slope fitted
for a non-zero intercept, anchored at `0%` on day 0, drops the whole line below
the data.

The fix recomputes the slope as a **regression through the origin** (line pinned
to `(0,0)`), which minimises `Σ(y − m·x)²` and gives `m = Σ(x·y) / Σ(x·x)`. The
dead free-intercept computation and the now-unused `sumX`/`sumY`/`n` terms were
removed. Day 0 stays `0%` (anchor unchanged); `predicted90DayPerformance` shifts
with the corrected slope (accepted consequence per #273); `calculateRSquared`
continues to measure the line actually drawn.

Closes #302.

## Evidence
Backend/pure-function change — no web UI to screenshot. Verified via Deno tests
calling the real exported `computeTrendLine`.

```mermaid
flowchart LR
    A["data points<br/>(rises then plateaus)"] --> B{slope}
    B -->|"old: free-intercept slope,<br/>intercept pinned to 0"| C["line below ALL points"]
    B -->|"new: m = Σxy / Σx²<br/>through origin"| D["points straddle the line"]
```

Before the fix the rises-then-plateaus fixture produced slope `3.0` (every
non-origin point strictly above the line). After the fix the slope is
`Σxy/Σx² ≈ 4.385` and at least one point lies on/below the line.

## Test Plan
- Added `tests/trend_line_origin_regression_test.ts`:
  - `computeTrendLine: rises-then-plateaus line is not below all points` —
    asserts `slope === Σxy/Σx²`, `intercept === 0`, day-0 value `0%`, and that
    the line is not strictly below every point. This reproduces #302 (fails
    against the unfixed code with slope `3.0`).
  - `computeTrendLine: recovers the exact rate for a linear-from-origin series`
    — sanity check that a `y = 3x` series recovers slope `3` with `R² = 1`.
- All existing tests pass, including `tests/projection_kernels_test.ts` and
  `tests/trend_line_extension_test.ts`.
- `./quality.sh` passes cleanly.



## Milestone
This PR is part of the **#273 bug: Portfolio & single-stock trend line sits below all performance points** milestone and targets the `milestone/273-bug-portfolio-single-stock-trend-line-sits-bel` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqoy4lls-1214f8`<!-- vibe-worker-issue-302 -->