### PR TITLE
Remove redundant source-text grep for inline handlers (Issue #268)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-268.md
+++ b/docs/archive/pr-summaries/pr-summary-268.md
@@ -1,0 +1,66 @@
+## Summary
+
+Removed the redundant source-text grep test `docs/app.js: generated rows use no inline event handlers` from `tests/csp_test.ts`. Closes #268.
+
+The deleted test read the source of `docs/app.js` and regex-matched it for a
+hard-coded subset of inline `on*=` event-handler spellings
+(`onclick|onchange|onerror|onload|oninput`). This was a static source-text proxy
+for a security property, not a behaviour assertion. It had two concrete flaws
+the issue called out:
+
+- **False positives** — it could match a benign string literal that happens to
+  contain `on… =`.
+- **Silent gaps** — it missed any handler attribute spelled outside its fixed
+  list (e.g. `onmouseover`, `onfocus`).
+
+Either way it reported on *how the source is written*, not on behaviour a caller
+can observe.
+
+### Why deletion (the issue's Option 1) rather than a DOM rewrite (Option 2)
+
+The *observable* contract — that inline `on*=` handlers never execute — is
+already enforced at runtime by the Content-Security-Policy and pinned by the
+same file's `script-src is strict (no unsafe-inline/eval)` test. An inline event
+handler requires `script-src 'unsafe-inline'` to run, which that test forbids on
+every page in `PAGES` (including `docs/index.html`, which loads
+`docs/app.js`). The grep was therefore redundant defence-in-depth.
+
+A DOM behaviour rewrite that renders rows through the app's real code path was
+considered but is not feasible in scope: `docs/app.js` (4242 lines) executes
+side-effects at import (`const validator = new GRQValidator();`), so it cannot
+be loaded into a Deno test without a full DOM/`fetch`/Chart/bootstrap stub — the
+reason the project deliberately extracts testable logic into separate modules
+(`escape.js`, `color_key.js`, `projection.js`) and never imports `app.js`.
+Adding an external DOM-parser dependency purely for a `severity:low` test-audit
+cleanup would be disproportionate and is quarantine-gated. The deletion is
+documented with an in-place comment in `tests/csp_test.ts` pointing to the CSP
+test that supersedes it.
+
+```mermaid
+flowchart LR
+    A["Inline on*= handler<br/>in injected markup"] -->|requires| B["script-src<br/>'unsafe-inline'"]
+    B -->|forbidden by| C["CSP strict script-src test<br/>(tests/csp_test.ts)"]
+    C --> D["Handler blocked at runtime"]
+    style C fill:#cfc,stroke:#393
+```
+
+## Evidence
+
+Backend/test-only change — no web UI to screenshot. Verified via the test suite:
+
+- `deno test --allow-read tests/csp_test.ts` → `9 passed | 0 failed` (the
+  removed grep test is gone; the CSP strict-policy tests that enforce the real
+  contract remain green).
+- Full suite `deno test --allow-read tests/*.ts` → `587 passed | 0 failed`.
+- `deno fmt`, `deno lint`, and `deno check` on `tests/csp_test.ts` all pass.
+
+## Test Plan
+
+- **Removed** `tests/csp_test.ts::"docs/app.js: generated rows use no inline event handlers"`
+  (the source-text grep), replaced with an in-place documentation comment
+  explaining the rationale and the CSP test that covers the same property.
+- **Retained** the runtime guard that enforces the observable contract:
+  `tests/csp_test.ts::"docs/index.html: script-src is strict (no unsafe-inline/eval)"`,
+  which blocks inline `on*=` handlers from executing on the page that loads
+  `docs/app.js`.
+- Confirmed no other test or source file references the removed test name.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.202">
+    <meta name="app-version" content="1.0.203">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -329,6 +329,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.202"></script>
+    <script src="sw-register.js?v=1.0.203"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.202")
+    navigator.serviceWorker.register("./sw.js?v=1.0.203")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.202";
+const APP_VERSION = "1.0.203";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/tests/csp_test.ts
+++ b/tests/csp_test.ts
@@ -173,15 +173,20 @@ for (const page of PAGES) {
 }
 
 // --- Generated-markup compatibility --------------------------------------
-
-Deno.test("docs/app.js: generated rows use no inline event handlers", async () => {
-  // A strict script-src blocks inline on*= handlers, so the row markup the
-  // dashboard injects must rely on delegated listeners + data attributes.
-  const source = await Deno.readTextFile("docs/app.js");
-  const handler = source.match(/\son(?:click|change|error|load|input)\s*=/i);
-  assertEquals(
-    handler,
-    null,
-    `docs/app.js must not emit inline event handlers (found ${handler?.[0]})`,
-  );
-});
+//
+// REMOVED (issue #268): the "docs/app.js: generated rows use no inline event
+// handlers" test grepped the source of docs/app.js for a hard-coded subset of
+// on*= attribute spellings. It was a source-text proxy for a security property,
+// not a behaviour assertion: it could false-positive on a benign string literal
+// containing "on… =" and silently missed any handler spelled outside its fixed
+// list (onmouseover, onfocus, …).
+//
+// The *observable* contract — inline on*= handlers never execute — is enforced
+// at runtime by the Content-Security-Policy and pinned by the
+// "script-src is strict (no unsafe-inline/eval)" test above: an inline event
+// handler requires script-src 'unsafe-inline' to run, which that test forbids
+// on every page in PAGES (including docs/index.html, which loads docs/app.js).
+// The source grep was therefore redundant defence-in-depth coupled to how the
+// source is written, so it was deleted rather than rewritten. docs/app.js boots
+// side-effects at import (new GRQValidator()), so it cannot be loaded into a
+// Deno test to render rows through its real code path without a full DOM stub.


### PR DESCRIPTION
## Summary

Removed the redundant source-text grep test `docs/app.js: generated rows use no inline event handlers` from `tests/csp_test.ts`. Closes #268.

The deleted test read the source of `docs/app.js` and regex-matched it for a
hard-coded subset of inline `on*=` event-handler spellings
(`onclick|onchange|onerror|onload|oninput`). This was a static source-text proxy
for a security property, not a behaviour assertion. It had two concrete flaws
the issue called out:

- **False positives** — it could match a benign string literal that happens to
  contain `on… =`.
- **Silent gaps** — it missed any handler attribute spelled outside its fixed
  list (e.g. `onmouseover`, `onfocus`).

Either way it reported on *how the source is written*, not on behaviour a caller
can observe.

### Why deletion (the issue's Option 1) rather than a DOM rewrite (Option 2)

The *observable* contract — that inline `on*=` handlers never execute — is
already enforced at runtime by the Content-Security-Policy and pinned by the
same file's `script-src is strict (no unsafe-inline/eval)` test. An inline event
handler requires `script-src 'unsafe-inline'` to run, which that test forbids on
every page in `PAGES` (including `docs/index.html`, which loads
`docs/app.js`). The grep was therefore redundant defence-in-depth.

A DOM behaviour rewrite that renders rows through the app's real code path was
considered but is not feasible in scope: `docs/app.js` (4242 lines) executes
side-effects at import (`const validator = new GRQValidator();`), so it cannot
be loaded into a Deno test without a full DOM/`fetch`/Chart/bootstrap stub — the
reason the project deliberately extracts testable logic into separate modules
(`escape.js`, `color_key.js`, `projection.js`) and never imports `app.js`.
Adding an external DOM-parser dependency purely for a `severity:low` test-audit
cleanup would be disproportionate and is quarantine-gated. The deletion is
documented with an in-place comment in `tests/csp_test.ts` pointing to the CSP
test that supersedes it.

```mermaid
flowchart LR
    A["Inline on*= handler<br/>in injected markup"] -->|requires| B["script-src<br/>'unsafe-inline'"]
    B -->|forbidden by| C["CSP strict script-src test<br/>(tests/csp_test.ts)"]
    C --> D["Handler blocked at runtime"]
    style C fill:#cfc,stroke:#393
```

## Evidence

Backend/test-only change — no web UI to screenshot. Verified via the test suite:

- `deno test --allow-read tests/csp_test.ts` → `9 passed | 0 failed` (the
  removed grep test is gone; the CSP strict-policy tests that enforce the real
  contract remain green).
- Full suite `deno test --allow-read tests/*.ts` → `587 passed | 0 failed`.
- `deno fmt`, `deno lint`, and `deno check` on `tests/csp_test.ts` all pass.

## Test Plan

- **Removed** `tests/csp_test.ts::"docs/app.js: generated rows use no inline event handlers"`
  (the source-text grep), replaced with an in-place documentation comment
  explaining the rationale and the CSP test that covers the same property.
- **Retained** the runtime guard that enforces the observable contract:
  `tests/csp_test.ts::"docs/index.html: script-src is strict (no unsafe-inline/eval)"`,
  which blocks inline `on*=` handlers from executing on the page that loads
  `docs/app.js`.
- Confirmed no other test or source file references the removed test name.
