### PR TITLE
Format index levels without decimals, percent change to one decimal (Issue #313)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1012,7 +1012,8 @@ class GRQValidator {
                 const performanceClass = perf.performance >= 0
                     ? 'performance-positive'
                     : 'performance-negative';
-                valueElement.textContent = this.formatPercent(perf.performance);
+                // Percentage change to one decimal place (issue #313).
+                valueElement.textContent = this.formatPercent(perf.performance, 1);
                 valueElement.className = `h5 mb-0 ${performanceClass}`;
                 detailsElement.textContent =
                     `${this.formatIndexLevel(perf.initialPrice)} → ${this.formatIndexLevel(perf.currentPrice)}`;

--- a/docs/archive/pr-summaries/pr-summary-313.md
+++ b/docs/archive/pr-summaries/pr-summary-313.md
@@ -1,0 +1,62 @@
+## Summary
+
+The dashboard's benchmark-comparison panel rendered market-index levels with two
+decimal places (e.g. `7,500.42`) and the percentage change with two decimals.
+Index levels are large whole-number figures and don't need decimal points, and
+the percentage change reads better with a single decimal.
+
+This PR changes the shared formatting so:
+
+- **Index levels** (`formatIndexLevel`) default to **0 decimals** with thousands
+  separators — SP500 now reads `7,501`, not `7,500.42`.
+- **Percentage change** in the market-comparison panel renders to **one decimal
+  place** (e.g. `+58.1%`).
+
+Both helpers retain an explicit `decimals` argument, so callers can still
+request more precision where needed.
+
+Closes #313.
+
+## Evidence
+
+Playwright MCP was not available in this environment, so no live browser
+screenshot could be captured. Instead the change was verified by running the
+**real shipped helpers** (`docs/format.js`) against the committed market data
+(`docs/market-indices.json`):
+
+```
+SP500        pct=+58.1%   levels=4,743 → 7,501
+NASDAQ       pct=+79.6%   levels=14,766 → 26,518
+RUSSELL2000  pct=+48.0%   levels=2,013 → 2,980
+```
+
+Index levels show no decimal points; the percentage change shows one decimal —
+matching the issue's requirement (SP500 formatted as `7,500`).
+
+```mermaid
+flowchart LR
+    A[market-indices.json] --> B[GRQMarketIndex.marketPerformanceData]
+    B --> C{updateMarketComparison}
+    C -->|formatPercent value, 1| D[+58.1%]
+    C -->|formatIndexLevel level| E[4,743 → 7,501]
+```
+
+## Test Plan
+
+- Updated `tests/format_test.ts::formatIndexLevel formats an index level with no
+  decimals by default (issue #313)` — asserts `7500.42 → "7,500"`,
+  `4742.83 → "4,743"`, `16057.44 → "16,057"`. This reproduces the bug (failed
+  before the fix) and passes after.
+- Added `tests/format_test.ts::formatIndexLevel still honours an explicit
+  decimals argument` — confirms `formatIndexLevel(4742.83, 2) === "4,742.83"`.
+- Existing `formatPercent` tests already cover the one-decimal case
+  (`formatPercent(12.5, 1) === "+12.5%"`).
+- `./quality.sh` passes cleanly (cargo fmt/clippy/check/test, deno
+  test/fmt/lint/check).
+
+### Business-logic change to existing test
+
+The previous `formatIndexLevel formats an index level with separators` test
+asserted two-decimal output (`4742.83 → "4,742.83"`). That assertion encoded the
+old behaviour the issue asks to change, so it was updated to the new
+no-decimals expectation rather than removed.

--- a/docs/format.js
+++ b/docs/format.js
@@ -46,9 +46,10 @@ function formatNumber(value, decimals = 2) {
     }).format(number);
 }
 
-// Format a market index level (e.g. 4742.83 → "4,742.83"). Two decimals by
-// default so every index reads consistently.
-function formatIndexLevel(value, decimals = 2) {
+// Format a market index level (e.g. 7500.42 → "7,500"). Index levels are large
+// whole-number figures, so no decimals by default (issue #313); thousands
+// separators still apply. Callers can pass an explicit decimals count.
+function formatIndexLevel(value, decimals = 0) {
     return formatNumber(value, decimals);
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.195">
+    <meta name="app-version" content="1.0.196">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -321,6 +321,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.195"></script>
+    <script src="sw-register.js?v=1.0.196"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.195")
+    navigator.serviceWorker.register("./sw.js?v=1.0.196")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.195";
+const APP_VERSION = "1.0.196";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/tests/format_test.ts
+++ b/tests/format_test.ts
@@ -62,10 +62,18 @@ Deno.test("formatNumber returns N/A for non-finite input", () => {
   assertEquals(formatNumber(""), "N/A");
 });
 
-Deno.test("formatIndexLevel formats an index level with separators", () => {
-  assertEquals(formatIndexLevel(4742.83), "4,742.83");
-  assertEquals(formatIndexLevel(16057.44), "16,057.44");
+Deno.test("formatIndexLevel formats an index level with no decimals by default (issue #313)", () => {
+  // Index levels (e.g. SP500) read as whole numbers with thousands separators:
+  // 7500.42 → "7,500", not "7,500.42".
+  assertEquals(formatIndexLevel(7500.42), "7,500");
+  assertEquals(formatIndexLevel(4742.83), "4,743");
+  assertEquals(formatIndexLevel(16057.44), "16,057");
   assertEquals(formatIndexLevel(null), "N/A");
+});
+
+Deno.test("formatIndexLevel still honours an explicit decimals argument", () => {
+  assertEquals(formatIndexLevel(4742.83, 2), "4,742.83");
+  assertEquals(formatIndexLevel(4742.83, 1), "4,742.8");
 });
 
 Deno.test("formatPercent adds an explicit + sign and trailing %", () => {


### PR DESCRIPTION
## Summary

The dashboard's benchmark-comparison panel rendered market-index levels with two
decimal places (e.g. `7,500.42`) and the percentage change with two decimals.
Index levels are large whole-number figures and don't need decimal points, and
the percentage change reads better with a single decimal.

This PR changes the shared formatting so:

- **Index levels** (`formatIndexLevel`) default to **0 decimals** with thousands
  separators — SP500 now reads `7,501`, not `7,500.42`.
- **Percentage change** in the market-comparison panel renders to **one decimal
  place** (e.g. `+58.1%`).

Both helpers retain an explicit `decimals` argument, so callers can still
request more precision where needed.

Closes #313.

## Evidence

Playwright MCP was not available in this environment, so no live browser
screenshot could be captured. Instead the change was verified by running the
**real shipped helpers** (`docs/format.js`) against the committed market data
(`docs/market-indices.json`):

```
SP500        pct=+58.1%   levels=4,743 → 7,501
NASDAQ       pct=+79.6%   levels=14,766 → 26,518
RUSSELL2000  pct=+48.0%   levels=2,013 → 2,980
```

Index levels show no decimal points; the percentage change shows one decimal —
matching the issue's requirement (SP500 formatted as `7,500`).

```mermaid
flowchart LR
    A[market-indices.json] --> B[GRQMarketIndex.marketPerformanceData]
    B --> C{updateMarketComparison}
    C -->|formatPercent value, 1| D[+58.1%]
    C -->|formatIndexLevel level| E[4,743 → 7,501]
```

## Test Plan

- Updated `tests/format_test.ts::formatIndexLevel formats an index level with no
  decimals by default (issue #313)` — asserts `7500.42 → "7,500"`,
  `4742.83 → "4,743"`, `16057.44 → "16,057"`. This reproduces the bug (failed
  before the fix) and passes after.
- Added `tests/format_test.ts::formatIndexLevel still honours an explicit
  decimals argument` — confirms `formatIndexLevel(4742.83, 2) === "4,742.83"`.
- Existing `formatPercent` tests already cover the one-decimal case
  (`formatPercent(12.5, 1) === "+12.5%"`).
- `./quality.sh` passes cleanly (cargo fmt/clippy/check/test, deno
  test/fmt/lint/check).

### Business-logic change to existing test

The previous `formatIndexLevel formats an index level with separators` test
asserted two-decimal output (`4742.83 → "4,742.83"`). That assertion encoded the
old behaviour the issue asks to change, so it was updated to the new
no-decimals expectation rather than removed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqoy4lls-1214f8`<!-- vibe-worker-issue-313 -->