### PR TITLE
Restore split-adjustment in src/utils.rs (Issue #340)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-340.md
+++ b/docs/archive/pr-summaries/pr-summary-340.md
@@ -1,0 +1,69 @@
+# Restore split-adjustment in `src/utils.rs` (Issue #340)
+
+## Summary
+
+The milestone branch did not build the split-adjustment feature from #294: a
+botched merge from `main` dropped the `SplitAdjustment` machinery and the
+later "fix" simply reverted `calculate_portfolio_performance` to a raw,
+non-split-adjusted `buy_price`. The Rust gate compiled, but the
+correct-or-exclude split behaviour the milestone exists to deliver was gone.
+
+This restores the feature to its pre-merge design (commit `3810684`), so
+`adjusted_buy_price` is genuinely split-adjusted rather than a rename of
+`buy_price`. Closes #340.
+
+Changes in `src/utils.rs`:
+
+1. **`is_priceable` is split-aware again** — third `split_reliable` argument
+   restored; the single gate drops split-unreliable stocks (mirrors the
+   frontend `isStockIncluded`).
+2. **`SplitAdjustment` + `compute_split_adjustment` restored** — de-duplicates
+   repeated split events, flags implausible coefficients, caps the cumulative
+   factor, and cross-checks each coefficient against the observed price drop.
+3. **`calculate_portfolio_performance` reconciles splits** — the buy-price
+   binding is now `(f64, NaiveDate)`; `buy_date` scopes which splits fall in the
+   holding window; `adjusted_buy_price = buy_price / split.factor` is the basis
+   for `gain_loss_percent`, `total_return_percent`, and the reported
+   `StockPerformance.buy_price`.
+4. **Hybrid projection** passes `true` for split reliability (split correction
+   is out of scope for #294), preserving its existing behaviour.
+
+```mermaid
+flowchart TD
+    A[buy_price, buy_date] --> B[compute_split_adjustment over window]
+    B -->|reliable=false| X[exclude via is_priceable gate]
+    B -->|reliable=true| C[adjusted_buy_price = buy_price / factor]
+    C --> D[gain_loss_percent and total_return_percent on adjusted basis]
+    D --> E[StockPerformance.buy_price = adjusted_buy_price]
+```
+
+## Evidence
+
+Backend-only change (no web interface to screenshot). Verified via the Rust
+test suite and the full quality gate:
+
+- `cargo fmt --all -- --check` — passes
+- `cargo clippy --locked --all-targets --all-features -- -D warnings` — passes
+- `cargo check --locked --all-targets --all-features` — passes
+- `./quality.sh` — runs past the Rust gate through tests and coverage
+  (`✅ Quality checks completed successfully!`)
+
+## Test Plan
+
+New/updated tests in `src/utils.rs`:
+
+- `test_is_priceable_*` updated to the three-argument signature; added
+  `test_is_priceable_split_unreliable_excludes_otherwise_priceable_stock`.
+- `test_compute_split_adjustment_no_splits_is_reliable_unity`
+- `test_compute_split_adjustment_clean_single_split`
+- `test_compute_split_adjustment_deduplicates_repeated_event`
+- `test_compute_split_adjustment_implausible_coefficient_unreliable`
+- `test_compute_split_adjustment_price_ratio_mismatch_unreliable`
+- `test_compute_split_adjustment_ignores_splits_before_buy_date`
+- `test_portfolio_performance_corrects_clean_split` — a clean 2:1 split inside
+  the window is corrected (buy basis 100 → 50, return +10%), not excluded.
+- `test_portfolio_performance_excludes_implausible_split` — an unreconcilable
+  coefficient drops the stock from the average, the count, and into
+  `excluded_tickers`.
+- `test_portfolio_performance_no_split_unchanged` — a no-split stock is
+  unchanged (regression guard).

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,13 +46,129 @@ pub fn validate_stock_symbol(symbol: &str) -> bool {
 /// ```
 /// use grq_validation::utils::is_priceable;
 ///
-/// assert!(is_priceable(10.5, 12.0));
-/// assert!(!is_priceable(0.0, 12.0));  // missing buy price
-/// assert!(!is_priceable(10.5, 0.0));  // missing current price
-/// assert!(!is_priceable(0.0, 0.0));   // both missing
+/// assert!(is_priceable(10.5, 12.0, true));
+/// assert!(!is_priceable(0.0, 12.0, true));  // missing buy price
+/// assert!(!is_priceable(10.5, 0.0, true));  // missing current price
+/// assert!(!is_priceable(0.0, 0.0, true));   // both missing
+/// assert!(!is_priceable(10.5, 12.0, false)); // split series unreliable
 /// ```
-pub fn is_priceable(buy_price: f64, current_price: f64) -> bool {
-    buy_price > 0.0 && current_price > 0.0
+///
+/// `split_reliable` mirrors the frontend `isStockIncluded` predicate (issue
+/// #293): a stock whose split series cannot be trustworthily reconciled is
+/// excluded through this single gate rather than via a parallel path.
+pub fn is_priceable(buy_price: f64, current_price: f64, split_reliable: bool) -> bool {
+    buy_price > 0.0 && current_price > 0.0 && split_reliable
+}
+
+/// Trustworthy split-adjustment thresholds, mirroring `docs/projection.js`
+/// (issues #291/#292, parent #272). Agreed in the #291 investigation — see
+/// `docs/fixes/klac-split-distortion-investigation.md`.
+const MAX_PLAUSIBLE_COEFFICIENT: f64 = 10.0; // a single split of <= 10:1 is plausible
+const DUPLICATE_WINDOW_DAYS: i64 = 5; // splits within 5 days = the same event twice
+const MAX_CUMULATIVE_FACTOR: f64 = 50.0; // cumulative factor cap over the window
+const RECONCILE_TOLERANCE: f64 = 0.15; // +/-15% price-ratio cross-check
+
+/// Cumulative split adjustment for a window plus whether it can be trusted.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SplitAdjustment {
+    /// De-duplicated, plausibility-checked cumulative split factor (kept for
+    /// diagnostics even when `reliable` is `false`).
+    pub factor: f64,
+    /// `false` when the series cannot be reconciled; callers must then exclude
+    /// the stock rather than silently apply `factor`.
+    pub reliable: bool,
+}
+
+impl SplitAdjustment {
+    /// A no-split, trivially-reliable adjustment (factor `1.0`).
+    pub const NONE: SplitAdjustment = SplitAdjustment {
+        factor: 1.0,
+        reliable: true,
+    };
+}
+
+/// Computes the cumulative split adjustment for splits strictly after
+/// `from_date`, judging whether the series can be trusted — the Rust mirror of
+/// the frontend `computeSplitAdjustment` (issue #294, parent #272).
+///
+/// Rules: de-duplicate split events recorded within [`DUPLICATE_WINDOW_DAYS`];
+/// flag any single coefficient above [`MAX_PLAUSIBLE_COEFFICIENT`]; cap the
+/// cumulative factor at [`MAX_CUMULATIVE_FACTOR`]; and cross-check each split
+/// against the observed pre/post price drop (a real N:1 split divides the price
+/// ~N-fold) within [`RECONCILE_TOLERANCE`]. A missing or empty series means no
+/// known splits, so the factor is `1.0` and the series is reliable.
+pub fn compute_split_adjustment(
+    series: &HashMap<String, DailyMarketPoint>,
+    from_date: NaiveDate,
+) -> SplitAdjustment {
+    // Sort by date so "the price immediately before a split" is well-defined
+    // regardless of map iteration order.
+    let mut points: Vec<(NaiveDate, &DailyMarketPoint)> = series
+        .iter()
+        .filter_map(|(date_str, point)| {
+            NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+                .ok()
+                .map(|date| (date, point))
+        })
+        .collect();
+    points.sort_by_key(|(date, _)| *date);
+
+    let mut factor = 1.0;
+    let mut reliable = true;
+    let mut last_event: Option<NaiveDate> = None;
+
+    for (i, (date, point)) in points.iter().enumerate() {
+        let date = *date;
+        let c = point.split_coefficient;
+
+        // Only splits strictly after the buy date adjust the buy price.
+        if date <= from_date {
+            continue;
+        }
+        // Invalid / non-split coefficients mean "no adjustment" (treat as 1.0)
+        // and are not, by themselves, a reliability failure.
+        if !c.is_finite() || c <= 1.0 {
+            continue;
+        }
+        // De-duplicate: a split within DUPLICATE_WINDOW_DAYS of the last kept
+        // one is the same corporate event recorded twice — apply it once.
+        if let Some(prev_event) = last_event {
+            if (date - prev_event).num_days() <= DUPLICATE_WINDOW_DAYS {
+                continue;
+            }
+        }
+        last_event = Some(date);
+
+        // Implausibly large single coefficient: cannot trust unguarded.
+        if c > MAX_PLAUSIBLE_COEFFICIENT {
+            reliable = false;
+        }
+
+        // Price-ratio cross-check: compare the midpoint just before the split
+        // with the split point's own (post-split) midpoint. Only checkable when
+        // a prior point exists; absent one we keep the data-feed invariant.
+        if i > 0 {
+            let prev = points[i - 1].1;
+            let prev_mid = (prev.high + prev.low) / 2.0;
+            let split_mid = (point.high + point.low) / 2.0;
+            if prev_mid.is_finite() && split_mid.is_finite() && split_mid > 0.0 {
+                let observed_ratio = prev_mid / split_mid;
+                if (observed_ratio / c - 1.0).abs() > RECONCILE_TOLERANCE {
+                    reliable = false;
+                }
+            }
+        }
+
+        factor *= c;
+    }
+
+    // Cumulative-factor plausibility bound: a larger factor almost certainly
+    // means duplicated or spurious coefficients.
+    if factor > MAX_CUMULATIVE_FACTOR {
+        reliable = false;
+    }
+
+    SplitAdjustment { factor, reliable }
 }
 
 /// Returns the arithmetic mean of `scores`, or `0.0` for an empty slice.
@@ -884,28 +1000,31 @@ pub fn calculate_portfolio_performance(
         // Use the full ticker (e.g., "NYSE:SEM") to match CSV data
         let full_ticker = &record.stock;
 
-        // Get the buy price (first day close) from CSV data.
-        let buy_price = if let Some(first_day_data) = market_data_csv.get(full_ticker) {
+        // Get the buy price (first day close) from CSV data, and the date it
+        // came from (needed to know which splits fall inside the window).
+        let (buy_price, buy_date) = if let Some(first_day_data) = market_data_csv.get(full_ticker) {
             if let Some(first_day) = first_day_data.get(score_file_date) {
-                *first_day
+                (*first_day, score_date)
             } else {
                 // Find the next available trading day
                 let mut next_trading_day_price = 0.0;
-                let mut next_trading_day_date: Option<NaiveDate> = None;
+                let mut next_trading_day_date = score_date;
+                let mut found: Option<NaiveDate> = None;
 
                 for (date_str, price) in first_day_data {
                     if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
-                        if date >= score_date && next_trading_day_date.is_none_or(|d| date < d) {
-                            next_trading_day_date = Some(date);
+                        if date >= score_date && found.is_none_or(|d| date < d) {
+                            found = Some(date);
+                            next_trading_day_date = date;
                             next_trading_day_price = *price;
                         }
                     }
                 }
 
-                next_trading_day_price
+                (next_trading_day_price, next_trading_day_date)
             }
         } else {
-            0.0
+            (0.0, score_date)
         };
 
         // Get the current price (90-day end date or latest available)
@@ -943,10 +1062,25 @@ pub fn calculate_portfolio_performance(
             0.0
         };
 
-        // Use the priceable predicate to determine inclusion
-        if is_priceable(buy_price, current_price) {
-            // Calculate price gain/loss
-            let gain_loss_percent = ((current_price - buy_price) / buy_price) * 100.0;
+        // Reconcile any split between the buy date and the current-price date.
+        // A reliable series is corrected (buy price restated to current terms);
+        // an unreliable one drops the stock through the single is_priceable gate.
+        let split = market
+            .points
+            .get(full_ticker)
+            .map(|series| compute_split_adjustment(series, buy_date))
+            .unwrap_or(SplitAdjustment::NONE);
+
+        // Use the priceable predicate (now split-aware) to determine inclusion.
+        if is_priceable(buy_price, current_price, split.reliable) {
+            // Restate the buy price into current (post-split) terms so the
+            // return is not distorted by a split inside the window. With no
+            // split the factor is 1.0 and the cost basis is unchanged.
+            let adjusted_buy_price = buy_price / split.factor;
+
+            // Calculate price gain/loss against the corrected cost basis.
+            let gain_loss_percent =
+                ((current_price - adjusted_buy_price) / adjusted_buy_price) * 100.0;
 
             // Calculate dividends for the 90-day period
             let dividends_total =
@@ -954,11 +1088,12 @@ pub fn calculate_portfolio_performance(
                     .unwrap_or(0.0);
 
             // Calculate total return (price + dividends) on the same basis.
-            let total_return_percent = gain_loss_percent + (dividends_total / buy_price * 100.0);
+            let total_return_percent =
+                gain_loss_percent + (dividends_total / adjusted_buy_price * 100.0);
 
             individual_performances.push(StockPerformance {
                 ticker: record.stock.clone(),
-                buy_price,
+                buy_price: adjusted_buy_price,
                 target_price: record.target,
                 current_price,
                 gain_loss_percent,
@@ -1077,8 +1212,11 @@ pub fn calculate_hybrid_projection(
                 0.0
             };
 
-            // Use the priceable predicate to determine inclusion
-            if is_priceable(buy_price, latest_price) {
+            // Use the priceable predicate to determine inclusion. The hybrid
+            // projection does not yet apply split correction (out of scope for
+            // issue #294), so split reliability is left at `true` to preserve
+            // its existing behaviour.
+            if is_priceable(buy_price, latest_price, true) {
                 let gain_loss_percent = ((latest_price - buy_price) / buy_price) * 100.0;
                 // Use market data days elapsed instead of calendar days
                 let market_days_elapsed = (latest_date - score_date).num_days();
@@ -2612,33 +2750,45 @@ mod tests {
 
     // --- Tests for stock priceable predicate (issue #286) ---
 
+    // The third `split_reliable` argument was added in issue #294 so the single
+    // predicate also drops split-unreliable stocks (mirroring the frontend
+    // `isStockIncluded`). These existing cases pass `true` to preserve their
+    // original price-only intent; a dedicated case below covers `false`.
     #[test]
     fn test_is_priceable_both_prices_present() {
-        assert!(is_priceable(10.5, 12.0));
-        assert!(is_priceable(0.01, 0.01));
-        assert!(is_priceable(100.0, 1.0));
+        assert!(is_priceable(10.5, 12.0, true));
+        assert!(is_priceable(0.01, 0.01, true));
+        assert!(is_priceable(100.0, 1.0, true));
     }
 
     #[test]
     fn test_is_priceable_buy_price_missing() {
-        assert!(!is_priceable(0.0, 12.0));
+        assert!(!is_priceable(0.0, 12.0, true));
     }
 
     #[test]
     fn test_is_priceable_current_price_missing() {
-        assert!(!is_priceable(10.5, 0.0));
+        assert!(!is_priceable(10.5, 0.0, true));
     }
 
     #[test]
     fn test_is_priceable_both_prices_missing() {
-        assert!(!is_priceable(0.0, 0.0));
+        assert!(!is_priceable(0.0, 0.0, true));
     }
 
     #[test]
     fn test_is_priceable_negative_prices() {
-        assert!(!is_priceable(-10.5, 12.0));
-        assert!(!is_priceable(10.5, -12.0));
-        assert!(!is_priceable(-10.5, -12.0));
+        assert!(!is_priceable(-10.5, 12.0, true));
+        assert!(!is_priceable(10.5, -12.0, true));
+        assert!(!is_priceable(-10.5, -12.0, true));
+    }
+
+    #[test]
+    fn test_is_priceable_split_unreliable_excludes_otherwise_priceable_stock() {
+        // Both prices usable, but an unreliable split series drops the stock
+        // through the single gate (issue #294).
+        assert!(!is_priceable(10.5, 12.0, false));
+        assert!(!is_priceable(100.0, 1.0, false));
     }
 
     #[test]
@@ -2670,18 +2820,18 @@ mod tests {
 
         // Simulate that GOOD1 and GOOD2 are priceable but MISSING_BUY is not
         // This is tested implicitly via the count and excluded list
-        assert!(is_priceable(20.0, 25.0)); // GOOD1 is priceable
-        assert!(is_priceable(20.0, 22.0)); // GOOD2 is priceable
-        assert!(!is_priceable(0.0, 0.0)); // MISSING_BUY is not priceable
+        assert!(is_priceable(20.0, 25.0, true)); // GOOD1 is priceable
+        assert!(is_priceable(20.0, 22.0, true)); // GOOD2 is priceable
+        assert!(!is_priceable(0.0, 0.0, true)); // MISSING_BUY is not priceable
     }
 
     #[test]
     fn test_portfolio_performance_excludes_missing_current_price() {
         // When a stock has a missing current price within the 90-day window,
         // it should be excluded from both the average and the count.
-        assert!(is_priceable(20.0, 25.0)); // priceable
-        assert!(!is_priceable(20.0, 0.0)); // missing current price is not priceable
-        assert!(!is_priceable(0.0, 25.0)); // missing buy price is not priceable
+        assert!(is_priceable(20.0, 25.0, true)); // priceable
+        assert!(!is_priceable(20.0, 0.0, true)); // missing current price is not priceable
+        assert!(!is_priceable(0.0, 25.0, true)); // missing buy price is not priceable
     }
 
     #[test]
@@ -2728,5 +2878,226 @@ mod tests {
         let wrong_average = good_returns.iter().sum::<f64>() / wrong_denominator as f64;
         assert_eq!(wrong_average, 20.0 / 3.0);
         assert_ne!(correct_average, wrong_average);
+    }
+
+    // --- Split-coefficient guard and correct-or-exclude (issue #294) ---
+
+    /// Builds a split-relevant series for one ticker from
+    /// `(date, high, low, split_coefficient)` points. `close` is not stored in
+    /// `DailyMarketPoint`, so only high/low/coefficient matter.
+    fn split_series(points: &[(&str, f64, f64, f64)]) -> HashMap<String, DailyMarketPoint> {
+        let mut series = HashMap::new();
+        for (date, high, low, split_coefficient) in points {
+            series.insert(
+                (*date).to_string(),
+                DailyMarketPoint {
+                    high: *high,
+                    low: *low,
+                    split_coefficient: *split_coefficient,
+                },
+            );
+        }
+        series
+    }
+
+    fn date(s: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(s, "%Y-%m-%d").unwrap()
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_no_splits_is_reliable_unity() {
+        let series = split_series(&[
+            ("2024-11-15", 100.0, 100.0, 1.0),
+            ("2024-12-15", 105.0, 105.0, 1.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert_eq!(adj, SplitAdjustment::NONE);
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_clean_single_split() {
+        // A real 2:1 split: the day before trades ~110, the split day ~55.
+        let series = split_series(&[
+            ("2024-12-14", 110.0, 110.0, 1.0),
+            ("2024-12-15", 55.0, 55.0, 2.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert!(adj.reliable, "a reconcilable 2:1 split must be reliable");
+        assert!((adj.factor - 2.0).abs() < 1e-9, "factor should be 2.0");
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_deduplicates_repeated_event() {
+        // The same 2:1 event recorded twice within five days applies once.
+        let series = split_series(&[
+            ("2024-12-14", 110.0, 110.0, 1.0),
+            ("2024-12-15", 55.0, 55.0, 2.0),
+            ("2024-12-17", 55.0, 55.0, 2.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert!(adj.reliable);
+        assert!(
+            (adj.factor - 2.0).abs() < 1e-9,
+            "duplicate within window must not compound to 4.0, got {}",
+            adj.factor
+        );
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_implausible_coefficient_unreliable() {
+        let series = split_series(&[
+            ("2024-12-14", 110.0, 110.0, 1.0),
+            ("2024-12-15", 2.0, 2.0, 50.0), // single coefficient far above 10
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert!(
+            !adj.reliable,
+            "an implausibly large single coefficient must be flagged unreliable"
+        );
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_price_ratio_mismatch_unreliable() {
+        // Coefficient claims 2:1 but the price barely moves: cannot reconcile.
+        let series = split_series(&[
+            ("2024-12-14", 100.0, 100.0, 1.0),
+            ("2024-12-15", 98.0, 98.0, 2.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-11-15"));
+        assert!(
+            !adj.reliable,
+            "a coefficient that does not match the observed price drop is unreliable"
+        );
+    }
+
+    #[test]
+    fn test_compute_split_adjustment_ignores_splits_before_buy_date() {
+        // A split that predates the buy date does not adjust the buy price.
+        let series = split_series(&[
+            ("2024-12-14", 110.0, 110.0, 1.0),
+            ("2024-12-15", 55.0, 55.0, 2.0),
+        ]);
+        let adj = compute_split_adjustment(&series, date("2024-12-31"));
+        assert_eq!(adj, SplitAdjustment::NONE);
+    }
+
+    /// Writes a score TSV and its derived market-data CSV into a temp dir, then
+    /// returns the temp dir (kept alive) and the score-file path.
+    fn write_portfolio_fixture(tsv: &str, csv: &str) -> (tempfile::TempDir, String) {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let tsv_path = dir.path().join("score.tsv");
+        let csv_path = dir.path().join("score.csv");
+        std::fs::File::create(&tsv_path)
+            .unwrap()
+            .write_all(tsv.as_bytes())
+            .unwrap();
+        std::fs::File::create(&csv_path)
+            .unwrap()
+            .write_all(csv.as_bytes())
+            .unwrap();
+        (dir, tsv_path.to_string_lossy().to_string())
+    }
+
+    const PERF_CSV_HEADER: &str = "date,ticker,high,low,open,close,split_coefficient\n";
+
+    /// Score-TSV header carrying every column `StockRecord` deserialises.
+    const PERF_TSV_HEADER: &str = "Stock\tScore\tTarget\tExDividendDate\tDividendPerShare\tNotes\tintrinsicValuePerShareBasic\tintrinsicValuePerShareAdjusted\n";
+
+    #[test]
+    fn test_portfolio_performance_corrects_clean_split() {
+        // A clean 2:1 split inside the window must be corrected, not excluded:
+        // raw close 100 -> 55 looks like -45%, but the split-adjusted return is
+        // +10% (buy basis restated to 50).
+        let tsv = format!("{PERF_TSV_HEADER}NYSE:CLEAN\t1.0\t$120.00\t\t\t\t\t\n");
+        let csv = format!(
+            "{PERF_CSV_HEADER}\
+             2024-11-15,NYSE:CLEAN,100,100,100,100,1.0\n\
+             2024-12-14,NYSE:CLEAN,110,110,110,110,1.0\n\
+             2024-12-15,NYSE:CLEAN,55,55,55,55,2.0\n\
+             2025-02-13,NYSE:CLEAN,55,55,55,55,1.0\n"
+        );
+        let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
+
+        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+
+        assert_eq!(result.total_stocks, 1, "a clean split stock stays included");
+        assert!(result.excluded_tickers.is_empty());
+        let stock = &result.individual_performances[0];
+        assert!(
+            (stock.buy_price - 50.0).abs() < 1e-6,
+            "buy basis must be restated to 50, got {}",
+            stock.buy_price
+        );
+        assert!(
+            (stock.gain_loss_percent - 10.0).abs() < 1e-6,
+            "corrected return must be +10%, got {}",
+            stock.gain_loss_percent
+        );
+        assert!((result.performance_90_day - 10.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_portfolio_performance_excludes_implausible_split() {
+        // Two stocks: one clean (+10%), one with an implausible coefficient that
+        // cannot be reconciled. The bad one must drop from the average, from the
+        // count, and appear in excluded_tickers (issue #294 + #286 plumbing).
+        let tsv = format!(
+            "{PERF_TSV_HEADER}\
+             NYSE:GOODSPLIT\t1.0\t$120.00\t\t\t\t\t\n\
+             NYSE:BADSPLIT\t1.0\t$120.00\t\t\t\t\t\n"
+        );
+        let csv = format!(
+            "{PERF_CSV_HEADER}\
+             2024-11-15,NYSE:GOODSPLIT,100,100,100,100,1.0\n\
+             2024-12-14,NYSE:GOODSPLIT,110,110,110,110,1.0\n\
+             2024-12-15,NYSE:GOODSPLIT,55,55,55,55,2.0\n\
+             2025-02-13,NYSE:GOODSPLIT,55,55,55,55,1.0\n\
+             2024-11-15,NYSE:BADSPLIT,100,100,100,100,1.0\n\
+             2024-12-15,NYSE:BADSPLIT,2,2,2,2,50.0\n\
+             2025-02-13,NYSE:BADSPLIT,2,2,2,2,1.0\n"
+        );
+        let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
+
+        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+
+        assert_eq!(
+            result.total_stocks, 1,
+            "only the reconcilable stock is counted"
+        );
+        assert_eq!(result.individual_performances.len(), 1);
+        assert_eq!(result.individual_performances[0].ticker, "NYSE:GOODSPLIT");
+        assert!(
+            result
+                .excluded_tickers
+                .contains(&"NYSE:BADSPLIT".to_string()),
+            "the unreconcilable split stock must be excluded"
+        );
+        // Average is over the single included stock only.
+        assert!((result.performance_90_day - 10.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_portfolio_performance_no_split_unchanged() {
+        // A stock with no split (coefficient 1.0 throughout) behaves exactly as
+        // before: 100 -> 110 is a straight +10%, buy basis unchanged.
+        let tsv = format!("{PERF_TSV_HEADER}NYSE:NOSPLIT\t1.0\t$120.00\t\t\t\t\t\n");
+        let csv = format!(
+            "{PERF_CSV_HEADER}\
+             2024-11-15,NYSE:NOSPLIT,100,100,100,100,1.0\n\
+             2025-02-13,NYSE:NOSPLIT,110,110,110,110,1.0\n"
+        );
+        let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
+
+        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+
+        assert_eq!(result.total_stocks, 1);
+        assert!(result.excluded_tickers.is_empty());
+        let stock = &result.individual_performances[0];
+        assert!(
+            (stock.buy_price - 100.0).abs() < 1e-6,
+            "no-split buy basis is unchanged"
+        );
+        assert!((stock.gain_loss_percent - 10.0).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
# Restore split-adjustment in `src/utils.rs` (Issue #340)

## Summary

The milestone branch did not build the split-adjustment feature from #294: a
botched merge from `main` dropped the `SplitAdjustment` machinery and the
later "fix" simply reverted `calculate_portfolio_performance` to a raw,
non-split-adjusted `buy_price`. The Rust gate compiled, but the
correct-or-exclude split behaviour the milestone exists to deliver was gone.

This restores the feature to its pre-merge design (commit `3810684`), so
`adjusted_buy_price` is genuinely split-adjusted rather than a rename of
`buy_price`. Closes #340.

Changes in `src/utils.rs`:

1. **`is_priceable` is split-aware again** — third `split_reliable` argument
   restored; the single gate drops split-unreliable stocks (mirrors the
   frontend `isStockIncluded`).
2. **`SplitAdjustment` + `compute_split_adjustment` restored** — de-duplicates
   repeated split events, flags implausible coefficients, caps the cumulative
   factor, and cross-checks each coefficient against the observed price drop.
3. **`calculate_portfolio_performance` reconciles splits** — the buy-price
   binding is now `(f64, NaiveDate)`; `buy_date` scopes which splits fall in the
   holding window; `adjusted_buy_price = buy_price / split.factor` is the basis
   for `gain_loss_percent`, `total_return_percent`, and the reported
   `StockPerformance.buy_price`.
4. **Hybrid projection** passes `true` for split reliability (split correction
   is out of scope for #294), preserving its existing behaviour.

```mermaid
flowchart TD
    A[buy_price, buy_date] --> B[compute_split_adjustment over window]
    B -->|reliable=false| X[exclude via is_priceable gate]
    B -->|reliable=true| C[adjusted_buy_price = buy_price / factor]
    C --> D[gain_loss_percent and total_return_percent on adjusted basis]
    D --> E[StockPerformance.buy_price = adjusted_buy_price]
```

## Evidence

Backend-only change (no web interface to screenshot). Verified via the Rust
test suite and the full quality gate:

- `cargo fmt --all -- --check` — passes
- `cargo clippy --locked --all-targets --all-features -- -D warnings` — passes
- `cargo check --locked --all-targets --all-features` — passes
- `./quality.sh` — runs past the Rust gate through tests and coverage
  (`✅ Quality checks completed successfully!`)

## Test Plan

New/updated tests in `src/utils.rs`:

- `test_is_priceable_*` updated to the three-argument signature; added
  `test_is_priceable_split_unreliable_excludes_otherwise_priceable_stock`.
- `test_compute_split_adjustment_no_splits_is_reliable_unity`
- `test_compute_split_adjustment_clean_single_split`
- `test_compute_split_adjustment_deduplicates_repeated_event`
- `test_compute_split_adjustment_implausible_coefficient_unreliable`
- `test_compute_split_adjustment_price_ratio_mismatch_unreliable`
- `test_compute_split_adjustment_ignores_splits_before_buy_date`
- `test_portfolio_performance_corrects_clean_split` — a clean 2:1 split inside
  the window is corrected (buy basis 100 → 50, return +10%), not excluded.
- `test_portfolio_performance_excludes_implausible_split` — an unreconcilable
  coefficient drops the stock from the average, the count, and into
  `excluded_tickers`.
- `test_portfolio_performance_no_split_unchanged` — a no-split stock is
  unchanged (regression guard).



## Milestone
This PR is part of the **#326 Milestone branch milestone/272 does not compile: src/utils.rs missing adjusted_buy_price + tuple type mismatch** milestone and targets the `milestone/326-milestone-branch-milestone-272-does-not-compil` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqp0lq28-1867f9`<!-- vibe-worker-issue-340 -->