### PR TITLE
feat: let projection.js window honour a 90/180 mobile choice (#448)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-448.md
+++ b/docs/archive/pr-summaries/pr-summary-448.md
@@ -1,0 +1,50 @@
+## Summary
+
+Taught the single source-of-truth window helpers in `docs/projection.js` to
+honour a chosen mobile window of **90 (default) or 180** days, while desktop
+stays at **180** and the chart and summary keep ending on the same date (the
+#367 invariant). Pure-function change only — no DOM, no storage. `Closes #448`.
+
+- `deviceWindowDays(isMobile, mobileWindowDays = 90)` — on mobile returns the
+  chosen value only when permitted (90 or 180), else falls back to 90; on
+  desktop always returns 180 (the toggle never affects desktop).
+- `deviceWindowEnd(scoreDate, isMobile, mobileWindowDays = 90)` — threads the
+  chosen window through, still returning `null` for a missing/unparseable score
+  date (blank-on-missing preserved).
+- Defaults equal today's behaviour, so all existing callers are unaffected until
+  the UI sub-issue passes a value — the #367 single-source guarantee holds.
+- `projection.js` stays pure: no `localStorage` / DOM access added; the caller
+  supplies the value.
+
+```mermaid
+flowchart LR
+    UI["UI sub-issue<br/>(supplies 90/180)"] -->|mobileWindowDays| DWD["deviceWindowDays(isMobile, mobileWindowDays)"]
+    DWD -->|days| DWE["deviceWindowEnd(scoreDate, isMobile, mobileWindowDays)"]
+    DWE -->|shared end date| Chart["prepareChartData (chart)"]
+    DWE -->|shared end date| Summary["getMarketPerformanceData (summary)"]
+```
+
+## Evidence
+
+Pure-maths change with no web interface to screenshot. Verified via unit tests
+covering the acceptance criteria:
+
+- `deviceWindowDays(true)` → 90; `(true, 180)` → 180; `(true, 999)` → 90;
+  `(false, 180)` → 180 (desktop ignores the override).
+- `deviceWindowEnd(scoreDate, true, 180)` ends 180 days after the score date;
+  `(scoreDate, false, 90)` still ends 180 days after; null/unparseable → `null`.
+- Chart and summary resolve to the same end date for each `(isMobile,
+  mobileWindowDays)` pair, including the new `(mobile, 180)` case.
+
+`./quality.sh` passes cleanly.
+
+## Test Plan
+
+- Added `tests/projection_kernels_test.ts::deviceWindowDays honours a permitted
+  mobile window, desktop ignores the override` and `::deviceWindowEnd threads
+  the chosen mobile window through to the end date`.
+- Extended `tests/chart_summary_window_test.ts` with `deviceWindowDays/
+  deviceWindowEnd - selectable mobile window keeps chart and summary on the SAME
+  end date (issue #448)`, covering the new `(mobile, 180)` case.
+- Cross-checked `tests/chart_summary_direction_consistency_test.ts` — still
+  passes unchanged.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -30,19 +30,37 @@ function setDateToMidnight(date) {
 const MOBILE_WINDOW_DAYS = 90;
 const DESKTOP_WINDOW_DAYS = 180;
 
+// The mobile window is selectable (issue #448, milestone #445): the user may
+// keep the 90-day default or opt into the full 180-day window. Desktop is
+// always 180 and the toggle never affects it. Only these two values are
+// permitted; anything else falls back to the 90-day default so a bad stored
+// value can never widen the window unexpectedly.
+const PERMITTED_MOBILE_WINDOW_DAYS = [MOBILE_WINDOW_DAYS, DESKTOP_WINDOW_DAYS];
+
 // Days in the visible window for the current device.
-function deviceWindowDays(isMobile) {
-    return isMobile ? MOBILE_WINDOW_DAYS : DESKTOP_WINDOW_DAYS;
+//
+// `mobileWindowDays` carries the chosen mobile window (90 or 180). It is honoured
+// only on mobile and only when permitted; otherwise the 90-day default applies.
+// Desktop always returns DESKTOP_WINDOW_DAYS (180) — the toggle is mobile-only.
+// projection.js stays pure: the caller supplies the value, this never reads
+// localStorage. The default keeps every existing caller unchanged until the UI
+// passes a value (preserves the #367 single-source guarantee).
+function deviceWindowDays(isMobile, mobileWindowDays = MOBILE_WINDOW_DAYS) {
+    if (!isMobile) return DESKTOP_WINDOW_DAYS;
+    return PERMITTED_MOBILE_WINDOW_DAYS.includes(mobileWindowDays)
+        ? mobileWindowDays
+        : MOBILE_WINDOW_DAYS;
 }
 
-// The window's end date: scoreDate + (mobile 90 / desktop 180) days, at local
-// midnight. Returns null when the score date is missing or unparseable so the
-// caller renders blank rather than erroring (preserves blank-on-missing).
-function deviceWindowEnd(scoreDate, isMobile) {
+// The window's end date: scoreDate + resolved-device-days, at local midnight.
+// `mobileWindowDays` is threaded through to deviceWindowDays (mobile-only, 90 or
+// 180). Returns null when the score date is missing or unparseable so the caller
+// renders blank rather than erroring (preserves blank-on-missing).
+function deviceWindowEnd(scoreDate, isMobile, mobileWindowDays = MOBILE_WINDOW_DAYS) {
     if (scoreDate === null || scoreDate === undefined) return null;
     const start = setDateToMidnight(new Date(scoreDate));
     if (Number.isNaN(start.getTime())) return null;
-    const days = deviceWindowDays(isMobile);
+    const days = deviceWindowDays(isMobile, mobileWindowDays);
     return setDateToMidnight(
         new Date(start.getTime() + days * 24 * 60 * 60 * 1000),
     );

--- a/tests/chart_summary_window_test.ts
+++ b/tests/chart_summary_window_test.ts
@@ -54,6 +54,55 @@ Deno.test("deviceWindowEnd - end is scoreDate + per-device days at local midnigh
   assert(desktopEnd.getTime() > mobileEnd.getTime());
 });
 
+Deno.test("deviceWindowDays/deviceWindowEnd - selectable mobile window keeps chart and summary on the SAME end date (issue #448)", () => {
+  // The chart (prepareChartData) and the summary (getMarketPerformanceData) both
+  // resolve their window through these same helpers, so for any
+  // (isMobile, mobileWindowDays) pair they MUST agree. Modelling both callers as
+  // identical calls proves they cannot drift for the new selectable window.
+  const scoreDate = new Date("2026-01-01T09:30:00");
+  const pairs: Array<[boolean, number | undefined]> = [
+    [true, undefined], // mobile default -> 90
+    [true, 90], // mobile explicit 90
+    [true, 180], // mobile opting into the full window (the new case)
+    [true, 999], // bad value -> falls back to 90
+    [false, 90], // desktop ignores the override -> 180
+    [false, 180], // desktop -> 180
+  ];
+
+  for (const [isMobile, mobileWindowDays] of pairs) {
+    const chartEnd = GRQProjection.deviceWindowEnd(
+      scoreDate,
+      isMobile,
+      mobileWindowDays,
+    );
+    const summaryEnd = GRQProjection.deviceWindowEnd(
+      scoreDate,
+      isMobile,
+      mobileWindowDays,
+    );
+    assertEquals(
+      chartEnd!.getTime(),
+      summaryEnd!.getTime(),
+      `chart and summary must share the window for (${isMobile}, ${mobileWindowDays})`,
+    );
+    // The end is exactly the resolved device days after the score date.
+    const days = GRQProjection.deviceWindowDays(isMobile, mobileWindowDays);
+    const base = GRQProjection.setDateToMidnight(new Date("2026-01-01"));
+    assertEquals(
+      chartEnd!.getTime(),
+      GRQProjection.setDateToMidnight(new Date(base.getTime() + days * DAY_MS))
+        .getTime(),
+    );
+  }
+
+  // The mobile (mobile, 180) window must land on the same end date the desktop
+  // window does — the toggle simply gives mobile the full desktop window.
+  assertEquals(
+    GRQProjection.deviceWindowEnd(scoreDate, true, 180)!.getTime(),
+    GRQProjection.deviceWindowEnd(scoreDate, false)!.getTime(),
+  );
+});
+
 Deno.test("deviceWindowEnd - unparseable / missing score date returns null (blank, never throws)", () => {
   assertEquals(
     GRQProjection.deviceWindowEnd(new Date("not-a-date"), true),

--- a/tests/projection_kernels_test.ts
+++ b/tests/projection_kernels_test.ts
@@ -23,6 +23,13 @@ interface Projection {
 
 const g = globalThis as unknown as {
   GRQProjection: {
+    deviceWindowDays: (isMobile: boolean, mobileWindowDays?: number) => number;
+    deviceWindowEnd: (
+      scoreDate: Date | string | null | undefined,
+      isMobile: boolean,
+      mobileWindowDays?: number,
+    ) => Date | null;
+    setDateToMidnight: (date: Date | string) => Date;
     formatCurrency: (value: number | null | undefined) => string;
     getSplitAdjustment: (
       marketData: MarketDataPoint[] | undefined,
@@ -87,6 +94,55 @@ function makePoint(
 ): MarketDataPoint {
   return { date, high, low, open: low, close: high, splitCoefficient: split };
 }
+
+// --- selectable mobile window (issue #448) ----------------------------------
+
+Deno.test("deviceWindowDays honours a permitted mobile window, desktop ignores the override", () => {
+  // Default mobile behaviour is unchanged (90 days).
+  assertEquals(GRQProjection.deviceWindowDays(true), 90);
+  // Mobile may opt into the full 180-day window.
+  assertEquals(GRQProjection.deviceWindowDays(true, 180), 180);
+  // Mobile explicit 90 stays 90.
+  assertEquals(GRQProjection.deviceWindowDays(true, 90), 90);
+  // A non-permitted value falls back to the 90-day default.
+  assertEquals(GRQProjection.deviceWindowDays(true, 999), 90);
+  // Desktop is always 180 — the override never affects it.
+  assertEquals(GRQProjection.deviceWindowDays(false), 180);
+  assertEquals(GRQProjection.deviceWindowDays(false, 90), 180);
+  assertEquals(GRQProjection.deviceWindowDays(false, 180), 180);
+});
+
+Deno.test("deviceWindowEnd threads the chosen mobile window through to the end date", () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const scoreDate = new Date("2026-01-01T13:45:00");
+  const base = GRQProjection.setDateToMidnight(new Date("2026-01-01"));
+
+  const expectEnd = (days: number) =>
+    GRQProjection.setDateToMidnight(new Date(base.getTime() + days * DAY_MS))
+      .getTime();
+
+  // Mobile default stays 90 days.
+  assertEquals(
+    GRQProjection.deviceWindowEnd(scoreDate, true)!.getTime(),
+    expectEnd(90),
+  );
+  // Mobile opting into 180 ends 180 days after the score date.
+  assertEquals(
+    GRQProjection.deviceWindowEnd(scoreDate, true, 180)!.getTime(),
+    expectEnd(180),
+  );
+  // Desktop ignores the override and always ends 180 days after.
+  assertEquals(
+    GRQProjection.deviceWindowEnd(scoreDate, false, 90)!.getTime(),
+    expectEnd(180),
+  );
+  // Null / unparseable score date still returns null (blank-on-missing).
+  assertEquals(GRQProjection.deviceWindowEnd(null, true, 180), null);
+  assertEquals(
+    GRQProjection.deviceWindowEnd(new Date("not-a-date"), true, 180),
+    null,
+  );
+});
 
 // --- formatCurrency ---------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Taught the single source-of-truth window helpers in `docs/projection.js` to
honour a chosen mobile window of **90 (default) or 180** days, while desktop
stays at **180** and the chart and summary keep ending on the same date (the
#367 invariant). Pure-function change only — no DOM, no storage. `Closes #448`.

- `deviceWindowDays(isMobile, mobileWindowDays = 90)` — on mobile returns the
  chosen value only when permitted (90 or 180), else falls back to 90; on
  desktop always returns 180 (the toggle never affects desktop).
- `deviceWindowEnd(scoreDate, isMobile, mobileWindowDays = 90)` — threads the
  chosen window through, still returning `null` for a missing/unparseable score
  date (blank-on-missing preserved).
- Defaults equal today's behaviour, so all existing callers are unaffected until
  the UI sub-issue passes a value — the #367 single-source guarantee holds.
- `projection.js` stays pure: no `localStorage` / DOM access added; the caller
  supplies the value.

```mermaid
flowchart LR
    UI["UI sub-issue<br/>(supplies 90/180)"] -->|mobileWindowDays| DWD["deviceWindowDays(isMobile, mobileWindowDays)"]
    DWD -->|days| DWE["deviceWindowEnd(scoreDate, isMobile, mobileWindowDays)"]
    DWE -->|shared end date| Chart["prepareChartData (chart)"]
    DWE -->|shared end date| Summary["getMarketPerformanceData (summary)"]
```

## Evidence

Pure-maths change with no web interface to screenshot. Verified via unit tests
covering the acceptance criteria:

- `deviceWindowDays(true)` → 90; `(true, 180)` → 180; `(true, 999)` → 90;
  `(false, 180)` → 180 (desktop ignores the override).
- `deviceWindowEnd(scoreDate, true, 180)` ends 180 days after the score date;
  `(scoreDate, false, 90)` still ends 180 days after; null/unparseable → `null`.
- Chart and summary resolve to the same end date for each `(isMobile,
  mobileWindowDays)` pair, including the new `(mobile, 180)` case.

`./quality.sh` passes cleanly.

## Test Plan

- Added `tests/projection_kernels_test.ts::deviceWindowDays honours a permitted
  mobile window, desktop ignores the override` and `::deviceWindowEnd threads
  the chosen mobile window through to the end date`.
- Extended `tests/chart_summary_window_test.ts` with `deviceWindowDays/
  deviceWindowEnd - selectable mobile window keeps chart and summary on the SAME
  end date (issue #448)`, covering the new `(mobile, 180)` case.
- Cross-checked `tests/chart_summary_direction_consistency_test.ts` — still
  passes unchanged.
