### PR TITLE
fix: reliably close mobile value popovers (incl. orphaned tips); consolidate global handlers (#371)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -98,35 +98,41 @@ class GRQValidator {
             });
         }
 
-        // Global click handler to manage popover behavior
+        // Single global popover click handler — the one source of truth for
+        // "tap outside to close" (issue #371). Replaces the two competing
+        // handlers that previously lived here and at module load. The dismissal
+        // logic is the shared, tested GRQPopover module, so an orphaned tip with
+        // no live trigger is still removed.
         document.addEventListener("click", (event) => {
-            const popoverTrigger = event.target.closest(
-                '[data-bs-toggle="popover"]',
+            const insidePopover = !!event.target.closest(
+                GRQPopover.POPOVER_TIP_SELECTOR,
             );
-            const popoverContent = event.target.closest(".popover");
+            const trigger = event.target.closest(
+                GRQPopover.POPOVER_TRIGGER_SELECTOR,
+            );
+            const action = GRQPopover.decidePopoverAction({
+                insidePopover,
+                hasTrigger: !!trigger,
+            });
 
-            // Don't do anything if clicking inside the popover content
-            if (popoverContent) {
+            // Tapping inside an open popover's content must not close it.
+            if (action === "ignore") {
                 return;
             }
 
-            // Close all existing popovers
-            const popovers = document.querySelectorAll(
-                '[data-bs-toggle="popover"]',
+            // Close every popover: hide live instances AND remove orphaned
+            // tips. Not gated on a trigger's aria-describedby.
+            GRQPopover.closeAllPopovers(
+                document,
+                (element) => bootstrap.Popover.getInstance(element),
             );
-            popovers.forEach((element) => {
-                const popover = bootstrap.Popover.getInstance(element);
-                if (popover && element.hasAttribute("aria-describedby")) {
-                    popover.hide();
-                }
-            });
 
-            // If we clicked on a popover trigger, show the new one after a brief delay
-            if (popoverTrigger) {
+            // Re-open the tapped trigger after the close settles (the popovers
+            // use a manual trigger, so they are shown here rather than by
+            // Bootstrap itself).
+            if (action === "closeAndReopen" && trigger) {
                 setTimeout(() => {
-                    const popover = bootstrap.Popover.getInstance(
-                        popoverTrigger,
-                    );
+                    const popover = bootstrap.Popover.getInstance(trigger);
                     if (popover) {
                         popover.show();
                     }
@@ -4222,24 +4228,6 @@ const debouncedSyncChartForViewport = globalThis.GRQColorKey.debounce(
 globalThis.addEventListener("resize", debouncedSyncChartForViewport);
 globalThis.addEventListener("orientationchange", debouncedSyncChartForViewport);
 
-// Add document click handler to close popovers when clicking outside
-document.addEventListener("click", (event) => {
-    // Check if the click was on a popover trigger or inside a popover
-    const isPopoverTrigger = event.target.closest(
-        ".clickable-value",
-    );
-    const isInsidePopover = event.target.closest(".popover");
-
-    if (!isPopoverTrigger && !isInsidePopover) {
-        // Close all open popovers
-        const clickableValues = document.querySelectorAll(
-            ".clickable-value",
-        );
-        clickableValues.forEach((element) => {
-            const popover = bootstrap.Popover.getInstance(element);
-            if (popover && element.hasAttribute("aria-describedby")) {
-                popover.hide();
-            }
-        });
-    }
-});
+// The second global popover click handler that used to live here was removed in
+// issue #371. Dismissal is now handled by the single consolidated handler in
+// initializeEventListeners() above, via the shared GRQPopover module.

--- a/docs/archive/pr-summaries/pr-summary-371.md
+++ b/docs/archive/pr-summaries/pr-summary-371.md
@@ -1,0 +1,84 @@
+## Summary
+
+"Tap outside to close" was unreliable for the dashboard's mobile value
+popovers. `docs/app.js` carried **two** competing global `document` click
+handlers (one in `initializeEventListeners()`, one at module load) with
+overlapping logic. Both closed popovers by iterating the live **triggers**
+(`.clickable-value` / `[data-bs-toggle="popover"]`) and calling `hide()`
+**only if the trigger still had `aria-describedby`**. An **orphaned tip** — a
+`.popover` node left on `<body>` after a re-render disposed its trigger — has
+no live trigger, so neither handler could reach it and tapping outside did
+nothing.
+
+This PR consolidates the two handlers into a **single** global click handler
+backed by a new shared, tested module `docs/popover_dismiss.js`
+(`GRQPopover`). The new dismissal path hides **every** live Bootstrap instance
+(no longer gated on `aria-describedby`) **and** removes any leftover `.popover`
+nodes from the DOM, so orphaned tips are dismissed too. Tapping inside popover
+content still does nothing; tapping a trigger still closes the others and
+re-opens the tapped one.
+
+Closes #371.
+
+## Changes
+
+- **`docs/popover_dismiss.js`** (new) — pure, dependency-injected `GRQPopover`
+  helpers published on `globalThis`, mirroring `escape.js` / `color_key.js`:
+  - `decidePopoverAction({ insidePopover, hasTrigger })` → `"ignore"` /
+    `"closeAndReopen"` / `"closeOnly"`.
+  - `closeAllPopovers(doc, getInstance)` → hides every live instance and
+    removes orphaned `.popover` nodes; returns `{ hidden, removed }`.
+- **`docs/app.js`** — replaced handler #1 with the single consolidated handler
+  using `GRQPopover`; removed handler #2 (left a breadcrumb comment). Exactly
+  one global popover click handler now remains.
+- **`docs/index.html`** — loads `popover_dismiss.js` before `app.js`.
+- **`tests/popover_dismiss_test.ts`** (new) — exercises the real shipped logic.
+
+## Evidence
+
+This is a small front-end behaviour change in vanilla JS with no JS test
+harness for `docs/app.js` itself (noted in the issue). The dismissal decision
+and the orphan-removal logic were extracted into `docs/popover_dismiss.js` so
+the **real shipped code** is unit-tested rather than a copy. Playwright MCP was
+not available in this run, so no live screenshot was captured; the behaviour is
+pinned by the unit tests below and was reasoned through against the acceptance
+criteria.
+
+```mermaid
+flowchart TD
+    A[document click] --> B{inside .popover content?}
+    B -- yes --> I[ignore: keep open]
+    B -- no --> C[closeAllPopovers]
+    C --> D[hide every live instance<br/>not gated on aria-describedby]
+    C --> E[remove orphaned .popover nodes]
+    A --> F{tapped a trigger?}
+    F -- yes --> G[re-open tapped popover]
+    F -- no --> H[stay closed]
+```
+
+Acceptance criteria mapping:
+
+- *Open any popover, tap outside → it closes* — `closeOnly` path runs
+  `closeAllPopovers`, which hides every live instance.
+- *Orphaned tip still removed* — `closeAllPopovers` removes leftover `.popover`
+  nodes even with no live trigger (test: "removes orphaned tips that have no
+  live trigger").
+- *Tapping inside the popover does not close it* — `decidePopoverAction`
+  returns `"ignore"` (test: "tapping inside popover content is ignored").
+- *Exactly one global popover click handler remains* — handler #2 removed; a
+  single `document.addEventListener("click", …)` remains in `docs/app.js`.
+
+## Test Plan
+
+- `tests/popover_dismiss_test.ts` (new):
+  - publishes helpers on `globalThis`;
+  - `decidePopoverAction` for inside-popover / trigger / outside taps;
+  - `closeAllPopovers` hides every live instance regardless of
+    `aria-describedby`;
+  - `closeAllPopovers` removes orphaned tips with no live trigger (core #371
+    bug);
+  - hides live instances **and** removes orphans together;
+  - safe no-op when nothing is open; tolerates a trigger with no instance;
+  - the module parses cleanly via `checkJsSyntax`.
+- `tests/js_syntax_test.ts` continues to confirm `docs/app.js` parses cleanly.
+- Full Deno suite (`deno test --allow-read tests/*.ts`) passes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -316,6 +316,9 @@
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
     <script src="stock_selection.js"></script>
 
+    <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
+    <script src="popover_dismiss.js"></script>
+
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
     <script src="dashboard_boot.js"></script>
 

--- a/docs/popover_dismiss.js
+++ b/docs/popover_dismiss.js
@@ -1,0 +1,86 @@
+// Consolidated dismissal logic for the dashboard's value popovers (issue #371,
+// part of the mobile info-popover milestone #335).
+//
+// Previously docs/app.js carried TWO competing global `document` click handlers
+// with overlapping logic. Both closed popovers by iterating the live triggers
+// (.clickable-value / [data-bs-toggle="popover"]) and calling hide() only when
+// the trigger still had `aria-describedby`. An ORPHANED tip — a `.popover` node
+// left on <body> after a re-render disposed its trigger — has no live trigger,
+// so neither handler could reach it and "tap outside to close" silently failed.
+//
+// This module holds the single source of truth for that behaviour:
+//   - decidePopoverAction() decides what an outside/inside tap should do; and
+//   - closeAllPopovers() hides every live instance AND removes any leftover
+//     `.popover` nodes, so orphaned tips are dismissed too.
+//
+// It mirrors docs/escape.js, docs/projection.js and docs/color_key.js: loaded
+// as a classic <script> in docs/index.html (no module syntax), publishing its
+// helpers on `globalThis` so both the browser dashboard (via `GRQValidator`)
+// and the Deno tests exercise the exact same code.
+
+// CSS selector for every popover trigger. Both clauses describe the same value
+// cells, but we keep the explicit pair so a future trigger that drops the
+// `.clickable-value` class is still matched on its `data-bs-toggle`.
+const POPOVER_TRIGGER_SELECTOR = '.clickable-value, [data-bs-toggle="popover"]';
+
+// CSS selector for a rendered Bootstrap popover tip in the DOM.
+const POPOVER_TIP_SELECTOR = ".popover";
+
+// Decide what a click should do, given whether it landed inside an open
+// popover's content and whether it landed on a popover trigger.
+//   - inside popover content -> "ignore" (must NOT close; criterion 3)
+//   - on a trigger           -> "closeAndReopen" (close others, show this one)
+//   - anywhere else outside   -> "closeOnly" (close every popover)
+function decidePopoverAction({ insidePopover, hasTrigger }) {
+    if (insidePopover) {
+        return "ignore";
+    }
+    if (hasTrigger) {
+        return "closeAndReopen";
+    }
+    return "closeOnly";
+}
+
+// Close every value popover, reliably.
+//
+// First hides every live Bootstrap instance found on a trigger — NOT gated on
+// `aria-describedby`, so a stale instance is still told to hide. Then removes
+// any `.popover` node still attached to the document: these are orphaned tips
+// whose trigger was disposed by a re-render, which `hide()` can never reach.
+//
+// Dependency-injected for testability:
+//   doc         - a document-like object exposing querySelectorAll(selector);
+//   getInstance - (element) => Bootstrap popover instance | null.
+// Returns { hidden, removed } counts so callers (and tests) can assert on the
+// work done.
+function closeAllPopovers(doc, getInstance) {
+    let hidden = 0;
+    let removed = 0;
+
+    const triggers = doc.querySelectorAll(POPOVER_TRIGGER_SELECTOR);
+    triggers.forEach((element) => {
+        const instance = getInstance(element);
+        if (instance && typeof instance.hide === "function") {
+            instance.hide();
+            hidden += 1;
+        }
+    });
+
+    // Anything still in the DOM after hiding live instances is an orphan.
+    const tips = doc.querySelectorAll(POPOVER_TIP_SELECTOR);
+    tips.forEach((node) => {
+        if (node && typeof node.remove === "function") {
+            node.remove();
+            removed += 1;
+        }
+    });
+
+    return { hidden, removed };
+}
+
+globalThis.GRQPopover = {
+    POPOVER_TRIGGER_SELECTOR,
+    POPOVER_TIP_SELECTOR,
+    decidePopoverAction,
+    closeAllPopovers,
+};

--- a/tests/popover_dismiss_test.ts
+++ b/tests/popover_dismiss_test.ts
@@ -1,0 +1,167 @@
+// Tests for the consolidated popover dismissal logic (issue #371, part of the
+// mobile info-popover milestone #335).
+//
+// docs/popover_dismiss.js holds the single source of truth for "tap outside to
+// close". The browser handler in docs/app.js is a thin wrapper around these
+// helpers, so these tests exercise the REAL shipped decision logic:
+//   - decidePopoverAction(): inside-popover taps are ignored; trigger taps
+//     close-and-reopen; outside taps close only;
+//   - closeAllPopovers(): hides EVERY live instance (not gated on
+//     aria-describedby) and removes ORPHANED .popover nodes that have no live
+//     trigger — the core bug from #371.
+import { assert, assertEquals } from "@std/assert";
+import { checkJsSyntax } from "../helpers/js_syntax.ts";
+import "../docs/popover_dismiss.js";
+
+interface Instance {
+  hidden: boolean;
+  hide(): void;
+}
+
+interface Tip {
+  removed: boolean;
+  remove(): void;
+}
+
+const g = globalThis as unknown as {
+  GRQPopover: {
+    POPOVER_TRIGGER_SELECTOR: string;
+    POPOVER_TIP_SELECTOR: string;
+    decidePopoverAction: (
+      ctx: { insidePopover: boolean; hasTrigger: boolean },
+    ) => string;
+    closeAllPopovers: (
+      doc: { querySelectorAll: (sel: string) => unknown[] },
+      getInstance: (el: unknown) => Instance | null,
+    ) => { hidden: number; removed: number };
+  };
+};
+const GRQPopover = g.GRQPopover;
+
+/** Build a document-like stub returning the given triggers and tips by selector. */
+function fakeDoc(triggers: unknown[], tips: Tip[]) {
+  return {
+    querySelectorAll(sel: string): unknown[] {
+      if (sel === GRQPopover.POPOVER_TIP_SELECTOR) return tips;
+      if (sel === GRQPopover.POPOVER_TRIGGER_SELECTOR) return triggers;
+      return [];
+    },
+  };
+}
+
+function makeInstance(): Instance {
+  return {
+    hidden: false,
+    hide() {
+      this.hidden = true;
+    },
+  };
+}
+
+function makeTip(): Tip {
+  return {
+    removed: false,
+    remove() {
+      this.removed = true;
+    },
+  };
+}
+
+Deno.test("popover_dismiss.js publishes its helpers on globalThis", () => {
+  assertEquals(typeof GRQPopover.decidePopoverAction, "function");
+  assertEquals(typeof GRQPopover.closeAllPopovers, "function");
+  assertEquals(typeof GRQPopover.POPOVER_TRIGGER_SELECTOR, "string");
+  assertEquals(typeof GRQPopover.POPOVER_TIP_SELECTOR, "string");
+});
+
+Deno.test("decidePopoverAction - tapping inside popover content is ignored (criterion 3)", () => {
+  assertEquals(
+    GRQPopover.decidePopoverAction({ insidePopover: true, hasTrigger: false }),
+    "ignore",
+  );
+  // Inside-popover wins even if the target also matches a trigger selector.
+  assertEquals(
+    GRQPopover.decidePopoverAction({ insidePopover: true, hasTrigger: true }),
+    "ignore",
+  );
+});
+
+Deno.test("decidePopoverAction - tapping a trigger closes others then reopens it", () => {
+  assertEquals(
+    GRQPopover.decidePopoverAction({ insidePopover: false, hasTrigger: true }),
+    "closeAndReopen",
+  );
+});
+
+Deno.test("decidePopoverAction - tapping anywhere else closes all popovers", () => {
+  assertEquals(
+    GRQPopover.decidePopoverAction({ insidePopover: false, hasTrigger: false }),
+    "closeOnly",
+  );
+});
+
+Deno.test("closeAllPopovers - hides every live instance regardless of aria-describedby", () => {
+  const a = {};
+  const b = {};
+  const instances = new Map<unknown, Instance>([
+    [a, makeInstance()],
+    [b, makeInstance()],
+  ]);
+  const doc = fakeDoc([a, b], []);
+
+  const result = GRQPopover.closeAllPopovers(
+    doc,
+    (el) => instances.get(el) ?? null,
+  );
+
+  assertEquals(result.hidden, 2);
+  assert(instances.get(a)!.hidden, "first instance was hidden");
+  assert(instances.get(b)!.hidden, "second instance was hidden");
+});
+
+Deno.test("closeAllPopovers - removes orphaned tips that have no live trigger (core #371 bug)", () => {
+  // No triggers at all — only a stray .popover left on <body> by a re-render.
+  const orphan = makeTip();
+  const doc = fakeDoc([], [orphan]);
+
+  const result = GRQPopover.closeAllPopovers(doc, () => null);
+
+  assertEquals(result.hidden, 0);
+  assertEquals(result.removed, 1);
+  assert(orphan.removed, "orphaned tip was removed from the DOM");
+});
+
+Deno.test("closeAllPopovers - hides live instances AND removes leftover orphans together", () => {
+  const trigger = {};
+  const live = makeInstance();
+  const orphan = makeTip();
+  const doc = fakeDoc([trigger], [orphan]);
+
+  const result = GRQPopover.closeAllPopovers(
+    doc,
+    (el) => (el === trigger ? live : null),
+  );
+
+  assertEquals(result.hidden, 1);
+  assertEquals(result.removed, 1);
+  assert(live.hidden, "live instance was hidden");
+  assert(orphan.removed, "leftover orphan was removed");
+});
+
+Deno.test("closeAllPopovers - no popovers present is a safe no-op", () => {
+  const result = GRQPopover.closeAllPopovers(fakeDoc([], []), () => null);
+  assertEquals(result, { hidden: 0, removed: 0 });
+});
+
+Deno.test("closeAllPopovers - tolerates a trigger with no instance", () => {
+  const result = GRQPopover.closeAllPopovers(fakeDoc([{}], []), () => null);
+  assertEquals(result, { hidden: 0, removed: 0 });
+});
+
+Deno.test("popover_dismiss.js parses cleanly as JavaScript", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../docs/popover_dismiss.js", import.meta.url),
+  );
+  const result = checkJsSyntax(source);
+  assertEquals(result.valid, true, result.error);
+});


### PR DESCRIPTION
## Summary

"Tap outside to close" was unreliable for the dashboard's mobile value
popovers. `docs/app.js` carried **two** competing global `document` click
handlers (one in `initializeEventListeners()`, one at module load) with
overlapping logic. Both closed popovers by iterating the live **triggers**
(`.clickable-value` / `[data-bs-toggle="popover"]`) and calling `hide()`
**only if the trigger still had `aria-describedby`**. An **orphaned tip** — a
`.popover` node left on `<body>` after a re-render disposed its trigger — has
no live trigger, so neither handler could reach it and tapping outside did
nothing.

This PR consolidates the two handlers into a **single** global click handler
backed by a new shared, tested module `docs/popover_dismiss.js`
(`GRQPopover`). The new dismissal path hides **every** live Bootstrap instance
(no longer gated on `aria-describedby`) **and** removes any leftover `.popover`
nodes from the DOM, so orphaned tips are dismissed too. Tapping inside popover
content still does nothing; tapping a trigger still closes the others and
re-opens the tapped one.

Closes #371.

## Changes

- **`docs/popover_dismiss.js`** (new) — pure, dependency-injected `GRQPopover`
  helpers published on `globalThis`, mirroring `escape.js` / `color_key.js`:
  - `decidePopoverAction({ insidePopover, hasTrigger })` → `"ignore"` /
    `"closeAndReopen"` / `"closeOnly"`.
  - `closeAllPopovers(doc, getInstance)` → hides every live instance and
    removes orphaned `.popover` nodes; returns `{ hidden, removed }`.
- **`docs/app.js`** — replaced handler #1 with the single consolidated handler
  using `GRQPopover`; removed handler #2 (left a breadcrumb comment). Exactly
  one global popover click handler now remains.
- **`docs/index.html`** — loads `popover_dismiss.js` before `app.js`.
- **`tests/popover_dismiss_test.ts`** (new) — exercises the real shipped logic.

## Evidence

This is a small front-end behaviour change in vanilla JS with no JS test
harness for `docs/app.js` itself (noted in the issue). The dismissal decision
and the orphan-removal logic were extracted into `docs/popover_dismiss.js` so
the **real shipped code** is unit-tested rather than a copy. Playwright MCP was
not available in this run, so no live screenshot was captured; the behaviour is
pinned by the unit tests below and was reasoned through against the acceptance
criteria.

```mermaid
flowchart TD
    A[document click] --> B{inside .popover content?}
    B -- yes --> I[ignore: keep open]
    B -- no --> C[closeAllPopovers]
    C --> D[hide every live instance<br/>not gated on aria-describedby]
    C --> E[remove orphaned .popover nodes]
    A --> F{tapped a trigger?}
    F -- yes --> G[re-open tapped popover]
    F -- no --> H[stay closed]
```

Acceptance criteria mapping:

- *Open any popover, tap outside → it closes* — `closeOnly` path runs
  `closeAllPopovers`, which hides every live instance.
- *Orphaned tip still removed* — `closeAllPopovers` removes leftover `.popover`
  nodes even with no live trigger (test: "removes orphaned tips that have no
  live trigger").
- *Tapping inside the popover does not close it* — `decidePopoverAction`
  returns `"ignore"` (test: "tapping inside popover content is ignored").
- *Exactly one global popover click handler remains* — handler #2 removed; a
  single `document.addEventListener("click", …)` remains in `docs/app.js`.

## Test Plan

- `tests/popover_dismiss_test.ts` (new):
  - publishes helpers on `globalThis`;
  - `decidePopoverAction` for inside-popover / trigger / outside taps;
  - `closeAllPopovers` hides every live instance regardless of
    `aria-describedby`;
  - `closeAllPopovers` removes orphaned tips with no live trigger (core #371
    bug);
  - hides live instances **and** removes orphans together;
  - safe no-op when nothing is open; tolerates a trigger with no instance;
  - the module parses cleanly via `checkJsSyntax`.
- `tests/js_syntax_test.ts` continues to confirm `docs/app.js` parses cleanly.
- Full Deno suite (`deno test --allow-read tests/*.ts`) passes.
