### PR TITLE
Headless benchmark-index overlay engine for the Trend view (Issue #431)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-431.md
+++ b/docs/archive/pr-summaries/pr-summary-431.md
@@ -1,0 +1,94 @@
+# Overlay benchmark indices on the Trend view (Issue #431)
+
+## Summary
+
+Adds the **headless benchmark-index overlay engine** for the new Trend view's
+stretch goal: optionally overlay SP500 / NASDAQ / Russell 2000 as extra lines so
+they can be compared against the portfolio Actual / Target series. Closes #431.
+
+This mirrors the layered approach the milestone already follows: issue #429
+shipped the Trend **data engine** (`docs/trend_series.js`) as a pure, DOM-free
+module, leaving rendering to the Trend view UI sub-issue (#430). This PR adds the
+matching **index-overlay layer** (`docs/index_overlay.js`, published on
+`globalThis.GRQIndexOverlay`) — the pure data pipeline plus the per-index
+on/off toggle-state model — so the UI sub-issue can drop it straight onto the
+chart. Persistence of the toggle choices remains owned by the "remember choices"
+sub-issue (#432).
+
+### No new index maths (the issue forbids it)
+
+Each index's value is **% return from the score-date baseline over the same
+matured 90-day window** as Actual / Target, computed by reusing the existing
+shared kernels — **no second calculation**:
+
+- `GRQProjection.buildIndexSeriesFromMap` slices the same-origin
+  `docs/market-indices.json` price map to the score date's 90-day window.
+- `GRQMarketIndex.indexPerformance` applies the exact percentage formula the
+  existing dashboard already plots benchmarks with.
+
+### Aligned on the same X buckets
+
+Maturity reuses `GRQTrendSeries.isMaturedScoreDate` and bucketing reuses
+`GRQTrendSeries.bucketStartDate`, so an index point lands on the **same**
+day/week/month/quarter bucket as the Actual / Target lines. Per-index bucket
+values are the mean of their members' non-null returns.
+
+### Per-index toggles, default all off
+
+`DEFAULT_TOGGLES` is `{ sp500: false, nasdaq: false, russell2000: false }` — the
+**documented default is all off**, so the Trend view starts uncluttered and the
+user opts each benchmark in. `buildIndexOverlayData(...)` emits chart-ready
+datasets for **only** the toggled-on indices, each carrying the distinct line
+colour the existing dashboard already uses for that index (so the Trend view's
+colour key / legend matches the rest of the site). Flipping a toggle changes
+only which datasets are returned, which is how the UI will update the chart live.
+
+### Scope / dependency note
+
+The issue's UI acceptance points (live toggle widgets, colour-key wiring) depend
+on the **Trend view UI** sub-issue (#430), which is not yet merged — there is no
+chart to attach to. Following the #429 precedent, this PR delivers everything
+that can be built and verified headlessly now; #430 wires
+`GRQIndexOverlay.buildIndexOverlayData(...)` into the chart and the toggle
+widgets. The existing dashboard is untouched (no `index.html` / `sw.js` change),
+satisfying the "Existing dashboard untouched" criterion.
+
+## Evidence
+
+This is a headless data/state module — no DOM, no rendering — so there is no UI
+to screenshot in this PR (the view itself arrives with #430). Verification is the
+Deno test suite, which drives the **real shipped** helpers (no mocks): full suite
+`701 passed | 0 failed`, including the new `tests/index_overlay_test.ts`.
+
+```mermaid
+flowchart LR
+    A["score dates (matured only)"] --> S[buildIndexOverlaySeries]
+    M["docs/market-indices.json<br/>{date: close} maps"] --> S
+    S -->|"per score date,<br/>reuse buildIndexSeriesFromMap<br/>+ indexPerformance"| R["{date, returns per index}"]
+    R --> AG[aggregateIndexOverlay]
+    AG -->|"same GRQTrendSeries.bucketStartDate"| B["buckets aligned with Actual/Target"]
+    B --> D[buildIndexOverlayData]
+    T["per-index toggles<br/>(default all off)"] --> D
+    D --> O["datasets for enabled indices<br/>(ready for the #430 chart)"]
+```
+
+## Test Plan
+
+New `tests/index_overlay_test.ts` (imports the real `docs/index_overlay.js` and
+its dependencies):
+
+- `indexReturnForScoreDate` — % return from the score-date baseline over the
+  90-day window; matches the shared `market_index` calc directly; null on an
+  empty window and on a missing/invalid price map.
+- `buildIndexOverlaySeries` — excludes non-matured score dates; per-index
+  returns with a missing index resolved to null; chronological ordering.
+- `aggregateIndexOverlay` — buckets align on `GRQTrendSeries.bucketStartDate`;
+  per-index mean ignores null members; unknown granularity throws.
+- `normaliseToggles` / `DEFAULT_TOGGLES` / `enabledIndexKeys` — all-off default,
+  boolean coercion, unknown keys ignored.
+- `buildIndexOverlayData` — default renders no index datasets; only toggled-on
+  indices become datasets aligned to the shared buckets; null buckets are
+  dropped from an enabled line.
+
+Also added a parse guard for the new module in `tests/js_syntax_test.ts`
+(`docs/index_overlay.js` parses cleanly).

--- a/docs/index_overlay.js
+++ b/docs/index_overlay.js
@@ -1,0 +1,279 @@
+// Headless benchmark-index overlay engine for the "Portfolio Actual vs Target
+// over time" Trend view (issue #431, the stretch goal of milestone #422).
+//
+// This delivers ONLY the pure data pipeline + toggle-state model — no DOM, no
+// chart, no UI control. The Trend view UI sub-issue (#430) owns the rendering,
+// the on/off toggle widgets and the colour-key wiring; this module hands it
+// chart-ready datasets so there is one place that decides what each index line
+// contains. Persistence of the toggle choices is owned by the "remember
+// choices" sub-issue (#432).
+//
+// No new index maths (the issue forbids it): each index's % return is produced
+// by reusing the existing shared kernels —
+// GRQProjection.buildIndexSeriesFromMap (slice the same-origin price map to a
+// score date's 90-day window) feeding GRQMarketIndex.indexPerformance (the exact
+// formula the existing dashboard plots). Buckets are aligned to the Trend
+// engine's own GRQTrendSeries.bucketStartDate, so the index lines land on the
+// SAME X buckets as the Actual / Target lines. Maturity reuses
+// GRQTrendSeries.isMaturedScoreDate so only fully-elapsed 90-day windows plot,
+// exactly as Actual / Target do.
+//
+// Mirrors docs/projection.js, docs/market_index.js and docs/trend_series.js:
+// loaded as a classic <script>, no module syntax, and published on
+// globalThis.GRQIndexOverlay. It depends on docs/projection.js,
+// docs/market_index.js and docs/trend_series.js being loaded first.
+
+// The 90-day validation window each matured prediction is scored over — the
+// same horizon the Trend engine matures on and the Actual / Target lines cover.
+const OVERLAY_WINDOW_DAYS = 90;
+
+// The benchmark indices the overlay can draw, in display order. Key and name
+// reuse GRQMarketIndex.BENCHMARK_INDICES (single source of truth for the index
+// list) and each is augmented with the distinct line colours the existing
+// dashboard already uses for that index, so the Trend view's colour key /
+// legend matches the rest of the site. Falls back to a local list if
+// market_index.js has not loaded (keeps this module's parse independent).
+const INDEX_LINE_STYLES = {
+    sp500: {
+        borderColor: "rgba(255, 99, 132, 0.8)",
+        backgroundColor: "rgba(255, 99, 132, 0.1)",
+    },
+    nasdaq: {
+        borderColor: "rgba(54, 162, 235, 0.8)",
+        backgroundColor: "rgba(54, 162, 235, 0.1)",
+    },
+    russell2000: {
+        borderColor: "rgba(75, 192, 192, 0.8)",
+        backgroundColor: "rgba(75, 192, 192, 0.1)",
+    },
+};
+
+const BASE_INDICES =
+    (globalThis.GRQMarketIndex && globalThis.GRQMarketIndex.BENCHMARK_INDICES) ||
+    [
+        { key: "sp500", name: "SP500" },
+        { key: "nasdaq", name: "NASDAQ" },
+        { key: "russell2000", name: "Russell 2000" },
+    ];
+
+const OVERLAY_INDICES = BASE_INDICES.map(({ key, name }) => ({
+    key,
+    name,
+    borderColor: (INDEX_LINE_STYLES[key] || {}).borderColor || null,
+    backgroundColor: (INDEX_LINE_STYLES[key] || {}).backgroundColor || null,
+}));
+
+// Default toggle state: every index OFF. The Trend view starts uncluttered
+// with just Actual / Target; the user opts each benchmark in. (#431 asks the
+// default to be documented — it is "all off".)
+const DEFAULT_TOGGLES = OVERLAY_INDICES.reduce((acc, { key }) => {
+    acc[key] = false;
+    return acc;
+}, {});
+
+// Coerce an arbitrary (possibly partial or null) toggle object into a full
+// { sp500, nasdaq, russell2000 } boolean map. Missing keys fall back to the
+// all-off default; unknown keys are ignored. Pure: never mutates its input.
+function normaliseToggles(toggles) {
+    const source = toggles && typeof toggles === "object" ? toggles : {};
+    const result = {};
+    for (const { key } of OVERLAY_INDICES) {
+        result[key] = key in source
+            ? Boolean(source[key])
+            : DEFAULT_TOGGLES[key];
+    }
+    return result;
+}
+
+// The keys of the indices that are toggled on, in display order.
+function enabledIndexKeys(toggles) {
+    const normalised = normaliseToggles(toggles);
+    return OVERLAY_INDICES
+        .map(({ key }) => key)
+        .filter((key) => normalised[key]);
+}
+
+// The local-midnight date `windowDays` after `scoreDate` — the end of a
+// prediction's validation window.
+function windowEndDate(scoreDate, windowDays) {
+    const end = GRQProjection.setDateToMidnight(new Date(scoreDate));
+    end.setDate(end.getDate() + windowDays);
+    return end;
+}
+
+// One benchmark index's % return from a score date's baseline over its
+// `windowDays` window, reusing the shared kernels (no new maths). `priceMap` is
+// the same-origin { "YYYY-MM-DD": close } map for the index (a property of
+// docs/market-indices.json). Returns the percentage number, or null when the
+// window has no usable prices. Pure: no DOM, never throws.
+function indexReturnForScoreDate(
+    priceMap,
+    scoreDate,
+    windowDays = OVERLAY_WINDOW_DAYS,
+) {
+    if (!priceMap || typeof priceMap !== "object") {
+        return null;
+    }
+    const start = GRQProjection.setDateToMidnight(new Date(scoreDate));
+    if (Number.isNaN(start.getTime())) {
+        return null;
+    }
+    const end = windowEndDate(start, windowDays);
+    const series = GRQProjection.buildIndexSeriesFromMap(
+        priceMap,
+        "",
+        start,
+        end,
+    );
+    const perf = GRQMarketIndex.indexPerformance(series, end);
+    return perf ? perf.performance : null;
+}
+
+// Build the ordered, matured-only per-score-date index-return series.
+//
+// `scoreDates` is the list of prediction (score) dates the Trend view plots —
+// strings ("YYYY-MM-DD") or Dates. `marketIndices` is the raw
+// docs/market-indices.json object ({ sp500, nasdaq, russell2000 } each a
+// { date: close } map). Only MATURED score dates (full 90-day window elapsed by
+// `today`, via the shared GRQTrendSeries.isMaturedScoreDate) are included, so
+// the overlay covers exactly the same dates as Actual / Target.
+//
+// Returns [{ date, returns: { sp500, nasdaq, russell2000 } }] ordered
+// chronologically; `date` is a Date at local midnight and any index with no
+// usable window prices is null.
+function buildIndexOverlaySeries(scoreDates, marketIndices, today) {
+    if (!Array.isArray(scoreDates)) {
+        return [];
+    }
+    const indices = marketIndices && typeof marketIndices === "object"
+        ? marketIndices
+        : {};
+    const series = [];
+    for (const scoreDate of scoreDates) {
+        if (scoreDate === null || scoreDate === undefined) {
+            continue;
+        }
+        if (!GRQTrendSeries.isMaturedScoreDate(scoreDate, today)) {
+            continue;
+        }
+        const date = GRQProjection.setDateToMidnight(new Date(scoreDate));
+        if (Number.isNaN(date.getTime())) {
+            continue;
+        }
+        const returns = {};
+        for (const { key } of OVERLAY_INDICES) {
+            returns[key] = indexReturnForScoreDate(indices[key], date);
+        }
+        series.push({ date, returns });
+    }
+    series.sort((a, b) => a.date.getTime() - b.date.getTime());
+    return series;
+}
+
+// Aggregate the per-score-date overlay series into chronological buckets at
+// `granularity`, aligned on the SAME bucket-start dates the Trend engine uses
+// (GRQTrendSeries.bucketStartDate), so index lines share the Actual / Target X
+// axis. Each bucket's per-index value is the MEAN of its members' non-null
+// returns (null when no member had a usable value); `count` is the number of
+// member score-date points. Returns
+// [{ date, returns: { sp500, nasdaq, russell2000 }, count }] ordered by bucket
+// start. An unrecognised granularity throws (matching aggregateTrendSeries).
+function aggregateIndexOverlay(series, granularity = "month") {
+    if (!GRQTrendSeries.GRANULARITIES.includes(granularity)) {
+        throw new Error(`Unknown granularity: ${granularity}`);
+    }
+    if (!Array.isArray(series)) {
+        return [];
+    }
+    const buckets = new Map();
+    for (const point of series) {
+        if (!point || !(point.date instanceof Date)) {
+            continue;
+        }
+        const start = GRQTrendSeries.bucketStartDate(point.date, granularity);
+        const key = start.getTime();
+        let bucket = buckets.get(key);
+        if (!bucket) {
+            bucket = { date: start, sums: {}, counts: {}, count: 0 };
+            for (const { key: indexKey } of OVERLAY_INDICES) {
+                bucket.sums[indexKey] = 0;
+                bucket.counts[indexKey] = 0;
+            }
+            buckets.set(key, bucket);
+        }
+        bucket.count++;
+        const returns = point.returns || {};
+        for (const { key: indexKey } of OVERLAY_INDICES) {
+            const value = returns[indexKey];
+            if (typeof value === "number" && Number.isFinite(value)) {
+                bucket.sums[indexKey] += value;
+                bucket.counts[indexKey]++;
+            }
+        }
+    }
+    return Array.from(buckets.values())
+        .sort((a, b) => a.date.getTime() - b.date.getTime())
+        .map((bucket) => {
+            const returns = {};
+            for (const { key: indexKey } of OVERLAY_INDICES) {
+                returns[indexKey] = bucket.counts[indexKey] > 0
+                    ? bucket.sums[indexKey] / bucket.counts[indexKey]
+                    : null;
+            }
+            return { date: bucket.date, returns, count: bucket.count };
+        });
+}
+
+// Convenience composition for the Trend view UI: build the matured overlay
+// series, bucket it, and emit chart-ready datasets for only the toggled-on
+// indices. Returns:
+//   {
+//     granularity,
+//     toggles,                  // the normalised { sp500, nasdaq, russell2000 }
+//     buckets,                  // all index buckets (every index, for the key)
+//     datasets: [               // one per ENABLED index, in display order
+//       { key, name, borderColor, backgroundColor,
+//         points: [{ x: Date, y: pct }] }   // null buckets dropped per line
+//     ],
+//   }
+// Because the buckets come from aggregateIndexOverlay (shared bucketStartDate),
+// each dataset point's `x` lands on the same bucket the Actual / Target lines
+// use. Flipping a toggle changes only which datasets appear, so the UI can call
+// this again to update the chart live.
+function buildIndexOverlayData(
+    scoreDates,
+    marketIndices,
+    today,
+    granularity = "month",
+    toggles = DEFAULT_TOGGLES,
+) {
+    const series = buildIndexOverlaySeries(scoreDates, marketIndices, today);
+    const buckets = aggregateIndexOverlay(series, granularity);
+    const normalised = normaliseToggles(toggles);
+    const datasets = OVERLAY_INDICES
+        .filter(({ key }) => normalised[key])
+        .map(({ key, name, borderColor, backgroundColor }) => ({
+            key,
+            name,
+            borderColor,
+            backgroundColor,
+            points: buckets
+                .filter((bucket) => bucket.returns[key] !== null)
+                .map((bucket) => ({ x: bucket.date, y: bucket.returns[key] })),
+        }));
+    return { granularity, toggles: normalised, buckets, datasets };
+}
+
+// Publish on globalThis so the browser dashboard and the Deno tests reach the
+// same helpers, mirroring docs/trend_series.js and docs/market_index.js.
+globalThis.GRQIndexOverlay = {
+    OVERLAY_WINDOW_DAYS,
+    OVERLAY_INDICES,
+    DEFAULT_TOGGLES,
+    normaliseToggles,
+    enabledIndexKeys,
+    indexReturnForScoreDate,
+    buildIndexOverlaySeries,
+    aggregateIndexOverlay,
+    buildIndexOverlayData,
+};

--- a/tests/index_overlay_test.ts
+++ b/tests/index_overlay_test.ts
@@ -1,0 +1,312 @@
+// Tests for the headless benchmark-index overlay engine (issue #431, the
+// stretch goal of milestone #422).
+//
+// These import the REAL shipped helpers from docs/index_overlay.js (and its
+// dependencies docs/projection.js, docs/market_index.js, docs/trend_series.js)
+// and assert on their observable output:
+//   - each index's % return reuses the shared GRQProjection.buildIndexSeriesFromMap
+//     + GRQMarketIndex.indexPerformance kernels (no new index maths);
+//   - non-matured score dates (newer than today - 90 days) are excluded, exactly
+//     as the Actual / Target trend series excludes them;
+//   - index buckets align on the SAME GRQTrendSeries.bucketStartDate buckets as
+//     Actual / Target, with the per-index mean ignoring missing values;
+//   - the per-index toggles default to all-off and gate which datasets appear.
+import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/market_index.js";
+import "../docs/trend_series.js";
+import "../docs/index_overlay.js";
+
+type PriceMap = Record<string, number>;
+
+interface OverlayPoint {
+  date: Date;
+  returns: Record<string, number | null>;
+}
+
+interface OverlayBucket extends OverlayPoint {
+  count: number;
+}
+
+interface OverlayDataset {
+  key: string;
+  name: string;
+  borderColor: string | null;
+  backgroundColor: string | null;
+  points: { x: Date; y: number }[];
+}
+
+const g = globalThis as unknown as {
+  GRQIndexOverlay: {
+    OVERLAY_WINDOW_DAYS: number;
+    OVERLAY_INDICES: {
+      key: string;
+      name: string;
+      borderColor: string | null;
+      backgroundColor: string | null;
+    }[];
+    DEFAULT_TOGGLES: Record<string, boolean>;
+    normaliseToggles: (
+      toggles: Record<string, unknown> | null | undefined,
+    ) => Record<string, boolean>;
+    enabledIndexKeys: (
+      toggles: Record<string, unknown> | null | undefined,
+    ) => string[];
+    indexReturnForScoreDate: (
+      priceMap: PriceMap | null,
+      scoreDate: string | Date,
+      windowDays?: number,
+    ) => number | null;
+    buildIndexOverlaySeries: (
+      scoreDates: (string | Date)[],
+      marketIndices: Record<string, PriceMap>,
+      today: Date,
+    ) => OverlayPoint[];
+    aggregateIndexOverlay: (
+      series: OverlayPoint[],
+      granularity?: string,
+    ) => OverlayBucket[];
+    buildIndexOverlayData: (
+      scoreDates: (string | Date)[],
+      marketIndices: Record<string, PriceMap>,
+      today: Date,
+      granularity?: string,
+      toggles?: Record<string, unknown>,
+    ) => {
+      granularity: string;
+      toggles: Record<string, boolean>;
+      buckets: OverlayBucket[];
+      datasets: OverlayDataset[];
+    };
+  };
+};
+const Overlay = g.GRQIndexOverlay;
+
+// June 1, 2025 → maturity cutoff is March 3, 2025 (today - 90 days). Score
+// dates on or before the cutoff are matured; later ones are not.
+const TODAY = new Date(2025, 5, 1);
+
+Deno.test("indexReturnForScoreDate - % return from baseline over the 90-day window", () => {
+  // Baseline = first close on/after the score date; end = last close on/before
+  // score date + 90 days. The 2025-05-01 close is outside the window so it does
+  // not move the result: (120 - 100) / 100 = 20%.
+  const priceMap: PriceMap = {
+    "2025-01-02": 100,
+    "2025-03-15": 120,
+    "2025-05-01": 200,
+  };
+  const ret = Overlay.indexReturnForScoreDate(priceMap, "2025-01-02");
+  assertAlmostEquals(ret as number, 20, 1e-9);
+});
+
+Deno.test("indexReturnForScoreDate - matches the shared market_index calc directly", () => {
+  const priceMap: PriceMap = { "2025-01-02": 100, "2025-03-15": 150 };
+  const start = new Date(2025, 0, 2);
+  const end = new Date(2025, 0, 2);
+  end.setDate(end.getDate() + Overlay.OVERLAY_WINDOW_DAYS);
+  const proj = (globalThis as unknown as {
+    GRQProjection: {
+      buildIndexSeriesFromMap: (
+        m: PriceMap,
+        n: string,
+        s: Date,
+        e: Date,
+      ) => unknown;
+    };
+  }).GRQProjection;
+  const market = (globalThis as unknown as {
+    GRQMarketIndex: {
+      indexPerformance: (
+        s: unknown,
+        e: Date,
+      ) => { performance: number } | null;
+    };
+  }).GRQMarketIndex;
+  const series = proj.buildIndexSeriesFromMap(priceMap, "", start, end);
+  const expected = market.indexPerformance(series, end);
+  assertAlmostEquals(
+    Overlay.indexReturnForScoreDate(priceMap, "2025-01-02") as number,
+    (expected as { performance: number }).performance,
+    1e-9,
+  );
+});
+
+Deno.test("indexReturnForScoreDate - null when window has no usable prices", () => {
+  // All prices precede the score date, so the window is empty.
+  const priceMap: PriceMap = { "2024-01-01": 100 };
+  assertEquals(Overlay.indexReturnForScoreDate(priceMap, "2025-01-02"), null);
+});
+
+Deno.test("indexReturnForScoreDate - null on missing / invalid price map", () => {
+  assertEquals(Overlay.indexReturnForScoreDate(null, "2025-01-02"), null);
+  assertEquals(
+    Overlay.indexReturnForScoreDate({} as PriceMap, "2025-01-02"),
+    null,
+  );
+});
+
+Deno.test("buildIndexOverlaySeries - excludes non-matured score dates", () => {
+  const indices: Record<string, PriceMap> = {
+    sp500: { "2025-01-02": 100, "2025-03-15": 110, "2025-06-30": 130 },
+  };
+  // 2025-01-02 is matured; 2025-04-01 is after the cutoff (not matured).
+  const series = Overlay.buildIndexOverlaySeries(
+    ["2025-01-02", "2025-04-01"],
+    indices,
+    TODAY,
+  );
+  assertEquals(series.length, 1);
+  assertEquals(series[0].date.getTime(), new Date(2025, 0, 2).getTime());
+  assertAlmostEquals(series[0].returns.sp500 as number, 10, 1e-9);
+});
+
+Deno.test("buildIndexOverlaySeries - per-index returns; missing index is null; chronological order", () => {
+  const indices: Record<string, PriceMap> = {
+    sp500: { "2025-01-02": 100, "2025-03-15": 110 },
+    // nasdaq has no data inside 2025-01-02's window ([01-02, 04-02]) but does
+    // inside 2025-02-03's window ([02-03, 05-04]).
+    nasdaq: { "2025-04-10": 200, "2025-04-20": 230 },
+    // russell2000 deliberately absent → null for every date.
+  };
+  const series = Overlay.buildIndexOverlaySeries(
+    ["2025-02-03", "2025-01-02"],
+    indices,
+    TODAY,
+  );
+  // Sorted ascending by date.
+  assertEquals(series[0].date.getTime(), new Date(2025, 0, 2).getTime());
+  assertEquals(series[1].date.getTime(), new Date(2025, 1, 3).getTime());
+  assertAlmostEquals(series[0].returns.sp500 as number, 10, 1e-9);
+  assertEquals(series[0].returns.nasdaq, null);
+  assertAlmostEquals(series[1].returns.nasdaq as number, 15, 1e-9);
+  assertEquals(series[1].returns.russell2000, null);
+});
+
+Deno.test("aggregateIndexOverlay - buckets align on bucketStartDate and mean per index", () => {
+  const Trend = (globalThis as unknown as {
+    GRQTrendSeries: { bucketStartDate: (d: Date, g: string) => Date };
+  }).GRQTrendSeries;
+  const series: OverlayPoint[] = [
+    { date: new Date(2025, 0, 6), returns: { sp500: 10 } },
+    { date: new Date(2025, 0, 20), returns: { sp500: 20 } },
+    { date: new Date(2025, 1, 10), returns: { sp500: 8 } },
+  ];
+  const buckets = Overlay.aggregateIndexOverlay(series, "month");
+  assertEquals(buckets.length, 2);
+  // First bucket is January's start date — the SAME representative date the
+  // Trend engine uses, so the index line shares the Actual / Target X axis.
+  assertEquals(
+    buckets[0].date.getTime(),
+    Trend.bucketStartDate(new Date(2025, 0, 6), "month").getTime(),
+  );
+  assertAlmostEquals(buckets[0].returns.sp500 as number, 15, 1e-9); // (10+20)/2
+  assertEquals(buckets[0].count, 2);
+  assertAlmostEquals(buckets[1].returns.sp500 as number, 8, 1e-9);
+});
+
+Deno.test("aggregateIndexOverlay - per-index mean ignores null members", () => {
+  const series: OverlayPoint[] = [
+    { date: new Date(2025, 0, 6), returns: { sp500: 10, nasdaq: null } },
+    { date: new Date(2025, 0, 20), returns: { sp500: null, nasdaq: 30 } },
+  ];
+  const [bucket] = Overlay.aggregateIndexOverlay(series, "month");
+  // sp500 had one usable member, nasdaq the other → each is that member's value.
+  assertAlmostEquals(bucket.returns.sp500 as number, 10, 1e-9);
+  assertAlmostEquals(bucket.returns.nasdaq as number, 30, 1e-9);
+  // russell2000 had no usable member anywhere → null.
+  assertEquals(bucket.returns.russell2000, null);
+});
+
+Deno.test("aggregateIndexOverlay - unknown granularity throws", () => {
+  assertThrows(
+    () => Overlay.aggregateIndexOverlay([], "fortnight"),
+    Error,
+    "Unknown granularity",
+  );
+});
+
+Deno.test("normaliseToggles - fills the all-off default and coerces booleans", () => {
+  assertEquals(Overlay.normaliseToggles(undefined), {
+    sp500: false,
+    nasdaq: false,
+    russell2000: false,
+  });
+  assertEquals(Overlay.normaliseToggles({ sp500: 1, bogus: true }), {
+    sp500: true,
+    nasdaq: false,
+    russell2000: false,
+  });
+});
+
+Deno.test("DEFAULT_TOGGLES - every index defaults off", () => {
+  assertEquals(Overlay.DEFAULT_TOGGLES, {
+    sp500: false,
+    nasdaq: false,
+    russell2000: false,
+  });
+  assertEquals(Overlay.enabledIndexKeys(Overlay.DEFAULT_TOGGLES), []);
+  assertEquals(Overlay.enabledIndexKeys({ nasdaq: true }), ["nasdaq"]);
+});
+
+Deno.test("buildIndexOverlayData - default renders no index datasets (all off)", () => {
+  const indices: Record<string, PriceMap> = {
+    sp500: { "2025-01-02": 100, "2025-03-15": 110 },
+  };
+  const result = Overlay.buildIndexOverlayData(
+    ["2025-01-02"],
+    indices,
+    TODAY,
+  );
+  assertEquals(result.datasets, []);
+  // Buckets are still computed (the colour key can list every index).
+  assertEquals(result.buckets.length, 1);
+  assertEquals(result.toggles, Overlay.DEFAULT_TOGGLES);
+});
+
+Deno.test("buildIndexOverlayData - only toggled-on indices become datasets, aligned to buckets", () => {
+  const Trend = (globalThis as unknown as {
+    GRQTrendSeries: { bucketStartDate: (d: Date, g: string) => Date };
+  }).GRQTrendSeries;
+  const indices: Record<string, PriceMap> = {
+    sp500: { "2025-01-02": 100, "2025-03-15": 110 },
+    nasdaq: { "2025-01-02": 100, "2025-03-15": 130 },
+  };
+  const result = Overlay.buildIndexOverlayData(
+    ["2025-01-02"],
+    indices,
+    TODAY,
+    "month",
+    { nasdaq: true },
+  );
+  assertEquals(result.datasets.length, 1);
+  const ds = result.datasets[0];
+  assertEquals(ds.key, "nasdaq");
+  assertEquals(ds.name, "NASDAQ");
+  assertEquals(ds.points.length, 1);
+  // Point lands on the shared month bucket-start date.
+  assertEquals(
+    ds.points[0].x.getTime(),
+    Trend.bucketStartDate(new Date(2025, 0, 2), "month").getTime(),
+  );
+  assertAlmostEquals(ds.points[0].y, 30, 1e-9);
+  // A distinct, non-null line colour is supplied for the legend.
+  assertEquals(typeof ds.borderColor, "string");
+});
+
+Deno.test("buildIndexOverlayData - drops null buckets from an enabled line", () => {
+  // nasdaq has no data in the window → its only bucket is null and is dropped,
+  // leaving an empty (but present) dataset for the enabled index.
+  const indices: Record<string, PriceMap> = {
+    sp500: { "2025-01-02": 100, "2025-03-15": 110 },
+  };
+  const result = Overlay.buildIndexOverlayData(
+    ["2025-01-02"],
+    indices,
+    TODAY,
+    "month",
+    { nasdaq: true },
+  );
+  assertEquals(result.datasets.length, 1);
+  assertEquals(result.datasets[0].key, "nasdaq");
+  assertEquals(result.datasets[0].points, []);
+});

--- a/tests/js_syntax_test.ts
+++ b/tests/js_syntax_test.ts
@@ -82,3 +82,11 @@ Deno.test("checkJsSyntax - production docs/trend_series.js parses cleanly", asyn
   const result = checkJsSyntax(source);
   assertEquals(result.valid, true, result.error);
 });
+
+Deno.test("checkJsSyntax - production docs/index_overlay.js parses cleanly", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../docs/index_overlay.js", import.meta.url),
+  );
+  const result = checkJsSyntax(source);
+  assertEquals(result.valid, true, result.error);
+});


### PR DESCRIPTION
# Overlay benchmark indices on the Trend view (Issue #431)

## Summary

Adds the **headless benchmark-index overlay engine** for the new Trend view's
stretch goal: optionally overlay SP500 / NASDAQ / Russell 2000 as extra lines so
they can be compared against the portfolio Actual / Target series. Closes #431.

This mirrors the layered approach the milestone already follows: issue #429
shipped the Trend **data engine** (`docs/trend_series.js`) as a pure, DOM-free
module, leaving rendering to the Trend view UI sub-issue (#430). This PR adds the
matching **index-overlay layer** (`docs/index_overlay.js`, published on
`globalThis.GRQIndexOverlay`) — the pure data pipeline plus the per-index
on/off toggle-state model — so the UI sub-issue can drop it straight onto the
chart. Persistence of the toggle choices remains owned by the "remember choices"
sub-issue (#432).

### No new index maths (the issue forbids it)

Each index's value is **% return from the score-date baseline over the same
matured 90-day window** as Actual / Target, computed by reusing the existing
shared kernels — **no second calculation**:

- `GRQProjection.buildIndexSeriesFromMap` slices the same-origin
  `docs/market-indices.json` price map to the score date's 90-day window.
- `GRQMarketIndex.indexPerformance` applies the exact percentage formula the
  existing dashboard already plots benchmarks with.

### Aligned on the same X buckets

Maturity reuses `GRQTrendSeries.isMaturedScoreDate` and bucketing reuses
`GRQTrendSeries.bucketStartDate`, so an index point lands on the **same**
day/week/month/quarter bucket as the Actual / Target lines. Per-index bucket
values are the mean of their members' non-null returns.

### Per-index toggles, default all off

`DEFAULT_TOGGLES` is `{ sp500: false, nasdaq: false, russell2000: false }` — the
**documented default is all off**, so the Trend view starts uncluttered and the
user opts each benchmark in. `buildIndexOverlayData(...)` emits chart-ready
datasets for **only** the toggled-on indices, each carrying the distinct line
colour the existing dashboard already uses for that index (so the Trend view's
colour key / legend matches the rest of the site). Flipping a toggle changes
only which datasets are returned, which is how the UI will update the chart live.

### Scope / dependency note

The issue's UI acceptance points (live toggle widgets, colour-key wiring) depend
on the **Trend view UI** sub-issue (#430), which is not yet merged — there is no
chart to attach to. Following the #429 precedent, this PR delivers everything
that can be built and verified headlessly now; #430 wires
`GRQIndexOverlay.buildIndexOverlayData(...)` into the chart and the toggle
widgets. The existing dashboard is untouched (no `index.html` / `sw.js` change),
satisfying the "Existing dashboard untouched" criterion.

## Evidence

This is a headless data/state module — no DOM, no rendering — so there is no UI
to screenshot in this PR (the view itself arrives with #430). Verification is the
Deno test suite, which drives the **real shipped** helpers (no mocks): full suite
`701 passed | 0 failed`, including the new `tests/index_overlay_test.ts`.

```mermaid
flowchart LR
    A["score dates (matured only)"] --> S[buildIndexOverlaySeries]
    M["docs/market-indices.json<br/>{date: close} maps"] --> S
    S -->|"per score date,<br/>reuse buildIndexSeriesFromMap<br/>+ indexPerformance"| R["{date, returns per index}"]
    R --> AG[aggregateIndexOverlay]
    AG -->|"same GRQTrendSeries.bucketStartDate"| B["buckets aligned with Actual/Target"]
    B --> D[buildIndexOverlayData]
    T["per-index toggles<br/>(default all off)"] --> D
    D --> O["datasets for enabled indices<br/>(ready for the #430 chart)"]
```

## Test Plan

New `tests/index_overlay_test.ts` (imports the real `docs/index_overlay.js` and
its dependencies):

- `indexReturnForScoreDate` — % return from the score-date baseline over the
  90-day window; matches the shared `market_index` calc directly; null on an
  empty window and on a missing/invalid price map.
- `buildIndexOverlaySeries` — excludes non-matured score dates; per-index
  returns with a missing index resolved to null; chronological ordering.
- `aggregateIndexOverlay` — buckets align on `GRQTrendSeries.bucketStartDate`;
  per-index mean ignores null members; unknown granularity throws.
- `normaliseToggles` / `DEFAULT_TOGGLES` / `enabledIndexKeys` — all-off default,
  boolean coercion, unknown keys ignored.
- `buildIndexOverlayData` — default renders no index datasets; only toggled-on
  indices become datasets aligned to the shared buckets; null buckets are
  dropped from an enabled line.

Also added a parse guard for the new module in `tests/js_syntax_test.ts`
(`docs/index_overlay.js` parses cleanly).
