### PR TITLE
Harden CI: run the Rust gate on milestone/** PRs (Issue #342)

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -11,6 +11,13 @@
   },
   "required_approving_review_count": 1,
   "enforcement": "Requires a repository administrator to enable on `main` via Settings -> Branches or a repository ruleset; the controls are not applied automatically from this file. The committed `.github/CODEOWNERS` rules become enforced (not merely advisory) once 'Require review from Code Owners' is turned on.",
+  "milestone_ruleset": {
+    "comment": "Intended ruleset for milestone integration branches (Issue #342). PRs into `milestone/**` previously bypassed the Rust quality gate because ci.yml triggered only on `main` and the milestone branches had no branch protection. The workflow trigger gap is fixed in `.github/workflows/ci.yml`; this block records the matching branch-protection posture that a repository administrator must apply (the worker account lacks admin rights, so it cannot create the ruleset itself).",
+    "branch_pattern": "milestone/**",
+    "required_status_checks": ["Test and Quality Checks"],
+    "require_branches_up_to_date": true,
+    "enforcement": "A repository administrator must create a ruleset matching `milestone/**` (Settings -> Rules -> Rulesets) that requires the `Test and Quality Checks` status check to pass and enables 'Require branches to be up to date before merging'. This blocks a non-compiling PR from merging into a milestone branch and prevents a green-in-isolation branch from breaking the target after it moves. Not applied automatically from this file."
+  },
   "accepted_relaxations": [
     {
       "control": "require_pull_request",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: CI/CD Pipeline
 
+# Run the Rust gate on `main` and on milestone integration branches
+# (Issue #342). PRs whose base is a `milestone/**` branch must run the same
+# fmt/clippy/check/test gate as `main`; previously they bypassed it because the
+# triggers listed only `main`. `deploy-pages` stays main-only via its own
+# `github.ref` guard below, so milestone PRs never publish Pages.
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "milestone/**" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "milestone/**" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -175,7 +175,11 @@ dependency hygiene.
 ### Workflows
 
 1. **CI** (`ci.yml`) — main continuous integration: build, test, formatting,
-   linting, and artifact upload.
+   linting, and artifact upload. Runs on pushes and pull requests to `main`
+   and to `milestone/**` integration branches, so the Rust quality gate
+   (`cargo fmt`/`clippy`/`check`/`test`) also guards milestone PRs. The
+   `deploy-pages` job stays `main`-only, so milestone branches never publish
+   the GitHub Pages dashboard.
 2. **Cargo Audit** (`cargo-audit.yml`) — runs `cargo audit` on every pull
    request and on a weekly schedule to catch newly disclosed advisories.
 3. **Deno Outdated** (`deno-outdated.yml`) — checks for outdated JSR/npm

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,14 @@ currently commit unsigned because per-identity signing keys are not yet
 provisioned. Both are accepted, documented postures tracked as future work — see
 `.github/branch-protection.json` for the per-control rationale.
 
+Milestone integration branches (`milestone/**`) carry their own intended
+ruleset, also recorded in `.github/branch-protection.json` under
+`milestone_ruleset`: the `Test and Quality Checks` Rust status check must pass
+and branches must be up to date before merging, so a non-compiling PR cannot
+merge into a milestone branch. The CI workflow already runs the gate on
+`milestone/**` PRs; an administrator must create the matching ruleset to make
+the check **required** (the worker account lacks admin rights).
+
 ## Emergency dependency-bump procedure
 
 When a malicious or vulnerable version of a dependency is disclosed, pin the

--- a/docs/archive/pr-summaries/pr-summary-342.md
+++ b/docs/archive/pr-summaries/pr-summary-342.md
@@ -1,0 +1,74 @@
+# Harden CI: run the Rust gate on `milestone/**` PRs
+
+## Summary
+
+PRs whose **base** is a `milestone/**` integration branch bypassed the Rust
+quality gate: `.github/workflows/ci.yml` triggered only on `push`/`pull_request`
+to `main`, so the `test` job (`cargo fmt`/`clippy`/`check`/`test`) never ran on
+milestone PRs, and the milestone branches had no branch protection requiring a
+green check.
+
+This PR (configuration only — no application code):
+
+1. **Extends the CI triggers** so the gate also runs on milestone branches —
+   `milestone/**` is added to both `on.push.branches` and
+   `on.pull_request.branches`. The `check-changes` path filter
+   (`^(src/|Cargo\.toml|Cargo\.lock|tests/)`) is unchanged, so the `test` job
+   still runs when `src/`, `Cargo.*`, or `tests/` change. `deploy-pages` keeps
+   its `github.ref == 'refs/heads/main'` guard, so milestone PRs never deploy
+   Pages.
+2. **Records the intended `milestone/**` branch-protection posture** in
+   `.github/branch-protection.json` under a new `milestone_ruleset` block:
+   require the `Test and Quality Checks` status check and require branches to be
+   up to date before merging. Following the repo's established Issue #180
+   pattern, branch-protection settings are not stored in the tree — a
+   repository administrator applies them. **The worker account has no admin
+   rights (`admin: false`), so it cannot create the ruleset itself**; the
+   descriptor documents the gap so a human admin can apply it and so static
+   scans see a documented posture rather than an undetected gap.
+
+Closes #342.
+
+## Admin follow-up required
+
+The workflow-trigger half of the acceptance criteria is fully delivered and
+tested here. Marking the `Test and Quality Checks` check **required** with
+**up-to-date** branches on `milestone/**` is a repository-settings change that
+needs repo-admin rights. A repository administrator must create a ruleset
+matching `milestone/**` per the `milestone_ruleset.enforcement` note in
+`.github/branch-protection.json` (Settings → Rules → Rulesets).
+
+## Evidence
+
+Configuration/CI change with no web interface to screenshot. Verified via the
+Deno test suite (`deno test --allow-read tests/*.ts`) — all 583 tests pass,
+including the new milestone trigger and ruleset descriptor tests.
+
+```mermaid
+flowchart LR
+    PR["PR base: milestone/**"] --> CI["CI/CD Pipeline (ci.yml)"]
+    CI --> CC["check-changes\n(path filter)"]
+    CC -->|"src/ Cargo.* tests/ changed"| T["test: fmt / clippy / check / test"]
+    T --> B["build (release + SBOM)"]
+    CI -.->|"ref != refs/heads/main"| DP["deploy-pages: SKIPPED"]
+    T --> RS["milestone/** ruleset\n(Test and Quality Checks required,\nup-to-date branches)"]
+    RS -->|"check red → merge blocked"| MERGE["merge into milestone branch"]
+```
+
+## Test Plan
+
+Added to `tests/ci_workflow_test.ts`:
+
+- `CI workflow triggers on push to main and milestone branches`
+- `CI workflow triggers on pull_request to main and milestone branches`
+- `deploy-pages stays main-only and is not widened to milestone branches`
+
+Added to `tests/branch_protection_governance_test.ts`:
+
+- `descriptor declares the milestone ruleset posture`
+- `milestone ruleset requires the Rust status check`
+- `milestone ruleset requires up-to-date branches`
+- `milestone ruleset records how it is enforced`
+
+All new tests failed before the change and pass after it; the full Deno suite
+(583 tests) passes.

--- a/tests/branch_protection_governance_test.ts
+++ b/tests/branch_protection_governance_test.ts
@@ -36,12 +36,20 @@ interface Relaxation {
   scope?: string;
 }
 
+interface MilestoneRuleset {
+  branch_pattern: string;
+  required_status_checks: string[];
+  require_branches_up_to_date: boolean;
+  enforcement: string;
+}
+
 interface Descriptor {
   default_branch: string;
   intended_controls: Record<string, boolean>;
   required_approving_review_count: number;
   enforcement: string;
   accepted_relaxations: Relaxation[];
+  milestone_ruleset: MilestoneRuleset;
 }
 
 async function loadDescriptor(): Promise<Descriptor> {
@@ -131,6 +139,48 @@ Deno.test("every relaxation references a declared control", async () => {
       `relaxation control "${relaxation.control}" must match a key in intended_controls`,
     );
   }
+});
+
+// Milestone integration branches require the Rust gate (Issue #342). Like the
+// `main` controls above, the milestone ruleset is a repository setting applied
+// out-of-band by an admin; this descriptor records the intended posture so the
+// gap is documented rather than undetected.
+Deno.test("descriptor declares the milestone ruleset posture", async () => {
+  const descriptor = await loadDescriptor();
+  const ruleset = descriptor.milestone_ruleset;
+  assert(ruleset, "descriptor must declare a milestone_ruleset block");
+  assertEquals(
+    ruleset.branch_pattern,
+    "milestone/**",
+    "milestone ruleset must target the `milestone/**` pattern",
+  );
+});
+
+Deno.test("milestone ruleset requires the Rust status check", async () => {
+  const descriptor = await loadDescriptor();
+  const checks = descriptor.milestone_ruleset.required_status_checks;
+  assert(
+    Array.isArray(checks) && checks.includes("Test and Quality Checks"),
+    "milestone ruleset must require the `Test and Quality Checks` status check",
+  );
+});
+
+Deno.test("milestone ruleset requires up-to-date branches", async () => {
+  const descriptor = await loadDescriptor();
+  assertEquals(
+    descriptor.milestone_ruleset.require_branches_up_to_date,
+    true,
+    "milestone ruleset must require branches to be up to date before merging",
+  );
+});
+
+Deno.test("milestone ruleset records how it is enforced", async () => {
+  const descriptor = await loadDescriptor();
+  assert(
+    typeof descriptor.milestone_ruleset.enforcement === "string" &&
+      descriptor.milestone_ruleset.enforcement.trim().length > 0,
+    "milestone ruleset must record a non-empty enforcement note",
+  );
 });
 
 Deno.test("the direct-push relaxation covers the automated score committer", async () => {

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -138,6 +138,54 @@ Deno.test("CI workflow declares a top-level concurrency group", async () => {
   );
 });
 
+// Milestone integration branches must run the Rust gate (Issue #342). PRs
+// whose base is a `milestone/**` branch previously bypassed the gate because
+// the workflow triggered only on `main`. The triggers must list both `main`
+// and `milestone/**` for push and pull_request so the test job (cargo
+// fmt/clippy/check/test) runs on milestone PRs too.
+Deno.test("CI workflow triggers on push to main and milestone branches", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const on = doc.on as { push?: { branches?: string[] } };
+  const branches = on.push?.branches ?? [];
+  assert(branches.includes("main"), "push trigger must keep `main`");
+  assert(
+    branches.includes("milestone/**"),
+    "push trigger must include `milestone/**`",
+  );
+});
+
+Deno.test("CI workflow triggers on pull_request to main and milestone branches", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const on = doc.on as { pull_request?: { branches?: string[] } };
+  const branches = on.pull_request?.branches ?? [];
+  assert(branches.includes("main"), "pull_request trigger must keep `main`");
+  assert(
+    branches.includes("milestone/**"),
+    "pull_request trigger must include `milestone/**`",
+  );
+});
+
+// No regression to Pages: deploy-pages must still run only on `main` so
+// milestone PRs never publish the site (Issue #342 acceptance criterion).
+Deno.test("deploy-pages stays main-only and is not widened to milestone branches", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const jobs = doc.jobs as Record<string, Record<string, unknown>>;
+  const deploy = jobs["deploy-pages"];
+  assert(deploy, "deploy-pages job must exist");
+  const guard = String(deploy.if ?? "");
+  assert(
+    guard.includes("github.ref == 'refs/heads/main'"),
+    "deploy-pages must remain guarded to refs/heads/main",
+  );
+  assert(
+    !guard.includes("milestone"),
+    "deploy-pages must not be widened to milestone branches",
+  );
+});
+
 // Multi-line bash run: blocks must fail fast (Issue #73). Without
 // `set -euo pipefail` an intermediate command that fails (or an unset
 // variable) is masked by the success of the final command, so the step


### PR DESCRIPTION
# Harden CI: run the Rust gate on `milestone/**` PRs

## Summary

PRs whose **base** is a `milestone/**` integration branch bypassed the Rust
quality gate: `.github/workflows/ci.yml` triggered only on `push`/`pull_request`
to `main`, so the `test` job (`cargo fmt`/`clippy`/`check`/`test`) never ran on
milestone PRs, and the milestone branches had no branch protection requiring a
green check.

This PR (configuration only — no application code):

1. **Extends the CI triggers** so the gate also runs on milestone branches —
   `milestone/**` is added to both `on.push.branches` and
   `on.pull_request.branches`. The `check-changes` path filter
   (`^(src/|Cargo\.toml|Cargo\.lock|tests/)`) is unchanged, so the `test` job
   still runs when `src/`, `Cargo.*`, or `tests/` change. `deploy-pages` keeps
   its `github.ref == 'refs/heads/main'` guard, so milestone PRs never deploy
   Pages.
2. **Records the intended `milestone/**` branch-protection posture** in
   `.github/branch-protection.json` under a new `milestone_ruleset` block:
   require the `Test and Quality Checks` status check and require branches to be
   up to date before merging. Following the repo's established Issue #180
   pattern, branch-protection settings are not stored in the tree — a
   repository administrator applies them. **The worker account has no admin
   rights (`admin: false`), so it cannot create the ruleset itself**; the
   descriptor documents the gap so a human admin can apply it and so static
   scans see a documented posture rather than an undetected gap.

Closes #342.

## Admin follow-up required

The workflow-trigger half of the acceptance criteria is fully delivered and
tested here. Marking the `Test and Quality Checks` check **required** with
**up-to-date** branches on `milestone/**` is a repository-settings change that
needs repo-admin rights. A repository administrator must create a ruleset
matching `milestone/**` per the `milestone_ruleset.enforcement` note in
`.github/branch-protection.json` (Settings → Rules → Rulesets).

## Evidence

Configuration/CI change with no web interface to screenshot. Verified via the
Deno test suite (`deno test --allow-read tests/*.ts`) — all 583 tests pass,
including the new milestone trigger and ruleset descriptor tests.

```mermaid
flowchart LR
    PR["PR base: milestone/**"] --> CI["CI/CD Pipeline (ci.yml)"]
    CI --> CC["check-changes\n(path filter)"]
    CC -->|"src/ Cargo.* tests/ changed"| T["test: fmt / clippy / check / test"]
    T --> B["build (release + SBOM)"]
    CI -.->|"ref != refs/heads/main"| DP["deploy-pages: SKIPPED"]
    T --> RS["milestone/** ruleset\n(Test and Quality Checks required,\nup-to-date branches)"]
    RS -->|"check red → merge blocked"| MERGE["merge into milestone branch"]
```

## Test Plan

Added to `tests/ci_workflow_test.ts`:

- `CI workflow triggers on push to main and milestone branches`
- `CI workflow triggers on pull_request to main and milestone branches`
- `deploy-pages stays main-only and is not widened to milestone branches`

Added to `tests/branch_protection_governance_test.ts`:

- `descriptor declares the milestone ruleset posture`
- `milestone ruleset requires the Rust status check`
- `milestone ruleset requires up-to-date branches`
- `milestone ruleset records how it is enforced`

All new tests failed before the change and pass after it; the full Deno suite
(583 tests) passes.



## Milestone
This PR is part of the **#326 Milestone branch milestone/272 does not compile: src/utils.rs missing adjusted_buy_price + tuple type mismatch** milestone and targets the `milestone/326-milestone-branch-milestone-272-does-not-compil` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqp3m7vb-b915d2`<!-- vibe-worker-issue-342 -->