### PR TITLE
Add bounded-window index price kernel (Issue #366)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-366.md
+++ b/docs/archive/pr-summaries/pr-summary-366.md
@@ -1,0 +1,71 @@
+## Summary
+
+Adds the pure data kernel that the #333 chart-vs-summary reconciliation needs:
+deriving each benchmark index's performance over a **bounded window** (score
+date → an explicit end date) instead of always running to the latest available
+price. Closes #366.
+
+Two additions to `docs/market_index.js`, both pure (no DOM, no class state) and
+published on `globalThis.GRQMarketIndex` so the browser dashboard and the Deno
+tests share the **same** shipped logic:
+
+- `priceAsOf(seriesOrPoints, endDate)` — returns the close of the latest point
+  with `date <= endDate` ("last close ≤ endDate"), or `null` when nothing
+  qualifies (empty/missing series, end date before all data, or an unparseable
+  date). Accepts either a built series object (`{ data: [{date, close}] }`) or a
+  bare `{date, close}` points array. Date comparison is at local midnight,
+  matching how `buildIndexSeriesFromMap` slices the series.
+- `indexPerformance(indexData, endDate)` — now takes an optional `endDate`. When
+  supplied, the end price becomes window-aware via `priceAsOf(indexData.data,
+  endDate)`; when omitted, behaviour is unchanged (runs to the latest close).
+  `initialPrice` semantics are untouched (still the score-date baseline) and the
+  `((endPrice - initialPrice) / initialPrice) * 100` formula is unchanged, so an
+  end date on the latest data date reproduces the full-period result.
+
+No DOM or app wiring is changed — that is the consuming #333 sub-issue. This
+change is additive and green on its own.
+
+## Why
+
+`indexPerformance` previously read `currentPrice` (the latest price in the
+window), and `docs/app.js` always set the window end to *today*, so the
+"Market Performance Comparison" summary always ran to today — disagreeing with
+the windowed dashboard chart (#333). There was no helper to read an index's
+close at/just-before an arbitrary date; this kernel supplies it.
+
+```mermaid
+flowchart LR
+    M["{date: close} map"] --> B[buildIndexSeriesFromMap]
+    B --> S["series {data, initialPrice, currentPrice}"]
+    S --> P["priceAsOf(series, endDate)<br/>last close ≤ endDate"]
+    P --> I["indexPerformance(indexData, endDate)<br/>((endPrice − initialPrice) / initialPrice) × 100"]
+```
+
+## Evidence
+
+Backend/kernel-only change (pure JS helpers, no web interface altered), so no
+screenshot applies. Verified by the unit tests below — all 17 tests in
+`tests/market_index_test.ts` pass, and the full suite is green
+(`deno test --allow-read tests/*.ts` → 602 passed, 0 failed).
+
+## Test Plan
+
+Added to `tests/market_index_test.ts`, driven by a synthetic `{date: close}`
+map with a mid-window dip (the #333 shape), built through the real
+`GRQProjection.buildIndexSeriesFromMap` (no test-only copy):
+
+- `priceAsOf` — end date between two points → returns the earlier point's close
+  (last ≤ endDate);
+- `priceAsOf` — end date exactly on a point → that point's close;
+- `priceAsOf` — end date before the first point → `null`;
+- `priceAsOf` — end date on the last point → equals the full-period
+  `currentPrice` (proves no regression);
+- `priceAsOf` — accepts a bare `{date, close}` points array;
+- `priceAsOf` — tolerant of empty/missing/unparseable inputs, never throws;
+- `indexPerformance` — end date inside the dip yields a **lower** figure (−10%)
+  than the latest (+10%) — the exact #333 disagreement;
+- `indexPerformance` — end date on the last point equals the full-period result
+  (regression-safe);
+- `indexPerformance` — end date before all data → `null` (render blank);
+- `indexPerformance` — omitting `endDate` preserves existing full-period
+  behaviour.

--- a/docs/market_index.js
+++ b/docs/market_index.js
@@ -23,20 +23,82 @@ const BENCHMARK_INDICES = [
     { key: "russell2000", name: "Russell 2000" },
 ];
 
+// Normalise an arbitrary date-ish value to its local-midnight epoch time, or
+// NaN when it cannot be parsed. Mirrors GRQProjection.setDateToMidnight so the
+// "last close <= endDate" comparison ignores any time-of-day component, matching
+// how buildIndexSeriesFromMap slices the series. Kept local so this kernel has
+// no load-order dependency on docs/projection.js.
+function toMidnightTime(value) {
+    if (value === null || value === undefined) return NaN;
+    const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    const time = date.getTime();
+    if (Number.isNaN(time)) return NaN;
+    date.setHours(0, 0, 0, 0);
+    return date.getTime();
+}
+
+// Resolve an index's close as of a bounded window end (issue #366): the close
+// of the latest point with `date <= endDate`. Accepts either a built series
+// object ({ data: [{date, close}] }) or a bare {date, close} points array, and
+// returns null when nothing qualifies — the series is empty/missing, the end
+// date precedes all data, or the end date is unparseable. Pure: no DOM, no
+// class state, never throws. This is the helper the #333 chart-vs-summary
+// reconciliation needs so the summary can read an as-of price instead of always
+// running to the latest available close.
+function priceAsOf(seriesOrPoints, endDate) {
+    const points = Array.isArray(seriesOrPoints)
+        ? seriesOrPoints
+        : (seriesOrPoints && Array.isArray(seriesOrPoints.data)
+            ? seriesOrPoints.data
+            : null);
+    if (!points || points.length === 0) return null;
+
+    const endTime = toMidnightTime(endDate);
+    if (Number.isNaN(endTime)) return null;
+
+    let bestTime = -Infinity;
+    let bestClose = null;
+    for (const point of points) {
+        if (!point) continue;
+        const close = point.close;
+        if (typeof close !== "number" || !Number.isFinite(close)) continue;
+        const time = toMidnightTime(point.date);
+        if (Number.isNaN(time) || time > endTime) continue;
+        if (time > bestTime) {
+            bestTime = time;
+            bestClose = close;
+        }
+    }
+    return bestClose;
+}
+
 // Compute one benchmark index's performance from its processed series. Returns
 // null when the required prices are missing, so callers render blank and never
 // fetch live data. Pure: no DOM, no class state.
-function indexPerformance(indexData) {
-    if (!indexData || !indexData.initialPrice || !indexData.currentPrice) {
+//
+// When `endDate` is supplied the end price becomes window-aware (issue #366):
+// the close of the last trading day at or before `endDate` (via priceAsOf over
+// `indexData.data`) instead of the latest available close. `initialPrice`
+// semantics are unchanged — it stays the score-date baseline. The formula is
+// identical, so an `endDate` on the latest data date reproduces the full-period
+// result. Omitting `endDate` keeps the original run-to-latest behaviour.
+function indexPerformance(indexData, endDate) {
+    if (!indexData || !indexData.initialPrice) {
+        return null;
+    }
+    const endPrice = (endDate === undefined || endDate === null)
+        ? indexData.currentPrice
+        : priceAsOf(indexData.data, endDate);
+    if (!endPrice) {
         return null;
     }
     const performance =
-        ((indexData.currentPrice - indexData.initialPrice) /
+        ((endPrice - indexData.initialPrice) /
             indexData.initialPrice) * 100;
     return {
         performance,
         initialPrice: indexData.initialPrice,
-        currentPrice: indexData.currentPrice,
+        currentPrice: endPrice,
     };
 }
 
@@ -62,5 +124,6 @@ function marketPerformanceData(marketIndexData) {
 globalThis.GRQMarketIndex = {
     BENCHMARK_INDICES,
     indexPerformance,
+    priceAsOf,
     marketPerformanceData,
 };

--- a/tests/market_index_test.ts
+++ b/tests/market_index_test.ts
@@ -14,6 +14,7 @@
 //   - a missing/partial index yields no figure (rendered blank, not an error);
 //   - null/undefined input is tolerated (empty result, never throws).
 import { assert, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 import "../docs/market_index.js";
 
 const g = globalThis as unknown as {
@@ -21,9 +22,11 @@ const g = globalThis as unknown as {
     BENCHMARK_INDICES: Array<{ key: string; name: string }>;
     indexPerformance: (
       indexData: unknown,
+      endDate?: unknown,
     ) =>
       | { performance: number; initialPrice: number; currentPrice: number }
       | null;
+    priceAsOf: (seriesOrPoints: unknown, endDate: unknown) => number | null;
     marketPerformanceData: (
       marketIndexData: unknown,
     ) => Record<
@@ -31,8 +34,22 @@ const g = globalThis as unknown as {
       { performance: number; initialPrice: number; currentPrice: number }
     >;
   };
+  GRQProjection: {
+    buildIndexSeriesFromMap: (
+      priceMap: unknown,
+      indexName: string,
+      startDate: unknown,
+      endDate: unknown,
+    ) => {
+      name: string;
+      data: Array<{ date: Date; close: number }>;
+      initialPrice: number | null;
+      currentPrice: number | null;
+    } | null;
+  };
 };
 const GRQMarketIndex = g.GRQMarketIndex;
+const GRQProjection = g.GRQProjection;
 
 Deno.test("market_index.js publishes the helpers on globalThis", () => {
   assertEquals(typeof GRQMarketIndex.indexPerformance, "function");
@@ -106,4 +123,109 @@ Deno.test("marketPerformanceData - null/undefined input returns an empty object"
   assertEquals(GRQMarketIndex.marketPerformanceData(null), {});
   assertEquals(GRQMarketIndex.marketPerformanceData(undefined), {});
   assertEquals(GRQMarketIndex.marketPerformanceData({}), {});
+});
+
+// --- Bounded-window price resolution (issue #366) --------------------------
+//
+// A synthetic SP500-shaped {date: close} map covering the score window. The
+// midpoint (2024-02-01) is a DIP: a window ending then must read a lower price
+// than the latest (2024-03-01) value — the exact shape behind #333 where the
+// chart (windowed) and the summary (run-to-today) disagreed.
+const PRICE_MAP = {
+  "2024-01-01": 4000, // score-date baseline (initialPrice)
+  "2024-02-01": 3600, // mid-window dip
+  "2024-03-01": 4400, // latest available price
+};
+const SERIES = GRQProjection.buildIndexSeriesFromMap(
+  PRICE_MAP,
+  "SP500",
+  "2024-01-01",
+  "2024-03-01",
+)!;
+
+Deno.test("priceAsOf - end date between two points returns the last close <= endDate", () => {
+  // 2024-02-15 is after the dip (02-01) but before the latest (03-01).
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "2024-02-15"), 3600);
+});
+
+Deno.test("priceAsOf - end date exactly on a point returns that point's close", () => {
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "2024-02-01"), 3600);
+});
+
+Deno.test("priceAsOf - end date before the first point returns null", () => {
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "2023-12-31"), null);
+});
+
+Deno.test("priceAsOf - end date on the last point equals the full-period currentPrice", () => {
+  // Regression-safety: the windowed end price at the latest date must equal the
+  // current full-period currentPrice computed by buildIndexSeriesFromMap.
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "2024-03-01"), 4400);
+  assertEquals(
+    GRQMarketIndex.priceAsOf(SERIES, "2024-03-01"),
+    SERIES.currentPrice,
+  );
+});
+
+Deno.test("priceAsOf - accepts a bare {date, close} points array", () => {
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES.data, "2024-02-15"), 3600);
+});
+
+Deno.test("priceAsOf - tolerant of empty/missing inputs, never throws", () => {
+  assertEquals(GRQMarketIndex.priceAsOf(null, "2024-02-15"), null);
+  assertEquals(GRQMarketIndex.priceAsOf(undefined, "2024-02-15"), null);
+  assertEquals(GRQMarketIndex.priceAsOf([], "2024-02-15"), null);
+  assertEquals(GRQMarketIndex.priceAsOf({ data: [] }, "2024-02-15"), null);
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "not-a-date"), null);
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, null), null);
+});
+
+Deno.test("indexPerformance - end date inside the dip yields a lower figure than the latest (the #333 shape)", () => {
+  const indexData = {
+    initialPrice: SERIES.initialPrice,
+    currentPrice: SERIES.currentPrice,
+    data: SERIES.data,
+  };
+  // Windowed to the dip: ((3600 - 4000) / 4000) * 100 = -10%.
+  const windowed = GRQMarketIndex.indexPerformance(indexData, "2024-02-15");
+  assert(windowed !== null);
+  assertEquals(windowed.performance, -10);
+  assertEquals(windowed.currentPrice, 3600);
+  assertEquals(windowed.initialPrice, 4000);
+
+  // Full period (run to latest): ((4400 - 4000) / 4000) * 100 = +10%.
+  const full = GRQMarketIndex.indexPerformance(indexData);
+  assert(full !== null);
+  assertEquals(full.performance, 10);
+  assert(windowed.performance < full.performance);
+});
+
+Deno.test("indexPerformance - end date on the last point equals the full-period result (no regression)", () => {
+  const indexData = {
+    initialPrice: SERIES.initialPrice,
+    currentPrice: SERIES.currentPrice,
+    data: SERIES.data,
+  };
+  const windowed = GRQMarketIndex.indexPerformance(indexData, "2024-03-01");
+  const full = GRQMarketIndex.indexPerformance(indexData);
+  assertEquals(windowed, full);
+});
+
+Deno.test("indexPerformance - end date before all data yields null (render blank, no throw)", () => {
+  const indexData = {
+    initialPrice: SERIES.initialPrice,
+    currentPrice: SERIES.currentPrice,
+    data: SERIES.data,
+  };
+  assertEquals(GRQMarketIndex.indexPerformance(indexData, "2023-12-31"), null);
+});
+
+Deno.test("indexPerformance - omitting endDate preserves the existing full-period behaviour", () => {
+  // No endDate argument: identical to the pre-#366 signature.
+  const perf = GRQMarketIndex.indexPerformance({
+    initialPrice: 4000,
+    currentPrice: 4400,
+  });
+  assert(perf !== null);
+  assertEquals(perf.performance, 10);
+  assertEquals(perf.currentPrice, 4400);
 });


### PR DESCRIPTION
## Summary

Adds the pure data kernel that the #333 chart-vs-summary reconciliation needs:
deriving each benchmark index's performance over a **bounded window** (score
date → an explicit end date) instead of always running to the latest available
price. Closes #366.

Two additions to `docs/market_index.js`, both pure (no DOM, no class state) and
published on `globalThis.GRQMarketIndex` so the browser dashboard and the Deno
tests share the **same** shipped logic:

- `priceAsOf(seriesOrPoints, endDate)` — returns the close of the latest point
  with `date <= endDate` ("last close ≤ endDate"), or `null` when nothing
  qualifies (empty/missing series, end date before all data, or an unparseable
  date). Accepts either a built series object (`{ data: [{date, close}] }`) or a
  bare `{date, close}` points array. Date comparison is at local midnight,
  matching how `buildIndexSeriesFromMap` slices the series.
- `indexPerformance(indexData, endDate)` — now takes an optional `endDate`. When
  supplied, the end price becomes window-aware via `priceAsOf(indexData.data,
  endDate)`; when omitted, behaviour is unchanged (runs to the latest close).
  `initialPrice` semantics are untouched (still the score-date baseline) and the
  `((endPrice - initialPrice) / initialPrice) * 100` formula is unchanged, so an
  end date on the latest data date reproduces the full-period result.

No DOM or app wiring is changed — that is the consuming #333 sub-issue. This
change is additive and green on its own.

## Why

`indexPerformance` previously read `currentPrice` (the latest price in the
window), and `docs/app.js` always set the window end to *today*, so the
"Market Performance Comparison" summary always ran to today — disagreeing with
the windowed dashboard chart (#333). There was no helper to read an index's
close at/just-before an arbitrary date; this kernel supplies it.

```mermaid
flowchart LR
    M["{date: close} map"] --> B[buildIndexSeriesFromMap]
    B --> S["series {data, initialPrice, currentPrice}"]
    S --> P["priceAsOf(series, endDate)<br/>last close ≤ endDate"]
    P --> I["indexPerformance(indexData, endDate)<br/>((endPrice − initialPrice) / initialPrice) × 100"]
```

## Evidence

Backend/kernel-only change (pure JS helpers, no web interface altered), so no
screenshot applies. Verified by the unit tests below — all 17 tests in
`tests/market_index_test.ts` pass, and the full suite is green
(`deno test --allow-read tests/*.ts` → 602 passed, 0 failed).

## Test Plan

Added to `tests/market_index_test.ts`, driven by a synthetic `{date: close}`
map with a mid-window dip (the #333 shape), built through the real
`GRQProjection.buildIndexSeriesFromMap` (no test-only copy):

- `priceAsOf` — end date between two points → returns the earlier point's close
  (last ≤ endDate);
- `priceAsOf` — end date exactly on a point → that point's close;
- `priceAsOf` — end date before the first point → `null`;
- `priceAsOf` — end date on the last point → equals the full-period
  `currentPrice` (proves no regression);
- `priceAsOf` — accepts a bare `{date, close}` points array;
- `priceAsOf` — tolerant of empty/missing/unparseable inputs, never throws;
- `indexPerformance` — end date inside the dip yields a **lower** figure (−10%)
  than the latest (+10%) — the exact #333 disagreement;
- `indexPerformance` — end date on the last point equals the full-period result
  (regression-safe);
- `indexPerformance` — end date before all data → `null` (render blank);
- `indexPerformance` — omitting `endDate` preserves existing full-period
  behaviour.



## Milestone
This PR is part of the **#333 bug: chart shows index down but Market Performance summary shows up** milestone and targets the `milestone/333-bug-chart-shows-index-down-but-market-performa` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqp88xcc-8c2d84`<!-- vibe-worker-issue-366 -->