### PR TITLE
Milestone: #333 bug: chart shows index down but Market Performance summary shows up

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -925,7 +925,22 @@ class GRQValidator {
         // Benchmark figures come ONLY from the already-loaded local data
         // (this.marketIndexData, i.e. docs/market-indices.json) — no live fetch.
         // The same extraction feeds both the aggregate and single-stock views.
-        return GRQMarketIndex.marketPerformanceData(this.marketIndexData);
+        //
+        // The summary is constrained to the SAME per-device window the chart
+        // plots (issue #367, milestone #333): its end price is the last close at
+        // or before scoreDate + (mobile 90 / desktop 180) days — the shared
+        // single source of truth — so the figures can never disagree with the
+        // chart's last visible point in direction. deviceWindowEnd returns null
+        // for a missing/unparseable score date, in which case marketPerformance
+        // Data falls back to the full-period figure rather than erroring.
+        const windowEnd = GRQProjection.deviceWindowEnd(
+            this.getScoreDate(this.selectedFile),
+            this.isMobileDevice(),
+        );
+        return GRQMarketIndex.marketPerformanceData(
+            this.marketIndexData,
+            windowEnd,
+        );
     }
 
     showMarketComparisonLoading() {
@@ -1598,11 +1613,14 @@ class GRQValidator {
         const breakpoint = this.getBootstrapBreakpoint();
         const isMobile = this.isMobileDevice();
         
-        // On mobile, limit to 90 days for better readability
-        const maxDays = isMobile ? 90 : 180;
-        const maxDate = this.setDateToMidnight(new Date(
-            this.getScoreDate(this.selectedFile).getTime() + (maxDays * 24 * 60 * 60 * 1000)
-        ));
+        // Per-device visible window (mobile 90 days, desktop 180). Shared with
+        // the Market Performance summary via GRQProjection so the chart and the
+        // summary cover the identical window and cannot disagree (issue #367).
+        const maxDays = GRQProjection.deviceWindowDays(isMobile);
+        const maxDate = GRQProjection.deviceWindowEnd(
+            this.getScoreDate(this.selectedFile),
+            isMobile,
+        );
 
         // Debug logging for mobile data limitation
         if (isMobile) {
@@ -2420,9 +2438,10 @@ class GRQValidator {
     calculateCostOfCapitalData() {
         const breakpoint = this.getBootstrapBreakpoint();
         const isMobile = this.isMobileDevice();
-        
-        // On mobile, limit to 90 days for better readability
-        const maxDays = isMobile ? 90 : 180;
+
+        // Per-device visible window, shared with the chart and summary via the
+        // single source of truth (issue #367) — mobile 90 days, desktop 180.
+        const maxDays = GRQProjection.deviceWindowDays(isMobile);
         const maxDate = new Date(
             this.getScoreDate(this.selectedFile).getTime() + (maxDays * 24 * 60 * 60 * 1000)
         );
@@ -4184,8 +4203,26 @@ if (typeof globalThis.matchMedia === "function") {
 // breakpoint flips the native Chart.js legend (the desktop identifier) and
 // shows+populates the mobile colour key, or tears it down again — so neither
 // is ever left stale (issue #246, milestone #236).
+// Remembers the breakpoint at the previous settle so we only rebuild the chart
+// and summary when the device boundary is actually crossed (issue #367).
+let lastViewportIsMobile;
+
 function syncChartForViewport() {
     const isMobile = validator.isMobileDevice();
+
+    // Crossing the mobile/desktop boundary changes the visible window (90 vs
+    // 180 days), so re-derive BOTH the chart series and the Market Performance
+    // summary to the new window — they share one source of truth, so they stay
+    // in agreement (issue #367, milestone #333). Only act on an actual crossing
+    // to avoid rebuilding the chart on same-device resizes. The chart must exist
+    // (data loaded) before a rebuild makes sense.
+    const crossedBreakpoint = lastViewportIsMobile !== undefined &&
+        lastViewportIsMobile !== isMobile;
+    lastViewportIsMobile = isMobile;
+    if (crossedBreakpoint && validator.chart && validator.marketIndexData) {
+        validator.updateChart();
+        validator.updateMarketComparison();
+    }
 
     // Keep the native legend in step with the breakpoint when a chart exists.
     if (

--- a/docs/archive/pr-summaries/pr-summary-366.md
+++ b/docs/archive/pr-summaries/pr-summary-366.md
@@ -3,7 +3,7 @@
 Adds the pure data kernel that the #333 chart-vs-summary reconciliation needs:
 deriving each benchmark index's performance over a **bounded window** (score
 date → an explicit end date) instead of always running to the latest available
-price. Closes #366.
+price. Closes #366
 
 Two additions to `docs/market_index.js`, both pure (no DOM, no class state) and
 published on `globalThis.GRQMarketIndex` so the browser dashboard and the Deno

--- a/docs/archive/pr-summaries/pr-summary-366.md
+++ b/docs/archive/pr-summaries/pr-summary-366.md
@@ -1,0 +1,71 @@
+## Summary
+
+Adds the pure data kernel that the #333 chart-vs-summary reconciliation needs:
+deriving each benchmark index's performance over a **bounded window** (score
+date → an explicit end date) instead of always running to the latest available
+price. Closes #366.
+
+Two additions to `docs/market_index.js`, both pure (no DOM, no class state) and
+published on `globalThis.GRQMarketIndex` so the browser dashboard and the Deno
+tests share the **same** shipped logic:
+
+- `priceAsOf(seriesOrPoints, endDate)` — returns the close of the latest point
+  with `date <= endDate` ("last close ≤ endDate"), or `null` when nothing
+  qualifies (empty/missing series, end date before all data, or an unparseable
+  date). Accepts either a built series object (`{ data: [{date, close}] }`) or a
+  bare `{date, close}` points array. Date comparison is at local midnight,
+  matching how `buildIndexSeriesFromMap` slices the series.
+- `indexPerformance(indexData, endDate)` — now takes an optional `endDate`. When
+  supplied, the end price becomes window-aware via `priceAsOf(indexData.data,
+  endDate)`; when omitted, behaviour is unchanged (runs to the latest close).
+  `initialPrice` semantics are untouched (still the score-date baseline) and the
+  `((endPrice - initialPrice) / initialPrice) * 100` formula is unchanged, so an
+  end date on the latest data date reproduces the full-period result.
+
+No DOM or app wiring is changed — that is the consuming #333 sub-issue. This
+change is additive and green on its own.
+
+## Why
+
+`indexPerformance` previously read `currentPrice` (the latest price in the
+window), and `docs/app.js` always set the window end to *today*, so the
+"Market Performance Comparison" summary always ran to today — disagreeing with
+the windowed dashboard chart (#333). There was no helper to read an index's
+close at/just-before an arbitrary date; this kernel supplies it.
+
+```mermaid
+flowchart LR
+    M["{date: close} map"] --> B[buildIndexSeriesFromMap]
+    B --> S["series {data, initialPrice, currentPrice}"]
+    S --> P["priceAsOf(series, endDate)<br/>last close ≤ endDate"]
+    P --> I["indexPerformance(indexData, endDate)<br/>((endPrice − initialPrice) / initialPrice) × 100"]
+```
+
+## Evidence
+
+Backend/kernel-only change (pure JS helpers, no web interface altered), so no
+screenshot applies. Verified by the unit tests below — all 17 tests in
+`tests/market_index_test.ts` pass, and the full suite is green
+(`deno test --allow-read tests/*.ts` → 602 passed, 0 failed).
+
+## Test Plan
+
+Added to `tests/market_index_test.ts`, driven by a synthetic `{date: close}`
+map with a mid-window dip (the #333 shape), built through the real
+`GRQProjection.buildIndexSeriesFromMap` (no test-only copy):
+
+- `priceAsOf` — end date between two points → returns the earlier point's close
+  (last ≤ endDate);
+- `priceAsOf` — end date exactly on a point → that point's close;
+- `priceAsOf` — end date before the first point → `null`;
+- `priceAsOf` — end date on the last point → equals the full-period
+  `currentPrice` (proves no regression);
+- `priceAsOf` — accepts a bare `{date, close}` points array;
+- `priceAsOf` — tolerant of empty/missing/unparseable inputs, never throws;
+- `indexPerformance` — end date inside the dip yields a **lower** figure (−10%)
+  than the latest (+10%) — the exact #333 disagreement;
+- `indexPerformance` — end date on the last point equals the full-period result
+  (regression-safe);
+- `indexPerformance` — end date before all data → `null` (render blank);
+- `indexPerformance` — omitting `endDate` preserves existing full-period
+  behaviour.

--- a/docs/archive/pr-summaries/pr-summary-367.md
+++ b/docs/archive/pr-summaries/pr-summary-367.md
@@ -1,0 +1,88 @@
+# Align Market Performance summary to the chart's per-device window
+
+## Summary
+
+The dashboard chart truncates its visible benchmark series to a per-device
+window measured from the score date (mobile 90 days, desktop 180 days), but the
+"Market Performance Comparison" summary ran to today's latest price. For a score
+date sitting before a later recovery the two contradicted each other — the chart
+showed an index **down** while the summary showed it **up**.
+
+This change constrains the summary to the **same** window the chart plots, via a
+single source of truth, so they can never disagree in direction. **Closes #367.**
+
+What changed:
+
+- **Single source of truth** — added `GRQProjection.deviceWindowDays(isMobile)`
+  and `GRQProjection.deviceWindowEnd(scoreDate, isMobile)` (pure helpers). The
+  90/180 value previously lived only inside `prepareChartData`; it now lives in
+  one place that `prepareChartData`, `calculateCostOfCapitalData` (the chart) and
+  `getMarketPerformanceData` (the summary) all consume, so they cannot drift.
+- **Window-aware summary** — `GRQMarketIndex.marketPerformanceData` now accepts
+  and forwards an `endDate`, so each index's end price is the last close at or
+  before the window end (via the `priceAsOf` helper from the #366 kernel) instead
+  of the latest price. `getMarketPerformanceData` passes
+  `deviceWindowEnd(scoreDate, isMobile)`.
+- **Runtime breakpoint change** — `syncChartForViewport` now detects a
+  mobile/desktop crossing (resize / orientation change) and re-derives **both**
+  the chart and the summary to the new window, so a desktop→mobile resize
+  re-narrows the summary to 90 days and they stay in agreement.
+- **Blank-on-missing preserved** — an index with no usable price in the window is
+  omitted (rendered blank), never an error. No live fetch is introduced; figures
+  still come only from the already-loaded local `this.marketIndexData`.
+
+```mermaid
+flowchart TD
+    SD[score date] --> W["GRQProjection.deviceWindowEnd<br/>scoreDate + (mobile 90 / desktop 180) days"]
+    W --> C[prepareChartData — chart visible series]
+    W --> S["getMarketPerformanceData → marketPerformanceData(data, windowEnd)"]
+    S --> P["priceAsOf: last close ≤ window end"]
+    C --> AGREE((chart & summary share one window — cannot disagree))
+    P --> AGREE
+    RS[resize / orientation change] --> X{breakpoint crossed?}
+    X -- yes --> C
+    X -- yes --> S
+```
+
+## Evidence
+
+Playwright MCP was not available in this environment, so visual capture was not
+possible. Instead the fix is demonstrated numerically against the **real shipped
+kernel** (`docs/projection.js`, `docs/market_index.js`) and the **actual**
+`docs/market-indices.json`, for the **1 Jan 2026** score date the issue cites:
+
+```
+score date: 2026-01-01
+mobile window end : 2026-03-31 (scoreDate +90d)
+desktop window end: 2026-06-28 (scoreDate +180d)
+
+index        | OLD run-to-today | NEW mobile 90d | NEW desktop 180d
+SP500        |           +9.36% |         -4.13% |           +9.36%
+NASDAQ       |          +14.13% |         -6.00% |          +14.13%
+Russell 2000 |          +18.80% |         +0.17% |          +18.80%
+```
+
+- The **OLD run-to-today** column reproduces the exact figures in the issue
+  (SP500 +9.36%, NASDAQ +14.13%, Russell 2000 +18.80%) — the buggy "summary up
+  while chart down" case.
+- The **mobile 90d** window ends inside the early-2026 dip, so SP500 and NASDAQ
+  now read **negative**, matching the sign of the chart's last visible point on
+  mobile — the contradiction is gone.
+- The **desktop 180d** window reaches the latest available data, so the chart and
+  summary both run to ~today and agree there too.
+
+## Test Plan
+
+- Added `tests/chart_summary_window_test.ts` exercising the real shipped helpers:
+  - `deviceWindowDays` → 90 (mobile) / 180 (desktop).
+  - `deviceWindowEnd` → `scoreDate + days` at local midnight; null on an
+    unparseable/missing score date (blank, never throws).
+  - `marketPerformanceData(data, endDate)` end-to-end reconciliation reproducing
+    the #333 shape (dip-then-recovery): mobile and desktop windows report the
+    in-window sign, not the recovered latest price; an index with no price in the
+    window renders blank.
+- Extended the existing typed wrapper in `tests/market_index_test.ts` continues
+  to pass (`marketPerformanceData` keeps its run-to-latest behaviour when no
+  `endDate` is supplied — backward compatible).
+- Full suite: `deno test --allow-read tests/*.ts` → **607 passed, 0 failed**.
+  `deno fmt --check`, `deno lint`, `deno check` all clean.

--- a/docs/archive/pr-summaries/pr-summary-368.md
+++ b/docs/archive/pr-summaries/pr-summary-368.md
@@ -1,0 +1,83 @@
+# TDD regression test: chart and summary must agree in direction (1 Jan 2026)
+
+## Summary
+
+Adds the failing-first (TDD) regression test for the #333 chart-vs-summary
+direction contradiction at a **1 January 2026** score date. Closes #368.
+
+With a 1 Jan 2026 score date the benchmark indices (SP500 / NASDAQ /
+Russell 2000) disagreed between two views that share the same score-date
+baseline and differ **only** in their end date:
+
+- the **chart** is truncated to `scoreDate + maxDays`
+  (`maxDays = isMobile ? 90 : 180`, `docs/app.js:1602`), so it stops inside the
+  early-2026 dip and trends **down**;
+- the **summary** ran `indexPerformance` over the full period to the latest
+  price (`docs/market_index.js`, fed by `endDate = new Date()` at
+  `docs/app.js:818`), so it read **up** (SP500 +9.36%, NASDAQ +14.13%,
+  Russell 2000 +18.80%).
+
+The new test (`tests/chart_summary_direction_consistency_test.ts`) reproduces
+that contradiction with deterministic early-2026 fixture data and guards
+against it. It drives the **real shipped kernels** — `docs/projection.js`
+(`buildIndexSeriesFromMap`, `setDateToMidnight`) and `docs/market_index.js`
+(`indexPerformance`, `priceAsOf`) — exactly as `docs/app.js` does, with **no
+re-implemented maths** and no network / no dependency on "today".
+
+The assertion is expressed against the **shared window end the fix introduces**
+(`scoreDate + maxDays`), so it is:
+
+- **RED against current `main`**, where `indexPerformance` has no window-aware
+  end date and `priceAsOf` does not exist — the summary still reads to the
+  latest price and disagrees in sign with the windowed chart (verified: against
+  `main`'s kernels the test fails with `GRQMarketIndex.priceAsOf is not a
+  function`);
+- **GREEN on the `milestone/333-…` branch**, where the #333 kernel landed and
+  the summary can be constrained to the chart window.
+
+> **Dependency note:** this is the TDD red test for #333. It is authored first
+> and lands green with/after the kernel + wiring sub-issues — never merge a red
+> test alone. On the milestone branch the window-aware kernel is present, so the
+> test passes here.
+
+## Test flow
+
+```mermaid
+flowchart TD
+    SD[Score date: 1 Jan 2026] --> S[buildIndexSeriesFromMap<br/>scoreDate..latest]
+    S --> WE[windowEnd = scoreDate + maxDays<br/>90 mobile / 180 desktop]
+    WE --> SUM["Summary (fix):<br/>indexPerformance(series, windowEnd)"]
+    WE --> CH["Chart last point:<br/>priceAsOf(series.data, windowEnd)"]
+    SUM --> A{Same sign &amp;<br/>magnitude within tol?}
+    CH --> A
+    A -- yes --> G[GREEN: views agree]
+    S --> FULL["Old summary:<br/>indexPerformance(series) run-to-latest"]
+    FULL --> C{Contradicts windowed?}
+    C -- "up vs down" --> DOC[Documents the #333 bug]
+```
+
+## Evidence
+
+Backend / test-only change (no web UI altered), so no screenshot. Evidence is
+the test run itself:
+
+- **Green on this milestone branch:** `deno test` →
+  `2 passed (8 steps) | 0 failed`; full suite `604 passed | 0 failed`.
+- **Red against `main`:** running the same test against `main`'s
+  `docs/market_index.js` / `docs/projection.js` fails with
+  `TypeError: GRQMarketIndex.priceAsOf is not a function`, confirming the
+  failing-first TDD behaviour.
+
+## Test Plan
+
+- Added `tests/chart_summary_direction_consistency_test.ts`:
+  - `chart and summary agree in direction at the shared per-device window end
+    (#368)` — for both the **mobile (90-day)** and **desktop (180-day)**
+    windows, and each of SP500 / NASDAQ / Russell 2000, asserts the windowed
+    summary and the chart's last-visible-point change share the same sign and
+    agree in magnitude within tolerance; asserts both read **down** in-window;
+    and asserts the old run-to-latest summary reads **up**, documenting the
+    contradiction the shared window end removes.
+  - `fixture reproduces the #333 full-period summary numbers` — pins the
+    full-period figures to the reported numbers (SP500 +9.36%, NASDAQ +14.13%,
+    Russell 2000 +18.80%) so the fixture stays faithful to the report.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.202">
+    <meta name="app-version" content="1.0.203">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -329,6 +329,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.202"></script>
+    <script src="sw-register.js?v=1.0.203"></script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.201">
+    <meta name="app-version" content="1.0.202">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -321,6 +321,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.201"></script>
+    <script src="sw-register.js?v=1.0.202"></script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.203">
+    <meta name="app-version" content="1.0.204">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -329,6 +329,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.203"></script>
+    <script src="sw-register.js?v=1.0.204"></script>
   </body>
 </html>

--- a/docs/market_index.js
+++ b/docs/market_index.js
@@ -106,11 +106,17 @@ function indexPerformance(indexData, endDate) {
 // index data (`this.marketIndexData`). Only indices with usable prices appear
 // in the result; missing ones are simply absent (rendered blank by the caller).
 // Accepts null/undefined and returns an empty object — never throws.
-function marketPerformanceData(marketIndexData) {
+//
+// When `endDate` is supplied the figures become window-aware (issue #367): each
+// index's end price is the last close at or before `endDate`, so the summary
+// covers the SAME per-device window the chart plots and the two can never
+// disagree in direction. An index with no usable price in the window is omitted
+// (rendered blank). Omitting `endDate` keeps the original run-to-latest result.
+function marketPerformanceData(marketIndexData, endDate) {
     const result = {};
     if (marketIndexData) {
         for (const { key } of BENCHMARK_INDICES) {
-            const perf = indexPerformance(marketIndexData[key]);
+            const perf = indexPerformance(marketIndexData[key], endDate);
             if (perf) {
                 result[key] = perf;
             }

--- a/docs/market_index.js
+++ b/docs/market_index.js
@@ -23,20 +23,82 @@ const BENCHMARK_INDICES = [
     { key: "russell2000", name: "Russell 2000" },
 ];
 
+// Normalise an arbitrary date-ish value to its local-midnight epoch time, or
+// NaN when it cannot be parsed. Mirrors GRQProjection.setDateToMidnight so the
+// "last close <= endDate" comparison ignores any time-of-day component, matching
+// how buildIndexSeriesFromMap slices the series. Kept local so this kernel has
+// no load-order dependency on docs/projection.js.
+function toMidnightTime(value) {
+    if (value === null || value === undefined) return NaN;
+    const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    const time = date.getTime();
+    if (Number.isNaN(time)) return NaN;
+    date.setHours(0, 0, 0, 0);
+    return date.getTime();
+}
+
+// Resolve an index's close as of a bounded window end (issue #366): the close
+// of the latest point with `date <= endDate`. Accepts either a built series
+// object ({ data: [{date, close}] }) or a bare {date, close} points array, and
+// returns null when nothing qualifies — the series is empty/missing, the end
+// date precedes all data, or the end date is unparseable. Pure: no DOM, no
+// class state, never throws. This is the helper the #333 chart-vs-summary
+// reconciliation needs so the summary can read an as-of price instead of always
+// running to the latest available close.
+function priceAsOf(seriesOrPoints, endDate) {
+    const points = Array.isArray(seriesOrPoints)
+        ? seriesOrPoints
+        : (seriesOrPoints && Array.isArray(seriesOrPoints.data)
+            ? seriesOrPoints.data
+            : null);
+    if (!points || points.length === 0) return null;
+
+    const endTime = toMidnightTime(endDate);
+    if (Number.isNaN(endTime)) return null;
+
+    let bestTime = -Infinity;
+    let bestClose = null;
+    for (const point of points) {
+        if (!point) continue;
+        const close = point.close;
+        if (typeof close !== "number" || !Number.isFinite(close)) continue;
+        const time = toMidnightTime(point.date);
+        if (Number.isNaN(time) || time > endTime) continue;
+        if (time > bestTime) {
+            bestTime = time;
+            bestClose = close;
+        }
+    }
+    return bestClose;
+}
+
 // Compute one benchmark index's performance from its processed series. Returns
 // null when the required prices are missing, so callers render blank and never
 // fetch live data. Pure: no DOM, no class state.
-function indexPerformance(indexData) {
-    if (!indexData || !indexData.initialPrice || !indexData.currentPrice) {
+//
+// When `endDate` is supplied the end price becomes window-aware (issue #366):
+// the close of the last trading day at or before `endDate` (via priceAsOf over
+// `indexData.data`) instead of the latest available close. `initialPrice`
+// semantics are unchanged — it stays the score-date baseline. The formula is
+// identical, so an `endDate` on the latest data date reproduces the full-period
+// result. Omitting `endDate` keeps the original run-to-latest behaviour.
+function indexPerformance(indexData, endDate) {
+    if (!indexData || !indexData.initialPrice) {
+        return null;
+    }
+    const endPrice = (endDate === undefined || endDate === null)
+        ? indexData.currentPrice
+        : priceAsOf(indexData.data, endDate);
+    if (!endPrice) {
         return null;
     }
     const performance =
-        ((indexData.currentPrice - indexData.initialPrice) /
+        ((endPrice - indexData.initialPrice) /
             indexData.initialPrice) * 100;
     return {
         performance,
         initialPrice: indexData.initialPrice,
-        currentPrice: indexData.currentPrice,
+        currentPrice: endPrice,
     };
 }
 
@@ -62,5 +124,6 @@ function marketPerformanceData(marketIndexData) {
 globalThis.GRQMarketIndex = {
     BENCHMARK_INDICES,
     indexPerformance,
+    priceAsOf,
     marketPerformanceData,
 };

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -20,6 +20,34 @@ function setDateToMidnight(date) {
     return d;
 }
 
+// Per-device chart/summary window (issue #367, milestone #333). The dashboard
+// chart truncates its visible benchmark series to a fixed window measured from
+// the score date — 90 days on mobile, 180 on desktop — so the "Market
+// Performance Comparison" summary must end on the SAME date or the two can
+// disagree in direction (chart down vs summary up). These pure helpers are the
+// single source of truth for that window, shared by prepareChartData (the
+// chart) and getMarketPerformanceData (the summary) so they cannot drift apart.
+const MOBILE_WINDOW_DAYS = 90;
+const DESKTOP_WINDOW_DAYS = 180;
+
+// Days in the visible window for the current device.
+function deviceWindowDays(isMobile) {
+    return isMobile ? MOBILE_WINDOW_DAYS : DESKTOP_WINDOW_DAYS;
+}
+
+// The window's end date: scoreDate + (mobile 90 / desktop 180) days, at local
+// midnight. Returns null when the score date is missing or unparseable so the
+// caller renders blank rather than erroring (preserves blank-on-missing).
+function deviceWindowEnd(scoreDate, isMobile) {
+    if (scoreDate === null || scoreDate === undefined) return null;
+    const start = setDateToMidnight(new Date(scoreDate));
+    if (Number.isNaN(start.getTime())) return null;
+    const days = deviceWindowDays(isMobile);
+    return setDateToMidnight(
+        new Date(start.getTime() + days * 24 * 60 * 60 * 1000),
+    );
+}
+
 // Choose the default score file for the dashboard (issue #275).
 //
 // By default we select the nearest available score date ON OR BEFORE 90 days
@@ -825,6 +853,8 @@ function buildIndexSeriesFromMap(priceMap, indexName, startDate, endDate) {
 // test importer can both reach the helpers, mirroring docs/escape.js.
 globalThis.GRQProjection = {
     setDateToMidnight,
+    deviceWindowDays,
+    deviceWindowEnd,
     selectDefaultScore,
     getDaysElapsed,
     calculatePerformanceReturn,

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.203")
+    navigator.serviceWorker.register("./sw.js?v=1.0.204")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.202")
+    navigator.serviceWorker.register("./sw.js?v=1.0.203")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.201")
+    navigator.serviceWorker.register("./sw.js?v=1.0.202")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.202";
+const APP_VERSION = "1.0.203";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.201";
+const APP_VERSION = "1.0.202";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.203";
+const APP_VERSION = "1.0.204";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/tests/chart_summary_direction_consistency_test.ts
+++ b/tests/chart_summary_direction_consistency_test.ts
@@ -1,0 +1,270 @@
+// Chart-vs-summary direction consistency regression test (issue #368,
+// part of milestone #333).
+//
+// #333: with a 1 January 2026 score date the benchmark indices (SP500 /
+// NASDAQ / Russell 2000) disagreed between two views that share the same
+// score-date baseline and differ ONLY in their end date:
+//   - the CHART is truncated to `scoreDate + maxDays` (maxDays = 90 on mobile,
+//     180 on desktop — docs/app.js:1602), so it stops inside the early-2026 dip
+//     and trends DOWN;
+//   - the SUMMARY ran `indexPerformance` over the full period to the latest
+//     price (docs/market_index.js, fed by `endDate = new Date()` at
+//     docs/app.js:818), so it read UP (SP500 +9.36%, NASDAQ +14.13%,
+//     Russell 2000 +18.80%).
+//
+// This test reproduces that contradiction with deterministic early-2026 fixture
+// data (no network, no dependency on "today") and guards against it. It drives
+// the REAL shipped kernels — docs/projection.js (`buildIndexSeriesFromMap`,
+// `setDateToMidnight`) and docs/market_index.js (`indexPerformance`,
+// `priceAsOf`) — exactly as docs/app.js does, with NO re-implemented maths.
+//
+// The assertion is expressed against the SHARED WINDOW END the fix introduces
+// (`scoreDate + maxDays`). It is therefore:
+//   - RED against current `main`, where `indexPerformance` has no window-aware
+//     end date (`priceAsOf` does not exist), so the summary still reads to the
+//     latest price and disagrees in sign with the windowed chart;
+//   - GREEN once the #333 kernel + wiring sub-issues constrain the summary to
+//     the chart window.
+import { assert, assertAlmostEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/market_index.js";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+interface IndexSeries {
+  name: string;
+  data: Array<{ date: Date; close: number }>;
+  initialPrice: number | null;
+  currentPrice: number | null;
+}
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    setDateToMidnight: (date: Date) => Date;
+    buildIndexSeriesFromMap: (
+      priceMap: Record<string, number>,
+      indexName: string,
+      startDate: Date,
+      endDate: Date,
+    ) => IndexSeries | null;
+  };
+  GRQMarketIndex: {
+    indexPerformance: (
+      indexData: unknown,
+      endDate?: unknown,
+    ) =>
+      | { performance: number; initialPrice: number; currentPrice: number }
+      | null;
+    priceAsOf: (seriesOrPoints: unknown, endDate: unknown) => number | null;
+  };
+};
+const GRQProjection = g.GRQProjection;
+const GRQMarketIndex = g.GRQMarketIndex;
+
+// 1 January 2026 score date, at local midnight — the #333 reproduction date.
+const SCORE_DATE = GRQProjection.setDateToMidnight(new Date(2026, 0, 1));
+
+// A fixed "latest" date well beyond the 180-day desktop window, standing in for
+// production's `endDate = new Date()` (docs/app.js:818) so the fixture is
+// deterministic and never depends on the real "today".
+const LATEST_DATE = GRQProjection.setDateToMidnight(new Date(2026, 11, 31));
+
+// Deterministic early-2026 benchmark fixtures shaped like the #333 data: each
+// index dips through the first half of 2026 (so any window ending inside the
+// 90- or 180-day horizon is DOWN against the score-date baseline) and only
+// recovers to a positive full-period change late in the year. Mid-month points
+// keep the per-device window end clear of any data point, so the result is
+// robust to daylight-saving drift in the date arithmetic.
+//
+// The November figures are chosen so the full-period change matches the #333
+// summary numbers exactly: SP500 +9.36%, NASDAQ +14.13%, Russell 2000 +18.80%.
+const FIXTURES: Array<
+  { key: string; name: string; priceMap: Record<string, number> }
+> = [
+  {
+    key: "sp500",
+    name: "SP500",
+    priceMap: {
+      "2026-01-15": 4000, // score-date baseline (initialPrice)
+      "2026-02-15": 3850,
+      "2026-03-15": 3650, // mobile (90d) window end lands here -> down
+      "2026-04-15": 3600,
+      "2026-05-15": 3580,
+      "2026-06-15": 3640, // desktop (180d) window end lands here -> down
+      "2026-07-15": 3850,
+      "2026-08-15": 4050,
+      "2026-09-15": 4200,
+      "2026-10-15": 4300,
+      "2026-11-15": 4374.40, // latest: +9.36% full period
+    },
+  },
+  {
+    key: "nasdaq",
+    name: "NASDAQ",
+    priceMap: {
+      "2026-01-15": 12000,
+      "2026-02-15": 11400,
+      "2026-03-15": 10800, // mobile window end -> down
+      "2026-04-15": 10600,
+      "2026-05-15": 10500,
+      "2026-06-15": 10920, // desktop window end -> down
+      "2026-07-15": 11600,
+      "2026-08-15": 12300,
+      "2026-09-15": 12900,
+      "2026-10-15": 13300,
+      "2026-11-15": 13695.60, // latest: +14.13% full period
+    },
+  },
+  {
+    key: "russell2000",
+    name: "Russell 2000",
+    priceMap: {
+      "2026-01-15": 2000,
+      "2026-02-15": 1920,
+      "2026-03-15": 1840, // mobile window end -> down
+      "2026-04-15": 1810,
+      "2026-05-15": 1790,
+      "2026-06-15": 1820, // desktop window end -> down
+      "2026-07-15": 1980,
+      "2026-08-15": 2150,
+      "2026-09-15": 2270,
+      "2026-10-15": 2330,
+      "2026-11-15": 2376, // latest: +18.80% full period
+    },
+  },
+];
+
+// Per-device chart windows. maxDays mirrors docs/app.js:1602.
+const WINDOWS = [
+  { label: "mobile", maxDays: 90 },
+  { label: "desktop", maxDays: 180 },
+];
+
+// The shared window end the fix introduces, computed exactly as the chart does
+// (docs/app.js:1603-1605): scoreDate + maxDays, snapped to local midnight.
+function windowEnd(maxDays: number): Date {
+  return GRQProjection.setDateToMidnight(
+    new Date(SCORE_DATE.getTime() + maxDays * DAY),
+  );
+}
+
+// Build the index series the way docs/app.js loadMarketIndexData() does
+// (docs/app.js:857): slice the {date: close} map from the score date to the
+// latest available date. This is the SAME object that feeds both the chart and
+// the summary, so the only thing that can differ between them is the end date.
+function buildSeries(priceMap: Record<string, number>, name: string) {
+  return GRQProjection.buildIndexSeriesFromMap(
+    priceMap,
+    name,
+    SCORE_DATE,
+    LATEST_DATE,
+  )!;
+}
+
+Deno.test("chart and summary agree in direction at the shared per-device window end (#368)", async (t) => {
+  for (const { label, maxDays } of WINDOWS) {
+    await t.step(`${label} (${maxDays} days)`, async (tt) => {
+      const end = windowEnd(maxDays);
+
+      for (const { name, priceMap } of FIXTURES) {
+        await tt.step(name, () => {
+          const series = buildSeries(priceMap, name);
+          assert(
+            series.initialPrice !== null && series.currentPrice !== null,
+            `${name}: fixture should produce a usable series`,
+          );
+
+          // Summary, constrained to the chart window (the fix): the close of the
+          // last trading day at or before the window end, vs the score-date
+          // baseline. This is the call that goes window-aware once #333 lands.
+          const summary = GRQMarketIndex.indexPerformance(series, end);
+          assert(
+            summary !== null,
+            `${name}: windowed summary should be computable`,
+          );
+
+          // Chart's last-visible-point change: the chart truncates the same
+          // series to the window end, so its final point is priceAsOf(window
+          // end) measured against the same baseline.
+          const lastVisibleClose = GRQMarketIndex.priceAsOf(series.data, end);
+          assert(
+            lastVisibleClose !== null,
+            `${name}: chart should have a visible point in the window`,
+          );
+          const chartChange =
+            ((lastVisibleClose - series.initialPrice!) / series.initialPrice!) *
+            100;
+
+          // Direction must agree: same sign.
+          assert(
+            Math.sign(summary.performance) === Math.sign(chartChange),
+            `${name} (${label}): summary ${
+              summary.performance.toFixed(2)
+            }% and chart ${
+              chartChange.toFixed(2)
+            }% must share the same direction`,
+          );
+
+          // Magnitude must agree within tolerance: both views read the same
+          // window end against the same baseline, so they coincide.
+          assertAlmostEquals(
+            summary.performance,
+            chartChange,
+            0.01,
+            `${name} (${label}): summary and chart magnitudes must agree`,
+          );
+
+          // The fixture is a within-window dip, so both views read DOWN — the
+          // chart direction #333 says the summary must match.
+          assert(
+            summary.performance < 0,
+            `${name} (${label}): windowed view should be down (got ${
+              summary.performance.toFixed(2)
+            }%)`,
+          );
+
+          // Document the #333 contradiction the fix removes: the OLD summary
+          // ran to the latest price (no window) and read UP, disagreeing in
+          // sign with the windowed chart. This is exactly what made the views
+          // contradict each other.
+          const fullPeriod = GRQMarketIndex.indexPerformance(series);
+          assert(fullPeriod !== null);
+          assert(
+            fullPeriod.performance > 0,
+            `${name}: full-period (run-to-latest) summary should read up`,
+          );
+          assert(
+            Math.sign(fullPeriod.performance) !==
+              Math.sign(summary.performance),
+            `${name} (${label}): run-to-latest summary (${
+              fullPeriod.performance.toFixed(2)
+            }%) and windowed view (${
+              summary.performance.toFixed(2)
+            }%) must contradict — the bug the shared window end fixes`,
+          );
+        });
+      }
+    });
+  }
+});
+
+// Pin the full-period figures to the #333 reproduction numbers so the fixture
+// stays faithful to the reported contradiction (chart down, summary up).
+Deno.test("fixture reproduces the #333 full-period summary numbers", () => {
+  const expected: Record<string, number> = {
+    sp500: 9.36,
+    nasdaq: 14.13,
+    russell2000: 18.80,
+  };
+  for (const { key, name, priceMap } of FIXTURES) {
+    const series = buildSeries(priceMap, name);
+    const fullPeriod = GRQMarketIndex.indexPerformance(series);
+    assert(fullPeriod !== null, `${name}: full-period summary should compute`);
+    assertAlmostEquals(
+      fullPeriod.performance,
+      expected[key],
+      0.01,
+      `${name}: full-period change should match the #333 number`,
+    );
+  }
+});

--- a/tests/chart_summary_window_test.ts
+++ b/tests/chart_summary_window_test.ts
@@ -1,0 +1,133 @@
+// WHAT-tests for the per-device chart/summary window single source of truth
+// (issue #367, milestone #333 "chart shows index down but Market Performance up").
+//
+// The dashboard chart truncates its visible benchmark series to a fixed window
+// measured from the score date — 90 days on mobile, 180 on desktop. The
+// "Market Performance Comparison" summary previously ran to today's latest
+// price, so for a score date sitting before a later recovery the chart could
+// show an index DOWN while the summary showed it UP. This wiring constrains the
+// summary to the SAME window the chart plots.
+//
+// These tests exercise the REAL shipped pure helpers that both the chart
+// (prepareChartData) and the summary (getMarketPerformanceData) call, so chart
+// and summary cannot drift apart:
+//   - GRQProjection.deviceWindowDays(isMobile)  -> 90 | 180
+//   - GRQProjection.deviceWindowEnd(scoreDate, isMobile) -> windowed end Date
+//   - GRQMarketIndex.marketPerformanceData(data, endDate) -> window-aware figs
+import { assert, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/market_index.js";
+
+// deno-lint-ignore no-explicit-any
+const g = globalThis as any;
+const GRQProjection = g.GRQProjection;
+const GRQMarketIndex = g.GRQMarketIndex;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+Deno.test("deviceWindowDays - mobile is 90 days, desktop is 180 days", () => {
+  assertEquals(GRQProjection.deviceWindowDays(true), 90);
+  assertEquals(GRQProjection.deviceWindowDays(false), 180);
+});
+
+Deno.test("deviceWindowEnd - end is scoreDate + per-device days at local midnight", () => {
+  // A time-of-day component on the score date must be ignored: the window end
+  // is anchored to local midnight, matching how the chart slices its series.
+  const scoreDate = new Date("2026-01-01T13:45:00");
+  const base = GRQProjection.setDateToMidnight(new Date("2026-01-01"));
+
+  const mobileEnd = GRQProjection.deviceWindowEnd(scoreDate, true);
+  const desktopEnd = GRQProjection.deviceWindowEnd(scoreDate, false);
+
+  // Mirror the production formula exactly so the assertion is DST-safe.
+  assertEquals(
+    mobileEnd.getTime(),
+    GRQProjection.setDateToMidnight(new Date(base.getTime() + 90 * DAY_MS))
+      .getTime(),
+  );
+  assertEquals(
+    desktopEnd.getTime(),
+    GRQProjection.setDateToMidnight(new Date(base.getTime() + 180 * DAY_MS))
+      .getTime(),
+  );
+  assertEquals(mobileEnd.getHours(), 0);
+  assert(desktopEnd.getTime() > mobileEnd.getTime());
+});
+
+Deno.test("deviceWindowEnd - unparseable / missing score date returns null (blank, never throws)", () => {
+  assertEquals(
+    GRQProjection.deviceWindowEnd(new Date("not-a-date"), true),
+    null,
+  );
+  assertEquals(GRQProjection.deviceWindowEnd(null, false), null);
+  assertEquals(GRQProjection.deviceWindowEnd(undefined, true), null);
+});
+
+// End-to-end reconciliation: a benchmark whose price dips after the score date
+// then recovers above the baseline by "today". The chart window ends inside the
+// dip, so the summary — fed the SAME window end — must report the dip (DOWN),
+// never the recovered latest price (UP). This is the exact #333 contradiction.
+const SCORE_DATE = "2026-01-01";
+const PRICE_MAP = {
+  "2026-01-01": 100, // score-date baseline
+  "2026-03-15": 80, // inside the 90-day mobile window: DOWN 20%
+  "2026-09-01": 130, // latest available "today" price: UP 30%
+};
+
+Deno.test("marketPerformanceData - summary follows the per-device window, not the latest price (#333 shape)", () => {
+  // Series built over the full loaded range (score date -> today), exactly as
+  // loadMarketIndexData does before the summary narrows it per device.
+  const series = GRQProjection.buildIndexSeriesFromMap(
+    PRICE_MAP,
+    "SP500",
+    SCORE_DATE,
+    "2026-09-01",
+  );
+  const marketIndexData = { sp500: series };
+
+  // Mobile (90 days): window ends 2026-04-01, inside the dip -> DOWN.
+  const mobileEnd = GRQProjection.deviceWindowEnd(new Date(SCORE_DATE), true);
+  const mobile = GRQMarketIndex.marketPerformanceData(
+    marketIndexData,
+    mobileEnd,
+  );
+  assert(mobile.sp500.performance < 0, "mobile 90d summary must be negative");
+  assertEquals(mobile.sp500.currentPrice, 80);
+
+  // Desktop (180 days): window ends 2026-06-30, still before the recovery -> DOWN.
+  const desktopEnd = GRQProjection.deviceWindowEnd(new Date(SCORE_DATE), false);
+  const desktop = GRQMarketIndex.marketPerformanceData(
+    marketIndexData,
+    desktopEnd,
+  );
+  assert(
+    desktop.sp500.performance < 0,
+    "desktop 180d summary must be negative",
+  );
+  assertEquals(desktop.sp500.currentPrice, 80);
+
+  // Without the window (the old behaviour) the summary ran to the latest price
+  // and reported UP — the contradiction this issue removes.
+  const unwindowed = GRQMarketIndex.marketPerformanceData(marketIndexData);
+  assert(
+    unwindowed.sp500.performance > 0,
+    "run-to-latest is the buggy UP case",
+  );
+  assert(mobile.sp500.performance < unwindowed.sp500.performance);
+});
+
+Deno.test("marketPerformanceData - index with no usable price in the window renders blank, never errors", () => {
+  const series = GRQProjection.buildIndexSeriesFromMap(
+    PRICE_MAP,
+    "SP500",
+    SCORE_DATE,
+    "2026-09-01",
+  );
+  const marketIndexData = { sp500: series };
+  // A window end before any data point yields no price -> index omitted.
+  const result = GRQMarketIndex.marketPerformanceData(
+    marketIndexData,
+    new Date("2025-12-01"),
+  );
+  assertEquals(result, {});
+});

--- a/tests/market_index_test.ts
+++ b/tests/market_index_test.ts
@@ -14,6 +14,7 @@
 //   - a missing/partial index yields no figure (rendered blank, not an error);
 //   - null/undefined input is tolerated (empty result, never throws).
 import { assert, assertEquals } from "@std/assert";
+import "../docs/projection.js";
 import "../docs/market_index.js";
 
 const g = globalThis as unknown as {
@@ -21,9 +22,11 @@ const g = globalThis as unknown as {
     BENCHMARK_INDICES: Array<{ key: string; name: string }>;
     indexPerformance: (
       indexData: unknown,
+      endDate?: unknown,
     ) =>
       | { performance: number; initialPrice: number; currentPrice: number }
       | null;
+    priceAsOf: (seriesOrPoints: unknown, endDate: unknown) => number | null;
     marketPerformanceData: (
       marketIndexData: unknown,
     ) => Record<
@@ -31,8 +34,22 @@ const g = globalThis as unknown as {
       { performance: number; initialPrice: number; currentPrice: number }
     >;
   };
+  GRQProjection: {
+    buildIndexSeriesFromMap: (
+      priceMap: unknown,
+      indexName: string,
+      startDate: unknown,
+      endDate: unknown,
+    ) => {
+      name: string;
+      data: Array<{ date: Date; close: number }>;
+      initialPrice: number | null;
+      currentPrice: number | null;
+    } | null;
+  };
 };
 const GRQMarketIndex = g.GRQMarketIndex;
+const GRQProjection = g.GRQProjection;
 
 Deno.test("market_index.js publishes the helpers on globalThis", () => {
   assertEquals(typeof GRQMarketIndex.indexPerformance, "function");
@@ -106,4 +123,109 @@ Deno.test("marketPerformanceData - null/undefined input returns an empty object"
   assertEquals(GRQMarketIndex.marketPerformanceData(null), {});
   assertEquals(GRQMarketIndex.marketPerformanceData(undefined), {});
   assertEquals(GRQMarketIndex.marketPerformanceData({}), {});
+});
+
+// --- Bounded-window price resolution (issue #366) --------------------------
+//
+// A synthetic SP500-shaped {date: close} map covering the score window. The
+// midpoint (2024-02-01) is a DIP: a window ending then must read a lower price
+// than the latest (2024-03-01) value — the exact shape behind #333 where the
+// chart (windowed) and the summary (run-to-today) disagreed.
+const PRICE_MAP = {
+  "2024-01-01": 4000, // score-date baseline (initialPrice)
+  "2024-02-01": 3600, // mid-window dip
+  "2024-03-01": 4400, // latest available price
+};
+const SERIES = GRQProjection.buildIndexSeriesFromMap(
+  PRICE_MAP,
+  "SP500",
+  "2024-01-01",
+  "2024-03-01",
+)!;
+
+Deno.test("priceAsOf - end date between two points returns the last close <= endDate", () => {
+  // 2024-02-15 is after the dip (02-01) but before the latest (03-01).
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "2024-02-15"), 3600);
+});
+
+Deno.test("priceAsOf - end date exactly on a point returns that point's close", () => {
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "2024-02-01"), 3600);
+});
+
+Deno.test("priceAsOf - end date before the first point returns null", () => {
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "2023-12-31"), null);
+});
+
+Deno.test("priceAsOf - end date on the last point equals the full-period currentPrice", () => {
+  // Regression-safety: the windowed end price at the latest date must equal the
+  // current full-period currentPrice computed by buildIndexSeriesFromMap.
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "2024-03-01"), 4400);
+  assertEquals(
+    GRQMarketIndex.priceAsOf(SERIES, "2024-03-01"),
+    SERIES.currentPrice,
+  );
+});
+
+Deno.test("priceAsOf - accepts a bare {date, close} points array", () => {
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES.data, "2024-02-15"), 3600);
+});
+
+Deno.test("priceAsOf - tolerant of empty/missing inputs, never throws", () => {
+  assertEquals(GRQMarketIndex.priceAsOf(null, "2024-02-15"), null);
+  assertEquals(GRQMarketIndex.priceAsOf(undefined, "2024-02-15"), null);
+  assertEquals(GRQMarketIndex.priceAsOf([], "2024-02-15"), null);
+  assertEquals(GRQMarketIndex.priceAsOf({ data: [] }, "2024-02-15"), null);
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, "not-a-date"), null);
+  assertEquals(GRQMarketIndex.priceAsOf(SERIES, null), null);
+});
+
+Deno.test("indexPerformance - end date inside the dip yields a lower figure than the latest (the #333 shape)", () => {
+  const indexData = {
+    initialPrice: SERIES.initialPrice,
+    currentPrice: SERIES.currentPrice,
+    data: SERIES.data,
+  };
+  // Windowed to the dip: ((3600 - 4000) / 4000) * 100 = -10%.
+  const windowed = GRQMarketIndex.indexPerformance(indexData, "2024-02-15");
+  assert(windowed !== null);
+  assertEquals(windowed.performance, -10);
+  assertEquals(windowed.currentPrice, 3600);
+  assertEquals(windowed.initialPrice, 4000);
+
+  // Full period (run to latest): ((4400 - 4000) / 4000) * 100 = +10%.
+  const full = GRQMarketIndex.indexPerformance(indexData);
+  assert(full !== null);
+  assertEquals(full.performance, 10);
+  assert(windowed.performance < full.performance);
+});
+
+Deno.test("indexPerformance - end date on the last point equals the full-period result (no regression)", () => {
+  const indexData = {
+    initialPrice: SERIES.initialPrice,
+    currentPrice: SERIES.currentPrice,
+    data: SERIES.data,
+  };
+  const windowed = GRQMarketIndex.indexPerformance(indexData, "2024-03-01");
+  const full = GRQMarketIndex.indexPerformance(indexData);
+  assertEquals(windowed, full);
+});
+
+Deno.test("indexPerformance - end date before all data yields null (render blank, no throw)", () => {
+  const indexData = {
+    initialPrice: SERIES.initialPrice,
+    currentPrice: SERIES.currentPrice,
+    data: SERIES.data,
+  };
+  assertEquals(GRQMarketIndex.indexPerformance(indexData, "2023-12-31"), null);
+});
+
+Deno.test("indexPerformance - omitting endDate preserves the existing full-period behaviour", () => {
+  // No endDate argument: identical to the pre-#366 signature.
+  const perf = GRQMarketIndex.indexPerformance({
+    initialPrice: 4000,
+    currentPrice: 4400,
+  });
+  assert(perf !== null);
+  assertEquals(perf.performance, 10);
+  assertEquals(perf.currentPrice, 4400);
 });


### PR DESCRIPTION
## Milestone: #333 bug: chart shows index down but Market Performance summary shows up

This PR merges the completed milestone branch into main.
Closes #390

### Issues addressed
- #368: TDD regression test: chart and summary must agree in direction for a 1 Jan 2026 score date
- #367: Align Market Performance summary to the chart's per-device window (mobile 90d / desktop 180d)
- #366: Kernel: derive Market Performance index figures over a bounded window (price as-of an end date)

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to main.