### PR TITLE
Trend data engine: matured Actual % / Target % series + day/week/month/quarter aggregation (Issue #429)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3368,29 +3368,32 @@ class GRQValidator {
     }
 
     calculatePortfolioTargetPercentage() {
-        // Calculate portfolio target based on the actual targets of all stocks
-        let totalTarget = 0;
-        let validStocks = 0;
+        // Portfolio target = equal-weight mean of the included stocks' target
+        // percentages. The maths lives in the shared projection module
+        // (issue #429) so the dashboard chart and the trend view call ONE
+        // function. Build the per-stock {buyPrice, currentPrice, adjustedTarget}
+        // inputs here, then delegate; the shared helper applies the same
+        // inclusion gate (issue #289) and 20.0% fallback.
         const scoreDate = this.getScoreDate(this.selectedFile);
-
-        this.scoreData.forEach((stock) => {
-            // Only included (priceable) stocks contribute to the portfolio
-            // target so the displayed allocation reflects the re-weighted
-            // remainder (issue #289).
-            if (!this.isStockPriceable(stock.stock, scoreDate)) {
-                return;
-            }
-            if (stock.target !== null && !isNaN(stock.target)) {
-                // Use centralized method to calculate target percentage
-                const targetPercentage = this.calculateTargetPercentage(stock, scoreDate);
-                if (targetPercentage !== null) {
-                    totalTarget += targetPercentage;
-                    validStocks++;
-                }
-            }
+        const stocks = this.scoreData.map((stock) => {
+            const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
+            const hasTarget = stock.target !== null && !isNaN(stock.target);
+            return {
+                buyPrice: buyPriceObj ? buyPriceObj.price : null,
+                currentPrice: GRQProjection.currentPriceFromLatest(
+                    this.marketData[stock.stock],
+                ),
+                adjustedTarget: hasTarget
+                    ? this.adjustHistoricalPriceToCurrent(
+                        stock.target,
+                        stock.stock,
+                        scoreDate,
+                    )
+                    : null,
+            };
         });
 
-        return validStocks > 0 ? totalTarget / validStocks : 20.0;
+        return GRQProjection.calculatePortfolioTargetPercentage(stocks);
     }
 
     // Whether a stock counts towards portfolio aggregates (issue #289): it must

--- a/docs/archive/pr-summaries/pr-summary-429.md
+++ b/docs/archive/pr-summaries/pr-summary-429.md
@@ -1,0 +1,66 @@
+# Trend data engine: matured Actual % / Target % time series + aggregation
+
+## Summary
+
+Adds the **headless data pipeline** for the new "Portfolio Actual vs Target
+over time" view (no UI — the Trend view UI sub-issue consumes this). Closes #429.
+
+A new DOM-free module `docs/trend_series.js` turns the loaded predictions into an
+ordered, **matured-only** time series of `{ date, actualPct, targetPct, count }`
+points and aggregates them into **day / week / month / quarter** buckets (mean
+per bucket).
+
+### Single source of truth (no second calculation)
+
+- **Actual %** is computed only by delegating to the existing shared kernel
+  `GRQProjection.calculateIncludedPortfolioPerformance()` (which itself calls
+  `calculatePerformanceReturn()`). The engine adds **no new actuals maths** and
+  never reads the backend-generated `performance_90_day` field.
+- **Target %** reuses the dashboard's target maths. To let the existing chart
+  and the new trend view call **one** function, the portfolio-target helper was
+  lifted into `docs/projection.js` as the pure
+  `GRQProjection.calculatePortfolioTargetPercentage(stocks)`, and
+  `GRQValidator.calculatePortfolioTargetPercentage()` in `docs/app.js` now
+  delegates to it (behaviour-preserving: same inclusion gate #289, same 20%
+  fallback).
+- **Matured-only rule**: a score date is included only once its full 90 days
+  have elapsed, reusing the same "on or before today − 90 days" boundary the
+  dashboard's `selectDefaultScore` applies. Dates newer than today − 90 days are
+  excluded.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    A[predictions: per score date<br/>resolved stock figures] --> B{matured?<br/>date <= today-90d}
+    B -- no --> X[excluded]
+    B -- yes --> C[Actual %:<br/>calculateIncludedPortfolioPerformance]
+    B -- yes --> D[Target %:<br/>calculatePortfolioTargetPercentage]
+    C --> E[series point<br/>date, actualPct, targetPct, count]
+    D --> E
+    E --> F[aggregateTrendSeries<br/>day / week / month / quarter<br/>mean per bucket]
+```
+
+## Evidence
+
+Headless backend/data change — no web interface to screenshot. Verified via
+`deno test`:
+
+- `tests/trend_series_test.ts` (11 tests) — per-date Actual/Target from the
+  shared kernels, non-matured dates excluded, null-Actual dates dropped, the
+  inclusion gate reflected in `count`, and correct day/week/month/quarter means
+  on hand-computable fixtures.
+- `tests/portfolio_target_tests.ts` — 3 added tests for the lifted
+  `calculatePortfolioTargetPercentage` (mean over included stocks, exclusion of
+  unpriceable stocks, 20% default).
+- `tests/js_syntax_test.ts` — `docs/trend_series.js` parses cleanly.
+
+Full suite: `deno test --allow-read tests/*.ts` → **680 passed, 0 failed**;
+`deno lint` and `deno check` clean.
+
+## Test Plan
+
+- Added `tests/trend_series_test.ts`.
+- Extended `tests/portfolio_target_tests.ts` with direct coverage of the shared
+  portfolio-target helper.
+- Extended `tests/js_syntax_test.ts` to parse the new module.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -516,6 +516,46 @@ function calculateTargetPercentage(buyPrice, adjustedTarget) {
     return null;
 }
 
+// Equal-weight portfolio target percentage over ONLY the included stocks
+// (issue #429, lifted from docs/app.js so the dashboard chart and the trend
+// view share ONE target calculation). Each stock object provides `buyPrice`,
+// `currentPrice` and `adjustedTarget` (the model's 90-day target restated into
+// current, post-split terms). Excluded stocks (per isStockIncluded) and stocks
+// with no usable target are dropped; the result is the mean of the remaining
+// per-stock target percentages, or the 20.0% default when none qualify (the
+// same fallback the dashboard's totals row applies). Returns 20.0 for a missing
+// or empty list so callers always have a usable figure.
+function calculatePortfolioTargetPercentage(stocks) {
+    if (!Array.isArray(stocks)) {
+        return 20.0;
+    }
+    let totalTarget = 0;
+    let validStocks = 0;
+    for (const stock of stocks) {
+        const buyPrice = stock && stock.buyPrice;
+        const currentPrice = stock && stock.currentPrice;
+        if (!isStockIncluded(buyPrice, currentPrice)) {
+            continue;
+        }
+        const adjustedTarget = stock.adjustedTarget;
+        if (
+            adjustedTarget === null || adjustedTarget === undefined ||
+            Number.isNaN(adjustedTarget)
+        ) {
+            continue;
+        }
+        const targetPercentage = calculateTargetPercentage(
+            buyPrice,
+            adjustedTarget,
+        );
+        if (targetPercentage !== null) {
+            totalTarget += targetPercentage;
+            validStocks++;
+        }
+    }
+    return validStocks > 0 ? totalTarget / validStocks : 20.0;
+}
+
 // Fair-value display band for a stock's analysis. Pure given the analysis
 // object so the dashboard (via GRQValidator) and the Deno tests share one set
 // of branch rules (issue #204):
@@ -936,6 +976,7 @@ globalThis.GRQProjection = {
     getBuyPrice,
     currentPriceFromLatest,
     calculateTargetPercentage,
+    calculatePortfolioTargetPercentage,
     getFairValueRange,
     getTargetPriceColor,
     calculateRSquared,

--- a/docs/trend_series.js
+++ b/docs/trend_series.js
@@ -1,0 +1,225 @@
+// Headless trend-data engine for the "Portfolio Actual vs Target over time"
+// view (issue #429, part of milestone #422). This delivers ONLY the pure data
+// pipeline — no DOM, no chart, no UI control. The Trend view UI sub-issue owns
+// the rendering and the default granularity control.
+//
+// The engine turns the loaded predictions into an ordered, matured-only time
+// series of { date, actualPct, targetPct, count } points and aggregates them
+// into day / week / month / quarter buckets (mean per bucket).
+//
+// Single source of truth (critical): the Actual % is computed by delegating to
+// GRQProjection.calculateIncludedPortfolioPerformance (which itself calls
+// calculatePerformanceReturn), and the Target % by delegating to
+// GRQProjection.calculatePortfolioTargetPercentage. This module adds NO new
+// actuals or target maths and never reads the backend-generated
+// performance_90_day field. It mirrors docs/projection.js and
+// docs/market_index.js: loaded as a classic <script>, no module syntax, and
+// publishes its helpers on globalThis.GRQTrendSeries. It depends on
+// docs/projection.js being loaded first (for the shared kernels).
+
+// Maturity window: a score date is "matured" once its full 90-day validation
+// window has elapsed, i.e. scoreDate <= today - 90 days. Reuses the exact
+// "on or before today - 90 days" boundary the dashboard's default-score
+// selection applies (GRQProjection.selectDefaultScore), so the trend view and
+// the chart agree on which dates are complete.
+const MATURITY_WINDOW_DAYS = 90;
+
+// The granularities the engine can bucket by. Order is irrelevant; membership
+// is what the validation checks.
+const GRANULARITIES = ["day", "week", "month", "quarter"];
+
+// Parse a score date (a "YYYY-MM-DD" string — possibly with unpadded month/day
+// such as "2024-12-3" — or a Date) to local midnight. Returns a Date, or an
+// Invalid Date when it cannot be parsed. Using local midnight (not UTC) keeps
+// the "on or before" calendar comparison and the bucket boundaries aligned with
+// the rest of the dashboard's date maths.
+function parseScoreDate(value) {
+    if (value instanceof Date) {
+        return GRQProjection.setDateToMidnight(value);
+    }
+    const match = /^(\d{4})-(\d{1,2})-(\d{1,2})/.exec(String(value));
+    if (match) {
+        return new Date(
+            Number(match[1]),
+            Number(match[2]) - 1,
+            Number(match[3]),
+        );
+    }
+    return GRQProjection.setDateToMidnight(new Date(value));
+}
+
+// Whether a score date's full 90-day window has elapsed by `today`. Pure given
+// the two dates: matured when the local-midnight score date is on or before
+// (today - 90 days) at local midnight.
+function isMaturedScoreDate(scoreDate, today) {
+    const score = parseScoreDate(scoreDate);
+    if (Number.isNaN(score.getTime())) {
+        return false;
+    }
+    const cutoff = GRQProjection.setDateToMidnight(today);
+    cutoff.setDate(cutoff.getDate() - MATURITY_WINDOW_DAYS);
+    return score.getTime() <= cutoff.getTime();
+}
+
+// Number of stocks that count towards the portfolio figures for a prediction
+// (the included-stock count surfaced on each series point). Delegates to the
+// shared inclusion predicate so it matches the Actual/Target averages exactly.
+function includedStockCount(stocks) {
+    if (!Array.isArray(stocks)) {
+        return 0;
+    }
+    let count = 0;
+    for (const stock of stocks) {
+        const buyPrice = stock && stock.buyPrice;
+        const currentPrice = stock && stock.currentPrice;
+        if (GRQProjection.isStockIncluded(buyPrice, currentPrice)) {
+            count++;
+        }
+    }
+    return count;
+}
+
+// Build the ordered, matured-only Actual-vs-Target time series.
+//
+// `predictions` is an array of { date, stocks } where `date` is the score date
+// and `stocks` is an array of resolved per-stock figures
+// { buyPrice, currentPrice, totalDividends, adjustedTarget }. The Trend view UI
+// sub-issue is responsible for loading each score date's market data and
+// resolving those figures; this engine stays DOM-free and deterministic.
+//
+// For each MATURED prediction it produces one point:
+//   - actualPct: GRQProjection.calculateIncludedPortfolioPerformance(stocks)
+//   - targetPct: GRQProjection.calculatePortfolioTargetPercentage(stocks)
+//   - count:     number of included stocks behind those averages
+// Predictions that are not yet matured, or whose Actual % is null (no included
+// stocks), are excluded. Points are returned ordered chronologically by date.
+// `date` on each point is a Date at local midnight.
+function buildMaturedTrendSeries(predictions, today) {
+    if (!Array.isArray(predictions)) {
+        return [];
+    }
+    const series = [];
+    for (const prediction of predictions) {
+        if (!prediction) {
+            continue;
+        }
+        if (!isMaturedScoreDate(prediction.date, today)) {
+            continue;
+        }
+        const stocks = prediction.stocks;
+        const actualPct = GRQProjection.calculateIncludedPortfolioPerformance(
+            stocks,
+        );
+        if (actualPct === null) {
+            // No included stocks: there is no portfolio Actual for this date.
+            continue;
+        }
+        const targetPct = GRQProjection.calculatePortfolioTargetPercentage(
+            stocks,
+        );
+        series.push({
+            date: parseScoreDate(prediction.date),
+            actualPct,
+            targetPct,
+            count: includedStockCount(stocks),
+        });
+    }
+    series.sort((a, b) => a.date.getTime() - b.date.getTime());
+    return series;
+}
+
+// The Monday (local midnight) that starts the ISO week containing `date`.
+function startOfIsoWeek(date) {
+    const d = GRQProjection.setDateToMidnight(date);
+    const day = d.getDay(); // 0 = Sunday .. 6 = Saturday
+    const shift = day === 0 ? -6 : 1 - day; // back to Monday
+    d.setDate(d.getDate() + shift);
+    return d;
+}
+
+// The representative bucket-start date (local midnight) for `date` at the given
+// granularity:
+//   - day:     the date itself
+//   - week:    the Monday of its ISO week
+//   - month:   the first of its month
+//   - quarter: the first day of its calendar quarter (Jan/Apr/Jul/Oct)
+// Buckets are keyed by this date's time, so all members of a bucket share one
+// representative date that the UI can label.
+function bucketStartDate(date, granularity) {
+    const d = GRQProjection.setDateToMidnight(date);
+    switch (granularity) {
+        case "day":
+            return d;
+        case "week":
+            return startOfIsoWeek(d);
+        case "month":
+            return new Date(d.getFullYear(), d.getMonth(), 1);
+        case "quarter": {
+            const quarterFirstMonth = Math.floor(d.getMonth() / 3) * 3;
+            return new Date(d.getFullYear(), quarterFirstMonth, 1);
+        }
+        default:
+            throw new Error(`Unknown granularity: ${granularity}`);
+    }
+}
+
+// Aggregate a matured trend series into chronological buckets at `granularity`
+// (default "month"; the UI owns the user-facing default). Each bucket's
+// actualPct / targetPct is the MEAN of its members' values; `count` is the
+// number of member score-date points in the bucket. Returns
+// [{ date, actualPct, targetPct, count }] ordered by bucket start date. An
+// unrecognised granularity throws so callers fail fast.
+function aggregateTrendSeries(series, granularity = "month") {
+    if (!GRANULARITIES.includes(granularity)) {
+        throw new Error(`Unknown granularity: ${granularity}`);
+    }
+    if (!Array.isArray(series)) {
+        return [];
+    }
+    const buckets = new Map();
+    for (const point of series) {
+        if (!point || !(point.date instanceof Date)) {
+            continue;
+        }
+        const start = bucketStartDate(point.date, granularity);
+        const key = start.getTime();
+        let bucket = buckets.get(key);
+        if (!bucket) {
+            bucket = { date: start, actualSum: 0, targetSum: 0, count: 0 };
+            buckets.set(key, bucket);
+        }
+        bucket.actualSum += point.actualPct;
+        bucket.targetSum += point.targetPct;
+        bucket.count++;
+    }
+    return Array.from(buckets.values())
+        .sort((a, b) => a.date.getTime() - b.date.getTime())
+        .map((bucket) => ({
+            date: bucket.date,
+            actualPct: bucket.actualSum / bucket.count,
+            targetPct: bucket.targetSum / bucket.count,
+            count: bucket.count,
+        }));
+}
+
+// Convenience composition for the Trend view: build the matured series and its
+// bucketed aggregation in one call. Returns { granularity, series, buckets }.
+function buildTrendData(predictions, today, granularity = "month") {
+    const series = buildMaturedTrendSeries(predictions, today);
+    return {
+        granularity,
+        series,
+        buckets: aggregateTrendSeries(series, granularity),
+    };
+}
+
+// Publish on globalThis so the browser dashboard and the Deno tests reach the
+// same helpers, mirroring docs/projection.js and docs/market_index.js.
+globalThis.GRQTrendSeries = {
+    GRANULARITIES,
+    isMaturedScoreDate,
+    buildMaturedTrendSeries,
+    bucketStartDate,
+    aggregateTrendSeries,
+    buildTrendData,
+};

--- a/tests/js_syntax_test.ts
+++ b/tests/js_syntax_test.ts
@@ -74,3 +74,11 @@ Deno.test("checkJsSyntax - production docs/format.js parses cleanly", async () =
   const result = checkJsSyntax(source);
   assertEquals(result.valid, true, result.error);
 });
+
+Deno.test("checkJsSyntax - production docs/trend_series.js parses cleanly", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../docs/trend_series.js", import.meta.url),
+  );
+  const result = checkJsSyntax(source);
+  assertEquals(result.valid, true, result.error);
+});

--- a/tests/portfolio_target_tests.ts
+++ b/tests/portfolio_target_tests.ts
@@ -29,6 +29,15 @@ const g = globalThis as unknown as {
       currentPrice: number,
       totalDividends?: number,
     ) => number | null;
+    calculatePortfolioTargetPercentage: (
+      stocks: Array<
+        {
+          buyPrice: number | null;
+          currentPrice: number | null;
+          adjustedTarget: number | null;
+        }
+      >,
+    ) => number;
   };
 };
 const GRQProjection = g.GRQProjection;
@@ -159,4 +168,42 @@ Deno.test("Portfolio Target Tests", async (t) => {
       "NYSE:WFG should have 2 dividends within 90 days",
     );
   });
+});
+
+// Direct coverage for the lifted, shared portfolio-target helper (issue #429).
+// The dashboard's GRQValidator.calculatePortfolioTargetPercentage now delegates
+// here, so the chart and the trend view share ONE target calculation.
+Deno.test("calculatePortfolioTargetPercentage - mean over included stocks", () => {
+  const portfolioTarget = GRQProjection.calculatePortfolioTargetPercentage([
+    { buyPrice: 100, currentPrice: 110, adjustedTarget: 120 }, // 20%
+    { buyPrice: 100, currentPrice: 90, adjustedTarget: 110 }, // 10%
+  ]);
+  assertAlmostEquals(portfolioTarget, 15.0);
+});
+
+Deno.test("calculatePortfolioTargetPercentage - excludes unpriceable stocks", () => {
+  // The second stock has a non-positive current price, so it is dropped from
+  // the average entirely — only the 50% target remains.
+  const portfolioTarget = GRQProjection.calculatePortfolioTargetPercentage([
+    { buyPrice: 100, currentPrice: 130, adjustedTarget: 150 }, // 50%
+    { buyPrice: 100, currentPrice: 0, adjustedTarget: 999 }, // excluded
+  ]);
+  assertAlmostEquals(portfolioTarget, 50.0);
+});
+
+Deno.test("calculatePortfolioTargetPercentage - 20% default when none qualify", () => {
+  // No usable stocks → the same 20.0% fallback the dashboard totals row uses.
+  assertEquals(GRQProjection.calculatePortfolioTargetPercentage([]), 20.0);
+  assertEquals(
+    GRQProjection.calculatePortfolioTargetPercentage([
+      { buyPrice: 100, currentPrice: 110, adjustedTarget: null },
+    ]),
+    20.0,
+  );
+  assertEquals(
+    GRQProjection.calculatePortfolioTargetPercentage(
+      null as unknown as [],
+    ),
+    20.0,
+  );
 });

--- a/tests/trend_series_test.ts
+++ b/tests/trend_series_test.ts
@@ -1,0 +1,259 @@
+// Tests for the headless trend-data engine (issue #429, milestone #422).
+//
+// These import the REAL shipped helpers from docs/trend_series.js (and its
+// dependency docs/projection.js) and assert on their observable output:
+//   - the per-date Actual % comes from the shared
+//     GRQProjection.calculateIncludedPortfolioPerformance kernel, NOT the
+//     backend performance_90_day field;
+//   - the per-date Target % comes from the shared
+//     GRQProjection.calculatePortfolioTargetPercentage kernel;
+//   - non-matured score dates (newer than today - 90 days) are excluded;
+//   - day / week / month / quarter buckets are the chronological mean of their
+//     members.
+import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_series.js";
+
+interface TrendStock {
+  buyPrice: number | null;
+  currentPrice: number | null;
+  totalDividends?: number;
+  adjustedTarget: number | null;
+}
+
+interface Prediction {
+  date: string;
+  stocks: TrendStock[];
+}
+
+interface TrendPoint {
+  date: Date;
+  actualPct: number;
+  targetPct: number;
+  count: number;
+}
+
+const g = globalThis as unknown as {
+  GRQTrendSeries: {
+    GRANULARITIES: string[];
+    isMaturedScoreDate: (scoreDate: string | Date, today: Date) => boolean;
+    buildMaturedTrendSeries: (
+      predictions: Prediction[],
+      today: Date,
+    ) => TrendPoint[];
+    bucketStartDate: (date: Date, granularity: string) => Date;
+    aggregateTrendSeries: (
+      series: TrendPoint[],
+      granularity?: string,
+    ) => TrendPoint[];
+    buildTrendData: (
+      predictions: Prediction[],
+      today: Date,
+      granularity?: string,
+    ) => { granularity: string; series: TrendPoint[]; buckets: TrendPoint[] };
+  };
+};
+const Trend = g.GRQTrendSeries;
+
+// June 1, 2025 → maturity cutoff is March 3, 2025 (today - 90 days).
+const TODAY = new Date(2025, 5, 1);
+
+// Fixture predictions with hand-computable Actual / Target figures.
+const PREDICTIONS: Prediction[] = [
+  // 2024-10-15: actual mean(10, -10) = 0; target mean(20, 10) = 15; count 2.
+  {
+    date: "2024-10-15",
+    stocks: [
+      { buyPrice: 100, currentPrice: 110, adjustedTarget: 120 },
+      { buyPrice: 100, currentPrice: 90, adjustedTarget: 110 },
+    ],
+  },
+  // 2024-11-05: actual 0; target 10; count 1.
+  {
+    date: "2024-11-05",
+    stocks: [
+      { buyPrice: 100, currentPrice: 100, adjustedTarget: 110 },
+    ],
+  },
+  // 2024-11-20: actual mean(20, -10) = 5; target mean(40, 10) = 25; count 2.
+  {
+    date: "2024-11-20",
+    stocks: [
+      { buyPrice: 100, currentPrice: 120, adjustedTarget: 140 },
+      { buyPrice: 200, currentPrice: 180, adjustedTarget: 220 },
+    ],
+  },
+  // 2025-01-10: the second stock is excluded (currentPrice 0), so actual 30,
+  // target 50, count 1 — exercising the inclusion gate.
+  {
+    date: "2025-01-10",
+    stocks: [
+      { buyPrice: 100, currentPrice: 130, adjustedTarget: 150 },
+      { buyPrice: 100, currentPrice: 0, adjustedTarget: 999 },
+    ],
+  },
+  // 2025-05-01: NOT matured (after the cutoff) — must be excluded entirely.
+  {
+    date: "2025-05-01",
+    stocks: [
+      { buyPrice: 100, currentPrice: 200, adjustedTarget: 250 },
+    ],
+  },
+  // 2024-12-15: every stock excluded → null Actual → dropped from the series.
+  {
+    date: "2024-12-15",
+    stocks: [
+      { buyPrice: 100, currentPrice: 0, adjustedTarget: 120 },
+      { buyPrice: 0, currentPrice: 100, adjustedTarget: 120 },
+    ],
+  },
+];
+
+Deno.test("trend_series.js publishes helpers on globalThis", () => {
+  assertEquals(typeof Trend, "object");
+  assertEquals(typeof Trend.buildMaturedTrendSeries, "function");
+  assertEquals(typeof Trend.aggregateTrendSeries, "function");
+  assertEquals(typeof Trend.buildTrendData, "function");
+});
+
+Deno.test("isMaturedScoreDate - boundary at exactly today - 90 days", () => {
+  // Cutoff = TODAY - 90 days = 2025-03-03. On/before is matured.
+  assertEquals(Trend.isMaturedScoreDate("2025-03-03", TODAY), true);
+  assertEquals(Trend.isMaturedScoreDate("2025-03-04", TODAY), false);
+  // Far past is matured; the future is not.
+  assertEquals(Trend.isMaturedScoreDate("2024-10-15", TODAY), true);
+  assertEquals(Trend.isMaturedScoreDate("2025-05-01", TODAY), false);
+});
+
+Deno.test("isMaturedScoreDate - unpadded and unparseable dates", () => {
+  // Unpadded month/day (as seen in scores/index.json, e.g. "2024-12-3").
+  assertEquals(Trend.isMaturedScoreDate("2024-12-3", TODAY), true);
+  // Garbage parses to Invalid Date → never matured (renders nothing).
+  assertEquals(Trend.isMaturedScoreDate("not-a-date", TODAY), false);
+});
+
+Deno.test("buildMaturedTrendSeries - per-date Actual/Target via shared kernels", () => {
+  const series = Trend.buildMaturedTrendSeries(PREDICTIONS, TODAY);
+
+  // Non-matured (2025-05-01) and null-Actual (2024-12-15) dates are excluded;
+  // the rest are ordered chronologically.
+  assertEquals(series.length, 4);
+  assertEquals(
+    series.map((p) => p.date.getTime()),
+    [
+      new Date(2024, 9, 15).getTime(),
+      new Date(2024, 10, 5).getTime(),
+      new Date(2024, 10, 20).getTime(),
+      new Date(2025, 0, 10).getTime(),
+    ],
+  );
+
+  assertAlmostEquals(series[0].actualPct, 0);
+  assertAlmostEquals(series[0].targetPct, 15);
+  assertEquals(series[0].count, 2);
+
+  assertAlmostEquals(series[1].actualPct, 0);
+  assertAlmostEquals(series[1].targetPct, 10);
+  assertEquals(series[1].count, 1);
+
+  assertAlmostEquals(series[2].actualPct, 5);
+  assertAlmostEquals(series[2].targetPct, 25);
+  assertEquals(series[2].count, 2);
+
+  // The excluded (currentPrice 0) stock drops out of both averages and count.
+  assertAlmostEquals(series[3].actualPct, 30);
+  assertAlmostEquals(series[3].targetPct, 50);
+  assertEquals(series[3].count, 1);
+});
+
+Deno.test("buildMaturedTrendSeries - tolerant of bad input", () => {
+  assertEquals(Trend.buildMaturedTrendSeries([], TODAY), []);
+  assertEquals(
+    Trend.buildMaturedTrendSeries(
+      null as unknown as Prediction[],
+      TODAY,
+    ),
+    [],
+  );
+});
+
+Deno.test("aggregateTrendSeries - day granularity keeps one bucket per date", () => {
+  const series = Trend.buildMaturedTrendSeries(PREDICTIONS, TODAY);
+  const buckets = Trend.aggregateTrendSeries(series, "day");
+  assertEquals(buckets.length, 4);
+  assertAlmostEquals(buckets[0].actualPct, 0);
+  assertAlmostEquals(buckets[3].actualPct, 30);
+  assertEquals(buckets.every((b) => b.count === 1), true);
+});
+
+Deno.test("aggregateTrendSeries - week granularity buckets by ISO Monday", () => {
+  const series = Trend.buildMaturedTrendSeries(PREDICTIONS, TODAY);
+  const buckets = Trend.aggregateTrendSeries(series, "week");
+  // All four dates fall in distinct ISO weeks.
+  assertEquals(buckets.length, 4);
+  // 2024-10-15 (Tue) → Monday 2024-10-14.
+  assertEquals(buckets[0].date.getTime(), new Date(2024, 9, 14).getTime());
+  // 2025-01-10 (Fri) → Monday 2025-01-06.
+  assertEquals(buckets[3].date.getTime(), new Date(2025, 0, 6).getTime());
+});
+
+Deno.test("aggregateTrendSeries - month granularity means the members", () => {
+  const series = Trend.buildMaturedTrendSeries(PREDICTIONS, TODAY);
+  const buckets = Trend.aggregateTrendSeries(series, "month");
+  assertEquals(buckets.length, 3);
+
+  // 2024-10: single member.
+  assertEquals(buckets[0].date.getTime(), new Date(2024, 9, 1).getTime());
+  assertAlmostEquals(buckets[0].actualPct, 0);
+  assertAlmostEquals(buckets[0].targetPct, 15);
+  assertEquals(buckets[0].count, 1);
+
+  // 2024-11: mean of 2024-11-05 (0, 10) and 2024-11-20 (5, 25).
+  assertEquals(buckets[1].date.getTime(), new Date(2024, 10, 1).getTime());
+  assertAlmostEquals(buckets[1].actualPct, 2.5);
+  assertAlmostEquals(buckets[1].targetPct, 17.5);
+  assertEquals(buckets[1].count, 2);
+
+  // 2025-01: single member.
+  assertEquals(buckets[2].date.getTime(), new Date(2025, 0, 1).getTime());
+  assertAlmostEquals(buckets[2].actualPct, 30);
+  assertAlmostEquals(buckets[2].targetPct, 50);
+  assertEquals(buckets[2].count, 1);
+});
+
+Deno.test("aggregateTrendSeries - quarter granularity means the members", () => {
+  const series = Trend.buildMaturedTrendSeries(PREDICTIONS, TODAY);
+  const buckets = Trend.aggregateTrendSeries(series, "quarter");
+  assertEquals(buckets.length, 2);
+
+  // 2024-Q4 (Oct 1): Oct15 (0,15), Nov05 (0,10), Nov20 (5,25).
+  assertEquals(buckets[0].date.getTime(), new Date(2024, 9, 1).getTime());
+  assertAlmostEquals(buckets[0].actualPct, 5 / 3);
+  assertAlmostEquals(buckets[0].targetPct, 50 / 3);
+  assertEquals(buckets[0].count, 3);
+
+  // 2025-Q1 (Jan 1): single member.
+  assertEquals(buckets[1].date.getTime(), new Date(2025, 0, 1).getTime());
+  assertAlmostEquals(buckets[1].actualPct, 30);
+  assertAlmostEquals(buckets[1].targetPct, 50);
+  assertEquals(buckets[1].count, 1);
+});
+
+Deno.test("aggregateTrendSeries - unknown granularity throws", () => {
+  assertThrows(
+    () => Trend.aggregateTrendSeries([], "fortnight"),
+    Error,
+    "Unknown granularity",
+  );
+});
+
+Deno.test("buildTrendData - composes series and buckets in one call", () => {
+  const result = Trend.buildTrendData(PREDICTIONS, TODAY, "quarter");
+  assertEquals(result.granularity, "quarter");
+  assertEquals(result.series.length, 4);
+  assertEquals(result.buckets.length, 2);
+  // Defaults to month when granularity is omitted.
+  const monthly = Trend.buildTrendData(PREDICTIONS, TODAY);
+  assertEquals(monthly.granularity, "month");
+  assertEquals(monthly.buckets.length, 3);
+});


### PR DESCRIPTION
# Trend data engine: matured Actual % / Target % time series + aggregation

## Summary

Adds the **headless data pipeline** for the new "Portfolio Actual vs Target
over time" view (no UI — the Trend view UI sub-issue consumes this). Closes #429.

A new DOM-free module `docs/trend_series.js` turns the loaded predictions into an
ordered, **matured-only** time series of `{ date, actualPct, targetPct, count }`
points and aggregates them into **day / week / month / quarter** buckets (mean
per bucket).

### Single source of truth (no second calculation)

- **Actual %** is computed only by delegating to the existing shared kernel
  `GRQProjection.calculateIncludedPortfolioPerformance()` (which itself calls
  `calculatePerformanceReturn()`). The engine adds **no new actuals maths** and
  never reads the backend-generated `performance_90_day` field.
- **Target %** reuses the dashboard's target maths. To let the existing chart
  and the new trend view call **one** function, the portfolio-target helper was
  lifted into `docs/projection.js` as the pure
  `GRQProjection.calculatePortfolioTargetPercentage(stocks)`, and
  `GRQValidator.calculatePortfolioTargetPercentage()` in `docs/app.js` now
  delegates to it (behaviour-preserving: same inclusion gate #289, same 20%
  fallback).
- **Matured-only rule**: a score date is included only once its full 90 days
  have elapsed, reusing the same "on or before today − 90 days" boundary the
  dashboard's `selectDefaultScore` applies. Dates newer than today − 90 days are
  excluded.

### Data flow

```mermaid
flowchart LR
    A[predictions: per score date<br/>resolved stock figures] --> B{matured?<br/>date <= today-90d}
    B -- no --> X[excluded]
    B -- yes --> C[Actual %:<br/>calculateIncludedPortfolioPerformance]
    B -- yes --> D[Target %:<br/>calculatePortfolioTargetPercentage]
    C --> E[series point<br/>date, actualPct, targetPct, count]
    D --> E
    E --> F[aggregateTrendSeries<br/>day / week / month / quarter<br/>mean per bucket]
```

## Evidence

Headless backend/data change — no web interface to screenshot. Verified via
`deno test`:

- `tests/trend_series_test.ts` (11 tests) — per-date Actual/Target from the
  shared kernels, non-matured dates excluded, null-Actual dates dropped, the
  inclusion gate reflected in `count`, and correct day/week/month/quarter means
  on hand-computable fixtures.
- `tests/portfolio_target_tests.ts` — 3 added tests for the lifted
  `calculatePortfolioTargetPercentage` (mean over included stocks, exclusion of
  unpriceable stocks, 20% default).
- `tests/js_syntax_test.ts` — `docs/trend_series.js` parses cleanly.

Full suite: `deno test --allow-read tests/*.ts` → **680 passed, 0 failed**;
`deno lint` and `deno check` clean.

## Test Plan

- Added `tests/trend_series_test.ts`.
- Extended `tests/portfolio_target_tests.ts` with direct coverage of the shared
  portfolio-target helper.
- Extended `tests/js_syntax_test.ts` to parse the new module.



## Milestone
This PR is part of the **#422 New view: portfolio actual vs target trend, grouped by day/week/month/quarter** milestone and targets the `milestone/422-new-view-portfolio-actual-vs-target-trend-grou` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqpxnrpm-437df0`<!-- vibe-worker-issue-429 -->