### PR TITLE
Add ?date= URL parameter to deep-link a score by date (#436)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,17 @@ Visit `http://localhost:8000` to access the dashboard.
 
 #### Deep-link URL parameters
 
-The dashboard reads three optional query parameters so a specific view can be
+The dashboard reads four optional query parameters so a specific view can be
 linked directly (and so the automated accessibility check can audit each view
 deterministically — issue #281):
 
 - `?file=<score-file>` — pre-select a score file, e.g.
   `?file=2026%2FMarch%2F23.tsv`.
+- `?date=<YYYY-MM-DD>` — pre-select the score for a date (issue #436), e.g.
+  `?date=2026-03-23`. This is the friendlier alternative to `?file=` — no
+  URL-encoded path needed. Unpadded month/day (`?date=2026-3-23`) is accepted;
+  an unknown or malformed date falls back to the default selection. When both
+  `?file=` and `?date=` are present, `?file=` wins.
 - `?stock=<symbol>` — open straight into the single-stock detail view, e.g.
   `?stock=NASDAQ%3AMGRC`. An unknown symbol falls back to the aggregate view.
 - `?theme=auto|light|dark` — force a theme for that page load (a transient

--- a/docs/app.js
+++ b/docs/app.js
@@ -170,25 +170,43 @@ class GRQValidator {
             });
 
             if (indexData.scores.length > 0) {
-                // Check for file parameter in URL first
+                // Check for file/date parameters in URL first. ?file= takes
+                // the exact score-file path; ?date= (issue #436) is the
+                // friendlier alternative, matching a score by its YYYY-MM-DD
+                // date. ?file= wins when both are present.
                 const urlParams = new URLSearchParams(window.location.search);
                 const fileParam = urlParams.get('file');
-                
+
+                let requestedFile = null;
                 if (fileParam) {
                     // Check if the file parameter matches any available score file
                     const matchingScore = indexData.scores.find(score => score.file === fileParam);
                     if (matchingScore) {
-                        console.log(`Auto-selecting score file from URL parameter: ${matchingScore.date} (${matchingScore.month} ${matchingScore.day})`);
-                        this.selectedFile = matchingScore.file;
-                        select.value = this.selectedFile;
-                        await this.loadScoreFile();
-                        this.applyStockSelectionFromUrl();
-                        return;
+                        requestedFile = matchingScore.file;
                     } else {
                         console.warn(`File parameter '${fileParam}' not found in available scores`);
                     }
                 }
-                
+
+                if (!requestedFile) {
+                    const dateParam = GRQDateSelection.dateFromSearch(window.location.search);
+                    if (dateParam) {
+                        requestedFile = GRQDateSelection.resolveDateSelection(indexData.scores, dateParam);
+                        if (!requestedFile) {
+                            console.warn(`Date parameter '${dateParam}' not found in available scores`);
+                        }
+                    }
+                }
+
+                if (requestedFile) {
+                    console.log(`Auto-selecting score file from URL parameter: ${requestedFile}`);
+                    this.selectedFile = requestedFile;
+                    select.value = this.selectedFile;
+                    await this.loadScoreFile();
+                    this.applyStockSelectionFromUrl();
+                    return;
+                }
+
                 // Fallback: select the nearest available score date ON OR
                 // BEFORE 90 days ago (issue #275). Delegates to the shared,
                 // unit-tested helper so the browser and Deno tests agree.

--- a/docs/archive/pr-summaries/pr-summary-436.md
+++ b/docs/archive/pr-summaries/pr-summary-436.md
@@ -1,0 +1,63 @@
+# Send dates via a URL parameter (issue #436)
+
+## Summary
+
+The dashboard could already be deep-linked to a score via `?file=`, but that
+needs the URL-encoded score-file path (`?file=2026%2FMarch%2F23.tsv`) — awkward
+to type or share. This PR adds a friendlier `?date=<YYYY-MM-DD>` query parameter
+that pre-selects the score for a given date, e.g.
+`index.html?date=2026-03-23`. Closes #436.
+
+- New pure helper module `docs/date_selection.js` (mirrors
+  `docs/stock_selection.js`): `dateFromSearch()` reads the `?date=` value and
+  `resolveDateSelection()` maps it to the matching score-file path. Unpadded
+  month/day (`2026-3-23`) is accepted; an unknown or malformed date returns
+  `null` so the dashboard falls back to its normal default selection.
+- `docs/app.js` `loadIndex()` now resolves the requested score from either
+  `?file=` or `?date=`. `?file=` keeps precedence when both are present, so
+  existing links are unaffected.
+- `docs/index.html` loads `date_selection.js` before `app.js` (same pattern as
+  the other helper modules). The CSP (`script-src 'self'`) already permits the
+  same-origin script; no change needed.
+- README deep-link section documents the new parameter.
+
+The helper touches no DOM and uses no module syntax, so it imports cleanly
+under both the browser and Deno.
+
+```mermaid
+flowchart TD
+    A[loadIndex] --> B{?file= matches a score?}
+    B -- yes --> S[select that score file]
+    B -- no --> C{?date= matches a score?}
+    C -- yes --> S
+    C -- no --> D[default: nearest score on/before 90 days ago]
+```
+
+## Evidence
+
+No browser automation tool (Playwright MCP / headless Chrome) was available in
+this environment, so no screenshot could be captured. The behaviour is instead
+verified by behavioural unit tests and an end-to-end resolution against the real
+committed `docs/scores/index.json`:
+
+```
+2026-06-22 -> 2026/June/22.tsv
+2026-6-22  -> 2026/June/22.tsv   (unpadded accepted)
+2099-01-01 -> null               (unknown date → fallback)
+garbage    -> null               (malformed → fallback)
+?date=2026-06-22&stock=X -> 2026-06-22  (parsed alongside other params)
+```
+
+`./quality.sh` passes cleanly (Rust fmt/clippy/check/test + full Deno suite of
+678 tests).
+
+## Test Plan
+
+- Added `tests/date_selection_test.ts` exercising the real shipped helpers from
+  `docs/date_selection.js`:
+  - `dateFromSearch` extracts the date, works alongside other params, trims
+    whitespace, and returns `null` when absent/blank/non-string.
+  - `resolveDateSelection` matches by exact date, accepts unpadded month/day,
+    and returns `null` for unknown dates, malformed input, and non-array
+    score lists.
+- All existing Rust and Deno tests continue to pass.

--- a/docs/date_selection.js
+++ b/docs/date_selection.js
@@ -1,0 +1,76 @@
+// Date deep-link selection helpers (issue #436).
+//
+// The dashboard can be deep-linked to a specific score date with a
+// `?date=<YYYY-MM-DD>` query parameter, e.g. `index.html?date=2026-03-23`.
+// This is friendlier than the existing `?file=` parameter, which needs the
+// URL-encoded score-file path (`?file=2026%2FMarch%2F23.tsv`).
+//
+// Like docs/escape.js, docs/projection.js, docs/theme.js and
+// docs/stock_selection.js, this file is loaded as a classic <script> in
+// docs/index.html and is also imported by the Deno tests. It uses no module
+// syntax, publishes its helpers on `globalThis.GRQDateSelection`, and touches
+// no DOM, so it imports cleanly in a non-browser (test) environment.
+(function () {
+  "use strict";
+
+  // Extract the requested date from a URL query string. Returns the trimmed
+  // raw value, or null when the parameter is absent or blank.
+  function dateFromSearch(search) {
+    try {
+      const value = new URLSearchParams(search || "").get("date");
+      if (value === null) {
+        return null;
+      }
+      const trimmed = value.trim();
+      return trimmed === "" ? null : trimmed;
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // Normalise a date string to canonical YYYY-MM-DD, accepting unpadded month
+  // and day (e.g. 2026-3-3). Returns null when the value is not a plausible
+  // calendar date, so callers fall back rather than guessing.
+  function normaliseDate(value) {
+    if (typeof value !== "string") {
+      return null;
+    }
+    const match = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(value.trim());
+    if (!match) {
+      return null;
+    }
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    if (month < 1 || month > 12 || day < 1 || day > 31) {
+      return null;
+    }
+    const mm = String(month).padStart(2, "0");
+    const dd = String(day).padStart(2, "0");
+    return `${match[1]}-${mm}-${dd}`;
+  }
+
+  // Resolve a requested date against the loaded score index. Returns the
+  // matching score file path when a score has that date, else null so the
+  // caller can fall back to the default selection. Each entry is expected to
+  // expose a `.date` (YYYY-MM-DD) and a `.file` (path) property.
+  function resolveDateSelection(scores, requested) {
+    if (!Array.isArray(scores)) {
+      return null;
+    }
+    const wanted = normaliseDate(requested);
+    if (wanted === null) {
+      return null;
+    }
+    const match = scores.find(
+      (row) =>
+        row && typeof row.date === "string" &&
+        normaliseDate(row.date) === wanted,
+    );
+    return match && typeof match.file === "string" ? match.file : null;
+  }
+
+  globalThis.GRQDateSelection = {
+    dateFromSearch,
+    resolveDateSelection,
+  };
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -316,6 +316,9 @@
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
     <script src="stock_selection.js"></script>
 
+    <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
+    <script src="date_selection.js"></script>
+
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
     <script src="popover_dismiss.js"></script>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.210">
+    <meta name="app-version" content="1.0.211">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -332,6 +332,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.210"></script>
+    <script src="sw-register.js?v=1.0.211"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.210")
+    navigator.serviceWorker.register("./sw.js?v=1.0.211")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.210";
+const APP_VERSION = "1.0.211";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/tests/date_selection_test.ts
+++ b/tests/date_selection_test.ts
@@ -1,0 +1,114 @@
+// Behavioural tests for the date deep-link helpers (issue #436).
+//
+// These import the REAL shipped helpers from docs/date_selection.js — the same
+// pure functions the dashboard uses to honour a `?date=<YYYY-MM-DD>` URL
+// parameter and pre-select the matching score file. The module publishes its
+// helpers on globalThis and touches no DOM, so it imports cleanly under Deno.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/date_selection.js";
+
+interface ScoreEntry {
+  file: string;
+  date: string;
+}
+
+const g = globalThis as unknown as {
+  GRQDateSelection: {
+    dateFromSearch: (search: unknown) => string | null;
+    resolveDateSelection: (
+      scores: unknown,
+      requested: unknown,
+    ) => string | null;
+  };
+};
+const GRQDateSelection = g.GRQDateSelection;
+
+const SCORES: ScoreEntry[] = [
+  { file: "2024/October/15.tsv", date: "2024-10-15" },
+  { file: "2026/March/23.tsv", date: "2026-03-23" },
+  { file: "2026/March/3.tsv", date: "2026-03-03" },
+];
+
+Deno.test("GRQDateSelection is published on globalThis", () => {
+  assert(
+    GRQDateSelection,
+    "date_selection.js should publish globalThis.GRQDateSelection",
+  );
+});
+
+Deno.test("dateFromSearch extracts the requested date", () => {
+  assertEquals(
+    GRQDateSelection.dateFromSearch("?date=2026-03-23"),
+    "2026-03-23",
+  );
+  // Works alongside other params.
+  assertEquals(
+    GRQDateSelection.dateFromSearch("?stock=NYSE%3ADD&date=2026-03-23"),
+    "2026-03-23",
+  );
+  assertEquals(
+    GRQDateSelection.dateFromSearch("date=2024-10-15"),
+    "2024-10-15",
+  );
+  // Surrounding whitespace is trimmed.
+  assertEquals(
+    GRQDateSelection.dateFromSearch("?date=%202026-03-23%20"),
+    "2026-03-23",
+  );
+});
+
+Deno.test("dateFromSearch returns null when absent or blank", () => {
+  assertEquals(
+    GRQDateSelection.dateFromSearch("?file=2026/March/23.tsv"),
+    null,
+  );
+  assertEquals(GRQDateSelection.dateFromSearch("?date="), null);
+  assertEquals(GRQDateSelection.dateFromSearch("?date=%20%20"), null);
+  assertEquals(GRQDateSelection.dateFromSearch(""), null);
+  assertEquals(GRQDateSelection.dateFromSearch(null), null);
+  assertEquals(GRQDateSelection.dateFromSearch(undefined), null);
+});
+
+Deno.test("resolveDateSelection matches a score by exact date", () => {
+  assertEquals(
+    GRQDateSelection.resolveDateSelection(SCORES, "2026-03-23"),
+    "2026/March/23.tsv",
+  );
+  assertEquals(
+    GRQDateSelection.resolveDateSelection(SCORES, "2024-10-15"),
+    "2024/October/15.tsv",
+  );
+});
+
+Deno.test("resolveDateSelection accepts unpadded month/day", () => {
+  // A user may type 2026-3-3 rather than the canonical 2026-03-03.
+  assertEquals(
+    GRQDateSelection.resolveDateSelection(SCORES, "2026-3-3"),
+    "2026/March/3.tsv",
+  );
+  assertEquals(
+    GRQDateSelection.resolveDateSelection(SCORES, "2026-3-23"),
+    "2026/March/23.tsv",
+  );
+});
+
+Deno.test("resolveDateSelection returns null for an unknown date", () => {
+  assertEquals(
+    GRQDateSelection.resolveDateSelection(SCORES, "2025-01-01"),
+    null,
+  );
+});
+
+Deno.test("resolveDateSelection returns null for malformed input", () => {
+  assertEquals(
+    GRQDateSelection.resolveDateSelection(SCORES, "not-a-date"),
+    null,
+  );
+  assertEquals(
+    GRQDateSelection.resolveDateSelection(SCORES, "2026-13-40"),
+    null,
+  );
+  assertEquals(GRQDateSelection.resolveDateSelection(SCORES, ""), null);
+  assertEquals(GRQDateSelection.resolveDateSelection(SCORES, null), null);
+  assertEquals(GRQDateSelection.resolveDateSelection(null, "2026-03-23"), null);
+});


### PR DESCRIPTION
# Send dates via a URL parameter (issue #436)

## Summary

The dashboard could already be deep-linked to a score via `?file=`, but that
needs the URL-encoded score-file path (`?file=2026%2FMarch%2F23.tsv`) — awkward
to type or share. This PR adds a friendlier `?date=<YYYY-MM-DD>` query parameter
that pre-selects the score for a given date, e.g.
`index.html?date=2026-03-23`. Closes #436.

- New pure helper module `docs/date_selection.js` (mirrors
  `docs/stock_selection.js`): `dateFromSearch()` reads the `?date=` value and
  `resolveDateSelection()` maps it to the matching score-file path. Unpadded
  month/day (`2026-3-23`) is accepted; an unknown or malformed date returns
  `null` so the dashboard falls back to its normal default selection.
- `docs/app.js` `loadIndex()` now resolves the requested score from either
  `?file=` or `?date=`. `?file=` keeps precedence when both are present, so
  existing links are unaffected.
- `docs/index.html` loads `date_selection.js` before `app.js` (same pattern as
  the other helper modules). The CSP (`script-src 'self'`) already permits the
  same-origin script; no change needed.
- README deep-link section documents the new parameter.

The helper touches no DOM and uses no module syntax, so it imports cleanly
under both the browser and Deno.

```mermaid
flowchart TD
    A[loadIndex] --> B{?file= matches a score?}
    B -- yes --> S[select that score file]
    B -- no --> C{?date= matches a score?}
    C -- yes --> S
    C -- no --> D[default: nearest score on/before 90 days ago]
```

## Evidence

No browser automation tool (Playwright MCP / headless Chrome) was available in
this environment, so no screenshot could be captured. The behaviour is instead
verified by behavioural unit tests and an end-to-end resolution against the real
committed `docs/scores/index.json`:

```
2026-06-22 -> 2026/June/22.tsv
2026-6-22  -> 2026/June/22.tsv   (unpadded accepted)
2099-01-01 -> null               (unknown date → fallback)
garbage    -> null               (malformed → fallback)
?date=2026-06-22&stock=X -> 2026-06-22  (parsed alongside other params)
```

`./quality.sh` passes cleanly (Rust fmt/clippy/check/test + full Deno suite of
678 tests).

## Test Plan

- Added `tests/date_selection_test.ts` exercising the real shipped helpers from
  `docs/date_selection.js`:
  - `dateFromSearch` extracts the date, works alongside other params, trims
    whitespace, and returns `null` when absent/blank/non-string.
  - `resolveDateSelection` matches by exact date, accepts unpadded month/day,
    and returns `null` for unknown dates, malformed input, and non-array
    score lists.
- All existing Rust and Deno tests continue to pass.
