### PR TITLE
feat: persist per-device desktop chart-window choice in GRQChartWindow (Issue #465)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-465.md
+++ b/docs/archive/pr-summaries/pr-summary-465.md
@@ -1,0 +1,62 @@
+## Summary
+
+Persist a **per-device desktop** 90/180 chart-window choice in the existing
+`GRQChartWindow` helper (`docs/chart_window_settings.js`), with a desktop
+default of **180**. Desktop gets its **own** storage key and its **own**
+default, so a desktop selection is remembered per device and can **never**
+regress mobile's required 90-day default (parent invariant #457). Pure
+persistence — no DOM, no chart. Closes #465.
+
+### Changes
+- New key `grq.chart.desktopWindowDays` (`DESKTOP_STORAGE_KEY`), separate from
+  the mobile key.
+- New default `DESKTOP_WINDOW_DAYS_DEFAULT = 180`.
+- `normaliseWindowDays(value, fallback)` is now parameterised — an omitted
+  `fallback` preserves the original mobile-90 behaviour for existing callers;
+  desktop passes 180 so missing / corrupt / out-of-range values fall back to
+  180.
+- New helpers `readDesktopWindowDays(storage)` / `writeDesktopWindowDays(value,
+  storage)`, published on `globalThis.GRQChartWindow` alongside the mobile
+  helpers.
+- Mobile key, mobile default (90), and `read/writeMobileWindowDays` left
+  **completely unchanged**. Allowed values remain `[90, 180]`.
+
+This is a backend/persistence-only change (no web UI), so evidence is the test
+suite below rather than a screenshot.
+
+## Evidence
+
+```mermaid
+flowchart LR
+    subgraph localStorage
+      M["grq.chart.mobileWindowDays"]
+      D["grq.chart.desktopWindowDays"]
+    end
+    RW_M["read/writeMobileWindowDays\n(default 90)"] --> M
+    RW_D["read/writeDesktopWindowDays\n(default 180)"] --> D
+    M -. independent keys .- D
+```
+
+Separate keys mean a desktop write never changes what mobile reads, and
+vice-versa — verified by the independence tests.
+
+`deno test tests/chart_window_settings_test.ts` → **27 passed | 0 failed**.
+`./quality.sh` → ✅ completed successfully.
+
+## Test Plan
+
+Extended `tests/chart_window_settings_test.ts`:
+- Desktop helpers published; `DESKTOP_WINDOW_DAYS_DEFAULT === 180`.
+- `DESKTOP_STORAGE_KEY` is its own `grq.chart.*` key, distinct from the mobile
+  key.
+- `normaliseWindowDays(value, 180)` honours the explicit desktop fallback.
+- Desktop read with empty / absent / null / throwing storage → **180**.
+- `writeDesktopWindowDays(90)` then read → 90; `writeDesktopWindowDays(180)`
+  then read → 180.
+- Corrupt / out-of-range desktop value → 180 (read and write).
+- Desktop write reports failure (not throw) in no-storage / private-mode paths.
+- **Independence:** writing the desktop key never changes
+  `readMobileWindowDays` (still 90 on empty storage), and writing the mobile
+  key never changes `readDesktopWindowDays` (still 180); both choices coexist.
+
+All pre-existing mobile tests remain unchanged and green.

--- a/docs/chart_window_settings.js
+++ b/docs/chart_window_settings.js
@@ -1,9 +1,11 @@
-// Client-side settings helper for the per-device mobile chart-window choice
-// (issue #447, sub-issue of milestone #445).
+// Client-side settings helper for the per-device chart-window choice
+// (issue #447, sub-issue of milestone #445; desktop added in issue #465).
 //
-// This remembers, per device, the user's choice of mobile chart window — the
-// default 90 days, or the full 180 days — backed by localStorage under a
-// namespaced `grq.chart.*` key (mirroring `grq.trend.*`).
+// This remembers, per device, the user's choice of chart window — 90 days or
+// the full 180 days — backed by localStorage under namespaced `grq.chart.*`
+// keys (mirroring `grq.trend.*`). Mobile and desktop have SEPARATE keys and
+// SEPARATE defaults (mobile 90, desktop 180) so a desktop choice can never
+// regress mobile's required 90-day default (parent invariant #457).
 //
 // Like docs/trend_settings.js and docs/theme.js this file is loaded as a
 // classic <script> and is also imported by the Deno tests. It uses no module
@@ -25,18 +27,30 @@
   // The user-facing default mobile chart window, in days (issue #447: 90).
   const MOBILE_WINDOW_DAYS_DEFAULT = 90;
 
+  // The user-facing default desktop chart window, in days (issue #465: 180).
+  const DESKTOP_WINDOW_DAYS_DEFAULT = 180;
+
   // The only two allowed window choices.
   const ALLOWED_WINDOW_DAYS = [90, 180];
 
   // Namespaced localStorage key (issue #447: key under `grq.chart.*`).
   const STORAGE_KEY = "grq.chart.mobileWindowDays";
 
-  // Coerce an arbitrary value to one of the allowed windows, defaulting to 90
-  // so a missing / corrupt stored value never breaks the view. Accepts both
-  // numbers and their string forms (localStorage only stores strings).
-  function normaliseWindowDays(value) {
+  // Namespaced localStorage key for the per-device desktop choice (issue #465).
+  // Desktop keeps its OWN key so a desktop write can never change what mobile
+  // reads — preserving mobile's required 90-day default (parent #457).
+  const DESKTOP_STORAGE_KEY = "grq.chart.desktopWindowDays";
+
+  // Coerce an arbitrary value to one of the allowed windows, defaulting to the
+  // supplied fallback so a missing / corrupt stored value never breaks the
+  // view. Accepts both numbers and their string forms (localStorage only stores
+  // strings). The fallback is parameterised (issue #465) so mobile falls back
+  // to 90 and desktop falls back to 180; an omitted fallback keeps the original
+  // mobile-90 behaviour for existing callers.
+  function normaliseWindowDays(value, fallback) {
+    const def = fallback === undefined ? MOBILE_WINDOW_DAYS_DEFAULT : fallback;
     const num = typeof value === "string" ? Number(value) : value;
-    return ALLOWED_WINDOW_DAYS.includes(num) ? num : MOBILE_WINDOW_DAYS_DEFAULT;
+    return ALLOWED_WINDOW_DAYS.includes(num) ? num : def;
   }
 
   // Resolve the storage to use: an explicitly-passed value (which may be null)
@@ -90,13 +104,37 @@
     return safeSet(storage, STORAGE_KEY, String(normaliseWindowDays(value)));
   }
 
+  // --- desktop chart window --------------------------------------------------
+  // Separate key + 180 default (issue #465). A missing / corrupt / out-of-range
+  // desktop value falls back to 180, NOT 90, and writing here never touches the
+  // mobile key.
+
+  function readDesktopWindowDays(storage) {
+    return normaliseWindowDays(
+      safeGet(storage, DESKTOP_STORAGE_KEY),
+      DESKTOP_WINDOW_DAYS_DEFAULT,
+    );
+  }
+
+  function writeDesktopWindowDays(value, storage) {
+    return safeSet(
+      storage,
+      DESKTOP_STORAGE_KEY,
+      String(normaliseWindowDays(value, DESKTOP_WINDOW_DAYS_DEFAULT)),
+    );
+  }
+
   // Publish the helpers for the dashboard and the tests.
   globalThis.GRQChartWindow = {
     STORAGE_KEY,
+    DESKTOP_STORAGE_KEY,
     MOBILE_WINDOW_DAYS_DEFAULT,
+    DESKTOP_WINDOW_DAYS_DEFAULT,
     ALLOWED_WINDOW_DAYS,
     normaliseWindowDays,
     readMobileWindowDays,
     writeMobileWindowDays,
+    readDesktopWindowDays,
+    writeDesktopWindowDays,
   };
 })();

--- a/tests/chart_window_settings_test.ts
+++ b/tests/chart_window_settings_test.ts
@@ -16,11 +16,15 @@ import "../docs/chart_window_settings.js";
 const g = globalThis as unknown as {
   GRQChartWindow: {
     STORAGE_KEY: string;
+    DESKTOP_STORAGE_KEY: string;
     MOBILE_WINDOW_DAYS_DEFAULT: number;
+    DESKTOP_WINDOW_DAYS_DEFAULT: number;
     ALLOWED_WINDOW_DAYS: number[];
-    normaliseWindowDays: (value: unknown) => number;
+    normaliseWindowDays: (value: unknown, fallback?: number) => number;
     readMobileWindowDays: (storage?: unknown) => number;
     writeMobileWindowDays: (value: unknown, storage?: unknown) => boolean;
+    readDesktopWindowDays: (storage?: unknown) => number;
+    writeDesktopWindowDays: (value: unknown, storage?: unknown) => boolean;
   };
 };
 
@@ -146,4 +150,101 @@ Deno.test("read/write fall back to default when no storage is available", () => 
   // environment without depending on the ambient global.
   assertEquals(S.readMobileWindowDays(null), 90);
   assertEquals(S.writeMobileWindowDays(180, null), false);
+});
+
+// --- desktop chart window (issue #465) -------------------------------------
+
+Deno.test("GRQChartWindow publishes desktop helpers and a 180 default", () => {
+  assertEquals(S.DESKTOP_WINDOW_DAYS_DEFAULT, 180);
+  assertEquals(typeof S.readDesktopWindowDays, "function");
+  assertEquals(typeof S.writeDesktopWindowDays, "function");
+});
+
+Deno.test("DESKTOP_STORAGE_KEY is its own grq.chart.* key", () => {
+  assert(S.DESKTOP_STORAGE_KEY.startsWith("grq.chart."));
+  assertEquals(S.DESKTOP_STORAGE_KEY, "grq.chart.desktopWindowDays");
+  // Desktop must not reuse the mobile key, or a desktop write would regress
+  // mobile's 90-day default.
+  assert(S.DESKTOP_STORAGE_KEY !== S.STORAGE_KEY);
+});
+
+Deno.test("normaliseWindowDays honours an explicit desktop fallback of 180", () => {
+  assertEquals(S.normaliseWindowDays("junk", 180), 180);
+  assertEquals(S.normaliseWindowDays(30, 180), 180);
+  assertEquals(S.normaliseWindowDays(null, 180), 180);
+  // Allowed values still pass through unchanged.
+  assertEquals(S.normaliseWindowDays(90, 180), 90);
+  assertEquals(S.normaliseWindowDays(180, 180), 180);
+});
+
+Deno.test("readDesktopWindowDays returns 180 when storage is empty", () => {
+  assertEquals(S.readDesktopWindowDays(fakeStorage()), 180);
+});
+
+Deno.test("readDesktopWindowDays returns 180 when no storage is available", () => {
+  assertEquals(S.readDesktopWindowDays(null), 180);
+});
+
+Deno.test("desktop write then read round-trips 90", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeDesktopWindowDays(90, store), true);
+  assertEquals(S.readDesktopWindowDays(store), 90);
+  assertEquals(store._dump()[S.DESKTOP_STORAGE_KEY], "90");
+});
+
+Deno.test("desktop write then read round-trips 180", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeDesktopWindowDays(180, store), true);
+  assertEquals(S.readDesktopWindowDays(store), 180);
+  assertEquals(store._dump()[S.DESKTOP_STORAGE_KEY], "180");
+});
+
+Deno.test("writeDesktopWindowDays normalises out-of-range to 180 before persisting", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeDesktopWindowDays(365, store), true);
+  assertEquals(store._dump()[S.DESKTOP_STORAGE_KEY], "180");
+  assertEquals(S.readDesktopWindowDays(store), 180);
+});
+
+Deno.test("readDesktopWindowDays tolerates a corrupt stored value (→180)", () => {
+  const store = fakeStorage({ [S.DESKTOP_STORAGE_KEY]: "garbage" });
+  assertEquals(S.readDesktopWindowDays(store), 180);
+});
+
+Deno.test("desktop read falls back to 180 when storage throws", () => {
+  assertEquals(S.readDesktopWindowDays(throwingStorage()), 180);
+});
+
+Deno.test("desktop write reports failure (not throw) when storage is unavailable", () => {
+  assertEquals(S.writeDesktopWindowDays(90, throwingStorage()), false);
+  assertEquals(S.writeDesktopWindowDays(90, null), false);
+});
+
+// --- independence: desktop and mobile never cross-contaminate ---------------
+
+Deno.test("writing the desktop key never changes readMobileWindowDays", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeDesktopWindowDays(180, store), true);
+  // Mobile still reads its own default — the desktop write did not touch it.
+  assertEquals(S.readMobileWindowDays(store), 90);
+  // Only the desktop key was written.
+  assertEquals(store._dump()[S.STORAGE_KEY], undefined);
+  assertEquals(store._dump()[S.DESKTOP_STORAGE_KEY], "180");
+});
+
+Deno.test("writing the mobile key never changes readDesktopWindowDays", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeMobileWindowDays(90, store), true);
+  // Desktop still reads its own 180 default — the mobile write did not touch it.
+  assertEquals(S.readDesktopWindowDays(store), 180);
+  assertEquals(store._dump()[S.DESKTOP_STORAGE_KEY], undefined);
+  assertEquals(store._dump()[S.STORAGE_KEY], "90");
+});
+
+Deno.test("desktop and mobile choices coexist independently", () => {
+  const store = fakeStorage();
+  assertEquals(S.writeMobileWindowDays(180, store), true);
+  assertEquals(S.writeDesktopWindowDays(90, store), true);
+  assertEquals(S.readMobileWindowDays(store), 180);
+  assertEquals(S.readDesktopWindowDays(store), 90);
 });


### PR DESCRIPTION
## Summary

Persist a **per-device desktop** 90/180 chart-window choice in the existing
`GRQChartWindow` helper (`docs/chart_window_settings.js`), with a desktop
default of **180**. Desktop gets its **own** storage key and its **own**
default, so a desktop selection is remembered per device and can **never**
regress mobile's required 90-day default (parent invariant #457). Pure
persistence — no DOM, no chart. Closes #465.

### Changes
- New key `grq.chart.desktopWindowDays` (`DESKTOP_STORAGE_KEY`), separate from
  the mobile key.
- New default `DESKTOP_WINDOW_DAYS_DEFAULT = 180`.
- `normaliseWindowDays(value, fallback)` is now parameterised — an omitted
  `fallback` preserves the original mobile-90 behaviour for existing callers;
  desktop passes 180 so missing / corrupt / out-of-range values fall back to
  180.
- New helpers `readDesktopWindowDays(storage)` / `writeDesktopWindowDays(value,
  storage)`, published on `globalThis.GRQChartWindow` alongside the mobile
  helpers.
- Mobile key, mobile default (90), and `read/writeMobileWindowDays` left
  **completely unchanged**. Allowed values remain `[90, 180]`.

This is a backend/persistence-only change (no web UI), so evidence is the test
suite below rather than a screenshot.

## Evidence

```mermaid
flowchart LR
    subgraph localStorage
      M["grq.chart.mobileWindowDays"]
      D["grq.chart.desktopWindowDays"]
    end
    RW_M["read/writeMobileWindowDays\n(default 90)"] --> M
    RW_D["read/writeDesktopWindowDays\n(default 180)"] --> D
    M -. independent keys .- D
```

Separate keys mean a desktop write never changes what mobile reads, and
vice-versa — verified by the independence tests.

`deno test tests/chart_window_settings_test.ts` → **27 passed | 0 failed**.
`./quality.sh` → ✅ completed successfully.

## Test Plan

Extended `tests/chart_window_settings_test.ts`:
- Desktop helpers published; `DESKTOP_WINDOW_DAYS_DEFAULT === 180`.
- `DESKTOP_STORAGE_KEY` is its own `grq.chart.*` key, distinct from the mobile
  key.
- `normaliseWindowDays(value, 180)` honours the explicit desktop fallback.
- Desktop read with empty / absent / null / throwing storage → **180**.
- `writeDesktopWindowDays(90)` then read → 90; `writeDesktopWindowDays(180)`
  then read → 180.
- Corrupt / out-of-range desktop value → 180 (read and write).
- Desktop write reports failure (not throw) in no-storage / private-mode paths.
- **Independence:** writing the desktop key never changes
  `readMobileWindowDays` (still 90 on empty storage), and writing the mobile
  key never changes `readDesktopWindowDays` (still 180); both choices coexist.

All pre-existing mobile tests remain unchanged and green.



## Milestone
This PR is part of the **#457 feat: let desktop optionally use the 90-day chart window (default stays 180)** milestone and targets the `milestone/457-feat-let-desktop-optionally-use-the-90-day-cha` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqrespxc-d63ac1`<!-- vibe-worker-issue-465 -->