### PR TITLE
Add behaviour tests for handleRequest (Issue #267)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-267.md
+++ b/docs/archive/pr-summaries/pr-summary-267.md
@@ -1,0 +1,56 @@
+## Summary
+
+Added behaviour tests for the previously untested exported `handleRequest` in
+`helpers/server.ts`. The function carries logic beyond the already-tested path
+containment (`getFilePath`): MIME-type mapping, 200/403/404/500 status
+selection, and cache-control headers. None of it was exercised by any test, so
+a refactor could silently break it. `handleRequest` is live code — it backs
+`Deno.serve` in the test server — so the function is kept and tested rather than
+deleted. Closes #267.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via the Deno test
+suite: the 6 new tests pass and the full suite stays green (582 passed).
+
+```
+ok | 6 passed | 0 failed (11ms)   # new file
+ok | 582 passed (55 steps) | 0 failed (2s)  # full tests/*.ts
+```
+
+The new tests are WHAT-tests: each passes a `Request` and asserts on the
+observable `Response` (status, headers, body), never on internal calls, so they
+survive refactors of the handler's internals.
+
+A design note worth recording: an *encoded* `../` sequence
+(`/%2e%2e/%2e%2e/etc/passwd`) does **not** reach the 403 branch through
+`handleRequest`, because the WHATWG `URL` parser collapses those dot-segments
+before `getFilePath` sees them. The realistic 403 trigger at the HTTP layer is a
+malformed percent-escape (a lone `%`), which `getFilePath` rejects. The encoded
+traversal rejection remains pinned directly on `getFilePath` by
+`tests/server_path_traversal_test.ts`.
+
+```mermaid
+flowchart LR
+    R[Request] --> H[handleRequest]
+    H --> P{getFilePath}
+    P -- null --> F[403 Forbidden]
+    P -- path --> S{Deno.stat}
+    S -- is file --> OK[200 + MIME + no-cache]
+    S -- not file --> NF[404 Not Found]
+    S -- NotFound --> NF
+    S -- other error --> E[500 Internal Server Error]
+```
+
+## Test Plan
+
+Added `tests/server_handle_request_test.ts` covering `handleRequest`:
+
+- serves `index.html` with 200 and `text/html` content-type (happy path)
+- maps `.json` files to `application/json` (MIME mapping)
+- sets `no-cache, no-store, must-revalidate` cache-control on served files
+- returns 404 for a missing file (error path)
+- returns 404 for a directory path (not-a-file edge case)
+- returns 403 for a malformed percent-escape (security/error path)
+
+Existing `tests/server_path_traversal_test.ts` is unchanged and still passes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.199">
+    <meta name="app-version" content="1.0.200">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -321,6 +321,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.199"></script>
+    <script src="sw-register.js?v=1.0.200"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.199")
+    navigator.serviceWorker.register("./sw.js?v=1.0.200")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.199";
+const APP_VERSION = "1.0.200";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/tests/server_handle_request_test.ts
+++ b/tests/server_handle_request_test.ts
@@ -1,0 +1,68 @@
+/**
+ * Behaviour tests for `handleRequest` in the static test server.
+ *
+ * Coverage gap for issue #267: the exported `handleRequest` carries logic
+ * beyond the already-tested path containment (`getFilePath`) — MIME-type
+ * mapping, 200/403/404/500 status selection, and cache-control headers — yet
+ * had no test. These are WHAT-tests: they pass a `Request` and assert on the
+ * observable `Response` (status, headers, body) without inspecting internals.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { handleRequest } from "../helpers/server.ts";
+
+// Happy path — the root path resolves to docs/index.html and is served as HTML.
+Deno.test("handleRequest - serves index.html with 200 and html content-type", async () => {
+  const res = await handleRequest(new Request("http://x/"));
+  await res.body?.cancel();
+  assertEquals(res.status, 200);
+  assert(
+    res.headers.get("content-type")?.includes("text/html"),
+    "expected text/html content-type",
+  );
+});
+
+// MIME mapping — a known extension maps to its configured media type.
+Deno.test("handleRequest - maps .json files to application/json", async () => {
+  const res = await handleRequest(new Request("http://x/manifest.json"));
+  await res.body?.cancel();
+  assertEquals(res.status, 200);
+  assert(
+    res.headers.get("content-type")?.includes("application/json"),
+    "expected application/json content-type",
+  );
+});
+
+// Cache-control — served files must not be cached by clients.
+Deno.test("handleRequest - sets no-cache headers on a served file", async () => {
+  const res = await handleRequest(new Request("http://x/"));
+  await res.body?.cancel();
+  assertEquals(
+    res.headers.get("cache-control"),
+    "no-cache, no-store, must-revalidate",
+  );
+});
+
+// Error path — a request for a non-existent file returns 404.
+Deno.test("handleRequest - returns 404 for a missing file", async () => {
+  const res = await handleRequest(new Request("http://x/does-not-exist.js"));
+  await res.body?.cancel();
+  assertEquals(res.status, 404);
+});
+
+// Error path — a directory (not a file) returns 404 rather than 200.
+Deno.test("handleRequest - returns 404 for a directory path", async () => {
+  const res = await handleRequest(new Request("http://x/scores/"));
+  await res.body?.cancel();
+  assertEquals(res.status, 404);
+});
+
+// Security path — a malformed percent-escape is rejected with 403 before any
+// read. (Note: the WHATWG URL parser already collapses `%2e%2e/` dot-segments,
+// so the 403 branch is reached via a malformed escape that `getFilePath`
+// rejects, not via an encoded `../` sequence.)
+Deno.test("handleRequest - returns 403 for a malformed percent-escape", async () => {
+  const res = await handleRequest(new Request("http://x/%"));
+  await res.body?.cancel();
+  assertEquals(res.status, 403);
+});


### PR DESCRIPTION
## Summary

Added behaviour tests for the previously untested exported `handleRequest` in
`helpers/server.ts`. The function carries logic beyond the already-tested path
containment (`getFilePath`): MIME-type mapping, 200/403/404/500 status
selection, and cache-control headers. None of it was exercised by any test, so
a refactor could silently break it. `handleRequest` is live code — it backs
`Deno.serve` in the test server — so the function is kept and tested rather than
deleted. Closes #267.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via the Deno test
suite: the 6 new tests pass and the full suite stays green (582 passed).

```
ok | 6 passed | 0 failed (11ms)   # new file
ok | 582 passed (55 steps) | 0 failed (2s)  # full tests/*.ts
```

The new tests are WHAT-tests: each passes a `Request` and asserts on the
observable `Response` (status, headers, body), never on internal calls, so they
survive refactors of the handler's internals.

A design note worth recording: an *encoded* `../` sequence
(`/%2e%2e/%2e%2e/etc/passwd`) does **not** reach the 403 branch through
`handleRequest`, because the WHATWG `URL` parser collapses those dot-segments
before `getFilePath` sees them. The realistic 403 trigger at the HTTP layer is a
malformed percent-escape (a lone `%`), which `getFilePath` rejects. The encoded
traversal rejection remains pinned directly on `getFilePath` by
`tests/server_path_traversal_test.ts`.

```mermaid
flowchart LR
    R[Request] --> H[handleRequest]
    H --> P{getFilePath}
    P -- null --> F[403 Forbidden]
    P -- path --> S{Deno.stat}
    S -- is file --> OK[200 + MIME + no-cache]
    S -- not file --> NF[404 Not Found]
    S -- NotFound --> NF
    S -- other error --> E[500 Internal Server Error]
```

## Test Plan

Added `tests/server_handle_request_test.ts` covering `handleRequest`:

- serves `index.html` with 200 and `text/html` content-type (happy path)
- maps `.json` files to `application/json` (MIME mapping)
- sets `no-cache, no-store, must-revalidate` cache-control on served files
- returns 404 for a missing file (error path)
- returns 404 for a directory path (not-a-file edge case)
- returns 403 for a malformed percent-escape (security/error path)

Existing `tests/server_path_traversal_test.ts` is unchanged and still passes.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqp3m7vb-b915d2`<!-- vibe-worker-issue-267 -->