### PR TITLE
feat: persist per-device mobile chart-window choice (90/180) — GRQChartWindow helper (#447)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-447.md
+++ b/docs/archive/pr-summaries/pr-summary-447.md
@@ -1,0 +1,70 @@
+# feat: persist per-device mobile chart-window choice (90/180) — GRQChartWindow helper
+
+## Summary
+
+Adds a small **pure persistence helper** that remembers, per device, the
+user's choice of mobile chart window: **90 days (default)** or the full
+**180 days**. This is the storage foundation that the toggle UI sub-issue of
+milestone #445 will read/write — no DOM and no chart, persistence only.
+
+The new module `docs/chart_window_settings.js` is modelled exactly on the
+existing `docs/trend_settings.js` (issue #432): it is a classic `<script>`
+with no module syntax, publishes its helpers on `globalThis.GRQChartWindow`,
+stores under the namespaced key `grq.chart.mobileWindowDays`, and guards every
+storage access so private mode / unavailable / throwing storage falls back to
+the default `90` without ever throwing.
+
+Closes #447.
+
+### Public API (`globalThis.GRQChartWindow`)
+
+- `STORAGE_KEY` — `"grq.chart.mobileWindowDays"`
+- `MOBILE_WINDOW_DAYS_DEFAULT` — `90`
+- `ALLOWED_WINDOW_DAYS` — `[90, 180]`
+- `normaliseWindowDays(value)` — coerces anything outside `{90, 180}` (missing /
+  corrupt / `"abc"` / `0`) to `90`; also accepts numeric strings from storage
+- `readMobileWindowDays(storage)` — returns the persisted window or `90`
+- `writeMobileWindowDays(value, storage)` — normalises then persists; returns
+  whether the write succeeded
+
+Storage is injectable on every read/write: omitted → ambient `localStorage`;
+explicit `null` → no-storage.
+
+### Wiring
+
+- `docs/chart_window_settings.js` added to `docs/index.html` script includes
+  (alongside `projection.js`), so it is available to the dashboard. Wiring the
+  value into the chart/summary is the UI sub-issue's job.
+- Added to the service worker precache list in `docs/sw.js` (mirroring
+  `trend_settings.js`) so it is available offline, and bumped `APP_VERSION`
+  `1.0.212 → 1.0.213` (aligned across `sw.js`, `sw-register.js`, `index.html`,
+  `trend.html`) to purge stale caches.
+
+```mermaid
+flowchart LR
+    UI[Toggle UI #445] -->|writeMobileWindowDays| H[GRQChartWindow]
+    UI -->|readMobileWindowDays| H
+    H -->|safeGet / safeSet| LS[(localStorage<br/>grq.chart.mobileWindowDays)]
+    H -.->|storage throws / absent| D[default 90]
+```
+
+## Evidence
+
+Backend/persistence-only change with no new visible UI — the toggle that
+surfaces this choice is the separate UI sub-issue. Verified via the new Deno
+behavioural test suite (13 tests, all passing) and the full `./quality.sh`
+gate (756 tests passing, lint + type-check clean).
+
+## Test Plan
+
+Added `tests/chart_window_settings_test.ts`, mirroring
+`tests/trend_settings_test.ts`:
+
+- publishes `globalThis.GRQChartWindow` with the default `90` and allowed `[90, 180]`
+- `STORAGE_KEY` namespaced under `grq.chart.*`
+- `normaliseWindowDays` keeps `90`/`180`, coerces numeric strings, and falls
+  back to `90` for junk (`"abc"`, `0`, `30`, `""`, `null`, `undefined`, `{}`)
+- write→read round-trips `90` and `180`; junk normalised to `90` before persisting
+- default `90` returned when storage empty or corrupt
+- injected throwing storage → read returns `90`, write returns `false` (never throws)
+- explicit `null` storage → read returns `90`, write returns `false`

--- a/docs/chart_window_settings.js
+++ b/docs/chart_window_settings.js
@@ -1,0 +1,102 @@
+// Client-side settings helper for the per-device mobile chart-window choice
+// (issue #447, sub-issue of milestone #445).
+//
+// This remembers, per device, the user's choice of mobile chart window — the
+// default 90 days, or the full 180 days — backed by localStorage under a
+// namespaced `grq.chart.*` key (mirroring `grq.trend.*`).
+//
+// Like docs/trend_settings.js and docs/theme.js this file is loaded as a
+// classic <script> and is also imported by the Deno tests. It uses no module
+// syntax, publishes its helpers on globalThis.GRQChartWindow, and guards EVERY
+// storage access so absent / corrupt / unavailable storage (e.g. private mode)
+// falls back to the default without ever throwing.
+//
+// This module owns only persistence — it adds no DOM and no chart. The toggle
+// UI sub-issue reads `readMobileWindowDays()` on init to restore the control,
+// and calls `writeMobileWindowDays(...)` on change.
+//
+// Storage is injectable: every read/write takes an optional `storage` argument
+// (any Web Storage-like { getItem, setItem }). When omitted it defaults to the
+// ambient `localStorage`; passing an explicit `null` models a no-storage
+// environment. This keeps the helpers pure and deterministically testable.
+(function () {
+  "use strict";
+
+  // The user-facing default mobile chart window, in days (issue #447: 90).
+  const MOBILE_WINDOW_DAYS_DEFAULT = 90;
+
+  // The only two allowed window choices.
+  const ALLOWED_WINDOW_DAYS = [90, 180];
+
+  // Namespaced localStorage key (issue #447: key under `grq.chart.*`).
+  const STORAGE_KEY = "grq.chart.mobileWindowDays";
+
+  // Coerce an arbitrary value to one of the allowed windows, defaulting to 90
+  // so a missing / corrupt stored value never breaks the view. Accepts both
+  // numbers and their string forms (localStorage only stores strings).
+  function normaliseWindowDays(value) {
+    const num = typeof value === "string" ? Number(value) : value;
+    return ALLOWED_WINDOW_DAYS.includes(num) ? num : MOBILE_WINDOW_DAYS_DEFAULT;
+  }
+
+  // Resolve the storage to use: an explicitly-passed value (which may be null)
+  // wins; otherwise fall back to the ambient localStorage, tolerating an
+  // environment where even touching it throws.
+  function resolveStorage(storage) {
+    if (storage !== undefined) {
+      return storage;
+    }
+    try {
+      return typeof localStorage !== "undefined" ? localStorage : null;
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // Read one key, returning null on any failure (no storage, throws, missing).
+  function safeGet(storage, key) {
+    const store = resolveStorage(storage);
+    if (!store || typeof store.getItem !== "function") {
+      return null;
+    }
+    try {
+      return store.getItem(key);
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // Write one key, returning whether it was persisted (false on any failure).
+  function safeSet(storage, key, value) {
+    const store = resolveStorage(storage);
+    if (!store || typeof store.setItem !== "function") {
+      return false;
+    }
+    try {
+      store.setItem(key, value);
+      return true;
+    } catch (_err) {
+      return false;
+    }
+  }
+
+  // --- mobile chart window ---------------------------------------------------
+
+  function readMobileWindowDays(storage) {
+    return normaliseWindowDays(safeGet(storage, STORAGE_KEY));
+  }
+
+  function writeMobileWindowDays(value, storage) {
+    return safeSet(storage, STORAGE_KEY, String(normaliseWindowDays(value)));
+  }
+
+  // Publish the helpers for the dashboard and the tests.
+  globalThis.GRQChartWindow = {
+    STORAGE_KEY,
+    MOBILE_WINDOW_DAYS_DEFAULT,
+    ALLOWED_WINDOW_DAYS,
+    normaliseWindowDays,
+    readMobileWindowDays,
+    writeMobileWindowDays,
+  };
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.212">
+    <meta name="app-version" content="1.0.213">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -312,6 +312,9 @@
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
     <script src="projection.js"></script>
 
+    <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
+    <script src="chart_window_settings.js"></script>
+
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
     <script src="color_key.js"></script>
 
@@ -343,6 +346,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.212"></script>
+    <script src="sw-register.js?v=1.0.213"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.212")
+    navigator.serviceWorker.register("./sw.js?v=1.0.213")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.212";
+const APP_VERSION = "1.0.213";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;
@@ -21,6 +21,7 @@ const STATIC_ASSETS = [
   "./index.html",
   "./app.js",
   "./projection.js",
+  "./chart_window_settings.js",
   "./color_key.js",
   "./series_label_colour.js",
   "./format.js",

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.212">
+    <meta name="app-version" content="1.0.213">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -190,6 +190,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.0.212"></script>
+    <script src="sw-register.js?v=1.0.213"></script>
   </body>
 </html>

--- a/tests/chart_window_settings_test.ts
+++ b/tests/chart_window_settings_test.ts
@@ -1,0 +1,149 @@
+// Behavioural tests for the per-device mobile chart-window settings helper
+// (issue #447, sub-issue of milestone #445).
+//
+// These import the REAL shipped helpers from docs/chart_window_settings.js —
+// the same pure functions the toggle UI will use to remember the user's mobile
+// chart window (90 or 180 days) across visits via localStorage. The module
+// publishes its helpers on globalThis.GRQChartWindow (mirroring
+// docs/trend_settings.js) and guards every storage access, so it imports
+// cleanly under Deno and tolerates absent / corrupt / unavailable storage.
+//
+// Storage is injectable: every read/write accepts a storage object so the tests
+// drive deterministic behaviour without touching the real localStorage.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/chart_window_settings.js";
+
+const g = globalThis as unknown as {
+  GRQChartWindow: {
+    STORAGE_KEY: string;
+    MOBILE_WINDOW_DAYS_DEFAULT: number;
+    ALLOWED_WINDOW_DAYS: number[];
+    normaliseWindowDays: (value: unknown) => number;
+    readMobileWindowDays: (storage?: unknown) => number;
+    writeMobileWindowDays: (value: unknown, storage?: unknown) => boolean;
+  };
+};
+
+const S = g.GRQChartWindow;
+
+// A minimal in-memory Web Storage stand-in for deterministic tests.
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem(key: string): string | null {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    setItem(key: string, value: string): void {
+      map.set(key, String(value));
+    },
+    removeItem(key: string): void {
+      map.delete(key);
+    },
+    // Test-only peek.
+    _dump(): Record<string, string> {
+      return Object.fromEntries(map);
+    },
+  };
+}
+
+// Storage that throws on every access — models private mode / disabled storage.
+function throwingStorage() {
+  return {
+    getItem(): string {
+      throw new Error("storage unavailable");
+    },
+    setItem(): void {
+      throw new Error("storage unavailable");
+    },
+    removeItem(): void {
+      throw new Error("storage unavailable");
+    },
+  };
+}
+
+Deno.test("GRQChartWindow is published on globalThis", () => {
+  assert(
+    S,
+    "chart_window_settings.js should publish globalThis.GRQChartWindow",
+  );
+  assertEquals(S.MOBILE_WINDOW_DAYS_DEFAULT, 90);
+  assertEquals(S.ALLOWED_WINDOW_DAYS, [90, 180]);
+});
+
+Deno.test("STORAGE_KEY is namespaced under grq.chart.*", () => {
+  assert(S.STORAGE_KEY.startsWith("grq.chart."));
+  assertEquals(S.STORAGE_KEY, "grq.chart.mobileWindowDays");
+});
+
+// --- normaliseWindowDays ---------------------------------------------------
+
+Deno.test("normaliseWindowDays keeps the two allowed windows", () => {
+  assertEquals(S.normaliseWindowDays(90), 90);
+  assertEquals(S.normaliseWindowDays(180), 180);
+});
+
+Deno.test("normaliseWindowDays coerces numeric strings", () => {
+  assertEquals(S.normaliseWindowDays("90"), 90);
+  assertEquals(S.normaliseWindowDays("180"), 180);
+});
+
+Deno.test("normaliseWindowDays falls back to 90 for junk", () => {
+  assertEquals(S.normaliseWindowDays("abc"), 90);
+  assertEquals(S.normaliseWindowDays(0), 90);
+  assertEquals(S.normaliseWindowDays(30), 90);
+  assertEquals(S.normaliseWindowDays(""), 90);
+  assertEquals(S.normaliseWindowDays(null), 90);
+  assertEquals(S.normaliseWindowDays(undefined), 90);
+  assertEquals(S.normaliseWindowDays({}), 90);
+});
+
+// --- round-trip ------------------------------------------------------------
+
+Deno.test("write then read round-trips 90", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeMobileWindowDays(90, store), true);
+  assertEquals(S.readMobileWindowDays(store), 90);
+  assertEquals(store._dump()[S.STORAGE_KEY], "90");
+});
+
+Deno.test("write then read round-trips 180", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeMobileWindowDays(180, store), true);
+  assertEquals(S.readMobileWindowDays(store), 180);
+  assertEquals(store._dump()[S.STORAGE_KEY], "180");
+});
+
+Deno.test("writeMobileWindowDays normalises junk to 90 before persisting", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeMobileWindowDays(365, store), true);
+  assertEquals(store._dump()[S.STORAGE_KEY], "90");
+  assertEquals(S.readMobileWindowDays(store), 90);
+});
+
+Deno.test("readMobileWindowDays returns the default when storage is empty", () => {
+  assertEquals(S.readMobileWindowDays(fakeStorage()), 90);
+});
+
+Deno.test("readMobileWindowDays tolerates a corrupt stored value", () => {
+  const store = fakeStorage({ [S.STORAGE_KEY]: "garbage" });
+  assertEquals(S.readMobileWindowDays(store), 90);
+});
+
+// --- unavailable storage (private mode) ------------------------------------
+
+Deno.test("read falls back to default when storage throws", () => {
+  const store = throwingStorage();
+  assertEquals(S.readMobileWindowDays(store), 90);
+});
+
+Deno.test("write reports failure (not throw) when storage is unavailable", () => {
+  const store = throwingStorage();
+  assertEquals(S.writeMobileWindowDays(180, store), false);
+});
+
+Deno.test("read/write fall back to default when no storage is available", () => {
+  // Passing an explicit null storage models a non-browser / no-localStorage
+  // environment without depending on the ambient global.
+  assertEquals(S.readMobileWindowDays(null), 90);
+  assertEquals(S.writeMobileWindowDays(180, null), false);
+});


### PR DESCRIPTION
# feat: persist per-device mobile chart-window choice (90/180) — GRQChartWindow helper

## Summary

Adds a small **pure persistence helper** that remembers, per device, the
user's choice of mobile chart window: **90 days (default)** or the full
**180 days**. This is the storage foundation that the toggle UI sub-issue of
milestone #445 will read/write — no DOM and no chart, persistence only.

The new module `docs/chart_window_settings.js` is modelled exactly on the
existing `docs/trend_settings.js` (issue #432): it is a classic `<script>`
with no module syntax, publishes its helpers on `globalThis.GRQChartWindow`,
stores under the namespaced key `grq.chart.mobileWindowDays`, and guards every
storage access so private mode / unavailable / throwing storage falls back to
the default `90` without ever throwing.

Closes #447.

### Public API (`globalThis.GRQChartWindow`)

- `STORAGE_KEY` — `"grq.chart.mobileWindowDays"`
- `MOBILE_WINDOW_DAYS_DEFAULT` — `90`
- `ALLOWED_WINDOW_DAYS` — `[90, 180]`
- `normaliseWindowDays(value)` — coerces anything outside `{90, 180}` (missing /
  corrupt / `"abc"` / `0`) to `90`; also accepts numeric strings from storage
- `readMobileWindowDays(storage)` — returns the persisted window or `90`
- `writeMobileWindowDays(value, storage)` — normalises then persists; returns
  whether the write succeeded

Storage is injectable on every read/write: omitted → ambient `localStorage`;
explicit `null` → no-storage.

### Wiring

- `docs/chart_window_settings.js` added to `docs/index.html` script includes
  (alongside `projection.js`), so it is available to the dashboard. Wiring the
  value into the chart/summary is the UI sub-issue's job.
- Added to the service worker precache list in `docs/sw.js` (mirroring
  `trend_settings.js`) so it is available offline, and bumped `APP_VERSION`
  `1.0.212 → 1.0.213` (aligned across `sw.js`, `sw-register.js`, `index.html`,
  `trend.html`) to purge stale caches.

```mermaid
flowchart LR
    UI[Toggle UI #445] -->|writeMobileWindowDays| H[GRQChartWindow]
    UI -->|readMobileWindowDays| H
    H -->|safeGet / safeSet| LS[(localStorage<br/>grq.chart.mobileWindowDays)]
    H -.->|storage throws / absent| D[default 90]
```

## Evidence

Backend/persistence-only change with no new visible UI — the toggle that
surfaces this choice is the separate UI sub-issue. Verified via the new Deno
behavioural test suite (13 tests, all passing) and the full `./quality.sh`
gate (756 tests passing, lint + type-check clean).

## Test Plan

Added `tests/chart_window_settings_test.ts`, mirroring
`tests/trend_settings_test.ts`:

- publishes `globalThis.GRQChartWindow` with the default `90` and allowed `[90, 180]`
- `STORAGE_KEY` namespaced under `grq.chart.*`
- `normaliseWindowDays` keeps `90`/`180`, coerces numeric strings, and falls
  back to `90` for junk (`"abc"`, `0`, `30`, `""`, `null`, `undefined`, `{}`)
- write→read round-trips `90` and `180`; junk normalised to `90` before persisting
- default `90` returned when storage empty or corrupt
- injected throwing storage → read returns `90`, write returns `false` (never throws)
- explicit `null` storage → read returns `90`, write returns `false`
