### PR TITLE
feat: chart-only pop-out — reconcile dashboard legend/colour key on close (#453)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ Pages.
   device back-gesture) and presents it in landscape — rotated via CSS on a
   portrait phone so a wide chart fills the screen, with an optional Screen
   Orientation lock where the platform supports it (iOS Safari falls back to the
-  CSS rotation). Desktop is unchanged.
+  CSS rotation). The overlay shows **only the chart** with readable axes and
+  scales — the mobile colour key and dashboard chrome stay behind it — and on
+  close the dashboard's colour key and native legend are reconciled back to
+  their pre-pop-out state. Desktop is unchanged.
 - **Hybrid Projection** — for score files less than 90 days old, project
   performance from the current actual prices.
 - **Automated Processing** — batch process score files with inline performance

--- a/docs/app.js
+++ b/docs/app.js
@@ -4443,6 +4443,20 @@ if (typeof globalThis.matchMedia === "function") {
 let lastViewportIsMobile;
 
 function syncChartForViewport() {
+    // While the chart pop-out overlay owns the canvas, the device class has not
+    // actually changed — the overlay is a presentation surface, not a resize.
+    // Suspend the breakpoint reconciliation so opening/closing (or rotating
+    // inside) the pop-out never triggers a spurious chart/summary rebuild and
+    // never clears the dashboard's mobile colour key behind the overlay. The
+    // close path reconciles once the canvas is back in .chart-container (#453).
+    if (
+        globalThis.GRQChartPopout &&
+        typeof globalThis.GRQChartPopout.isPopoutOpen === "function" &&
+        globalThis.GRQChartPopout.isPopoutOpen(document)
+    ) {
+        return;
+    }
+
     const isMobile = validator.isMobileDevice();
 
     // Crossing the mobile/desktop boundary changes the visible window (90 vs
@@ -4506,6 +4520,12 @@ if (
     globalThis.GRQChartPopout.createChartPopout({
         document,
         getChart: () => validator.chart,
+        // On close, reconcile the dashboard to the real current viewport now the
+        // canvas is back in .chart-container: re-runs the legend sync and
+        // renderColorKey() so the mobile colour key and native legend match
+        // their pre-pop-out state (issue #453). Reuses the shared viewport sync
+        // rather than duplicating that logic.
+        onClose: () => syncChartForViewport(),
     });
 }
 

--- a/docs/archive/pr-summaries/pr-summary-453.md
+++ b/docs/archive/pr-summaries/pr-summary-453.md
@@ -1,0 +1,82 @@
+# chart-only pop-out — reconcile dashboard legend/colour key on close (#453)
+
+## Summary
+
+Sub-issue of #446. The mobile chart pop-out (#451) re-parents the single live
+`#performanceChart` canvas into an **opaque, full-viewport** overlay
+(`.chart-popout`, `background: var(--grq-surface)`, `position: fixed; inset: 0`).
+Because only the canvas moves into the overlay, the pop-out already renders
+**just the chart** — with its Chart.js axes, scales and tick labels intact — while
+the mobile colour key (`#chartColorKey`) and all dashboard chrome (cards,
+headings, market comparison, tables) stay behind the overlay. This PR owns the
+remaining half of the sub-issue: **keeping the underlying dashboard correct after
+the shared canvas is moved out and back**.
+
+Without reconciliation, a resize/orientation event fired while the overlay is
+open would run the debounced `syncChartForViewport()` and — if the
+device crossed the mobile/desktop breakpoint (e.g. a landscape rotation) —
+rebuild the chart/summary and clear `#chartColorKey` behind the overlay, leaving
+it stale when the canvas returned on close. The fix suspends that sync while the
+pop-out owns the canvas and reconciles once on close:
+
+- **`docs/chart_popout.js`**
+  - Add `isPopoutOpen(doc)` — a pure predicate reading the `body.chart-popout-open`
+    contract class, published on `globalThis.GRQChartPopout`.
+  - Add an optional `onClose` hook to `createChartPopout()`, fired in
+    `finishClose()` once the canvas is back in `.chart-container` (guarded so a
+    throwing hook never leaves the overlay half-closed).
+- **`docs/app.js`**
+  - `syncChartForViewport()` returns early while `isPopoutOpen(document)` is true,
+    so opening, closing or rotating inside the pop-out never triggers a spurious
+    chart/summary rebuild via the breakpoint-crossing path, and never clears the
+    mobile colour key behind the overlay. `lastViewportIsMobile` stays frozen at
+    its pre-pop-out value, so no false "crossing" is recorded.
+  - The pop-out is wired with `onClose: () => syncChartForViewport()`, reusing the
+    shared `renderColorKey()` + legend-sync logic (not a duplicate) to restore the
+    colour key and native legend to their pre-pop-out state.
+
+Desktop is unchanged — the expand trigger is CSS-hidden at ≥768px, so the overlay
+can never be opened there.
+
+Closes #453.
+
+## Evidence
+
+Playwright MCP and pa11y were unavailable in this run, so no browser screenshot
+could be captured. The behaviour is covered by headless Deno tests that drive the
+**real shipped** `chart_popout.js` module through a fake DOM, asserting the exact
+acceptance criteria (state preserved across open/close and open/rotate/close, and
+the sync suspended while open).
+
+```mermaid
+sequenceDiagram
+    participant U as User (mobile)
+    participant P as chart_popout.js
+    participant A as app.js · syncChartForViewport()
+    Note over A: pre-pop-out — legend hidden, colour key populated
+    U->>P: tap ⤢ (open)
+    P->>P: re-parent canvas into overlay,<br/>add body.chart-popout-open
+    U-->>A: resize / orientationchange while open
+    A->>P: isPopoutOpen(document)?
+    P-->>A: true → return early (suspended)
+    Note over A: no rebuild · legend & colour key untouched
+    U->>P: ✕ / Esc / back (close)
+    P->>P: restore canvas to .chart-container,<br/>remove body class
+    P->>A: onClose() → syncChartForViewport()
+    Note over A: reconcile to real viewport —<br/>colour key & legend match pre-pop-out state
+```
+
+## Test Plan
+
+New `tests/chart_popout_reconcile_test.ts` (exercises the real module):
+
+- `isPopoutOpen - reflects the body contract class`
+- `isPopoutOpen - tolerates a missing/partial document`
+- `syncChartForViewport stays idle while the pop-out is open` — a breakpoint-crossing
+  resize while open produces no rebuild and leaves legend + colour key untouched.
+- `closing the pop-out preserves the colour key and legend (open/close)`
+- `closing preserves state across an open → rotate → close cycle`
+- `onClose reconcile is optional - close still works without it`
+
+Existing `tests/chart_popout_test.ts` (16 tests) and the full Deno suite (786
+tests) remain green. `./quality.sh` passes.

--- a/docs/chart_popout.js
+++ b/docs/chart_popout.js
@@ -32,6 +32,22 @@ const EXPAND_ID = "chartPopoutExpand";
 const CLOSE_ID = "chartPopoutClose";
 const CANVAS_ID = "performanceChart";
 
+// True while the chart pop-out overlay owns the canvas, detected from the body
+// contract class set on open (issue #453). The dashboard's viewport sync
+// consults this to stay idle while the pop-out is open: the device class has
+// NOT actually changed, so rebuilding the chart/summary or flipping the native
+// legend then would be a spurious rebuild and would leave the dashboard's mobile
+// colour key stale when the canvas returns on close. `doc` is injectable so the
+// Deno tests drive it headless.
+function isPopoutOpen(doc) {
+    const d = doc || globalThis.document;
+    return !!(
+        d && d.body && d.body.classList &&
+        typeof d.body.classList.contains === "function" &&
+        d.body.classList.contains(BODY_OPEN_CLASS)
+    );
+}
+
 // Resize-and-update the live chart, guarded so a missing/half-built chart (no
 // data loaded yet) is a silent no-op rather than a throw. Chart.js needs both:
 // resize() recomputes the canvas box for its new parent, update() repaints.
@@ -211,6 +227,12 @@ function createChartPopout(options) {
     const getChart = typeof opts.getChart === "function"
         ? opts.getChart
         : () => null;
+    // Reconciliation hook run once the canvas is back in the dashboard on close
+    // (issue #453). The app passes its viewport sync here so the mobile colour
+    // key + native legend are restored to match the real current device class —
+    // reusing renderColorKey()/syncChartForViewport() rather than duplicating
+    // that logic. Optional: a page without it just closes with no reconcile.
+    const onClose = typeof opts.onClose === "function" ? opts.onClose : null;
     if (!doc || typeof doc.getElementById !== "function") return null;
 
     const overlay = doc.getElementById(OVERLAY_ID);
@@ -271,7 +293,20 @@ function createChartPopout(options) {
     // Close the overlay and release any orientation lock taken on open.
     function finishClose() {
         const closed = closePopout(ctx);
-        if (closed) releaseOrientationLock(screen);
+        if (closed) {
+            releaseOrientationLock(screen);
+            // Reconcile the dashboard now the canvas is restored: the colour key
+            // and native legend are re-synced to the real current viewport so
+            // they match their pre-pop-out state (issue #453). Guarded so a hook
+            // that throws never leaves the overlay half-closed.
+            if (onClose) {
+                try {
+                    onClose();
+                } catch (_e) {
+                    // Reconciliation is best-effort; the close itself succeeded.
+                }
+            }
+        }
         return closed;
     }
 
@@ -341,6 +376,7 @@ function createChartPopout(options) {
 // test importer reach the same code, mirroring docs/color_key.js.
 globalThis.GRQChartPopout = {
     BODY_OPEN_CLASS,
+    isPopoutOpen,
     resizeChart,
     openPopout,
     closePopout,

--- a/tests/chart_popout_reconcile_test.ts
+++ b/tests/chart_popout_reconcile_test.ts
@@ -1,0 +1,292 @@
+// Tests for the chart pop-out → dashboard reconciliation (issue #453, part of
+// the full-screen landscape pop-out milestone #446).
+//
+// The mobile pop-out re-parents the single live #performanceChart canvas into a
+// full-viewport overlay and back (issue #451). While it owns the canvas the
+// device class has NOT changed, so the dashboard's viewport sync must stay idle:
+// otherwise a resize/orientation event fired while the overlay is open would
+// rebuild the chart/summary and clear the mobile colour key behind the overlay,
+// leaving it stale when the canvas returns on close.
+//
+// docs/chart_popout.js owns two pieces of that contract, both exercised here
+// against the REAL shipped module:
+//   - isPopoutOpen(doc): the predicate the app's syncChartForViewport() consults
+//     to suspend the breakpoint reconciliation while the overlay is open;
+//   - the onClose hook: run once the canvas is back in the dashboard so the app
+//     can reconcile the colour key + native legend to the real viewport.
+//
+// The dependency-injected core only touches classList / hidden / appendChild /
+// focus, so a tiny fake DOM drives it headless, mirroring chart_popout_test.ts.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/chart_popout.js";
+
+// ---------------------------------------------------------------------------
+// Minimal fake DOM — only the surface chart_popout.js actually touches.
+// ---------------------------------------------------------------------------
+class FakeClassList {
+  private set = new Set<string>();
+  add(c: string) {
+    this.set.add(c);
+  }
+  remove(c: string) {
+    this.set.delete(c);
+  }
+  contains(c: string) {
+    return this.set.has(c);
+  }
+}
+
+class FakeElement {
+  hidden = false;
+  classList = new FakeClassList();
+  children: FakeElement[] = [];
+  parent: FakeElement | null = null;
+  attrs: Record<string, string> = {};
+  doc: FakeDocument | null = null;
+  constructor(public id = "") {}
+  appendChild(child: FakeElement) {
+    if (child.parent) {
+      child.parent.children = child.parent.children.filter((c) => c !== child);
+    }
+    child.parent = this;
+    this.children.push(child);
+    return child;
+  }
+  setAttribute(k: string, v: string) {
+    this.attrs[k] = v;
+  }
+  getAttribute(k: string) {
+    return k in this.attrs ? this.attrs[k] : null;
+  }
+  focus() {
+    if (this.doc) this.doc.activeElement = this;
+  }
+}
+
+class FakeDocument {
+  activeElement: FakeElement | null = null;
+  body = new FakeElement("body");
+}
+
+const g = globalThis as unknown as {
+  GRQChartPopout: {
+    BODY_OPEN_CLASS: string;
+    // deno-lint-ignore no-explicit-any
+    isPopoutOpen: (doc: any) => boolean;
+    // deno-lint-ignore no-explicit-any
+    openPopout: (ctx: any) => boolean;
+    // deno-lint-ignore no-explicit-any
+    closePopout: (ctx: any) => boolean;
+    createChartPopout: (opts: unknown) => {
+      open: () => boolean;
+      close: () => boolean;
+      isOpen: () => boolean;
+    } | null;
+  };
+};
+const GRQChartPopout = g.GRQChartPopout;
+
+// A stand-in dashboard: a chart whose native legend is toggled by the viewport,
+// and a #chartColorKey container the app populates on mobile / clears on desktop.
+// `syncViewport` mirrors docs/app.js syncChartForViewport(): it consults the REAL
+// isPopoutOpen() to stay idle while the overlay is open, then sets the legend and
+// (re)renders the colour key from the live "datasets" for the current device.
+function makeDashboard() {
+  const doc = new FakeDocument();
+  const elements: Record<string, FakeElement> = {
+    chartPopout: Object.assign(new FakeElement("chartPopout"), {
+      hidden: true,
+    }),
+    chartPopoutBody: new FakeElement("chartPopoutBody"),
+    chartPopoutExpand: new FakeElement("chartPopoutExpand"),
+    chartPopoutClose: new FakeElement("chartPopoutClose"),
+    performanceChart: new FakeElement("performanceChart"),
+  };
+  const container = new FakeElement("chart-container");
+  container.appendChild(elements.performanceChart);
+  const colorKey = new FakeElement("chartColorKey");
+  for (const el of Object.values(elements)) el.doc = doc;
+  container.doc = doc;
+  colorKey.doc = doc;
+  (colorKey as unknown as { innerHTML: string }).innerHTML = "";
+
+  // Live datasets are the single source of truth for both legend and key.
+  const colorKeyEl = colorKey as unknown as { innerHTML: string };
+  const chart = {
+    options: { plugins: { legend: { display: true } } },
+    resize() {},
+    update() {},
+  };
+
+  let isMobile = true;
+  let rebuilds = 0;
+
+  // Mirror of app.js renderColorKey(): mobile mirrors the datasets, desktop
+  // clears the key (the native legend takes over).
+  function renderColorKey() {
+    colorKeyEl.innerHTML = isMobile
+      ? "<chip>SP500</chip><chip>NASDAQ</chip>"
+      : "";
+  }
+
+  function syncViewport() {
+    // Suspend while the pop-out owns the canvas — the real predicate under test.
+    if (GRQChartPopout.isPopoutOpen(doc)) return;
+    rebuilds++;
+    chart.options.plugins.legend.display = !isMobile;
+    renderColorKey();
+  }
+
+  const fakeDoc = {
+    body: doc.body,
+    get activeElement() {
+      return doc.activeElement;
+    },
+    getElementById: (id: string) => elements[id] ?? null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+
+  return {
+    doc,
+    fakeDoc,
+    chart,
+    colorKey: colorKeyEl,
+    syncViewport,
+    setMobile: (v: boolean) => (isMobile = v),
+    rebuildCount: () => rebuilds,
+  };
+}
+
+Deno.test("isPopoutOpen - reflects the body contract class", () => {
+  const doc = new FakeDocument();
+  assertEquals(GRQChartPopout.isPopoutOpen(doc), false, "closed by default");
+  doc.body.classList.add(GRQChartPopout.BODY_OPEN_CLASS);
+  assertEquals(
+    GRQChartPopout.isPopoutOpen(doc),
+    true,
+    "true once class is set",
+  );
+  doc.body.classList.remove(GRQChartPopout.BODY_OPEN_CLASS);
+  assertEquals(GRQChartPopout.isPopoutOpen(doc), false, "false once removed");
+});
+
+Deno.test("isPopoutOpen - tolerates a missing/partial document", () => {
+  assertEquals(GRQChartPopout.isPopoutOpen(null), false);
+  assertEquals(GRQChartPopout.isPopoutOpen({}), false);
+  assertEquals(GRQChartPopout.isPopoutOpen({ body: {} }), false);
+});
+
+Deno.test("syncChartForViewport stays idle while the pop-out is open", () => {
+  const d = makeDashboard();
+  d.setMobile(true);
+  d.syncViewport(); // establish the mobile baseline
+  const baseRebuilds = d.rebuildCount();
+
+  const controller = GRQChartPopout.createChartPopout({
+    document: d.fakeDoc,
+    getChart: () => d.chart,
+    onClose: () => d.syncViewport(),
+  })!;
+  assert(controller, "controller must build from the fake dashboard");
+
+  controller.open();
+
+  // A resize fires while open and the device crosses into the desktop class.
+  // The sync must be SUSPENDED: no rebuild, legend + colour key left untouched.
+  d.setMobile(false);
+  d.syncViewport();
+  assertEquals(d.rebuildCount(), baseRebuilds, "no rebuild while overlay open");
+  assertEquals(
+    d.chart.options.plugins.legend.display,
+    false,
+    "legend must not flip on while the pop-out is open",
+  );
+  assertEquals(
+    d.colorKey.innerHTML,
+    "<chip>SP500</chip><chip>NASDAQ</chip>",
+    "colour key must not be cleared while the pop-out is open",
+  );
+});
+
+Deno.test("closing the pop-out preserves the colour key and legend (open/close)", () => {
+  const d = makeDashboard();
+  d.setMobile(true);
+  d.syncViewport();
+  const legendBefore = d.chart.options.plugins.legend.display;
+  const keyBefore = d.colorKey.innerHTML;
+  assertEquals(legendBefore, false, "mobile: native legend hidden");
+  assertEquals(keyBefore, "<chip>SP500</chip><chip>NASDAQ</chip>");
+
+  const controller = GRQChartPopout.createChartPopout({
+    document: d.fakeDoc,
+    getChart: () => d.chart,
+    onClose: () => d.syncViewport(),
+  })!;
+
+  controller.open();
+  controller.close();
+
+  assertEquals(controller.isOpen(), false, "overlay closed");
+  assertEquals(
+    d.chart.options.plugins.legend.display,
+    legendBefore,
+    "native legend identical to before opening",
+  );
+  assertEquals(
+    d.colorKey.innerHTML,
+    keyBefore,
+    "mobile colour key identical to before opening",
+  );
+});
+
+Deno.test("closing preserves state across an open → rotate → close cycle", () => {
+  const d = makeDashboard();
+  d.setMobile(true);
+  d.syncViewport();
+  const legendBefore = d.chart.options.plugins.legend.display;
+  const keyBefore = d.colorKey.innerHTML;
+
+  const controller = GRQChartPopout.createChartPopout({
+    document: d.fakeDoc,
+    getChart: () => d.chart,
+    onClose: () => d.syncViewport(),
+  })!;
+
+  controller.open();
+  // Rotate to landscape while open: a resize crosses the breakpoint but is
+  // suspended, so nothing changes behind the overlay.
+  d.setMobile(false);
+  d.syncViewport();
+  // Rotate back to portrait before closing (the device returns to its class).
+  d.setMobile(true);
+
+  controller.close();
+
+  assertEquals(
+    d.chart.options.plugins.legend.display,
+    legendBefore,
+    "native legend identical after open → rotate → close",
+  );
+  assertEquals(
+    d.colorKey.innerHTML,
+    keyBefore,
+    "colour key identical after open → rotate → close",
+  );
+});
+
+Deno.test("onClose reconcile is optional - close still works without it", () => {
+  const d = makeDashboard();
+  const controller = GRQChartPopout.createChartPopout({
+    document: d.fakeDoc,
+    getChart: () => d.chart,
+  })!;
+  controller.open();
+  assertEquals(controller.isOpen(), true);
+  controller.close();
+  assertEquals(
+    controller.isOpen(),
+    false,
+    "closes cleanly with no onClose hook",
+  );
+});


### PR DESCRIPTION
# chart-only pop-out — reconcile dashboard legend/colour key on close (#453)

## Summary

Sub-issue of #446. The mobile chart pop-out (#451) re-parents the single live
`#performanceChart` canvas into an **opaque, full-viewport** overlay
(`.chart-popout`, `background: var(--grq-surface)`, `position: fixed; inset: 0`).
Because only the canvas moves into the overlay, the pop-out already renders
**just the chart** — with its Chart.js axes, scales and tick labels intact — while
the mobile colour key (`#chartColorKey`) and all dashboard chrome (cards,
headings, market comparison, tables) stay behind the overlay. This PR owns the
remaining half of the sub-issue: **keeping the underlying dashboard correct after
the shared canvas is moved out and back**.

Without reconciliation, a resize/orientation event fired while the overlay is
open would run the debounced `syncChartForViewport()` and — if the
device crossed the mobile/desktop breakpoint (e.g. a landscape rotation) —
rebuild the chart/summary and clear `#chartColorKey` behind the overlay, leaving
it stale when the canvas returned on close. The fix suspends that sync while the
pop-out owns the canvas and reconciles once on close:

- **`docs/chart_popout.js`**
  - Add `isPopoutOpen(doc)` — a pure predicate reading the `body.chart-popout-open`
    contract class, published on `globalThis.GRQChartPopout`.
  - Add an optional `onClose` hook to `createChartPopout()`, fired in
    `finishClose()` once the canvas is back in `.chart-container` (guarded so a
    throwing hook never leaves the overlay half-closed).
- **`docs/app.js`**
  - `syncChartForViewport()` returns early while `isPopoutOpen(document)` is true,
    so opening, closing or rotating inside the pop-out never triggers a spurious
    chart/summary rebuild via the breakpoint-crossing path, and never clears the
    mobile colour key behind the overlay. `lastViewportIsMobile` stays frozen at
    its pre-pop-out value, so no false "crossing" is recorded.
  - The pop-out is wired with `onClose: () => syncChartForViewport()`, reusing the
    shared `renderColorKey()` + legend-sync logic (not a duplicate) to restore the
    colour key and native legend to their pre-pop-out state.

Desktop is unchanged — the expand trigger is CSS-hidden at ≥768px, so the overlay
can never be opened there.

Closes #453.

## Evidence

Playwright MCP and pa11y were unavailable in this run, so no browser screenshot
could be captured. The behaviour is covered by headless Deno tests that drive the
**real shipped** `chart_popout.js` module through a fake DOM, asserting the exact
acceptance criteria (state preserved across open/close and open/rotate/close, and
the sync suspended while open).

```mermaid
sequenceDiagram
    participant U as User (mobile)
    participant P as chart_popout.js
    participant A as app.js · syncChartForViewport()
    Note over A: pre-pop-out — legend hidden, colour key populated
    U->>P: tap ⤢ (open)
    P->>P: re-parent canvas into overlay,<br/>add body.chart-popout-open
    U-->>A: resize / orientationchange while open
    A->>P: isPopoutOpen(document)?
    P-->>A: true → return early (suspended)
    Note over A: no rebuild · legend & colour key untouched
    U->>P: ✕ / Esc / back (close)
    P->>P: restore canvas to .chart-container,<br/>remove body class
    P->>A: onClose() → syncChartForViewport()
    Note over A: reconcile to real viewport —<br/>colour key & legend match pre-pop-out state
```

## Test Plan

New `tests/chart_popout_reconcile_test.ts` (exercises the real module):

- `isPopoutOpen - reflects the body contract class`
- `isPopoutOpen - tolerates a missing/partial document`
- `syncChartForViewport stays idle while the pop-out is open` — a breakpoint-crossing
  resize while open produces no rebuild and leaves legend + colour key untouched.
- `closing the pop-out preserves the colour key and legend (open/close)`
- `closing preserves state across an open → rotate → close cycle`
- `onClose reconcile is optional - close still works without it`

Existing `tests/chart_popout_test.ts` (16 tests) and the full Deno suite (786
tests) remain green. `./quality.sh` passes.
