### PR TITLE
feat: relax projection.js desktop-180 lock so deviceWindowDays honours a 90-day choice (#464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to
   cache key always changes and clients pick up the new build. The bump is
   idempotent relative to the base branch (Issue #323).
 
+### Changed
+
+- `GRQProjection.deviceWindowDays`/`deviceWindowEnd` (`docs/projection.js`) now
+  honour an explicit permitted window (90 or 180) on **either** device, relaxing
+  the old desktop-180 lock so a desktop 90-day choice can take effect. Each
+  device keeps its own default when the value is missing or invalid (mobile 90,
+  desktop 180). The helper stays pure — the caller supplies the value — and the
+  allow-list constant is renamed `PERMITTED_WINDOW_DAYS` (Issue #464).
+
 ### Removed
 
 - Dead `[dependencies]` `walkdir` and `thiserror`, which were declared but never

--- a/docs/archive/pr-summaries/pr-summary-464.md
+++ b/docs/archive/pr-summaries/pr-summary-464.md
@@ -1,0 +1,96 @@
+# Relax the desktop-180 chart-window lock (foundation)
+
+## Summary
+
+Relaxes the hard desktop-180 lock in the pure window helper
+(`docs/projection.js`) so a permitted **90-day** choice can take effect on
+desktop. `deviceWindowDays`/`deviceWindowEnd` now honour an **explicit permitted
+value (90 or 180) on either device**, while each device keeps its own default
+when the value is missing or invalid:
+
+- desktop default stays **180**; desktop with an explicit `90` → **90** (NEW);
+- mobile default stays **90**; mobile with an explicit `180` → **180** (unchanged
+  from #448).
+
+The helper stays **pure** — the caller supplies the value, the function never
+reads `localStorage` — preserving the #367 single-source chart/summary
+guarantee. The device-neutral allow-list constant is renamed
+`PERMITTED_MOBILE_WINDOW_DAYS` → `PERMITTED_WINDOW_DAYS` (`[90, 180]`).
+
+This is the foundation sub-issue of milestone #457; the toggle UI, the desktop
+`GRQChartWindow` persistence key, and `?window=` URL honouring land in their own
+sub-issues. No UI, persistence, or `localStorage` changes here. Closes #464.
+
+## Implementation
+
+The old helper hard-returned `DESKTOP_WINDOW_DAYS` on desktop, discarding any
+supplied value. The new helper resolves a per-device default and honours an
+explicit permitted value on either device:
+
+```js
+function deviceWindowDays(isMobile, windowDays) {
+    const deviceDefault = isMobile ? MOBILE_WINDOW_DAYS : DESKTOP_WINDOW_DAYS;
+    if (windowDays === undefined) return deviceDefault;
+    return PERMITTED_WINDOW_DAYS.includes(windowDays)
+        ? windowDays
+        : deviceDefault;
+}
+```
+
+`deviceWindowEnd` threads `windowDays` through unchanged (no implicit default
+parameter, so omitting it falls back to the device default rather than a fixed
+90). `null`/blank-on-missing-score-date behaviour is unchanged.
+
+```mermaid
+flowchart LR
+    C["caller (isMobile, windowDays)"] --> DWD["deviceWindowDays"]
+    DWD -->|windowDays undefined| DEF{"isMobile?"}
+    DEF -->|yes| M90[90]
+    DEF -->|no| D180[180]
+    DWD -->|windowDays in 90,180| HON["honour value (either device)"]
+    DWD -->|otherwise| DEF
+    HON --> DWE["deviceWindowEnd: scoreDate + days"]
+    M90 --> DWE
+    D180 --> DWE
+```
+
+## Evidence
+
+Backend/pure-module change with no web interface to screenshot. Verified via the
+Deno unit tests below. `deno test --allow-read tests/*.ts` → **769 passed, 0
+failed**; `deno fmt`, `deno lint`, and `deno check` all clean.
+
+## Test Plan
+
+Extended the two suites named in the acceptance criteria:
+
+- `tests/projection_kernels_test.ts`
+  - `deviceWindowDays honours an explicit permitted window on either device,
+    each device keeps its own default` — asserts the full matrix:
+    `(false)`→180, `(false, 90)`→**90** (new), `(false, 180)`→180,
+    `(false, 999)`→180, `(true)`→90, `(true, 180)`→180, `(true, 90)`→90,
+    `(true, 999)`→90.
+  - `deviceWindowEnd threads the chosen ... window through to the end date` —
+    added a desktop-90 case (`(scoreDate, false, 90)` → scoreDate + 90 days) and
+    a desktop-default case; mobile cases unchanged.
+- `tests/chart_summary_window_test.ts`
+  - Extended the shared-window pair matrix with `[false, undefined]`,
+    `[false, 90]`, and `[false, 999]`, and added a symmetric assertion that the
+    desktop-90 window lands on the same end date as the mobile default window.
+
+### Business-logic test changes (documented)
+
+The lock is being deliberately relaxed, so two previously-correct assertions
+encoding the old desktop-180 lock were updated (not removed):
+
+- `deviceWindowDays(false, 90)` expectation changed from `180` → `90`.
+- `deviceWindowEnd(scoreDate, false, 90)` expectation changed from
+  `scoreDate + 180` → `scoreDate + 90`.
+
+Stale "desktop ignores the override" comments were updated accordingly.
+
+## Scope notes
+
+`docs/app.js` is intentionally untouched — the toggle/persistence wiring belongs
+to separate sub-issues of milestone #457. This PR targets the milestone branch
+`milestone/457-feat-let-desktop-optionally-use-the-90-day-cha`.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -30,37 +30,41 @@ function setDateToMidnight(date) {
 const MOBILE_WINDOW_DAYS = 90;
 const DESKTOP_WINDOW_DAYS = 180;
 
-// The mobile window is selectable (issue #448, milestone #445): the user may
-// keep the 90-day default or opt into the full 180-day window. Desktop is
-// always 180 and the toggle never affects it. Only these two values are
-// permitted; anything else falls back to the 90-day default so a bad stored
-// value can never widen the window unexpectedly.
-const PERMITTED_MOBILE_WINDOW_DAYS = [MOBILE_WINDOW_DAYS, DESKTOP_WINDOW_DAYS];
+// The chart window is selectable (issue #448, milestone #445; relaxed by #464,
+// milestone #457): the user may keep their device default or opt into the other
+// permitted window. Only these two values are permitted; anything else falls
+// back to the device default so a bad stored value can never widen the window
+// unexpectedly.
+const PERMITTED_WINDOW_DAYS = [MOBILE_WINDOW_DAYS, DESKTOP_WINDOW_DAYS];
 
 // Days in the visible window for the current device.
 //
-// `mobileWindowDays` carries the chosen mobile window (90 or 180). It is honoured
-// only on mobile and only when permitted; otherwise the 90-day default applies.
-// Desktop always returns DESKTOP_WINDOW_DAYS (180) — the toggle is mobile-only.
+// `windowDays` carries an explicit chosen window (90 or 180). An explicit
+// permitted value is honoured on EITHER device — desktop may now opt into 90
+// just as mobile may opt into 180 (issue #464 relaxes the old desktop-180 lock
+// from #448). When the value is missing (undefined) or not permitted, each
+// device keeps its own default: 90 on mobile, 180 on desktop.
 // projection.js stays pure: the caller supplies the value, this never reads
-// localStorage. The default keeps every existing caller unchanged until the UI
-// passes a value (preserves the #367 single-source guarantee).
-function deviceWindowDays(isMobile, mobileWindowDays = MOBILE_WINDOW_DAYS) {
-    if (!isMobile) return DESKTOP_WINDOW_DAYS;
-    return PERMITTED_MOBILE_WINDOW_DAYS.includes(mobileWindowDays)
-        ? mobileWindowDays
-        : MOBILE_WINDOW_DAYS;
+// localStorage. Omitting the argument keeps every existing caller unchanged
+// (preserves the #367 single-source guarantee).
+function deviceWindowDays(isMobile, windowDays) {
+    const deviceDefault = isMobile ? MOBILE_WINDOW_DAYS : DESKTOP_WINDOW_DAYS;
+    if (windowDays === undefined) return deviceDefault;
+    return PERMITTED_WINDOW_DAYS.includes(windowDays)
+        ? windowDays
+        : deviceDefault;
 }
 
 // The window's end date: scoreDate + resolved-device-days, at local midnight.
-// `mobileWindowDays` is threaded through to deviceWindowDays (mobile-only, 90 or
-// 180). Returns null when the score date is missing or unparseable so the caller
-// renders blank rather than erroring (preserves blank-on-missing).
-function deviceWindowEnd(scoreDate, isMobile, mobileWindowDays = MOBILE_WINDOW_DAYS) {
+// `windowDays` is threaded through to deviceWindowDays (an explicit permitted
+// 90/180 honoured on either device). Returns null when the score date is missing
+// or unparseable so the caller renders blank rather than erroring (preserves
+// blank-on-missing).
+function deviceWindowEnd(scoreDate, isMobile, windowDays) {
     if (scoreDate === null || scoreDate === undefined) return null;
     const start = setDateToMidnight(new Date(scoreDate));
     if (Number.isNaN(start.getTime())) return null;
-    const days = deviceWindowDays(isMobile, mobileWindowDays);
+    const days = deviceWindowDays(isMobile, windowDays);
     return setDateToMidnight(
         new Date(start.getTime() + days * 24 * 60 * 60 * 1000),
     );

--- a/tests/chart_summary_window_test.ts
+++ b/tests/chart_summary_window_test.ts
@@ -54,39 +54,41 @@ Deno.test("deviceWindowEnd - end is scoreDate + per-device days at local midnigh
   assert(desktopEnd.getTime() > mobileEnd.getTime());
 });
 
-Deno.test("deviceWindowDays/deviceWindowEnd - selectable mobile window keeps chart and summary on the SAME end date (issue #448)", () => {
+Deno.test("deviceWindowDays/deviceWindowEnd - selectable window keeps chart and summary on the SAME end date (issue #448; desktop-90 opt-in #464)", () => {
   // The chart (prepareChartData) and the summary (getMarketPerformanceData) both
   // resolve their window through these same helpers, so for any
-  // (isMobile, mobileWindowDays) pair they MUST agree. Modelling both callers as
-  // identical calls proves they cannot drift for the new selectable window.
+  // (isMobile, windowDays) pair they MUST agree. Modelling both callers as
+  // identical calls proves they cannot drift for the selectable window.
   const scoreDate = new Date("2026-01-01T09:30:00");
   const pairs: Array<[boolean, number | undefined]> = [
     [true, undefined], // mobile default -> 90
     [true, 90], // mobile explicit 90
-    [true, 180], // mobile opting into the full window (the new case)
-    [true, 999], // bad value -> falls back to 90
-    [false, 90], // desktop ignores the override -> 180
-    [false, 180], // desktop -> 180
+    [true, 180], // mobile opting into the full window
+    [true, 999], // bad value -> falls back to mobile 90
+    [false, undefined], // desktop default -> 180
+    [false, 90], // desktop opting into 90 (the new #464 case)
+    [false, 180], // desktop explicit 180
+    [false, 999], // bad value -> falls back to desktop 180
   ];
 
-  for (const [isMobile, mobileWindowDays] of pairs) {
+  for (const [isMobile, windowDays] of pairs) {
     const chartEnd = GRQProjection.deviceWindowEnd(
       scoreDate,
       isMobile,
-      mobileWindowDays,
+      windowDays,
     );
     const summaryEnd = GRQProjection.deviceWindowEnd(
       scoreDate,
       isMobile,
-      mobileWindowDays,
+      windowDays,
     );
     assertEquals(
       chartEnd!.getTime(),
       summaryEnd!.getTime(),
-      `chart and summary must share the window for (${isMobile}, ${mobileWindowDays})`,
+      `chart and summary must share the window for (${isMobile}, ${windowDays})`,
     );
     // The end is exactly the resolved device days after the score date.
-    const days = GRQProjection.deviceWindowDays(isMobile, mobileWindowDays);
+    const days = GRQProjection.deviceWindowDays(isMobile, windowDays);
     const base = GRQProjection.setDateToMidnight(new Date("2026-01-01"));
     assertEquals(
       chartEnd!.getTime(),
@@ -96,10 +98,17 @@ Deno.test("deviceWindowDays/deviceWindowEnd - selectable mobile window keeps cha
   }
 
   // The mobile (mobile, 180) window must land on the same end date the desktop
-  // window does — the toggle simply gives mobile the full desktop window.
+  // default window does — the toggle simply gives mobile the full desktop window.
   assertEquals(
     GRQProjection.deviceWindowEnd(scoreDate, true, 180)!.getTime(),
     GRQProjection.deviceWindowEnd(scoreDate, false)!.getTime(),
+  );
+
+  // Symmetrically, a desktop (desktop, 90) window must land on the same end date
+  // the mobile default window does — the relaxed lock gives desktop the 90 window.
+  assertEquals(
+    GRQProjection.deviceWindowEnd(scoreDate, false, 90)!.getTime(),
+    GRQProjection.deviceWindowEnd(scoreDate, true)!.getTime(),
   );
 });
 

--- a/tests/projection_kernels_test.ts
+++ b/tests/projection_kernels_test.ts
@@ -95,21 +95,25 @@ function makePoint(
   return { date, high, low, open: low, close: high, splitCoefficient: split };
 }
 
-// --- selectable mobile window (issue #448) ----------------------------------
+// --- selectable window (issue #448; desktop-180 lock relaxed by #464) -------
 
-Deno.test("deviceWindowDays honours a permitted mobile window, desktop ignores the override", () => {
+Deno.test("deviceWindowDays honours an explicit permitted window on either device, each device keeps its own default", () => {
   // Default mobile behaviour is unchanged (90 days).
   assertEquals(GRQProjection.deviceWindowDays(true), 90);
   // Mobile may opt into the full 180-day window.
   assertEquals(GRQProjection.deviceWindowDays(true, 180), 180);
   // Mobile explicit 90 stays 90.
   assertEquals(GRQProjection.deviceWindowDays(true, 90), 90);
-  // A non-permitted value falls back to the 90-day default.
+  // A non-permitted value falls back to the mobile 90-day default.
   assertEquals(GRQProjection.deviceWindowDays(true, 999), 90);
-  // Desktop is always 180 — the override never affects it.
+  // Desktop default is preserved (180 days).
   assertEquals(GRQProjection.deviceWindowDays(false), 180);
-  assertEquals(GRQProjection.deviceWindowDays(false, 90), 180);
+  // Desktop may now opt into 90 — the old #448 desktop-180 lock is relaxed (#464).
+  assertEquals(GRQProjection.deviceWindowDays(false, 90), 90);
+  // Desktop explicit 180 stays 180.
   assertEquals(GRQProjection.deviceWindowDays(false, 180), 180);
+  // A non-permitted value falls back to the desktop 180-day default.
+  assertEquals(GRQProjection.deviceWindowDays(false, 999), 180);
 });
 
 Deno.test("deviceWindowEnd threads the chosen mobile window through to the end date", () => {
@@ -131,10 +135,15 @@ Deno.test("deviceWindowEnd threads the chosen mobile window through to the end d
     GRQProjection.deviceWindowEnd(scoreDate, true, 180)!.getTime(),
     expectEnd(180),
   );
-  // Desktop ignores the override and always ends 180 days after.
+  // Desktop default (no explicit value) still ends 180 days after.
+  assertEquals(
+    GRQProjection.deviceWindowEnd(scoreDate, false)!.getTime(),
+    expectEnd(180),
+  );
+  // Desktop opting into 90 ends 90 days after the score date (lock relaxed, #464).
   assertEquals(
     GRQProjection.deviceWindowEnd(scoreDate, false, 90)!.getTime(),
-    expectEnd(180),
+    expectEnd(90),
   );
   // Null / unparseable score date still returns null (blank-on-missing).
   assertEquals(GRQProjection.deviceWindowEnd(null, true, 180), null);


### PR DESCRIPTION
# Relax the desktop-180 chart-window lock (foundation)

## Summary

Relaxes the hard desktop-180 lock in the pure window helper
(`docs/projection.js`) so a permitted **90-day** choice can take effect on
desktop. `deviceWindowDays`/`deviceWindowEnd` now honour an **explicit permitted
value (90 or 180) on either device**, while each device keeps its own default
when the value is missing or invalid:

- desktop default stays **180**; desktop with an explicit `90` → **90** (NEW);
- mobile default stays **90**; mobile with an explicit `180` → **180** (unchanged
  from #448).

The helper stays **pure** — the caller supplies the value, the function never
reads `localStorage` — preserving the #367 single-source chart/summary
guarantee. The device-neutral allow-list constant is renamed
`PERMITTED_MOBILE_WINDOW_DAYS` → `PERMITTED_WINDOW_DAYS` (`[90, 180]`).

This is the foundation sub-issue of milestone #457; the toggle UI, the desktop
`GRQChartWindow` persistence key, and `?window=` URL honouring land in their own
sub-issues. No UI, persistence, or `localStorage` changes here. Closes #464.

## Implementation

The old helper hard-returned `DESKTOP_WINDOW_DAYS` on desktop, discarding any
supplied value. The new helper resolves a per-device default and honours an
explicit permitted value on either device:

```js
function deviceWindowDays(isMobile, windowDays) {
    const deviceDefault = isMobile ? MOBILE_WINDOW_DAYS : DESKTOP_WINDOW_DAYS;
    if (windowDays === undefined) return deviceDefault;
    return PERMITTED_WINDOW_DAYS.includes(windowDays)
        ? windowDays
        : deviceDefault;
}
```

`deviceWindowEnd` threads `windowDays` through unchanged (no implicit default
parameter, so omitting it falls back to the device default rather than a fixed
90). `null`/blank-on-missing-score-date behaviour is unchanged.

```mermaid
flowchart LR
    C["caller (isMobile, windowDays)"] --> DWD["deviceWindowDays"]
    DWD -->|windowDays undefined| DEF{"isMobile?"}
    DEF -->|yes| M90[90]
    DEF -->|no| D180[180]
    DWD -->|windowDays in 90,180| HON["honour value (either device)"]
    DWD -->|otherwise| DEF
    HON --> DWE["deviceWindowEnd: scoreDate + days"]
    M90 --> DWE
    D180 --> DWE
```

## Evidence

Backend/pure-module change with no web interface to screenshot. Verified via the
Deno unit tests below. `deno test --allow-read tests/*.ts` → **769 passed, 0
failed**; `deno fmt`, `deno lint`, and `deno check` all clean.

## Test Plan

Extended the two suites named in the acceptance criteria:

- `tests/projection_kernels_test.ts`
  - `deviceWindowDays honours an explicit permitted window on either device,
    each device keeps its own default` — asserts the full matrix:
    `(false)`→180, `(false, 90)`→**90** (new), `(false, 180)`→180,
    `(false, 999)`→180, `(true)`→90, `(true, 180)`→180, `(true, 90)`→90,
    `(true, 999)`→90.
  - `deviceWindowEnd threads the chosen ... window through to the end date` —
    added a desktop-90 case (`(scoreDate, false, 90)` → scoreDate + 90 days) and
    a desktop-default case; mobile cases unchanged.
- `tests/chart_summary_window_test.ts`
  - Extended the shared-window pair matrix with `[false, undefined]`,
    `[false, 90]`, and `[false, 999]`, and added a symmetric assertion that the
    desktop-90 window lands on the same end date as the mobile default window.

### Business-logic test changes (documented)

The lock is being deliberately relaxed, so two previously-correct assertions
encoding the old desktop-180 lock were updated (not removed):

- `deviceWindowDays(false, 90)` expectation changed from `180` → `90`.
- `deviceWindowEnd(scoreDate, false, 90)` expectation changed from
  `scoreDate + 180` → `scoreDate + 90`.

Stale "desktop ignores the override" comments were updated accordingly.

## Scope notes

`docs/app.js` is intentionally untouched — the toggle/persistence wiring belongs
to separate sub-issues of milestone #457. This PR targets the milestone branch
`milestone/457-feat-let-desktop-optionally-use-the-90-day-cha`.



## Milestone
This PR is part of the **#457 feat: let desktop optionally use the 90-day chart window (default stays 180)** milestone and targets the `milestone/457-feat-let-desktop-optionally-use-the-90-day-cha` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqrespxc-d63ac1`<!-- vibe-worker-issue-464 -->