### PR TITLE
Centralise chart actual-performance + dividend maths onto shared calculatePerformanceReturn() (Issue #424)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -2357,10 +2357,6 @@ class GRQValidator {
                                 dataPoint.date,
                             );
 
-                        // Calculate price return
-                        const priceReturn =
-                            ((currentPrice - buyPrice) / buyPrice) * 100;
-
                         // Add dividend return up to this date (but only count dividends within 90 days)
                         const dividends = this.getDividendsWithin90Days(
                             stock.stock,
@@ -2372,14 +2368,23 @@ class GRQValidator {
                             (sum, div) => sum + div.amount,
                             0,
                         );
-                        const dividendReturn = (totalDividends / buyPrice) *
-                            100;
 
-                        // Total return including dividends
-                        const totalReturn = priceReturn + dividendReturn;
+                        // Total return (price + dividends) via the shared
+                        // projection kernel (issue #424) so the chart, the
+                        // summary and the portfolio mean can never disagree.
+                        // Honour the helper's null guard (buyPrice <= 0) the
+                        // same way the summary path does.
+                        const totalReturn = GRQProjection
+                            .calculatePerformanceReturn(
+                                buyPrice,
+                                currentPrice,
+                                totalDividends,
+                            );
 
-                        totalPerformance += totalReturn;
-                        validStocks++;
+                        if (totalReturn !== null) {
+                            totalPerformance += totalReturn;
+                            validStocks++;
+                        }
                     } else if (timestamp === scoreDate.getTime()) {
                         // For the score date, performance is 0%
                         validStocks++;

--- a/docs/archive/pr-summaries/pr-summary-424.md
+++ b/docs/archive/pr-summaries/pr-summary-424.md
@@ -1,0 +1,61 @@
+## Summary
+
+Centralised the "Performance Over Time" chart's actual-performance + dividend
+maths onto the shared `GRQProjection.calculatePerformanceReturn()` kernel. The
+chart time-series loop in `docs/app.js` previously **inlined** the identical
+price-return / dividend-return / total-return formula already implemented by the
+shared helper that the per-stock summary and the equal-weight portfolio mean
+(`calculateIncludedPortfolioPerformance`) use. Two copies of the same formula can
+drift, so the chart now delegates to the single shared implementation — the
+chart, the summary and the per-stock views can never disagree. This is a
+behaviour-preserving refactor (the numbers are unchanged); it pins the
+behaviour to one source of truth. Closes #424.
+
+Item (1) of #420. Frontend-only, in `docs/` (Deno repo — no Node tooling).
+
+### Change
+- `docs/app.js` (chart loop, ~line 2360): removed the inlined
+  `priceReturn` / `dividendReturn` / `totalReturn` block and replaced it with
+  `GRQProjection.calculatePerformanceReturn(buyPrice, currentPrice, totalDividends)`.
+  The helper's `null` guard (`buyPrice <= 0`) is honoured the same way the
+  summary path does — a stock returning `null` is dropped from the equal-weight
+  average rather than counted as 0%. The existing equal-weight averaging
+  (`totalPerformance / validStocks`) and the 90-day dividend filtering are
+  unchanged.
+
+```mermaid
+flowchart LR
+    Chart["Chart time-series loop<br/>(docs/app.js)"] --> K
+    Summary["Per-stock summary"] --> K
+    Portfolio["Equal-weight portfolio mean<br/>calculateIncludedPortfolioPerformance"] --> K
+    K["calculatePerformanceReturn()<br/>(docs/projection.js — single source of truth)"]
+```
+
+## Evidence
+
+Backend/maths refactor with no visual change (a refactor that preserves the
+chart numbers). Verified by the Deno test suite anchored on the issue's
+**ABC/XYZ** worked example:
+
+- ABC: buy $1, current $1, dividends $0.01 → dividend return **1.0%**.
+- XYZ: buy $20, current $20, dividends $0.05 → dividend return **0.25%**.
+- ABC's dividend return is **4×** XYZ's for an equal-dollar buy.
+- Equal-weighted portfolio dividend return = (1.0% + 0.25%) / 2 = **0.625%**, and
+  the chart point equals `calculateIncludedPortfolioPerformance` for the same
+  inputs — any future divergence between the chart loop and the shared kernel
+  fails the suite.
+
+`./quality.sh` (deno lint + deno test + Rust suite) passes cleanly.
+
+## Test Plan
+
+- Extended `tests/chart_data_test.ts` with `Chart actual-performance maths
+  (issue #424)`, which:
+  - asserts ABC = 1.0% and XYZ = 0.25% via the shared kernel,
+  - asserts ABC is 4× XYZ,
+  - models the chart's per-point equal-weight portfolio loop and asserts it
+    equals both 0.625% and `calculateIncludedPortfolioPerformance` for the same
+    inputs (call-equivalence guard),
+  - asserts the chart point honours the `null` guard (a zero-buy stock is
+    excluded from the mean, not counted as 0%).
+- `deno test tests/chart_data_test.ts` and full `./quality.sh` pass.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.207">
+    <meta name="app-version" content="1.0.208">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -329,6 +329,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.207"></script>
+    <script src="sw-register.js?v=1.0.208"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.207")
+    navigator.serviceWorker.register("./sw.js?v=1.0.208")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.207";
+const APP_VERSION = "1.0.208";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/tests/chart_data_test.ts
+++ b/tests/chart_data_test.ts
@@ -56,6 +56,11 @@ const g = globalThis as unknown as {
       buyPrice: number | null,
       adjustedTarget: number | null,
     ) => number | null;
+    calculateIncludedPortfolioPerformance: (
+      stocks: Array<
+        { buyPrice: number; currentPrice: number; totalDividends?: number }
+      >,
+    ) => number | null;
   };
 };
 const GRQProjection = g.GRQProjection;
@@ -271,4 +276,104 @@ Deno.test("Market Index Data Clearing", async (t) => {
       assertEquals(actual.length, expected.length, "Only portfolio data shown");
     },
   );
+});
+
+// Issue #424: the "Performance Over Time" chart time-series loop must compute
+// each stock's actual total return (price + dividends) via the SAME shared
+// kernel the summary and portfolio mean use — GRQProjection
+// .calculatePerformanceReturn — so the chart, the summary and the per-stock
+// views can never disagree. This models the per-point portfolio loop from
+// docs/app.js (the equal-weight average over priceable stocks) and pins it to
+// the shared functions using the issue's ABC/XYZ worked example.
+
+interface ChartStock {
+  buyPrice: number;
+  currentPrice: number;
+  totalDividends: number;
+}
+
+// Mirror of the chart's per-point portfolio computation in docs/app.js: for
+// each included stock, delegate to the shared kernel, honour its null guard
+// (buyPrice <= 0), then equal-weight the included total returns.
+function chartPortfolioReturnAtPoint(stocks: ChartStock[]): number | null {
+  let totalPerformance = 0;
+  let validStocks = 0;
+  for (const stock of stocks) {
+    const totalReturn = GRQProjection.calculatePerformanceReturn(
+      stock.buyPrice,
+      stock.currentPrice,
+      stock.totalDividends,
+    );
+    if (totalReturn !== null) {
+      totalPerformance += totalReturn;
+      validStocks++;
+    }
+  }
+  return validStocks > 0 ? totalPerformance / validStocks : null;
+}
+
+Deno.test("Chart actual-performance maths (issue #424)", async (t) => {
+  // ABC: $1 buy, $1 current, $0.01 dividends -> 1.0% dividend return.
+  const abc: ChartStock = {
+    buyPrice: 1,
+    currentPrice: 1,
+    totalDividends: 0.01,
+  };
+  // XYZ: $20 buy, $20 current, $0.05 dividends -> 0.25% dividend return.
+  const xyz: ChartStock = {
+    buyPrice: 20,
+    currentPrice: 20,
+    totalDividends: 0.05,
+  };
+
+  await t.step("ABC dividend return is 1.0% via the shared kernel", () => {
+    const abcReturn = GRQProjection.calculatePerformanceReturn(
+      abc.buyPrice,
+      abc.currentPrice,
+      abc.totalDividends,
+    );
+    assertEquals(abcReturn, 1.0);
+  });
+
+  await t.step("XYZ dividend return is 0.25% via the shared kernel", () => {
+    const xyzReturn = GRQProjection.calculatePerformanceReturn(
+      xyz.buyPrice,
+      xyz.currentPrice,
+      xyz.totalDividends,
+    );
+    assertEquals(xyzReturn, 0.25);
+  });
+
+  await t.step("ABC dividend return is 4x XYZ for an equal-dollar buy", () => {
+    const abcReturn = GRQProjection.calculatePerformanceReturn(1, 1, 0.01)!;
+    const xyzReturn = GRQProjection.calculatePerformanceReturn(20, 20, 0.05)!;
+    assertEquals(abcReturn / xyzReturn, 4);
+  });
+
+  await t.step(
+    "chart point equals the equal-weight portfolio mean (0.625%)",
+    () => {
+      const chartPoint = chartPortfolioReturnAtPoint([abc, xyz]);
+      assertEquals(chartPoint, 0.625);
+      // The chart loop must agree with the shared portfolio kernel for the
+      // same inputs — any future divergence between the two implementations
+      // fails the suite.
+      const portfolioMean = GRQProjection.calculateIncludedPortfolioPerformance(
+        [abc, xyz],
+      );
+      assertEquals(chartPoint, portfolioMean);
+    },
+  );
+
+  await t.step("chart point honours the null guard (buyPrice <= 0)", () => {
+    // A stock with a non-positive buy price returns null from the kernel and
+    // must be dropped from the equal-weight average, not counted as 0%.
+    const zeroBuy: ChartStock = {
+      buyPrice: 0,
+      currentPrice: 5,
+      totalDividends: 0,
+    };
+    const chartPoint = chartPortfolioReturnAtPoint([abc, xyz, zeroBuy]);
+    assertEquals(chartPoint, 0.625, "zero-buy stock excluded from the mean");
+  });
 });


### PR DESCRIPTION
## Summary

Centralised the "Performance Over Time" chart's actual-performance + dividend
maths onto the shared `GRQProjection.calculatePerformanceReturn()` kernel. The
chart time-series loop in `docs/app.js` previously **inlined** the identical
price-return / dividend-return / total-return formula already implemented by the
shared helper that the per-stock summary and the equal-weight portfolio mean
(`calculateIncludedPortfolioPerformance`) use. Two copies of the same formula can
drift, so the chart now delegates to the single shared implementation — the
chart, the summary and the per-stock views can never disagree. This is a
behaviour-preserving refactor (the numbers are unchanged); it pins the
behaviour to one source of truth. Closes #424.

Item (1) of #420. Frontend-only, in `docs/` (Deno repo — no Node tooling).

### Change
- `docs/app.js` (chart loop, ~line 2360): removed the inlined
  `priceReturn` / `dividendReturn` / `totalReturn` block and replaced it with
  `GRQProjection.calculatePerformanceReturn(buyPrice, currentPrice, totalDividends)`.
  The helper's `null` guard (`buyPrice <= 0`) is honoured the same way the
  summary path does — a stock returning `null` is dropped from the equal-weight
  average rather than counted as 0%. The existing equal-weight averaging
  (`totalPerformance / validStocks`) and the 90-day dividend filtering are
  unchanged.

```mermaid
flowchart LR
    Chart["Chart time-series loop<br/>(docs/app.js)"] --> K
    Summary["Per-stock summary"] --> K
    Portfolio["Equal-weight portfolio mean<br/>calculateIncludedPortfolioPerformance"] --> K
    K["calculatePerformanceReturn()<br/>(docs/projection.js — single source of truth)"]
```

## Evidence

Backend/maths refactor with no visual change (a refactor that preserves the
chart numbers). Verified by the Deno test suite anchored on the issue's
**ABC/XYZ** worked example:

- ABC: buy $1, current $1, dividends $0.01 → dividend return **1.0%**.
- XYZ: buy $20, current $20, dividends $0.05 → dividend return **0.25%**.
- ABC's dividend return is **4×** XYZ's for an equal-dollar buy.
- Equal-weighted portfolio dividend return = (1.0% + 0.25%) / 2 = **0.625%**, and
  the chart point equals `calculateIncludedPortfolioPerformance` for the same
  inputs — any future divergence between the chart loop and the shared kernel
  fails the suite.

`./quality.sh` (deno lint + deno test + Rust suite) passes cleanly.

## Test Plan

- Extended `tests/chart_data_test.ts` with `Chart actual-performance maths
  (issue #424)`, which:
  - asserts ABC = 1.0% and XYZ = 0.25% via the shared kernel,
  - asserts ABC is 4× XYZ,
  - models the chart's per-point equal-weight portfolio loop and asserts it
    equals both 0.625% and `calculateIncludedPortfolioPerformance` for the same
    inputs (call-equivalence guard),
  - asserts the chart point honours the `null` guard (a zero-buy stock is
    excluded from the mean, not counted as 0%).
- `deno test tests/chart_data_test.ts` and full `./quality.sh` pass.
