### PR TITLE
Remember Trend-view choices across visits via localStorage (Issue #432)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-432.md
+++ b/docs/archive/pr-summaries/pr-summary-432.md
@@ -1,0 +1,100 @@
+# Remember Trend-view choices across visits (Issue #432)
+
+## Summary
+
+Adds **`docs/trend_settings.js`** — the client-side settings helper that
+remembers the Trend view's choices across visits, backed by `localStorage`
+under namespaced `grq.trend.*` keys. Closes #432.
+
+It persists the two selections #432 asks for:
+
+- the **grouping granularity** — `day` / `week` / `month` / `quarter`
+  (default **month**), under `grq.trend.grouping`; and
+- each **benchmark-index on/off toggle** — SP500 / NASDAQ / Russell 2000
+  (default **all off**), under `grq.trend.indices`.
+
+This mirrors the layered approach the milestone already follows: #429 shipped
+the Trend **data engine** (`docs/trend_series.js`) and #431 the **index-overlay
+engine** (`docs/index_overlay.js`), both as pure, DOM-free modules that left
+rendering to the Trend view UI sub-issue (#430). This PR adds the matching
+**persistence layer** (published on `globalThis.GRQTrendSettings`) so the UI
+sub-issue can call `readTrendSettings()` on view init to restore the controls,
+and `writeGrouping(...)` / `setIndexToggle(...)` on change.
+
+### Tolerates absent / corrupt / unavailable storage
+
+Every storage access is guarded, so the acceptance criterion "no errors when
+`localStorage` is unavailable (e.g. private mode)" holds:
+
+- **First visit / cleared storage** → defaults apply (`month`, all indices off).
+- **Corrupt value** → a non-granularity grouping or non-JSON toggles blob falls
+  back to defaults rather than throwing.
+- **Unavailable storage** → reads return defaults and writes report `false`
+  (never throw); `setIndexToggle(...)` still returns a sane in-memory map so the
+  live chart keeps working even when nothing can be saved.
+
+### Single source of truth
+
+The toggle shape and the granularity list are reused from the existing engines
+when loaded — `GRQIndexOverlay.normaliseToggles` / `OVERLAY_INDICES` and
+`GRQTrendSeries.GRANULARITIES` — with local fallbacks so the module still parses
+and tests independently. No new index or grouping definitions are introduced.
+
+### Scope / dependency note
+
+The acceptance criteria's reload-restores-state flow depends on the **Trend view
+UI** sub-issue (#430), which is not yet merged — there are no grouping/toggle
+DOM controls to wire to (and `trend_series.js` / `index_overlay.js` are likewise
+not yet loaded in `index.html`). Following the #429 / #431 precedent, this PR
+delivers everything that can be built and verified headlessly now; #430 wires
+`GRQTrendSettings` into the controls. The existing dashboard is untouched (no
+`index.html` / `sw.js` change), satisfying the "No impact on the existing
+dashboard" criterion.
+
+## Evidence
+
+This is a headless persistence/state module — no DOM, no rendering — so there is
+no UI to screenshot in this PR (the `needs-screenshot` view itself arrives with
+the Trend view UI sub-issue #430, which wires these helpers to real controls).
+Verification is the Deno test
+suite, which drives the **real shipped** helpers (no mocks) via an injectable
+in-memory storage: full suite **730 passed | 0 failed**, including the new
+`tests/trend_settings_test.ts`.
+
+```mermaid
+flowchart LR
+    V["Trend view init (#430)"] --> R[readTrendSettings]
+    LS[("localStorage<br/>grq.trend.*")] --> R
+    R --> C["restore controls<br/>(grouping + index toggles)"]
+    C -->|user changes grouping| WG[writeGrouping]
+    C -->|user flips a toggle| WT[setIndexToggle]
+    WG --> LS
+    WT --> LS
+    R -.->|absent / corrupt / unavailable| D["defaults:<br/>month, all off"]
+```
+
+## Test Plan
+
+New `tests/trend_settings_test.ts` (imports the real `docs/trend_settings.js`)
+exercises the happy, error and edge paths:
+
+- **Publication / keys** — `GRQTrendSettings` on `globalThis`; keys namespaced
+  under `grq.trend.*`; granularities and default month exposed.
+- **`normaliseGrouping`** — keeps the four valid granularities; junk / empty /
+  null / wrong-type → `month`.
+- **`normaliseToggles`** — all-off default; boolean coercion; unknown keys
+  ignored.
+- **Grouping round-trip** — `writeGrouping` → `readGrouping`; junk normalised to
+  `month` before persisting; empty storage → default; corrupt value → default.
+- **Toggle round-trip** — `writeToggles` → `readToggles`; empty → all-off;
+  corrupt (non-JSON) → defaults; partial stored object normalised.
+- **`setIndexToggle`** — flips a single index while persisting the rest across
+  successive writes; unknown index key ignored.
+- **Combined settings** — `writeTrendSettings` → `readTrendSettings`; defaults
+  on first visit.
+- **Unavailable storage** — throwing storage and explicit `null` storage: reads
+  fall back to defaults, writes return `false` (never throw), `setIndexToggle`
+  still returns a sane map.
+
+Also added a parse guard for the new module in `tests/js_syntax_test.ts`
+(`docs/trend_settings.js` parses cleanly).

--- a/docs/trend_settings.js
+++ b/docs/trend_settings.js
@@ -1,0 +1,195 @@
+// Client-side settings helper for the "Portfolio Actual vs Target over time"
+// Trend view (issue #432, part of milestone #422).
+//
+// This remembers the user's Trend-view choices across visits, backed by
+// localStorage under namespaced `grq.trend.*` keys:
+//   - the grouping granularity (day / week / month / quarter), and
+//   - each benchmark-index on/off toggle (SP500 / NASDAQ / Russell 2000).
+//
+// Like docs/theme.js, docs/trend_series.js and docs/index_overlay.js this file
+// is loaded as a classic <script> and is also imported by the Deno tests. It
+// uses no module syntax, publishes its helpers on globalThis.GRQTrendSettings,
+// and guards EVERY storage access so absent / corrupt / unavailable storage
+// (e.g. private mode) falls back to defaults without ever throwing.
+//
+// This module owns only persistence — it adds no DOM and no chart. The Trend
+// view UI sub-issue (#430) calls `readTrendSettings()` on view init to restore
+// the controls, and `writeGrouping(...)` / `setIndexToggle(...)` on change.
+//
+// Storage is injectable: every read/write takes an optional `storage` argument
+// (any Web Storage-like { getItem, setItem }). When omitted it defaults to the
+// ambient `localStorage`; passing an explicit `null` models a no-storage
+// environment. This keeps the helpers pure and deterministically testable.
+(function () {
+  "use strict";
+
+  // The grouping granularities, mirroring GRQTrendSeries.GRANULARITIES (reused
+  // when that engine has loaded, else a local copy so this module parses and
+  // tests independently).
+  const GRANULARITIES =
+    (globalThis.GRQTrendSeries && globalThis.GRQTrendSeries.GRANULARITIES) ||
+    ["day", "week", "month", "quarter"];
+
+  // The user-facing default grouping (issue #432: grouping = month).
+  const DEFAULT_GROUPING = "month";
+
+  // The benchmark indices whose toggles we persist, reusing the overlay
+  // engine's single source of truth when present, else a local fallback list.
+  const INDEX_KEYS =
+    (globalThis.GRQIndexOverlay && globalThis.GRQIndexOverlay.OVERLAY_INDICES &&
+      globalThis.GRQIndexOverlay.OVERLAY_INDICES.map((i) => i.key)) ||
+    ["sp500", "nasdaq", "russell2000"];
+
+  // Namespaced localStorage keys (issue #432: keys under `grq.trend.*`).
+  const STORAGE_KEYS = {
+    grouping: "grq.trend.grouping",
+    indices: "grq.trend.indices",
+  };
+
+  // Coerce an arbitrary value to a known granularity, defaulting to month so a
+  // corrupt or missing stored value never breaks the view.
+  function normaliseGrouping(value) {
+    return GRANULARITIES.includes(value) ? value : DEFAULT_GROUPING;
+  }
+
+  // Coerce an arbitrary (possibly partial / null) toggle object into a full
+  // boolean map. Delegates to the overlay engine when present (one source of
+  // truth) so the persisted shape matches what the chart consumes; otherwise
+  // applies the same all-off default locally.
+  function normaliseToggles(toggles) {
+    if (
+      globalThis.GRQIndexOverlay &&
+      typeof globalThis.GRQIndexOverlay.normaliseToggles === "function"
+    ) {
+      return globalThis.GRQIndexOverlay.normaliseToggles(toggles);
+    }
+    const source = toggles && typeof toggles === "object" ? toggles : {};
+    const result = {};
+    for (const key of INDEX_KEYS) {
+      result[key] = key in source ? Boolean(source[key]) : false;
+    }
+    return result;
+  }
+
+  // Resolve the storage to use: an explicitly-passed value (which may be null)
+  // wins; otherwise fall back to the ambient localStorage, tolerating an
+  // environment where even touching it throws.
+  function resolveStorage(storage) {
+    if (storage !== undefined) {
+      return storage;
+    }
+    try {
+      return typeof localStorage !== "undefined" ? localStorage : null;
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // Read one key, returning null on any failure (no storage, throws, missing).
+  function safeGet(storage, key) {
+    const store = resolveStorage(storage);
+    if (!store || typeof store.getItem !== "function") {
+      return null;
+    }
+    try {
+      return store.getItem(key);
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // Write one key, returning whether it was persisted (false on any failure).
+  function safeSet(storage, key, value) {
+    const store = resolveStorage(storage);
+    if (!store || typeof store.setItem !== "function") {
+      return false;
+    }
+    try {
+      store.setItem(key, value);
+      return true;
+    } catch (_err) {
+      return false;
+    }
+  }
+
+  // --- grouping ------------------------------------------------------------
+
+  function readGrouping(storage) {
+    return normaliseGrouping(safeGet(storage, STORAGE_KEYS.grouping));
+  }
+
+  function writeGrouping(value, storage) {
+    return safeSet(storage, STORAGE_KEYS.grouping, normaliseGrouping(value));
+  }
+
+  // --- index toggles -------------------------------------------------------
+
+  function readToggles(storage) {
+    const raw = safeGet(storage, STORAGE_KEYS.indices);
+    if (raw === null) {
+      return normaliseToggles(null);
+    }
+    let parsed = null;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (_err) {
+      parsed = null; // corrupt JSON -> defaults
+    }
+    return normaliseToggles(parsed);
+  }
+
+  function writeToggles(toggles, storage) {
+    return safeSet(
+      storage,
+      STORAGE_KEYS.indices,
+      JSON.stringify(normaliseToggles(toggles)),
+    );
+  }
+
+  // Read-modify-write a single index toggle (the "write on change" path the UI
+  // calls when the user flips one benchmark). Returns the resulting normalised
+  // map regardless of whether the save succeeded, so the caller can still drive
+  // the live chart when storage is unavailable. Unknown keys are ignored.
+  function setIndexToggle(key, on, storage) {
+    const toggles = readToggles(storage);
+    if (INDEX_KEYS.includes(key)) {
+      toggles[key] = Boolean(on);
+    }
+    writeToggles(toggles, storage);
+    return toggles;
+  }
+
+  // --- combined ------------------------------------------------------------
+
+  function readTrendSettings(storage) {
+    return {
+      grouping: readGrouping(storage),
+      toggles: readToggles(storage),
+    };
+  }
+
+  // Persist both parts. Returns true only when BOTH writes succeeded. A missing
+  // part falls back to its default before being written.
+  function writeTrendSettings(settings, storage) {
+    const source = settings && typeof settings === "object" ? settings : {};
+    const groupingOk = writeGrouping(source.grouping, storage);
+    const togglesOk = writeToggles(source.toggles, storage);
+    return groupingOk && togglesOk;
+  }
+
+  // Publish the helpers for the dashboard and the tests.
+  globalThis.GRQTrendSettings = {
+    GRANULARITIES,
+    DEFAULT_GROUPING,
+    STORAGE_KEYS,
+    normaliseGrouping,
+    normaliseToggles,
+    readGrouping,
+    writeGrouping,
+    readToggles,
+    writeToggles,
+    setIndexToggle,
+    readTrendSettings,
+    writeTrendSettings,
+  };
+})();

--- a/tests/js_syntax_test.ts
+++ b/tests/js_syntax_test.ts
@@ -90,3 +90,11 @@ Deno.test("checkJsSyntax - production docs/index_overlay.js parses cleanly", asy
   const result = checkJsSyntax(source);
   assertEquals(result.valid, true, result.error);
 });
+
+Deno.test("checkJsSyntax - production docs/trend_settings.js parses cleanly", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../docs/trend_settings.js", import.meta.url),
+  );
+  const result = checkJsSyntax(source);
+  assertEquals(result.valid, true, result.error);
+});

--- a/tests/trend_settings_test.ts
+++ b/tests/trend_settings_test.ts
@@ -1,0 +1,286 @@
+// Behavioural tests for the Trend-view settings helper (issue #432, part of
+// milestone #422).
+//
+// These import the REAL shipped helpers from docs/trend_settings.js — the same
+// pure functions the Trend view will use to remember the user's grouping
+// granularity and per-index on/off toggles across visits via localStorage. The
+// module publishes its helpers on globalThis.GRQTrendSettings (mirroring
+// docs/theme.js and docs/index_overlay.js) and guards every storage access, so
+// it imports cleanly under Deno and tolerates absent / corrupt / unavailable
+// storage.
+//
+// Storage is injectable: every read/write accepts a storage object so the tests
+// drive deterministic behaviour without touching the real localStorage.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/trend_settings.js";
+
+const g = globalThis as unknown as {
+  GRQTrendSettings: {
+    GRANULARITIES: string[];
+    DEFAULT_GROUPING: string;
+    STORAGE_KEYS: { grouping: string; indices: string };
+    normaliseGrouping: (value: unknown) => string;
+    normaliseToggles: (
+      toggles: unknown,
+    ) => Record<string, boolean>;
+    readGrouping: (storage?: unknown) => string;
+    writeGrouping: (value: unknown, storage?: unknown) => boolean;
+    readToggles: (storage?: unknown) => Record<string, boolean>;
+    writeToggles: (toggles: unknown, storage?: unknown) => boolean;
+    setIndexToggle: (
+      key: string,
+      on: unknown,
+      storage?: unknown,
+    ) => Record<string, boolean>;
+    readTrendSettings: (
+      storage?: unknown,
+    ) => { grouping: string; toggles: Record<string, boolean> };
+    writeTrendSettings: (settings: unknown, storage?: unknown) => boolean;
+  };
+};
+
+const S = g.GRQTrendSettings;
+
+// A minimal in-memory Web Storage stand-in for deterministic tests.
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem(key: string): string | null {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    setItem(key: string, value: string): void {
+      map.set(key, String(value));
+    },
+    removeItem(key: string): void {
+      map.delete(key);
+    },
+    // Test-only peek.
+    _dump(): Record<string, string> {
+      return Object.fromEntries(map);
+    },
+  };
+}
+
+// Storage that throws on every access — models private mode / disabled storage.
+function throwingStorage() {
+  return {
+    getItem(): string {
+      throw new Error("storage unavailable");
+    },
+    setItem(): void {
+      throw new Error("storage unavailable");
+    },
+    removeItem(): void {
+      throw new Error("storage unavailable");
+    },
+  };
+}
+
+Deno.test("GRQTrendSettings is published on globalThis", () => {
+  assert(S, "trend_settings.js should publish globalThis.GRQTrendSettings");
+  assertEquals(S.GRANULARITIES, ["day", "week", "month", "quarter"]);
+  assertEquals(S.DEFAULT_GROUPING, "month");
+});
+
+Deno.test("STORAGE_KEYS are namespaced under grq.trend.*", () => {
+  assert(S.STORAGE_KEYS.grouping.startsWith("grq.trend."));
+  assert(S.STORAGE_KEYS.indices.startsWith("grq.trend."));
+});
+
+// --- normaliseGrouping -----------------------------------------------------
+
+Deno.test("normaliseGrouping keeps the four valid granularities", () => {
+  assertEquals(S.normaliseGrouping("day"), "day");
+  assertEquals(S.normaliseGrouping("week"), "week");
+  assertEquals(S.normaliseGrouping("month"), "month");
+  assertEquals(S.normaliseGrouping("quarter"), "quarter");
+});
+
+Deno.test("normaliseGrouping falls back to month for junk", () => {
+  assertEquals(S.normaliseGrouping("year"), "month");
+  assertEquals(S.normaliseGrouping(""), "month");
+  assertEquals(S.normaliseGrouping(null), "month");
+  assertEquals(S.normaliseGrouping(undefined), "month");
+  assertEquals(S.normaliseGrouping(42), "month");
+});
+
+// --- normaliseToggles ------------------------------------------------------
+
+Deno.test("normaliseToggles defaults every index to off", () => {
+  assertEquals(S.normaliseToggles(null), {
+    sp500: false,
+    nasdaq: false,
+    russell2000: false,
+  });
+  assertEquals(S.normaliseToggles(undefined), {
+    sp500: false,
+    nasdaq: false,
+    russell2000: false,
+  });
+});
+
+Deno.test("normaliseToggles coerces values and ignores unknown keys", () => {
+  assertEquals(
+    S.normaliseToggles({ sp500: 1, nasdaq: "", bogus: true }),
+    { sp500: true, nasdaq: false, russell2000: false },
+  );
+});
+
+// --- grouping round-trip ---------------------------------------------------
+
+Deno.test("writeGrouping then readGrouping round-trips a valid value", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeGrouping("week", store), true);
+  assertEquals(S.readGrouping(store), "week");
+  assertEquals(store._dump()[S.STORAGE_KEYS.grouping], "week");
+});
+
+Deno.test("writeGrouping normalises junk to month before persisting", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeGrouping("decade", store), true);
+  assertEquals(store._dump()[S.STORAGE_KEYS.grouping], "month");
+  assertEquals(S.readGrouping(store), "month");
+});
+
+Deno.test("readGrouping returns the default when storage is empty", () => {
+  assertEquals(S.readGrouping(fakeStorage()), "month");
+});
+
+Deno.test("readGrouping tolerates a corrupt stored value", () => {
+  const store = fakeStorage({ [S.STORAGE_KEYS.grouping]: "garbage" });
+  assertEquals(S.readGrouping(store), "month");
+});
+
+// --- toggles round-trip ----------------------------------------------------
+
+Deno.test("writeToggles then readToggles round-trips a full map", () => {
+  const store = fakeStorage();
+  assertEquals(
+    S.writeToggles({ sp500: true, nasdaq: false, russell2000: true }, store),
+    true,
+  );
+  assertEquals(S.readToggles(store), {
+    sp500: true,
+    nasdaq: false,
+    russell2000: true,
+  });
+});
+
+Deno.test("readToggles returns all-off defaults when storage is empty", () => {
+  assertEquals(S.readToggles(fakeStorage()), {
+    sp500: false,
+    nasdaq: false,
+    russell2000: false,
+  });
+});
+
+Deno.test("readToggles tolerates corrupt (non-JSON) stored value", () => {
+  const store = fakeStorage({ [S.STORAGE_KEYS.indices]: "{not json" });
+  assertEquals(S.readToggles(store), {
+    sp500: false,
+    nasdaq: false,
+    russell2000: false,
+  });
+});
+
+Deno.test("readToggles normalises a partial stored object", () => {
+  const store = fakeStorage({
+    [S.STORAGE_KEYS.indices]: JSON.stringify({ nasdaq: true }),
+  });
+  assertEquals(S.readToggles(store), {
+    sp500: false,
+    nasdaq: true,
+    russell2000: false,
+  });
+});
+
+// --- setIndexToggle (write-on-change convenience) --------------------------
+
+Deno.test("setIndexToggle flips a single index and persists the rest", () => {
+  const store = fakeStorage();
+  let toggles = S.setIndexToggle("sp500", true, store);
+  assertEquals(toggles, { sp500: true, nasdaq: false, russell2000: false });
+
+  toggles = S.setIndexToggle("russell2000", true, store);
+  assertEquals(toggles, { sp500: true, nasdaq: false, russell2000: true });
+  // Persisted across the two writes.
+  assertEquals(S.readToggles(store), {
+    sp500: true,
+    nasdaq: false,
+    russell2000: true,
+  });
+
+  toggles = S.setIndexToggle("sp500", false, store);
+  assertEquals(toggles.sp500, false);
+});
+
+Deno.test("setIndexToggle ignores an unknown index key", () => {
+  const store = fakeStorage();
+  const toggles = S.setIndexToggle("dowjones", true, store);
+  assertEquals(toggles, { sp500: false, nasdaq: false, russell2000: false });
+});
+
+// --- combined settings -----------------------------------------------------
+
+Deno.test("writeTrendSettings then readTrendSettings round-trips both", () => {
+  const store = fakeStorage();
+  assertEquals(
+    S.writeTrendSettings(
+      { grouping: "quarter", toggles: { nasdaq: true } },
+      store,
+    ),
+    true,
+  );
+  assertEquals(S.readTrendSettings(store), {
+    grouping: "quarter",
+    toggles: { sp500: false, nasdaq: true, russell2000: false },
+  });
+});
+
+Deno.test("readTrendSettings returns defaults on first visit", () => {
+  assertEquals(S.readTrendSettings(fakeStorage()), {
+    grouping: "month",
+    toggles: { sp500: false, nasdaq: false, russell2000: false },
+  });
+});
+
+// --- unavailable storage (private mode) ------------------------------------
+
+Deno.test("reads fall back to defaults when storage throws", () => {
+  const store = throwingStorage();
+  assertEquals(S.readGrouping(store), "month");
+  assertEquals(S.readToggles(store), {
+    sp500: false,
+    nasdaq: false,
+    russell2000: false,
+  });
+  assertEquals(S.readTrendSettings(store), {
+    grouping: "month",
+    toggles: { sp500: false, nasdaq: false, russell2000: false },
+  });
+});
+
+Deno.test("writes report failure (not throw) when storage is unavailable", () => {
+  const store = throwingStorage();
+  assertEquals(S.writeGrouping("week", store), false);
+  assertEquals(S.writeToggles({ sp500: true }, store), false);
+  assertEquals(S.writeTrendSettings({ grouping: "day" }, store), false);
+  // setIndexToggle still returns a sane in-memory map even when it cannot save.
+  assertEquals(S.setIndexToggle("sp500", true, store), {
+    sp500: true,
+    nasdaq: false,
+    russell2000: false,
+  });
+});
+
+Deno.test("reads fall back to defaults when no storage is available", () => {
+  // Passing an explicit null storage models a non-browser / no-localStorage
+  // environment without depending on the ambient global.
+  assertEquals(S.readGrouping(null), "month");
+  assertEquals(S.readToggles(null), {
+    sp500: false,
+    nasdaq: false,
+    russell2000: false,
+  });
+  assertEquals(S.writeGrouping("week", null), false);
+});


### PR DESCRIPTION
# Remember Trend-view choices across visits (Issue #432)

## Summary

Adds **`docs/trend_settings.js`** — the client-side settings helper that
remembers the Trend view's choices across visits, backed by `localStorage`
under namespaced `grq.trend.*` keys. Closes #432.

It persists the two selections #432 asks for:

- the **grouping granularity** — `day` / `week` / `month` / `quarter`
  (default **month**), under `grq.trend.grouping`; and
- each **benchmark-index on/off toggle** — SP500 / NASDAQ / Russell 2000
  (default **all off**), under `grq.trend.indices`.

This mirrors the layered approach the milestone already follows: #429 shipped
the Trend **data engine** (`docs/trend_series.js`) and #431 the **index-overlay
engine** (`docs/index_overlay.js`), both as pure, DOM-free modules that left
rendering to the Trend view UI sub-issue (#430). This PR adds the matching
**persistence layer** (published on `globalThis.GRQTrendSettings`) so the UI
sub-issue can call `readTrendSettings()` on view init to restore the controls,
and `writeGrouping(...)` / `setIndexToggle(...)` on change.

### Tolerates absent / corrupt / unavailable storage

Every storage access is guarded, so the acceptance criterion "no errors when
`localStorage` is unavailable (e.g. private mode)" holds:

- **First visit / cleared storage** → defaults apply (`month`, all indices off).
- **Corrupt value** → a non-granularity grouping or non-JSON toggles blob falls
  back to defaults rather than throwing.
- **Unavailable storage** → reads return defaults and writes report `false`
  (never throw); `setIndexToggle(...)` still returns a sane in-memory map so the
  live chart keeps working even when nothing can be saved.

### Single source of truth

The toggle shape and the granularity list are reused from the existing engines
when loaded — `GRQIndexOverlay.normaliseToggles` / `OVERLAY_INDICES` and
`GRQTrendSeries.GRANULARITIES` — with local fallbacks so the module still parses
and tests independently. No new index or grouping definitions are introduced.

### Scope / dependency note

The acceptance criteria's reload-restores-state flow depends on the **Trend view
UI** sub-issue (#430), which is not yet merged — there are no grouping/toggle
DOM controls to wire to (and `trend_series.js` / `index_overlay.js` are likewise
not yet loaded in `index.html`). Following the #429 / #431 precedent, this PR
delivers everything that can be built and verified headlessly now; #430 wires
`GRQTrendSettings` into the controls. The existing dashboard is untouched (no
`index.html` / `sw.js` change), satisfying the "No impact on the existing
dashboard" criterion.

## Evidence

This is a headless persistence/state module — no DOM, no rendering — so there is
no UI to screenshot in this PR (the `needs-screenshot` view itself arrives with
the Trend view UI sub-issue #430, which wires these helpers to real controls).
Verification is the Deno test
suite, which drives the **real shipped** helpers (no mocks) via an injectable
in-memory storage: full suite **730 passed | 0 failed**, including the new
`tests/trend_settings_test.ts`.

```mermaid
flowchart LR
    V["Trend view init (#430)"] --> R[readTrendSettings]
    LS[("localStorage<br/>grq.trend.*")] --> R
    R --> C["restore controls<br/>(grouping + index toggles)"]
    C -->|user changes grouping| WG[writeGrouping]
    C -->|user flips a toggle| WT[setIndexToggle]
    WG --> LS
    WT --> LS
    R -.->|absent / corrupt / unavailable| D["defaults:<br/>month, all off"]
```

## Test Plan

New `tests/trend_settings_test.ts` (imports the real `docs/trend_settings.js`)
exercises the happy, error and edge paths:

- **Publication / keys** — `GRQTrendSettings` on `globalThis`; keys namespaced
  under `grq.trend.*`; granularities and default month exposed.
- **`normaliseGrouping`** — keeps the four valid granularities; junk / empty /
  null / wrong-type → `month`.
- **`normaliseToggles`** — all-off default; boolean coercion; unknown keys
  ignored.
- **Grouping round-trip** — `writeGrouping` → `readGrouping`; junk normalised to
  `month` before persisting; empty storage → default; corrupt value → default.
- **Toggle round-trip** — `writeToggles` → `readToggles`; empty → all-off;
  corrupt (non-JSON) → defaults; partial stored object normalised.
- **`setIndexToggle`** — flips a single index while persisting the rest across
  successive writes; unknown index key ignored.
- **Combined settings** — `writeTrendSettings` → `readTrendSettings`; defaults
  on first visit.
- **Unavailable storage** — throwing storage and explicit `null` storage: reads
  fall back to defaults, writes return `false` (never throw), `setIndexToggle`
  still returns a sane map.

Also added a parse guard for the new module in `tests/js_syntax_test.ts`
(`docs/trend_settings.js` parses cleanly).
