### PR TITLE
fix: portfolio trend line uses regression through origin (Issue #303)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3987,23 +3987,6 @@ class GRQValidator {
         return trendLine;
     }
 
-    // Calculate R-squared for trend line quality
-    calculateRSquared(dataPoints, slope, intercept) {
-        const n = dataPoints.length;
-        const meanY = dataPoints.reduce((sum, point) => sum + point.y, 0) / n;
-        
-        let ssRes = 0; // Sum of squared residuals
-        let ssTot = 0; // Total sum of squares
-        
-        dataPoints.forEach((point) => {
-            const predicted = slope * point.x + intercept;
-            ssRes += Math.pow(point.y - predicted, 2);
-            ssTot += Math.pow(point.y - meanY, 2);
-        });
-        
-        return ssTot > 0 ? 1 - (ssRes / ssTot) : 0;
-    }
-
     // Calculate linear regression for portfolio trend prediction
     calculatePortfolioTrendLine() {
         const scoreDate = this.getScoreDate(this.selectedFile);
@@ -4038,37 +4021,26 @@ class GRQValidator {
             return null;
         }
 
-        // Calculate linear regression (y = mx + b)
-        const n = dataPoints.length;
-        const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
-        const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
-        const sumXY = dataPoints.reduce((sum, point) => sum + point.x * point.y, 0);
-        const sumXX = dataPoints.reduce((sum, point) => sum + point.x * point.x, 0);
+        // Regression through the origin (issue #303). Day 0 = 0% by definition
+        // (portfolio performance is measured against the buy prices on the score
+        // date), so the line must pass through (0,0); the slope is the
+        // least-squares slope subject to that anchor, m = Σ(x·y) / Σ(x·x). This
+        // delegates to the single shared kernel in docs/projection.js so the
+        // portfolio and single-stock trend lines cannot drift apart (issue #273).
+        const trend = GRQProjection.computeTrendLine(dataPoints);
+        if (!trend) {
+            console.log("Portfolio trend line - regression returned null");
+            return null;
+        }
 
-        const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-        const intercept = (sumY - slope * sumX) / n;
-
-        // Force the trend line to start at zero on the score date
-        // Adjust the intercept so that when x=0 (score date), y=0
-        const adjustedIntercept = 0;
-        const adjustedSlope = slope;
-
-        // Predict performance at 90 days using the adjusted line
-        const predicted90DayPerformance = adjustedSlope * 90 + adjustedIntercept;
-
-        // Cap the prediction at -100% since you can't lose more than 100% of your investment
-        const cappedPredicted90DayPerformance = Math.max(predicted90DayPerformance, -100);
-
-        const rSquared = this.calculateRSquared(dataPoints, adjustedSlope, adjustedIntercept);
-        
-        console.log("Portfolio trend line - slope:", adjustedSlope, "intercept:", adjustedIntercept, "R²:", rSquared, "Predicted 90-day:", cappedPredicted90DayPerformance, "(original:", predicted90DayPerformance, ")");
+        console.log("Portfolio trend line - slope:", trend.slope, "intercept:", trend.intercept, "R²:", trend.rSquared, "Predicted 90-day:", trend.predicted90DayPerformance);
 
         return {
-            slope: adjustedSlope,
-            intercept: adjustedIntercept,
-            predicted90DayPerformance: cappedPredicted90DayPerformance,
+            slope: trend.slope,
+            intercept: trend.intercept,
+            predicted90DayPerformance: trend.predicted90DayPerformance,
             dataPoints,
-            rSquared: rSquared
+            rSquared: trend.rSquared
         };
     }
 

--- a/docs/archive/pr-summaries/pr-summary-303.md
+++ b/docs/archive/pr-summaries/pr-summary-303.md
@@ -1,0 +1,51 @@
+# Portfolio trend line: regression through the origin
+
+## Summary
+The dashed **"Portfolio Trend (Low Confidence)"** line sat **below all**
+Performance points on portfolio charts that rise fast then plateau.
+`calculatePortfolioTrendLine()` in `docs/app.js` fitted a **free-intercept**
+least-squares slope **and** intercept, then discarded the intercept (forced `0`)
+while keeping the free-intercept slope. A slope fitted for a non-zero start,
+anchored at `0%` on day 0, drops the whole line below the data.
+
+The fix delegates the portfolio regression to the single shared kernel
+`GRQProjection.computeTrendLine()` (`docs/projection.js`) — the same kernel the
+single-stock trend line now uses (#302). It fits a **regression through the
+origin** pinned to `(0,0)`, minimising `Σ(y − m·x)²`, which gives
+`m = Σ(x·y) / Σ(x·x)`, intercept `0`. The now-dead free-intercept
+`slope`/`intercept` computation and the `sumX`/`sumY`/`n` terms were removed,
+along with the orphaned per-class `calculateRSquared()` (the shared kernel
+computes R² internally). Day 0 stays `0%`; `predicted90DayPerformance` shifts
+with the corrected slope (accepted consequence per #273); R² keeps measuring the
+line actually drawn. No change to the line's colour/label.
+
+Closes #303.
+
+## Evidence
+Browser-only UI maths — the dashboard needs live per-stock market data to
+render, so (mirroring #302) the change is verified via Deno tests that call the
+real shipped kernel the production code now delegates to. The portfolio glue is
+a thin wrapper that builds `{ x: daysSinceScore, y: portfolioReturn }` points
+and forwards them to `computeTrendLine`.
+
+```mermaid
+flowchart LR
+    A["portfolio points<br/>(rises then plateaus)"] --> B{slope}
+    B -->|"old: free-intercept slope,<br/>intercept pinned to 0"| C["line below ALL points"]
+    B -->|"new: m = Σxy / Σx²<br/>through origin (shared kernel)"| D["points straddle the line"]
+```
+
+Acceptance criteria met: `slope === Σ(x·y) / Σ(x·x)`, `intercept === 0`,
+day-0 value exactly `0%`, and the line is not below every Performance point.
+
+## Test Plan
+- Added `tests/portfolio_trend_line_origin_test.ts`:
+  - `portfolio trend line: rises-then-plateaus is not below all points` —
+    asserts `slope === Σxy/Σx²`, `intercept === 0`, day-0 value `0%`, and that
+    the line is not strictly below every point (reproduces #303).
+  - `portfolio trend line: 90-day prediction tracks the through-origin slope` —
+    asserts the prediction equals `slope * 90` floored at `-100%`.
+- Existing `tests/portfolio_view_consistency_test.ts` (which already models the
+  delegation to `computeTrendLine`) and `tests/trend_line_origin_regression_test.ts`
+  continue to pass.
+- Full `./quality.sh` passes (lint, type checks, Rust + Deno tests).

--- a/tests/portfolio_trend_line_origin_test.ts
+++ b/tests/portfolio_trend_line_origin_test.ts
@@ -1,0 +1,85 @@
+// Regression-through-the-origin tests for the PORTFOLIO trend line (issue #303).
+//
+// calculatePortfolioTrendLine() in docs/app.js used to fit a *free-intercept*
+// slope and then pin the intercept to 0, which dropped the whole dashed
+// "Portfolio Trend (Low Confidence)" line below data that rises fast then
+// plateaus. The fix delegates the portfolio regression to the single shared
+// kernel GRQProjection.computeTrendLine (docs/projection.js), which fits a
+// least-squares line pinned to (0,0): slope = Σ(x·y) / Σ(x·x), intercept = 0.
+//
+// app.js is a browser-only UI class, so these tests exercise the kernel the
+// production code now delegates to, feeding it the same { x: daysSinceScore,
+// y: portfolioReturn } points app.js builds, mirroring
+// tests/portfolio_view_consistency_test.ts.
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    computeTrendLine: (
+      dataPoints: { x: number; y: number }[],
+    ) => {
+      slope: number;
+      intercept: number;
+      predicted90DayPerformance: number;
+      rSquared: number;
+    } | null;
+  };
+};
+
+const GRQProjection = g.GRQProjection;
+
+Deno.test("portfolio trend line: rises-then-plateaus is not below all points", () => {
+  // Portfolio average performance rises fast off the score date then plateaus
+  // around 18%. With a free-intercept slope pinned to 0 the old line sat below
+  // every point; the through-origin line must straddle them.
+  const points = [
+    { x: 0, y: 0 },
+    { x: 1, y: 9 },
+    { x: 2, y: 14 },
+    { x: 3, y: 17 },
+    { x: 4, y: 18 },
+    { x: 5, y: 18 },
+    { x: 6, y: 18 },
+  ];
+
+  const trend = GRQProjection.computeTrendLine(points);
+  assert(trend !== null);
+
+  // slope === Σ(x·y) / Σ(x·x), intercept === 0 (acceptance criteria).
+  const sumXY = points.reduce((s, p) => s + p.x * p.y, 0);
+  const sumXX = points.reduce((s, p) => s + p.x * p.x, 0);
+  assertEquals(trend!.intercept, 0, "portfolio line must pass through (0,0)");
+  assertAlmostEquals(trend!.slope, sumXY / sumXX, 1e-9);
+
+  // Day-0 value is exactly 0%.
+  assertEquals(trend!.slope * 0 + trend!.intercept, 0);
+
+  // The line must NOT sit below every Performance point — points straddle it.
+  const someOnOrBelow = points.some((p) => p.y <= trend!.slope * p.x + 1e-9);
+  assert(someOnOrBelow, "trend line must not be strictly below all points");
+});
+
+Deno.test("portfolio trend line: 90-day prediction tracks the through-origin slope", () => {
+  const points = [
+    { x: 0, y: 0 },
+    { x: 10, y: 5 },
+    { x: 20, y: 10 },
+    { x: 30, y: 15 },
+  ];
+
+  const trend = GRQProjection.computeTrendLine(points);
+  assert(trend !== null);
+  assertEquals(trend!.intercept, 0);
+
+  const sumXY = points.reduce((s, p) => s + p.x * p.y, 0);
+  const sumXX = points.reduce((s, p) => s + p.x * p.x, 0);
+  const expectedSlope = sumXY / sumXX;
+  assertAlmostEquals(trend!.slope, expectedSlope, 1e-9);
+  // predicted90DayPerformance = slope * 90 (intercept 0), floored at -100%.
+  assertAlmostEquals(
+    trend!.predicted90DayPerformance,
+    Math.max(expectedSlope * 90, -100),
+    1e-9,
+  );
+});


### PR DESCRIPTION
# Portfolio trend line: regression through the origin

## Summary
The dashed **"Portfolio Trend (Low Confidence)"** line sat **below all**
Performance points on portfolio charts that rise fast then plateau.
`calculatePortfolioTrendLine()` in `docs/app.js` fitted a **free-intercept**
least-squares slope **and** intercept, then discarded the intercept (forced `0`)
while keeping the free-intercept slope. A slope fitted for a non-zero start,
anchored at `0%` on day 0, drops the whole line below the data.

The fix delegates the portfolio regression to the single shared kernel
`GRQProjection.computeTrendLine()` (`docs/projection.js`) — the same kernel the
single-stock trend line now uses (#302). It fits a **regression through the
origin** pinned to `(0,0)`, minimising `Σ(y − m·x)²`, which gives
`m = Σ(x·y) / Σ(x·x)`, intercept `0`. The now-dead free-intercept
`slope`/`intercept` computation and the `sumX`/`sumY`/`n` terms were removed,
along with the orphaned per-class `calculateRSquared()` (the shared kernel
computes R² internally). Day 0 stays `0%`; `predicted90DayPerformance` shifts
with the corrected slope (accepted consequence per #273); R² keeps measuring the
line actually drawn. No change to the line's colour/label.

Closes #303.

## Evidence
Browser-only UI maths — the dashboard needs live per-stock market data to
render, so (mirroring #302) the change is verified via Deno tests that call the
real shipped kernel the production code now delegates to. The portfolio glue is
a thin wrapper that builds `{ x: daysSinceScore, y: portfolioReturn }` points
and forwards them to `computeTrendLine`.

```mermaid
flowchart LR
    A["portfolio points<br/>(rises then plateaus)"] --> B{slope}
    B -->|"old: free-intercept slope,<br/>intercept pinned to 0"| C["line below ALL points"]
    B -->|"new: m = Σxy / Σx²<br/>through origin (shared kernel)"| D["points straddle the line"]
```

Acceptance criteria met: `slope === Σ(x·y) / Σ(x·x)`, `intercept === 0`,
day-0 value exactly `0%`, and the line is not below every Performance point.

## Test Plan
- Added `tests/portfolio_trend_line_origin_test.ts`:
  - `portfolio trend line: rises-then-plateaus is not below all points` —
    asserts `slope === Σxy/Σx²`, `intercept === 0`, day-0 value `0%`, and that
    the line is not strictly below every point (reproduces #303).
  - `portfolio trend line: 90-day prediction tracks the through-origin slope` —
    asserts the prediction equals `slope * 90` floored at `-100%`.
- Existing `tests/portfolio_view_consistency_test.ts` (which already models the
  delegation to `computeTrendLine`) and `tests/trend_line_origin_regression_test.ts`
  continue to pass.
- Full `./quality.sh` passes (lint, type checks, Rust + Deno tests).



## Milestone
This PR is part of the **#273 bug: Portfolio & single-stock trend line sits below all performance points** milestone and targets the `milestone/273-bug-portfolio-single-stock-trend-line-sits-bel` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqoy4lls-1214f8`<!-- vibe-worker-issue-303 -->