### PR TITLE
Milestone: #335 bug: mobile info popover can't be dismissed after selecting a stock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/docs/app.js
+++ b/docs/app.js
@@ -2488,6 +2488,11 @@ class GRQValidator {
     }
 
     updateStockTable() {
+        // Start every re-render from a clean popover state (issue #370): hide
+        // and dispose all live popovers, then sweep any orphaned `.popover`
+        // tips before the innerHTML="" below destroys their triggers.
+        globalThis.GRQPopovers.clearAllPopovers(document, bootstrap.Popover);
+
         const tbody = document.getElementById("stockTableBody");
         tbody.innerHTML = "";
 
@@ -2888,16 +2893,11 @@ class GRQValidator {
             tbody.appendChild(totalsRow);
         }
 
-        // Dispose of existing popovers
-        const existingPopovers = document.querySelectorAll(
-            '.clickable-value[data-bs-toggle="popover"]',
-        );
-        existingPopovers.forEach((element) => {
-            const popover = bootstrap.Popover.getInstance(element);
-            if (popover) {
-                popover.dispose();
-            }
-        });
+        // Dispose of existing popovers and sweep any orphaned tips before
+        // recreating instances (issue #370). Hiding before disposing and
+        // sweeping stray `.popover` nodes ensures no popover survives into the
+        // freshly rendered DOM.
+        globalThis.GRQPopovers.clearAllPopovers(document, bootstrap.Popover);
 
         // Loop through all .clickable-value elements
         const clickableValues = document.querySelectorAll(
@@ -2930,6 +2930,10 @@ class GRQValidator {
     }
 
     updateBasicStockTable() {
+        // Clean popover state before re-rendering the basic view too (issue
+        // #370) so no tip survives a basic ↔ market view change.
+        globalThis.GRQPopovers.clearAllPopovers(document, bootstrap.Popover);
+
         const tbody = document.getElementById("stockTableBody");
         tbody.innerHTML = "";
 

--- a/docs/app.js
+++ b/docs/app.js
@@ -110,9 +110,16 @@ class GRQValidator {
             const trigger = event.target.closest(
                 GRQPopover.POPOVER_TRIGGER_SELECTOR,
             );
+            // Capture whether the tapped trigger's popover is already open
+            // BEFORE the close-all loop runs. Bootstrap sets aria-describedby
+            // on the trigger while its popover is shown, so a second tap on the
+            // same value toggles it shut instead of re-opening it (issue #372).
+            const triggerAlreadyOpen = !!trigger &&
+                trigger.hasAttribute("aria-describedby");
             const action = GRQPopover.decidePopoverAction({
                 insidePopover,
                 hasTrigger: !!trigger,
+                triggerAlreadyOpen,
             });
 
             // Tapping inside an open popover's content must not close it.

--- a/docs/app.js
+++ b/docs/app.js
@@ -98,35 +98,41 @@ class GRQValidator {
             });
         }
 
-        // Global click handler to manage popover behavior
+        // Single global popover click handler — the one source of truth for
+        // "tap outside to close" (issue #371). Replaces the two competing
+        // handlers that previously lived here and at module load. The dismissal
+        // logic is the shared, tested GRQPopover module, so an orphaned tip with
+        // no live trigger is still removed.
         document.addEventListener("click", (event) => {
-            const popoverTrigger = event.target.closest(
-                '[data-bs-toggle="popover"]',
+            const insidePopover = !!event.target.closest(
+                GRQPopover.POPOVER_TIP_SELECTOR,
             );
-            const popoverContent = event.target.closest(".popover");
+            const trigger = event.target.closest(
+                GRQPopover.POPOVER_TRIGGER_SELECTOR,
+            );
+            const action = GRQPopover.decidePopoverAction({
+                insidePopover,
+                hasTrigger: !!trigger,
+            });
 
-            // Don't do anything if clicking inside the popover content
-            if (popoverContent) {
+            // Tapping inside an open popover's content must not close it.
+            if (action === "ignore") {
                 return;
             }
 
-            // Close all existing popovers
-            const popovers = document.querySelectorAll(
-                '[data-bs-toggle="popover"]',
+            // Close every popover: hide live instances AND remove orphaned
+            // tips. Not gated on a trigger's aria-describedby.
+            GRQPopover.closeAllPopovers(
+                document,
+                (element) => bootstrap.Popover.getInstance(element),
             );
-            popovers.forEach((element) => {
-                const popover = bootstrap.Popover.getInstance(element);
-                if (popover && element.hasAttribute("aria-describedby")) {
-                    popover.hide();
-                }
-            });
 
-            // If we clicked on a popover trigger, show the new one after a brief delay
-            if (popoverTrigger) {
+            // Re-open the tapped trigger after the close settles (the popovers
+            // use a manual trigger, so they are shown here rather than by
+            // Bootstrap itself).
+            if (action === "closeAndReopen" && trigger) {
                 setTimeout(() => {
-                    const popover = bootstrap.Popover.getInstance(
-                        popoverTrigger,
-                    );
+                    const popover = bootstrap.Popover.getInstance(trigger);
                     if (popover) {
                         popover.show();
                     }
@@ -4222,24 +4228,6 @@ const debouncedSyncChartForViewport = globalThis.GRQColorKey.debounce(
 globalThis.addEventListener("resize", debouncedSyncChartForViewport);
 globalThis.addEventListener("orientationchange", debouncedSyncChartForViewport);
 
-// Add document click handler to close popovers when clicking outside
-document.addEventListener("click", (event) => {
-    // Check if the click was on a popover trigger or inside a popover
-    const isPopoverTrigger = event.target.closest(
-        ".clickable-value",
-    );
-    const isInsidePopover = event.target.closest(".popover");
-
-    if (!isPopoverTrigger && !isInsidePopover) {
-        // Close all open popovers
-        const clickableValues = document.querySelectorAll(
-            ".clickable-value",
-        );
-        clickableValues.forEach((element) => {
-            const popover = bootstrap.Popover.getInstance(element);
-            if (popover && element.hasAttribute("aria-describedby")) {
-                popover.hide();
-            }
-        });
-    }
-});
+// The second global popover click handler that used to live here was removed in
+// issue #371. Dismissal is now handled by the single consolidated handler in
+// initializeEventListeners() above, via the shared GRQPopover module.

--- a/docs/archive/pr-summaries/pr-summary-370.md
+++ b/docs/archive/pr-summaries/pr-summary-370.md
@@ -1,0 +1,68 @@
+# Auto-dismiss/sweep value popovers on every re-render (Issue #370)
+
+## Summary
+
+On a ~375px mobile viewport, opening a value popover (e.g. **Portfolio
+Target**) and then selecting a single stock left the popover stuck on screen
+with no way to close it. Every `.clickable-value` popover is created with
+`container: "body"`, so its visible tip is appended to `<body>`. A re-render
+replaces the table via `tbody.innerHTML = ""`, destroying the trigger `<span>`
+but **orphaning** the tip on `<body>`; the old dispose loop iterated only the
+current triggers, so it could never dispose the orphaned instance and the tip
+stayed visible forever.
+
+The fix adds a shared, pure helper
+`clearAllPopovers(document, bootstrap.Popover)` in `docs/popover_cleanup.js`
+(published as `globalThis.GRQPopovers`) that:
+
+1. hides **then** disposes every live popover instance attached to a trigger, and
+2. sweeps any stray `.popover` tips off the document
+   (`querySelectorAll('.popover').forEach((n) => n.remove())`) — the orphaned
+   tip has no live trigger, so disposing by trigger alone cannot remove it.
+
+It is invoked at the start of both `updateStockTable()` and
+`updateBasicStockTable()` (before `tbody.innerHTML = ""`) and replaces the
+previous trigger-only dispose loop in `updateStockTable()`. Because every view
+change / re-render routes through `updateDisplay()` → one of those two table
+methods, single-stock selection, score-file switching, basic ↔ market view and
+back-to-aggregate all now start from a clean popover state.
+
+Closes #370.
+
+## Evidence
+
+Playwright MCP / a headless browser was not available in this environment, and
+this is a Deno repo (adding Node browser tooling would be a regression), so the
+behaviour is verified by automated tests that exercise the **real shipped
+helper** against a DOM mock, plus a recorded manual procedure in
+`docs/fixes/POPOVER_AUTO_DISMISS_FIX.md`.
+
+```mermaid
+flowchart TD
+    A[View change / re-render] --> B[updateDisplay]
+    B --> C[updateStockTable / updateBasicStockTable]
+    C --> D[clearAllPopovers: hide + dispose + sweep tips]
+    D --> E["tbody.innerHTML = '' rebuild rows"]
+    E --> F[Recreate popover instances]
+    F --> G["document.querySelectorAll('.popover').length === 0"]
+```
+
+Acceptance criteria mapped to tests in `tests/popover_cleanup_test.ts`:
+
+- Orphaned tip with no live trigger is swept → `.popover` count is `0`
+  (`clearAllPopovers sweeps an orphaned tip with no live trigger`).
+- Mixed open + orphan state leaves no `.popover`
+  (`clearAllPopovers leaves no .popover after a mixed open+orphan state`).
+- Live popovers are hidden **before** disposal
+  (`clearAllPopovers hides then disposes every live popover`).
+
+## Test Plan
+
+- Added `tests/popover_cleanup_test.ts` (7 tests) covering: hide-before-dispose
+  ordering, sweeping the orphaned-tip bug, the mixed open+orphan case,
+  no-instance triggers, invalid/missing document, and a missing Popover API.
+- `deno test --allow-read tests/*.ts` → 599 passed, 0 failed.
+- `tests/js_syntax_test.ts` confirms `docs/app.js` still parses cleanly after
+  the wiring change.
+- `tests/sw_precache_list_test.ts` passes with `popover_cleanup.js` added to
+  the service-worker precache list.

--- a/docs/archive/pr-summaries/pr-summary-371.md
+++ b/docs/archive/pr-summaries/pr-summary-371.md
@@ -1,0 +1,84 @@
+## Summary
+
+"Tap outside to close" was unreliable for the dashboard's mobile value
+popovers. `docs/app.js` carried **two** competing global `document` click
+handlers (one in `initializeEventListeners()`, one at module load) with
+overlapping logic. Both closed popovers by iterating the live **triggers**
+(`.clickable-value` / `[data-bs-toggle="popover"]`) and calling `hide()`
+**only if the trigger still had `aria-describedby`**. An **orphaned tip** — a
+`.popover` node left on `<body>` after a re-render disposed its trigger — has
+no live trigger, so neither handler could reach it and tapping outside did
+nothing.
+
+This PR consolidates the two handlers into a **single** global click handler
+backed by a new shared, tested module `docs/popover_dismiss.js`
+(`GRQPopover`). The new dismissal path hides **every** live Bootstrap instance
+(no longer gated on `aria-describedby`) **and** removes any leftover `.popover`
+nodes from the DOM, so orphaned tips are dismissed too. Tapping inside popover
+content still does nothing; tapping a trigger still closes the others and
+re-opens the tapped one.
+
+Closes #371.
+
+## Changes
+
+- **`docs/popover_dismiss.js`** (new) — pure, dependency-injected `GRQPopover`
+  helpers published on `globalThis`, mirroring `escape.js` / `color_key.js`:
+  - `decidePopoverAction({ insidePopover, hasTrigger })` → `"ignore"` /
+    `"closeAndReopen"` / `"closeOnly"`.
+  - `closeAllPopovers(doc, getInstance)` → hides every live instance and
+    removes orphaned `.popover` nodes; returns `{ hidden, removed }`.
+- **`docs/app.js`** — replaced handler #1 with the single consolidated handler
+  using `GRQPopover`; removed handler #2 (left a breadcrumb comment). Exactly
+  one global popover click handler now remains.
+- **`docs/index.html`** — loads `popover_dismiss.js` before `app.js`.
+- **`tests/popover_dismiss_test.ts`** (new) — exercises the real shipped logic.
+
+## Evidence
+
+This is a small front-end behaviour change in vanilla JS with no JS test
+harness for `docs/app.js` itself (noted in the issue). The dismissal decision
+and the orphan-removal logic were extracted into `docs/popover_dismiss.js` so
+the **real shipped code** is unit-tested rather than a copy. Playwright MCP was
+not available in this run, so no live screenshot was captured; the behaviour is
+pinned by the unit tests below and was reasoned through against the acceptance
+criteria.
+
+```mermaid
+flowchart TD
+    A[document click] --> B{inside .popover content?}
+    B -- yes --> I[ignore: keep open]
+    B -- no --> C[closeAllPopovers]
+    C --> D[hide every live instance<br/>not gated on aria-describedby]
+    C --> E[remove orphaned .popover nodes]
+    A --> F{tapped a trigger?}
+    F -- yes --> G[re-open tapped popover]
+    F -- no --> H[stay closed]
+```
+
+Acceptance criteria mapping:
+
+- *Open any popover, tap outside → it closes* — `closeOnly` path runs
+  `closeAllPopovers`, which hides every live instance.
+- *Orphaned tip still removed* — `closeAllPopovers` removes leftover `.popover`
+  nodes even with no live trigger (test: "removes orphaned tips that have no
+  live trigger").
+- *Tapping inside the popover does not close it* — `decidePopoverAction`
+  returns `"ignore"` (test: "tapping inside popover content is ignored").
+- *Exactly one global popover click handler remains* — handler #2 removed; a
+  single `document.addEventListener("click", …)` remains in `docs/app.js`.
+
+## Test Plan
+
+- `tests/popover_dismiss_test.ts` (new):
+  - publishes helpers on `globalThis`;
+  - `decidePopoverAction` for inside-popover / trigger / outside taps;
+  - `closeAllPopovers` hides every live instance regardless of
+    `aria-describedby`;
+  - `closeAllPopovers` removes orphaned tips with no live trigger (core #371
+    bug);
+  - hides live instances **and** removes orphans together;
+  - safe no-op when nothing is open; tolerates a trigger with no instance;
+  - the module parses cleanly via `checkJsSyntax`.
+- `tests/js_syntax_test.ts` continues to confirm `docs/app.js` parses cleanly.
+- Full Deno suite (`deno test --allow-read tests/*.ts`) passes.

--- a/docs/archive/pr-summaries/pr-summary-372.md
+++ b/docs/archive/pr-summaries/pr-summary-372.md
@@ -1,0 +1,66 @@
+# Toggle a value popover shut on a second tap (mobile)
+
+## Summary
+
+On mobile, tapping a `.clickable-value` opened its popover, but tapping the
+**same** value again re-opened it — there was no way to dismiss a popover by
+tapping its own trigger. The consolidated global click handler
+(`docs/app.js`) always re-showed the tapped trigger after closing all
+popovers.
+
+The fix makes the trigger tap **toggle**:
+
+- `docs/app.js` now captures whether the tapped trigger's popover is already
+  open **before** the close-all loop runs. Bootstrap sets `aria-describedby`
+  on a trigger while its popover is shown, so `trigger.hasAttribute(
+  "aria-describedby")` is a reliable "already open" signal.
+- `docs/popover_dismiss.js`'s `decidePopoverAction()` accepts a new
+  `triggerAlreadyOpen` flag. When a trigger is tapped and its popover was
+  already open it returns `"closeOnly"` (toggle shut); otherwise it returns
+  `"closeAndReopen"` as before. The flag defaults to `false`, so any existing
+  caller keeps the original behaviour.
+
+This applies to every `.clickable-value` popover, not only Portfolio Target.
+
+Closes #372.
+
+## Behaviour
+
+```mermaid
+flowchart TD
+    Tap[Tap a value] --> Open{Trigger's popover<br/>already open?}
+    Open -- "No (closed / different value)" --> Reopen[closeAndReopen:<br/>close others, show this one]
+    Open -- "Yes (same value)" --> CloseOnly[closeOnly:<br/>leave it shut · issue #372]
+    InsideTap[Tap inside popover content] --> Ignore[ignore: keep it open]
+    OutsideTap[Tap elsewhere] --> CloseAll[closeOnly: close everything]
+```
+
+## Evidence
+
+Playwright MCP was unavailable in this run, so no live screenshot could be
+captured. The change is driven entirely by the pure, dependency-injected
+`decidePopoverAction()` helper, which is exercised directly by unit tests:
+
+- Tapping the **same** already-open trigger → `closeOnly` (toggles shut).
+- Tapping a **different** (closed) trigger → `closeAndReopen` (unchanged).
+- Tapping inside popover content still wins (`ignore`), even over an open
+  trigger.
+- Tapping outside still closes everything (`closeOnly`).
+
+The `docs/app.js` wrapper is a thin shim that reads `aria-describedby` and
+forwards the flag, matching the manual acceptance criteria at ~375px:
+
+- Tap a value → opens; tap the same value again → closes.
+- Tap a different value → first closes, second opens.
+
+Full `./quality.sh` passes cleanly (Rust + 612 Deno tests).
+
+## Test Plan
+
+Added to `tests/popover_dismiss_test.ts` (existing tests unchanged):
+
+- `decidePopoverAction - tapping the SAME already-open trigger toggles it shut (issue #372)`
+- `decidePopoverAction - tapping a DIFFERENT (closed) trigger still closes others then reopens it (issue #372)`
+- `decidePopoverAction - tapping inside content wins even over an already-open trigger (issue #372)`
+
+All 13 tests in the file pass; the full Deno suite (612 tests) is green.

--- a/docs/fixes/POPOVER_AUTO_DISMISS_FIX.md
+++ b/docs/fixes/POPOVER_AUTO_DISMISS_FIX.md
@@ -1,0 +1,59 @@
+# Auto-dismiss value popovers on every re-render (issue #370)
+
+## Symptom
+
+On a ~375px mobile viewport, opening a value popover (e.g. tapping
+**Portfolio Target**) and then **selecting a single stock** left the popover
+stuck on screen with no way to close it. The same applied to other view
+changes (switching score file, basic ↔ market view, back-to-aggregate).
+
+## Root cause
+
+Every `.clickable-value` popover is created with `trigger: "manual"` and
+`container: "body"`, so the visible `.popover` tip is appended to `<body>`
+rather than next to its trigger. A re-render replaces the table with
+`tbody.innerHTML = ""`, destroying the trigger `<span>`. The orphaned tip
+already living on `<body>` survives, and the old dispose loop iterated only the
+*current* `.clickable-value` triggers — so it never disposed the now-orphaned
+instance and the tip stayed visible forever.
+
+## Fix
+
+A shared, pure helper `clearAllPopovers(document, bootstrap.Popover)` in
+`docs/popover_cleanup.js` (published as `globalThis.GRQPopovers`):
+
+1. Hides **then** disposes every live popover instance attached to a trigger.
+2. Sweeps any stray `.popover` tips off the document
+   (`querySelectorAll('.popover').forEach((n) => n.remove())`) — the orphaned
+   tip has no live trigger, so disposing by trigger alone cannot remove it.
+
+It is invoked at the start of both `updateStockTable()` and
+`updateBasicStockTable()` (before `tbody.innerHTML = ""`), and it replaces the
+previous trigger-only dispose loop in `updateStockTable()`. Because every
+view change / re-render routes through `updateDisplay()` → one of those two
+table methods, all of them now start from a clean popover state.
+
+```mermaid
+flowchart TD
+    A[View change / re-render] --> B[updateDisplay]
+    B --> C[updateStockTable / updateBasicStockTable]
+    C --> D[clearAllPopovers: hide + dispose + sweep tips]
+    D --> E[tbody.innerHTML = ''  rebuild rows]
+    E --> F[Recreate popover instances]
+    F --> G[document.querySelectorAll('.popover').length === 0]
+```
+
+## Verification
+
+Automated: `tests/popover_cleanup_test.ts` imports the real shipped helper and
+asserts the orphaned-tip case is swept, live instances are hidden before
+disposal, and `document.querySelectorAll('.popover').length === 0` after a
+mixed open+orphan state.
+
+Manual (at ~375px, Bootstrap `Mobile: true`, `Width: 375px`):
+
+1. Open any value popover (Portfolio Target, Stars, Target, Gain/Loss, …).
+2. Select a single stock → the popover is gone (no orphaned tip on `<body>`).
+3. Repeat for switching score files, basic ↔ market view and
+   back-to-aggregate → no popover survives any of these.
+4. In devtools, `document.querySelectorAll('.popover').length === 0`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.201">
+    <meta name="app-version" content="1.0.202">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -329,6 +329,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.201"></script>
+    <script src="sw-register.js?v=1.0.202"></script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -316,6 +316,9 @@
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
     <script src="stock_selection.js"></script>
 
+    <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
+    <script src="popover_dismiss.js"></script>
+
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
     <script src="dashboard_boot.js"></script>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -319,6 +319,11 @@
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
     <script src="popover_dismiss.js"></script>
 
+    <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
+         which calls globalThis.GRQPopovers.clearAllPopovers() on every
+         re-render. Without this the dashboard throws and never renders. -->
+    <script src="popover_cleanup.js"></script>
+
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
     <script src="dashboard_boot.js"></script>
 

--- a/docs/popover_cleanup.js
+++ b/docs/popover_cleanup.js
@@ -1,0 +1,75 @@
+// Shared popover-cleanup helper for the dashboard (issue #370).
+//
+// Every `.clickable-value` cell is a Bootstrap popover created with
+// `trigger: "manual"` and `container: "body"`, so the visible `.popover` tip
+// is appended to `<body>` rather than next to its trigger. When the dashboard
+// re-renders a table it replaces the rows with `tbody.innerHTML = ""`, which
+// destroys the trigger `<span>` but leaves any open tip orphaned on `<body>`
+// — there is no live trigger left to dispose it, so the tip stays on screen
+// forever (the "stuck after selecting a stock" bug on mobile).
+//
+// `clearAllPopovers` makes every re-render / view change start from a clean
+// popover state: it hides and disposes every live popover instance, then
+// sweeps any stray `.popover` tips left behind on the document. Disposing by
+// trigger alone is insufficient because an orphaned tip has no live trigger,
+// so the sweep is what actually removes it.
+//
+// Like the other docs/*.js modules this file is loaded as a classic <script>
+// in docs/index.html and imported by the Deno tests. It uses no module syntax
+// and is pure (the document and Bootstrap Popover API are injected), so it
+// runs in both the browser and the test harness, and publishes its helper on
+// `globalThis`.
+
+// Iterate any array-like (NodeList in the browser, Array in tests) safely.
+function forEachNode(nodes, fn) {
+    if (!nodes) return;
+    Array.prototype.forEach.call(nodes, fn);
+}
+
+// Hide + dispose every live popover instance and sweep orphaned tips.
+//
+// - `doc` is a document-like object exposing `querySelectorAll`.
+// - `PopoverApi` is the Bootstrap Popover constructor (with `getInstance`).
+//
+// Returns `{ disposed, swept }` counts so the behaviour is observable in tests.
+function clearAllPopovers(doc, PopoverApi) {
+    if (!doc || typeof doc.querySelectorAll !== "function") {
+        return { disposed: 0, swept: 0 };
+    }
+
+    const getInstance =
+        PopoverApi && typeof PopoverApi.getInstance === "function"
+            ? (el) => PopoverApi.getInstance(el)
+            : () => null;
+
+    // 1. Hide then dispose every popover still attached to a live trigger.
+    let disposed = 0;
+    forEachNode(
+        doc.querySelectorAll('[data-bs-toggle="popover"]'),
+        (el) => {
+            const instance = getInstance(el);
+            if (!instance) return;
+            if (typeof instance.hide === "function") instance.hide();
+            if (typeof instance.dispose === "function") instance.dispose();
+            disposed++;
+        },
+    );
+
+    // 2. Sweep any orphaned tips left on the document (the open-popover case
+    //    whose trigger was just destroyed by an innerHTML replacement).
+    let swept = 0;
+    forEachNode(doc.querySelectorAll(".popover"), (node) => {
+        if (typeof node.remove === "function") {
+            node.remove();
+            swept++;
+        }
+    });
+
+    return { disposed, swept };
+}
+
+// Publish on globalThis so the browser dashboard (classic script) and the Deno
+// test importer can both reach the helper.
+globalThis.GRQPopovers = {
+    clearAllPopovers,
+};

--- a/docs/popover_dismiss.js
+++ b/docs/popover_dismiss.js
@@ -27,16 +27,23 @@ const POPOVER_TRIGGER_SELECTOR = '.clickable-value, [data-bs-toggle="popover"]';
 const POPOVER_TIP_SELECTOR = ".popover";
 
 // Decide what a click should do, given whether it landed inside an open
-// popover's content and whether it landed on a popover trigger.
-//   - inside popover content -> "ignore" (must NOT close; criterion 3)
-//   - on a trigger           -> "closeAndReopen" (close others, show this one)
-//   - anywhere else outside   -> "closeOnly" (close every popover)
-function decidePopoverAction({ insidePopover, hasTrigger }) {
+// popover's content, whether it landed on a popover trigger, and whether that
+// trigger's own popover was already open (captured BEFORE closing everything).
+//   - inside popover content      -> "ignore" (must NOT close; criterion 3)
+//   - on an already-open trigger  -> "closeOnly" (toggle it shut; issue #372)
+//   - on a different/closed trigger -> "closeAndReopen" (close others, show it)
+//   - anywhere else outside        -> "closeOnly" (close every popover)
+//
+// `triggerAlreadyOpen` defaults to false so existing callers that only pass
+// { insidePopover, hasTrigger } keep the original close-and-reopen behaviour.
+function decidePopoverAction({ insidePopover, hasTrigger, triggerAlreadyOpen }) {
     if (insidePopover) {
         return "ignore";
     }
     if (hasTrigger) {
-        return "closeAndReopen";
+        // Tapping the same value again closes its popover rather than
+        // re-opening it (issue #372).
+        return triggerAlreadyOpen ? "closeOnly" : "closeAndReopen";
     }
     return "closeOnly";
 }

--- a/docs/popover_dismiss.js
+++ b/docs/popover_dismiss.js
@@ -1,0 +1,86 @@
+// Consolidated dismissal logic for the dashboard's value popovers (issue #371,
+// part of the mobile info-popover milestone #335).
+//
+// Previously docs/app.js carried TWO competing global `document` click handlers
+// with overlapping logic. Both closed popovers by iterating the live triggers
+// (.clickable-value / [data-bs-toggle="popover"]) and calling hide() only when
+// the trigger still had `aria-describedby`. An ORPHANED tip — a `.popover` node
+// left on <body> after a re-render disposed its trigger — has no live trigger,
+// so neither handler could reach it and "tap outside to close" silently failed.
+//
+// This module holds the single source of truth for that behaviour:
+//   - decidePopoverAction() decides what an outside/inside tap should do; and
+//   - closeAllPopovers() hides every live instance AND removes any leftover
+//     `.popover` nodes, so orphaned tips are dismissed too.
+//
+// It mirrors docs/escape.js, docs/projection.js and docs/color_key.js: loaded
+// as a classic <script> in docs/index.html (no module syntax), publishing its
+// helpers on `globalThis` so both the browser dashboard (via `GRQValidator`)
+// and the Deno tests exercise the exact same code.
+
+// CSS selector for every popover trigger. Both clauses describe the same value
+// cells, but we keep the explicit pair so a future trigger that drops the
+// `.clickable-value` class is still matched on its `data-bs-toggle`.
+const POPOVER_TRIGGER_SELECTOR = '.clickable-value, [data-bs-toggle="popover"]';
+
+// CSS selector for a rendered Bootstrap popover tip in the DOM.
+const POPOVER_TIP_SELECTOR = ".popover";
+
+// Decide what a click should do, given whether it landed inside an open
+// popover's content and whether it landed on a popover trigger.
+//   - inside popover content -> "ignore" (must NOT close; criterion 3)
+//   - on a trigger           -> "closeAndReopen" (close others, show this one)
+//   - anywhere else outside   -> "closeOnly" (close every popover)
+function decidePopoverAction({ insidePopover, hasTrigger }) {
+    if (insidePopover) {
+        return "ignore";
+    }
+    if (hasTrigger) {
+        return "closeAndReopen";
+    }
+    return "closeOnly";
+}
+
+// Close every value popover, reliably.
+//
+// First hides every live Bootstrap instance found on a trigger — NOT gated on
+// `aria-describedby`, so a stale instance is still told to hide. Then removes
+// any `.popover` node still attached to the document: these are orphaned tips
+// whose trigger was disposed by a re-render, which `hide()` can never reach.
+//
+// Dependency-injected for testability:
+//   doc         - a document-like object exposing querySelectorAll(selector);
+//   getInstance - (element) => Bootstrap popover instance | null.
+// Returns { hidden, removed } counts so callers (and tests) can assert on the
+// work done.
+function closeAllPopovers(doc, getInstance) {
+    let hidden = 0;
+    let removed = 0;
+
+    const triggers = doc.querySelectorAll(POPOVER_TRIGGER_SELECTOR);
+    triggers.forEach((element) => {
+        const instance = getInstance(element);
+        if (instance && typeof instance.hide === "function") {
+            instance.hide();
+            hidden += 1;
+        }
+    });
+
+    // Anything still in the DOM after hiding live instances is an orphan.
+    const tips = doc.querySelectorAll(POPOVER_TIP_SELECTOR);
+    tips.forEach((node) => {
+        if (node && typeof node.remove === "function") {
+            node.remove();
+            removed += 1;
+        }
+    });
+
+    return { hidden, removed };
+}
+
+globalThis.GRQPopover = {
+    POPOVER_TRIGGER_SELECTOR,
+    POPOVER_TIP_SELECTOR,
+    decidePopoverAction,
+    closeAllPopovers,
+};

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.201")
+    navigator.serviceWorker.register("./sw.js?v=1.0.202")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -26,6 +26,7 @@ const STATIC_ASSETS = [
   "./format.js",
   "./market_index.js",
   "./escape.js",
+  "./popover_cleanup.js",
   "./version.js",
   "./theme.js",
   "./dashboard_boot.js",

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.201";
+const APP_VERSION = "1.0.202";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/tests/popover_cleanup_test.ts
+++ b/tests/popover_cleanup_test.ts
@@ -1,0 +1,165 @@
+// Tests for the shared popover-cleanup helper (issue #370).
+//
+// On a ~375px mobile viewport, opening a value popover and then re-rendering
+// the dashboard (selecting a single stock, switching score file, basic ↔
+// market view, or back-to-aggregate) used to leave the popover tip orphaned on
+// `<body>` with no way to close it. `clearAllPopovers` must hide+dispose every
+// live popover instance AND sweep any stray `.popover` tips, so that
+// `document.querySelectorAll('.popover').length === 0` after a re-render.
+//
+// These import the REAL shipped helper from docs/popover_cleanup.js and assert
+// on its observable behaviour against a minimal DOM mock — no browser needed.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/popover_cleanup.js";
+
+const g = globalThis as unknown as {
+  GRQPopovers: {
+    clearAllPopovers: (
+      doc: unknown,
+      popoverApi: unknown,
+    ) => { disposed: number; swept: number };
+  };
+};
+const { clearAllPopovers } = g.GRQPopovers;
+
+// --- Minimal DOM mock -------------------------------------------------------
+
+interface FakeInstance {
+  hidden: boolean;
+  disposed: boolean;
+  hide: () => void;
+  dispose: () => void;
+}
+
+class FakeNode {
+  removed = false;
+  constructor(public className: string) {}
+  remove() {
+    this.removed = true;
+  }
+}
+
+class FakeTrigger {
+  constructor(public instance: FakeInstance | null) {}
+}
+
+// A document-like object whose querySelectorAll dispatches on the two selectors
+// the helper uses: the popover triggers and the `.popover` tips.
+class FakeDoc {
+  constructor(
+    public triggers: FakeTrigger[],
+    public tips: FakeNode[],
+  ) {}
+  querySelectorAll(selector: string): unknown[] {
+    if (selector === '[data-bs-toggle="popover"]') return this.triggers;
+    if (selector === ".popover") return this.tips.filter((n) => !n.removed);
+    return [];
+  }
+}
+
+// A fake Bootstrap Popover API: getInstance returns the instance stored on the
+// trigger (mirroring bootstrap.Popover.getInstance(element)).
+function makePopoverApi() {
+  return {
+    getInstance(el: unknown): FakeInstance | null {
+      return (el as FakeTrigger).instance;
+    },
+  };
+}
+
+function makeInstance(): FakeInstance {
+  const inst: FakeInstance = {
+    hidden: false,
+    disposed: false,
+    hide() {
+      inst.hidden = true;
+    },
+    dispose() {
+      inst.disposed = true;
+    },
+  };
+  return inst;
+}
+
+// --- Tests ------------------------------------------------------------------
+
+Deno.test("clearAllPopovers publishes on globalThis", () => {
+  assertEquals(typeof clearAllPopovers, "function");
+});
+
+Deno.test("clearAllPopovers hides then disposes every live popover", () => {
+  const a = makeInstance();
+  const b = makeInstance();
+  const doc = new FakeDoc(
+    [new FakeTrigger(a), new FakeTrigger(b)],
+    [],
+  );
+  const result = clearAllPopovers(doc, makePopoverApi());
+
+  assert(a.hidden, "first popover should be hidden before disposal");
+  assert(a.disposed, "first popover should be disposed");
+  assert(b.hidden, "second popover should be hidden before disposal");
+  assert(b.disposed, "second popover should be disposed");
+  assertEquals(result.disposed, 2);
+});
+
+Deno.test("clearAllPopovers sweeps an orphaned tip with no live trigger (the stuck-popover bug)", () => {
+  // The reported symptom: the trigger was destroyed by innerHTML="" but the
+  // open tip survives on <body>. There is NO live trigger, so disposing by
+  // trigger alone cannot remove it — only the sweep can.
+  const orphanTip = new FakeNode("popover");
+  const doc = new FakeDoc([], [orphanTip]);
+
+  const result = clearAllPopovers(doc, makePopoverApi());
+
+  assert(orphanTip.removed, "orphaned tip must be removed from the document");
+  assertEquals(result.swept, 1);
+  // Acceptance criterion: no .popover survives.
+  assertEquals(doc.querySelectorAll(".popover").length, 0);
+});
+
+Deno.test("clearAllPopovers leaves no .popover after a mixed open+orphan state", () => {
+  // One open popover (live trigger + tip) plus a leftover orphaned tip.
+  const open = makeInstance();
+  const openTip = new FakeNode("popover");
+  const orphanTip = new FakeNode("popover");
+  const doc = new FakeDoc(
+    [new FakeTrigger(open)],
+    [openTip, orphanTip],
+  );
+
+  const result = clearAllPopovers(doc, makePopoverApi());
+
+  assert(open.disposed, "the live popover should be disposed");
+  assertEquals(result.disposed, 1);
+  assertEquals(result.swept, 2);
+  assertEquals(doc.querySelectorAll(".popover").length, 0);
+});
+
+Deno.test("clearAllPopovers ignores triggers with no popover instance", () => {
+  const doc = new FakeDoc([new FakeTrigger(null)], []);
+  const result = clearAllPopovers(doc, makePopoverApi());
+  assertEquals(result.disposed, 0);
+  assertEquals(result.swept, 0);
+});
+
+Deno.test("clearAllPopovers is a no-op for a missing/invalid document", () => {
+  assertEquals(clearAllPopovers(null, makePopoverApi()), {
+    disposed: 0,
+    swept: 0,
+  });
+  assertEquals(clearAllPopovers({}, makePopoverApi()), {
+    disposed: 0,
+    swept: 0,
+  });
+});
+
+Deno.test("clearAllPopovers tolerates a missing Popover API", () => {
+  // If bootstrap is unavailable, the helper must still sweep stray tips.
+  const orphanTip = new FakeNode("popover");
+  const doc = new FakeDoc([new FakeTrigger(makeInstance())], [orphanTip]);
+  const result = clearAllPopovers(doc, undefined);
+  assertEquals(result.disposed, 0);
+  assertEquals(result.swept, 1);
+  assert(orphanTip.removed);
+});

--- a/tests/popover_dismiss_test.ts
+++ b/tests/popover_dismiss_test.ts
@@ -28,7 +28,11 @@ const g = globalThis as unknown as {
     POPOVER_TRIGGER_SELECTOR: string;
     POPOVER_TIP_SELECTOR: string;
     decidePopoverAction: (
-      ctx: { insidePopover: boolean; hasTrigger: boolean },
+      ctx: {
+        insidePopover: boolean;
+        hasTrigger: boolean;
+        triggerAlreadyOpen?: boolean;
+      },
     ) => string;
     closeAllPopovers: (
       doc: { querySelectorAll: (sel: string) => unknown[] },
@@ -90,6 +94,41 @@ Deno.test("decidePopoverAction - tapping a trigger closes others then reopens it
   assertEquals(
     GRQPopover.decidePopoverAction({ insidePopover: false, hasTrigger: true }),
     "closeAndReopen",
+  );
+});
+
+Deno.test("decidePopoverAction - tapping the SAME already-open trigger toggles it shut (issue #372)", () => {
+  // Second tap on the value whose popover is currently shown: close only, do
+  // not re-open it.
+  assertEquals(
+    GRQPopover.decidePopoverAction({
+      insidePopover: false,
+      hasTrigger: true,
+      triggerAlreadyOpen: true,
+    }),
+    "closeOnly",
+  );
+});
+
+Deno.test("decidePopoverAction - tapping a DIFFERENT (closed) trigger still closes others then reopens it (issue #372)", () => {
+  assertEquals(
+    GRQPopover.decidePopoverAction({
+      insidePopover: false,
+      hasTrigger: true,
+      triggerAlreadyOpen: false,
+    }),
+    "closeAndReopen",
+  );
+});
+
+Deno.test("decidePopoverAction - tapping inside content wins even over an already-open trigger (issue #372)", () => {
+  assertEquals(
+    GRQPopover.decidePopoverAction({
+      insidePopover: true,
+      hasTrigger: true,
+      triggerAlreadyOpen: true,
+    }),
+    "ignore",
   );
 });
 

--- a/tests/popover_dismiss_test.ts
+++ b/tests/popover_dismiss_test.ts
@@ -1,0 +1,167 @@
+// Tests for the consolidated popover dismissal logic (issue #371, part of the
+// mobile info-popover milestone #335).
+//
+// docs/popover_dismiss.js holds the single source of truth for "tap outside to
+// close". The browser handler in docs/app.js is a thin wrapper around these
+// helpers, so these tests exercise the REAL shipped decision logic:
+//   - decidePopoverAction(): inside-popover taps are ignored; trigger taps
+//     close-and-reopen; outside taps close only;
+//   - closeAllPopovers(): hides EVERY live instance (not gated on
+//     aria-describedby) and removes ORPHANED .popover nodes that have no live
+//     trigger — the core bug from #371.
+import { assert, assertEquals } from "@std/assert";
+import { checkJsSyntax } from "../helpers/js_syntax.ts";
+import "../docs/popover_dismiss.js";
+
+interface Instance {
+  hidden: boolean;
+  hide(): void;
+}
+
+interface Tip {
+  removed: boolean;
+  remove(): void;
+}
+
+const g = globalThis as unknown as {
+  GRQPopover: {
+    POPOVER_TRIGGER_SELECTOR: string;
+    POPOVER_TIP_SELECTOR: string;
+    decidePopoverAction: (
+      ctx: { insidePopover: boolean; hasTrigger: boolean },
+    ) => string;
+    closeAllPopovers: (
+      doc: { querySelectorAll: (sel: string) => unknown[] },
+      getInstance: (el: unknown) => Instance | null,
+    ) => { hidden: number; removed: number };
+  };
+};
+const GRQPopover = g.GRQPopover;
+
+/** Build a document-like stub returning the given triggers and tips by selector. */
+function fakeDoc(triggers: unknown[], tips: Tip[]) {
+  return {
+    querySelectorAll(sel: string): unknown[] {
+      if (sel === GRQPopover.POPOVER_TIP_SELECTOR) return tips;
+      if (sel === GRQPopover.POPOVER_TRIGGER_SELECTOR) return triggers;
+      return [];
+    },
+  };
+}
+
+function makeInstance(): Instance {
+  return {
+    hidden: false,
+    hide() {
+      this.hidden = true;
+    },
+  };
+}
+
+function makeTip(): Tip {
+  return {
+    removed: false,
+    remove() {
+      this.removed = true;
+    },
+  };
+}
+
+Deno.test("popover_dismiss.js publishes its helpers on globalThis", () => {
+  assertEquals(typeof GRQPopover.decidePopoverAction, "function");
+  assertEquals(typeof GRQPopover.closeAllPopovers, "function");
+  assertEquals(typeof GRQPopover.POPOVER_TRIGGER_SELECTOR, "string");
+  assertEquals(typeof GRQPopover.POPOVER_TIP_SELECTOR, "string");
+});
+
+Deno.test("decidePopoverAction - tapping inside popover content is ignored (criterion 3)", () => {
+  assertEquals(
+    GRQPopover.decidePopoverAction({ insidePopover: true, hasTrigger: false }),
+    "ignore",
+  );
+  // Inside-popover wins even if the target also matches a trigger selector.
+  assertEquals(
+    GRQPopover.decidePopoverAction({ insidePopover: true, hasTrigger: true }),
+    "ignore",
+  );
+});
+
+Deno.test("decidePopoverAction - tapping a trigger closes others then reopens it", () => {
+  assertEquals(
+    GRQPopover.decidePopoverAction({ insidePopover: false, hasTrigger: true }),
+    "closeAndReopen",
+  );
+});
+
+Deno.test("decidePopoverAction - tapping anywhere else closes all popovers", () => {
+  assertEquals(
+    GRQPopover.decidePopoverAction({ insidePopover: false, hasTrigger: false }),
+    "closeOnly",
+  );
+});
+
+Deno.test("closeAllPopovers - hides every live instance regardless of aria-describedby", () => {
+  const a = {};
+  const b = {};
+  const instances = new Map<unknown, Instance>([
+    [a, makeInstance()],
+    [b, makeInstance()],
+  ]);
+  const doc = fakeDoc([a, b], []);
+
+  const result = GRQPopover.closeAllPopovers(
+    doc,
+    (el) => instances.get(el) ?? null,
+  );
+
+  assertEquals(result.hidden, 2);
+  assert(instances.get(a)!.hidden, "first instance was hidden");
+  assert(instances.get(b)!.hidden, "second instance was hidden");
+});
+
+Deno.test("closeAllPopovers - removes orphaned tips that have no live trigger (core #371 bug)", () => {
+  // No triggers at all — only a stray .popover left on <body> by a re-render.
+  const orphan = makeTip();
+  const doc = fakeDoc([], [orphan]);
+
+  const result = GRQPopover.closeAllPopovers(doc, () => null);
+
+  assertEquals(result.hidden, 0);
+  assertEquals(result.removed, 1);
+  assert(orphan.removed, "orphaned tip was removed from the DOM");
+});
+
+Deno.test("closeAllPopovers - hides live instances AND removes leftover orphans together", () => {
+  const trigger = {};
+  const live = makeInstance();
+  const orphan = makeTip();
+  const doc = fakeDoc([trigger], [orphan]);
+
+  const result = GRQPopover.closeAllPopovers(
+    doc,
+    (el) => (el === trigger ? live : null),
+  );
+
+  assertEquals(result.hidden, 1);
+  assertEquals(result.removed, 1);
+  assert(live.hidden, "live instance was hidden");
+  assert(orphan.removed, "leftover orphan was removed");
+});
+
+Deno.test("closeAllPopovers - no popovers present is a safe no-op", () => {
+  const result = GRQPopover.closeAllPopovers(fakeDoc([], []), () => null);
+  assertEquals(result, { hidden: 0, removed: 0 });
+});
+
+Deno.test("closeAllPopovers - tolerates a trigger with no instance", () => {
+  const result = GRQPopover.closeAllPopovers(fakeDoc([{}], []), () => null);
+  assertEquals(result, { hidden: 0, removed: 0 });
+});
+
+Deno.test("popover_dismiss.js parses cleanly as JavaScript", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../docs/popover_dismiss.js", import.meta.url),
+  );
+  const result = checkJsSyntax(source);
+  assertEquals(result.valid, true, result.error);
+});

--- a/tests/popover_scripts_loaded_test.ts
+++ b/tests/popover_scripts_loaded_test.ts
@@ -1,0 +1,43 @@
+// Regression test for PR #389 / pa11y CI failure.
+//
+// docs/app.js calls both globalThis.GRQPopover.* (popover_dismiss.js) and
+// globalThis.GRQPopovers.* (popover_cleanup.js) on every dashboard re-render.
+// popover_cleanup.js was added to the service-worker precache list but NOT to
+// index.html, so the browser left globalThis.GRQPopovers undefined,
+// updateStockTable() threw, and #stockDetailCard never rendered — pa11y timed
+// out waiting for it (exit code 2).
+//
+// These tests assert that each popover helper script app.js depends on is
+// loaded by index.html, before the app.js bootstrap, so a missing <script>
+// tag is caught here instead of in CI.
+
+import { assert } from "@std/assert";
+
+const html = await Deno.readTextFile("docs/index.html");
+const appJs = await Deno.readTextFile("docs/app.js");
+
+// Map the globalThis namespace app.js consumes to the file that publishes it.
+const MODULES: Array<{ global: string; src: string }> = [
+  { global: "GRQPopover.", src: "popover_dismiss.js" },
+  { global: "GRQPopovers.", src: "popover_cleanup.js" },
+];
+
+for (const { global, src } of MODULES) {
+  Deno.test(`index.html loads ${src} that app.js depends on (${global})`, () => {
+    // Only require the script tag when app.js actually uses the global.
+    if (!appJs.includes(global)) return;
+
+    const scriptIndex = html.indexOf(`src="${src}"`);
+    assert(
+      scriptIndex !== -1,
+      `docs/index.html must load ${src}; app.js uses globalThis.${global}`,
+    );
+
+    const bootIndex = html.indexOf('src="dashboard_boot.js"');
+    assert(bootIndex !== -1, "dashboard_boot.js script tag must be present");
+    assert(
+      scriptIndex < bootIndex,
+      `${src} must be loaded before dashboard_boot.js (app.js)`,
+    );
+  });
+}


### PR DESCRIPTION
## Milestone: #335 bug: mobile info popover can't be dismissed after selecting a stock

This PR merges the completed milestone branch into main.
Closes #392

### Issues addressed
- #372: bug: tapping the same value again should toggle its popover shut (mobile)
- #371: bug: tapping outside must reliably close mobile value popovers (incl. orphaned tips); consolidate the two global handlers
- #370: bug: auto-dismiss/sweep all value popovers on every dashboard re-render and view change

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to main.