### PR TITLE
Milestone: #273 bug: Portfolio & single-stock trend line sits below all performance points

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3987,23 +3987,6 @@ class GRQValidator {
         return trendLine;
     }
 
-    // Calculate R-squared for trend line quality
-    calculateRSquared(dataPoints, slope, intercept) {
-        const n = dataPoints.length;
-        const meanY = dataPoints.reduce((sum, point) => sum + point.y, 0) / n;
-        
-        let ssRes = 0; // Sum of squared residuals
-        let ssTot = 0; // Total sum of squares
-        
-        dataPoints.forEach((point) => {
-            const predicted = slope * point.x + intercept;
-            ssRes += Math.pow(point.y - predicted, 2);
-            ssTot += Math.pow(point.y - meanY, 2);
-        });
-        
-        return ssTot > 0 ? 1 - (ssRes / ssTot) : 0;
-    }
-
     // Calculate linear regression for portfolio trend prediction
     calculatePortfolioTrendLine() {
         const scoreDate = this.getScoreDate(this.selectedFile);
@@ -4038,37 +4021,26 @@ class GRQValidator {
             return null;
         }
 
-        // Calculate linear regression (y = mx + b)
-        const n = dataPoints.length;
-        const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
-        const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
-        const sumXY = dataPoints.reduce((sum, point) => sum + point.x * point.y, 0);
-        const sumXX = dataPoints.reduce((sum, point) => sum + point.x * point.x, 0);
+        // Regression through the origin (issue #303). Day 0 = 0% by definition
+        // (portfolio performance is measured against the buy prices on the score
+        // date), so the line must pass through (0,0); the slope is the
+        // least-squares slope subject to that anchor, m = Σ(x·y) / Σ(x·x). This
+        // delegates to the single shared kernel in docs/projection.js so the
+        // portfolio and single-stock trend lines cannot drift apart (issue #273).
+        const trend = GRQProjection.computeTrendLine(dataPoints);
+        if (!trend) {
+            console.log("Portfolio trend line - regression returned null");
+            return null;
+        }
 
-        const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-        const intercept = (sumY - slope * sumX) / n;
-
-        // Force the trend line to start at zero on the score date
-        // Adjust the intercept so that when x=0 (score date), y=0
-        const adjustedIntercept = 0;
-        const adjustedSlope = slope;
-
-        // Predict performance at 90 days using the adjusted line
-        const predicted90DayPerformance = adjustedSlope * 90 + adjustedIntercept;
-
-        // Cap the prediction at -100% since you can't lose more than 100% of your investment
-        const cappedPredicted90DayPerformance = Math.max(predicted90DayPerformance, -100);
-
-        const rSquared = this.calculateRSquared(dataPoints, adjustedSlope, adjustedIntercept);
-        
-        console.log("Portfolio trend line - slope:", adjustedSlope, "intercept:", adjustedIntercept, "R²:", rSquared, "Predicted 90-day:", cappedPredicted90DayPerformance, "(original:", predicted90DayPerformance, ")");
+        console.log("Portfolio trend line - slope:", trend.slope, "intercept:", trend.intercept, "R²:", trend.rSquared, "Predicted 90-day:", trend.predicted90DayPerformance);
 
         return {
-            slope: adjustedSlope,
-            intercept: adjustedIntercept,
-            predicted90DayPerformance: cappedPredicted90DayPerformance,
+            slope: trend.slope,
+            intercept: trend.intercept,
+            predicted90DayPerformance: trend.predicted90DayPerformance,
             dataPoints,
-            rSquared: rSquared
+            rSquared: trend.rSquared
         };
     }
 

--- a/docs/archive/pr-summaries/pr-summary-302.md
+++ b/docs/archive/pr-summaries/pr-summary-302.md
@@ -1,0 +1,45 @@
+# Single-stock trend line: regression through the origin
+
+## Summary
+The single-stock trend line sat **below all** performance points on charts that
+rise fast then plateau. `computeTrendLine()` in `docs/projection.js` fitted a
+**free-intercept** least-squares slope and then pinned the intercept to `0`,
+keeping a slope that only made sense alongside a non-zero start. A slope fitted
+for a non-zero intercept, anchored at `0%` on day 0, drops the whole line below
+the data.
+
+The fix recomputes the slope as a **regression through the origin** (line pinned
+to `(0,0)`), which minimises `Σ(y − m·x)²` and gives `m = Σ(x·y) / Σ(x·x)`. The
+dead free-intercept computation and the now-unused `sumX`/`sumY`/`n` terms were
+removed. Day 0 stays `0%` (anchor unchanged); `predicted90DayPerformance` shifts
+with the corrected slope (accepted consequence per #273); `calculateRSquared`
+continues to measure the line actually drawn.
+
+Closes #302.
+
+## Evidence
+Backend/pure-function change — no web UI to screenshot. Verified via Deno tests
+calling the real exported `computeTrendLine`.
+
+```mermaid
+flowchart LR
+    A["data points<br/>(rises then plateaus)"] --> B{slope}
+    B -->|"old: free-intercept slope,<br/>intercept pinned to 0"| C["line below ALL points"]
+    B -->|"new: m = Σxy / Σx²<br/>through origin"| D["points straddle the line"]
+```
+
+Before the fix the rises-then-plateaus fixture produced slope `3.0` (every
+non-origin point strictly above the line). After the fix the slope is
+`Σxy/Σx² ≈ 4.385` and at least one point lies on/below the line.
+
+## Test Plan
+- Added `tests/trend_line_origin_regression_test.ts`:
+  - `computeTrendLine: rises-then-plateaus line is not below all points` —
+    asserts `slope === Σxy/Σx²`, `intercept === 0`, day-0 value `0%`, and that
+    the line is not strictly below every point. This reproduces #302 (fails
+    against the unfixed code with slope `3.0`).
+  - `computeTrendLine: recovers the exact rate for a linear-from-origin series`
+    — sanity check that a `y = 3x` series recovers slope `3` with `R² = 1`.
+- All existing tests pass, including `tests/projection_kernels_test.ts` and
+  `tests/trend_line_extension_test.ts`.
+- `./quality.sh` passes cleanly.

--- a/docs/archive/pr-summaries/pr-summary-303.md
+++ b/docs/archive/pr-summaries/pr-summary-303.md
@@ -1,0 +1,51 @@
+# Portfolio trend line: regression through the origin
+
+## Summary
+The dashed **"Portfolio Trend (Low Confidence)"** line sat **below all**
+Performance points on portfolio charts that rise fast then plateau.
+`calculatePortfolioTrendLine()` in `docs/app.js` fitted a **free-intercept**
+least-squares slope **and** intercept, then discarded the intercept (forced `0`)
+while keeping the free-intercept slope. A slope fitted for a non-zero start,
+anchored at `0%` on day 0, drops the whole line below the data.
+
+The fix delegates the portfolio regression to the single shared kernel
+`GRQProjection.computeTrendLine()` (`docs/projection.js`) — the same kernel the
+single-stock trend line now uses (#302). It fits a **regression through the
+origin** pinned to `(0,0)`, minimising `Σ(y − m·x)²`, which gives
+`m = Σ(x·y) / Σ(x·x)`, intercept `0`. The now-dead free-intercept
+`slope`/`intercept` computation and the `sumX`/`sumY`/`n` terms were removed,
+along with the orphaned per-class `calculateRSquared()` (the shared kernel
+computes R² internally). Day 0 stays `0%`; `predicted90DayPerformance` shifts
+with the corrected slope (accepted consequence per #273); R² keeps measuring the
+line actually drawn. No change to the line's colour/label.
+
+Closes #303.
+
+## Evidence
+Browser-only UI maths — the dashboard needs live per-stock market data to
+render, so (mirroring #302) the change is verified via Deno tests that call the
+real shipped kernel the production code now delegates to. The portfolio glue is
+a thin wrapper that builds `{ x: daysSinceScore, y: portfolioReturn }` points
+and forwards them to `computeTrendLine`.
+
+```mermaid
+flowchart LR
+    A["portfolio points<br/>(rises then plateaus)"] --> B{slope}
+    B -->|"old: free-intercept slope,<br/>intercept pinned to 0"| C["line below ALL points"]
+    B -->|"new: m = Σxy / Σx²<br/>through origin (shared kernel)"| D["points straddle the line"]
+```
+
+Acceptance criteria met: `slope === Σ(x·y) / Σ(x·x)`, `intercept === 0`,
+day-0 value exactly `0%`, and the line is not below every Performance point.
+
+## Test Plan
+- Added `tests/portfolio_trend_line_origin_test.ts`:
+  - `portfolio trend line: rises-then-plateaus is not below all points` —
+    asserts `slope === Σxy/Σx²`, `intercept === 0`, day-0 value `0%`, and that
+    the line is not strictly below every point (reproduces #303).
+  - `portfolio trend line: 90-day prediction tracks the through-origin slope` —
+    asserts the prediction equals `slope * 90` floored at `-100%`.
+- Existing `tests/portfolio_view_consistency_test.ts` (which already models the
+  delegation to `computeTrendLine`) and `tests/trend_line_origin_regression_test.ts`
+  continue to pass.
+- Full `./quality.sh` passes (lint, type checks, Rust + Deno tests).

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.196">
+    <meta name="app-version" content="1.0.197">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -321,6 +321,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.196"></script>
+    <script src="sw-register.js?v=1.0.197"></script>
   </body>
 </html>

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -510,17 +510,15 @@ function computeTrendLine(dataPoints) {
         return null;
     }
 
-    const n = dataPoints.length;
-    const sumX = dataPoints.reduce((sum, point) => sum + point.x, 0);
-    const sumY = dataPoints.reduce((sum, point) => sum + point.y, 0);
     const sumXY = dataPoints.reduce((sum, point) => sum + point.x * point.y, 0);
     const sumXX = dataPoints.reduce((sum, point) => sum + point.x * point.x, 0);
 
-    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-
-    // Force the line through zero on the score date (x = 0 -> y = 0).
+    // Regression through the origin. Day 0 = 0% by definition (performance is
+    // measured against the buy price on the score date), so the line must pass
+    // through (0,0); the slope is the least-squares slope subject to that
+    // anchor, minimising Σ(y − m·x)² which gives m = Σ(x·y) / Σ(x·x).
     const adjustedIntercept = 0;
-    const adjustedSlope = slope;
+    const adjustedSlope = sumXX !== 0 ? sumXY / sumXX : 0;
 
     const predicted90DayPerformance = adjustedSlope * 90 + adjustedIntercept;
     // Cannot lose more than 100% of the investment.

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.196")
+    navigator.serviceWorker.register("./sw.js?v=1.0.197")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.196";
+const APP_VERSION = "1.0.197";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/tests/portfolio_trend_line_origin_test.ts
+++ b/tests/portfolio_trend_line_origin_test.ts
@@ -1,0 +1,85 @@
+// Regression-through-the-origin tests for the PORTFOLIO trend line (issue #303).
+//
+// calculatePortfolioTrendLine() in docs/app.js used to fit a *free-intercept*
+// slope and then pin the intercept to 0, which dropped the whole dashed
+// "Portfolio Trend (Low Confidence)" line below data that rises fast then
+// plateaus. The fix delegates the portfolio regression to the single shared
+// kernel GRQProjection.computeTrendLine (docs/projection.js), which fits a
+// least-squares line pinned to (0,0): slope = Σ(x·y) / Σ(x·x), intercept = 0.
+//
+// app.js is a browser-only UI class, so these tests exercise the kernel the
+// production code now delegates to, feeding it the same { x: daysSinceScore,
+// y: portfolioReturn } points app.js builds, mirroring
+// tests/portfolio_view_consistency_test.ts.
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    computeTrendLine: (
+      dataPoints: { x: number; y: number }[],
+    ) => {
+      slope: number;
+      intercept: number;
+      predicted90DayPerformance: number;
+      rSquared: number;
+    } | null;
+  };
+};
+
+const GRQProjection = g.GRQProjection;
+
+Deno.test("portfolio trend line: rises-then-plateaus is not below all points", () => {
+  // Portfolio average performance rises fast off the score date then plateaus
+  // around 18%. With a free-intercept slope pinned to 0 the old line sat below
+  // every point; the through-origin line must straddle them.
+  const points = [
+    { x: 0, y: 0 },
+    { x: 1, y: 9 },
+    { x: 2, y: 14 },
+    { x: 3, y: 17 },
+    { x: 4, y: 18 },
+    { x: 5, y: 18 },
+    { x: 6, y: 18 },
+  ];
+
+  const trend = GRQProjection.computeTrendLine(points);
+  assert(trend !== null);
+
+  // slope === Σ(x·y) / Σ(x·x), intercept === 0 (acceptance criteria).
+  const sumXY = points.reduce((s, p) => s + p.x * p.y, 0);
+  const sumXX = points.reduce((s, p) => s + p.x * p.x, 0);
+  assertEquals(trend!.intercept, 0, "portfolio line must pass through (0,0)");
+  assertAlmostEquals(trend!.slope, sumXY / sumXX, 1e-9);
+
+  // Day-0 value is exactly 0%.
+  assertEquals(trend!.slope * 0 + trend!.intercept, 0);
+
+  // The line must NOT sit below every Performance point — points straddle it.
+  const someOnOrBelow = points.some((p) => p.y <= trend!.slope * p.x + 1e-9);
+  assert(someOnOrBelow, "trend line must not be strictly below all points");
+});
+
+Deno.test("portfolio trend line: 90-day prediction tracks the through-origin slope", () => {
+  const points = [
+    { x: 0, y: 0 },
+    { x: 10, y: 5 },
+    { x: 20, y: 10 },
+    { x: 30, y: 15 },
+  ];
+
+  const trend = GRQProjection.computeTrendLine(points);
+  assert(trend !== null);
+  assertEquals(trend!.intercept, 0);
+
+  const sumXY = points.reduce((s, p) => s + p.x * p.y, 0);
+  const sumXX = points.reduce((s, p) => s + p.x * p.x, 0);
+  const expectedSlope = sumXY / sumXX;
+  assertAlmostEquals(trend!.slope, expectedSlope, 1e-9);
+  // predicted90DayPerformance = slope * 90 (intercept 0), floored at -100%.
+  assertAlmostEquals(
+    trend!.predicted90DayPerformance,
+    Math.max(expectedSlope * 90, -100),
+    1e-9,
+  );
+});

--- a/tests/trend_line_origin_regression_test.ts
+++ b/tests/trend_line_origin_regression_test.ts
@@ -1,0 +1,76 @@
+// Regression-through-the-origin tests for computeTrendLine (issue #302).
+//
+// The single-stock trend line must be a least-squares regression pinned to
+// (0, 0) — day 0 reads 0% by definition (performance is measured against the
+// buy price on the score date). The previous code fitted a *free-intercept*
+// slope and then pinned the intercept to 0, which dropped the whole line below
+// data that rises fast then plateaus. These tests import the REAL shipped
+// helper from docs/projection.js and assert on its observable output.
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    computeTrendLine: (
+      dataPoints: { x: number; y: number }[],
+    ) => {
+      slope: number;
+      intercept: number;
+      predicted90DayPerformance: number;
+      rSquared: number;
+    } | null;
+  };
+};
+
+const GRQProjection = g.GRQProjection;
+
+Deno.test("computeTrendLine: rises-then-plateaus line is not below all points", () => {
+  // Performance rises fast off the score date then plateaus around 20%.
+  const points = [
+    { x: 0, y: 0 },
+    { x: 1, y: 10 },
+    { x: 2, y: 16 },
+    { x: 3, y: 19 },
+    { x: 4, y: 20 },
+    { x: 5, y: 20 },
+    { x: 6, y: 20 },
+  ];
+
+  const trend = GRQProjection.computeTrendLine(points);
+  assert(trend !== null);
+
+  // Regression through the origin: slope = Σ(x·y) / Σ(x·x), intercept = 0.
+  const sumXY = points.reduce((s, p) => s + p.x * p.y, 0);
+  const sumXX = points.reduce((s, p) => s + p.x * p.x, 0);
+  const expectedSlope = sumXY / sumXX;
+
+  assertEquals(trend!.intercept, 0, "line must pass through the origin");
+  assertAlmostEquals(trend!.slope, expectedSlope, 1e-9);
+
+  // Day 0 reads exactly 0%.
+  assertEquals(trend!.slope * 0 + trend!.intercept, 0);
+
+  // The line must NOT sit below every data point: at least one actual point
+  // lies on or below the line (points straddle the line).
+  const someOnOrBelow = points.some((p) => p.y <= trend!.slope * p.x + 1e-9);
+  assert(
+    someOnOrBelow,
+    "trend line must not be strictly below all data points",
+  );
+});
+
+Deno.test("computeTrendLine: recovers the exact rate for a linear-from-origin series", () => {
+  // y = 3x exactly — through-origin regression must recover slope 3.
+  const points = [
+    { x: 0, y: 0 },
+    { x: 5, y: 15 },
+    { x: 10, y: 30 },
+    { x: 20, y: 60 },
+  ];
+
+  const trend = GRQProjection.computeTrendLine(points);
+  assert(trend !== null);
+  assertEquals(trend!.intercept, 0);
+  assertAlmostEquals(trend!.slope, 3, 1e-9);
+  assertAlmostEquals(trend!.rSquared, 1, 1e-9);
+});


### PR DESCRIPTION
## Milestone: #273 bug: Portfolio & single-stock trend line sits below all performance points

This PR merges the completed milestone branch into main.
Closes #356

### Issues addressed
- #302: bug: single-stock trend line below all points — use regression through origin (projection.js computeTrendLine)

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to main.