### PR TITLE
feat: honour ?window=90|180 on desktop (visit-only) (#467)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Visit `http://localhost:8000` to access the dashboard.
 
 #### Deep-link URL parameters
 
-The dashboard reads four optional query parameters so a specific view can be
+The dashboard reads five optional query parameters so a specific view can be
 linked directly (and so the automated accessibility check can audit each view
 deterministically — issue #281):
 
@@ -166,6 +166,13 @@ deterministically — issue #281):
   `?stock=NASDAQ%3AMGRC`. An unknown symbol falls back to the aggregate view.
 - `?theme=auto|light|dark` — force a theme for that page load (a transient
   override that is **not** persisted to `localStorage`).
+- `?window=90|180` — switch the chart (and aligned Market Performance summary)
+  to a 90- or 180-day window for that page load, on **both** desktop and mobile
+  (issues #450, #467). Like `?theme=`, this is a **transient** override: it
+  wins over the saved per-device choice but is **never** persisted, so a reload
+  without the param returns to the saved window (desktop 180 / mobile 90). Both
+  windows end on the same date (#367); an absent or invalid value falls back to
+  the saved choice, then the device default.
 
 All views meet **WCAG 2 AA** colour contrast in both the light and dark themes;
 `pa11yci.json` scans the aggregate, single-stock and Trend views in both themes

--- a/docs/app.js
+++ b/docs/app.js
@@ -90,10 +90,27 @@ class GRQValidator {
     // window-sizing call site (chart, summary, cost-of-capital floor) resolves
     // through this single accessor so the chart and the summary always cover the
     // identical window (#367) — a desktop 90 choice narrows both together.
+    //
+    // A `?window=90|180` deep link (issue #467) takes precedence for THIS visit
+    // only: the transient URL value (parsed by the shared #450 helper) wins over
+    // the saved per-device choice, which wins over the device default. The URL
+    // value is NEVER persisted, so a reload without the param returns to the
+    // saved/180 window and mobile's 90 default is never regressed. Guarded so a
+    // missing helper degrades cleanly to the saved per-device value.
     currentWindowDays() {
-        return this.isMobileDevice()
+        const saved = this.isMobileDevice()
             ? this.mobileWindowDays()
             : this.desktopWindowDays();
+        if (
+            typeof GRQChartWindow === "undefined" ||
+            typeof GRQChartWindow.effectiveWindowDays !== "function"
+        ) {
+            return saved;
+        }
+        const search = (typeof window !== "undefined" && window.location)
+            ? window.location.search
+            : "";
+        return GRQChartWindow.effectiveWindowDays(search, saved);
     }
 
     // Restore the 90/180-day toggle to THIS device's stored choice and, on

--- a/docs/archive/pr-summaries/pr-summary-467.md
+++ b/docs/archive/pr-summaries/pr-summary-467.md
@@ -1,0 +1,69 @@
+## Summary
+
+Make a `?window=90` / `?window=180` deep link take effect **on desktop**
+(and mobile), **visit-only**, so a shared link can switch the chart — and the
+aligned Market Performance summary — to a 90- or 180-day window without writing
+the saved per-device preference. Closes #467.
+
+Parsing of `?window=` is owned by #450; since #450 has not merged yet, this PR
+adds the **single shared parser** (`windowDaysFromSearch`) alongside the
+existing window helpers so #450 can consume the same implementation — the
+parameter is built **once**, not twice.
+
+What changed:
+
+- `docs/chart_window_settings.js` — adds two pure helpers on
+  `globalThis.GRQChartWindow`, mirroring `theme.js`'s `preferenceFromSearch`:
+  - `windowDaysFromSearch(search)` — the shared `?window=` parser. Returns `90`
+    or `180` for a permitted value, else `null` (absent / blank / disallowed).
+  - `effectiveWindowDays(search, savedWindowDays)` — the visit-only precedence
+    resolver: a `?window=` URL override **wins** over the saved per-device
+    choice, which wins over the device default. Pure — it writes nothing, so a
+    URL-supplied window is honoured for the visit only.
+- `docs/app.js` — `currentWindowDays()` now resolves the saved per-device value
+  (mobile 90 / desktop 180) and then applies the transient `?window=` override
+  through `effectiveWindowDays`. Because every window-sizing call site (chart,
+  summary, cost-of-capital floor) already routes through this single accessor,
+  a `?window=90` link narrows the chart **and** the summary together, ending on
+  the same date (#367). The URL value is **never** persisted, so a reload
+  without the param returns to the saved/180 window. Guarded so a missing helper
+  degrades cleanly to the saved value.
+- `README.md` — documents the new `?window=90|180` transient deep link.
+
+### Precedence
+
+```mermaid
+flowchart LR
+    A["?window=90|180<br/>(transient, #450 parser)"] -->|wins| R[currentWindowDays]
+    B["saved per-device choice<br/>(grq.chart.*WindowDays)"] -->|fallback| R
+    C["device default<br/>(desktop 180 / mobile 90)"] -->|fallback| R
+    R --> D[chart]
+    R --> E[Market Performance summary]
+```
+
+### Mobile invariant
+
+A `?window=` value is per-visit only and writes nothing, so a desktop link
+never changes mobile's stored 90 default. With no override, mobile still
+resolves to its saved/90 value.
+
+## Evidence
+
+Backend/front-end logic change with no new visual chrome (the toggle UI and
+styles ship under #466). Verified behaviourally via the Deno test suite — the
+new parser and precedence resolver are exercised against the real shipped
+helpers. Full suite green: `deno test --allow-read tests/*.ts` → `799 passed`.
+
+## Test Plan
+
+- Added `tests/chart_window_url_test.ts` (real-function behavioural tests):
+  - `windowDaysFromSearch` — `?window=90`/`?window=180` parse to `90`/`180`;
+    leading `?` optional; whitespace tolerated; absent / blank / disallowed /
+    rubbish input → `null` (never throws).
+  - `effectiveWindowDays` — `?window=90` overrides a saved desktop `180`;
+    `?window=180` overrides a saved desktop `90`; absent/invalid falls back to
+    the saved value; mobile's `90` default is preserved when no override is
+    present (override is per-visit, writes nothing).
+- Existing `tests/chart_window_settings_test.ts` and
+  `tests/chart_window_toggle_test.ts` continue to pass unchanged (no persisted
+  behaviour altered).

--- a/docs/chart_window_settings.js
+++ b/docs/chart_window_settings.js
@@ -124,6 +124,42 @@
     );
   }
 
+  // --- transient `?window=` deep link (issues #450, #467) --------------------
+  // The single shared `?window=` parser. Parsing of `?window=` is owned by
+  // #450 (which mirrors `?theme=` / `?date=`); it lives here — beside
+  // `normaliseWindowDays` and `ALLOWED_WINDOW_DAYS` — so the parameter is
+  // implemented ONCE and both #450 and the desktop wiring (#467) consume the
+  // same helper. The value is TRANSIENT: applying it must never write storage.
+
+  // Read a transient chart-window override from a URL query string, e.g.
+  // `?window=90` or `?window=180`. Returns 90 or 180 when the value is a
+  // permitted window, else null (absent / blank / disallowed) so callers fall
+  // back to the saved choice or device default. Mirrors theme.js's
+  // preferenceFromSearch — guarded so malformed input never throws.
+  function windowDaysFromSearch(search) {
+    try {
+      const value = new URLSearchParams(search || "").get("window");
+      if (value === null) {
+        return null;
+      }
+      const num = Number(value.trim());
+      return ALLOWED_WINDOW_DAYS.includes(num) ? num : null;
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // Resolve the effective chart window for a visit, applying the visit-only
+  // precedence (issue #467): a `?window=` URL override (transient, never
+  // persisted) wins over `savedWindowDays` — the already-resolved saved
+  // per-device choice or device default (mobile 90 / desktop 180). An absent or
+  // invalid override leaves the saved value in place. Pure: writes nothing, so
+  // a URL-supplied window is honoured for the visit without persisting.
+  function effectiveWindowDays(search, savedWindowDays) {
+    const fromUrl = windowDaysFromSearch(search);
+    return fromUrl === null ? savedWindowDays : fromUrl;
+  }
+
   // Publish the helpers for the dashboard and the tests.
   globalThis.GRQChartWindow = {
     STORAGE_KEY,
@@ -136,5 +172,7 @@
     writeMobileWindowDays,
     readDesktopWindowDays,
     writeDesktopWindowDays,
+    windowDaysFromSearch,
+    effectiveWindowDays,
   };
 })();

--- a/tests/chart_window_url_test.ts
+++ b/tests/chart_window_url_test.ts
@@ -1,0 +1,106 @@
+// Behavioural tests for the transient `?window=90|180` deep-link override
+// (issue #467, coordinating with #450 which owns the parser).
+//
+// A `?window=` deep link switches the chart (and aligned summary) window for a
+// VISIT only — it is never persisted to localStorage. These tests exercise the
+// REAL shipped helpers from docs/chart_window_settings.js:
+//   - windowDaysFromSearch() — the single shared `?window=` parser (#450/#467),
+//     mirroring theme.js's preferenceFromSearch();
+//   - effectiveWindowDays()  — the visit-only precedence resolver:
+//     `?window=` (transient) > saved per-device choice > device default.
+//
+// They follow the `?theme=` / `?date=` transient-precedence pattern: the URL
+// value wins for the visit, an absent/invalid value falls back to the saved
+// value, and nothing is written.
+import { assertEquals } from "@std/assert";
+import "../docs/chart_window_settings.js";
+
+const g = globalThis as unknown as {
+  GRQChartWindow: {
+    ALLOWED_WINDOW_DAYS: number[];
+    windowDaysFromSearch: (search: unknown) => number | null;
+    effectiveWindowDays: (search: unknown, saved: number) => number;
+  };
+};
+
+const S = g.GRQChartWindow;
+
+// --- the shared parser is published (single implementation for #450) --------
+
+Deno.test("GRQChartWindow publishes the shared ?window= parser + resolver", () => {
+  assertEquals(typeof S.windowDaysFromSearch, "function");
+  assertEquals(typeof S.effectiveWindowDays, "function");
+});
+
+// --- windowDaysFromSearch ---------------------------------------------------
+
+Deno.test("windowDaysFromSearch returns 90 for ?window=90", () => {
+  assertEquals(S.windowDaysFromSearch("?window=90"), 90);
+  // The leading '?' is optional (URLSearchParams tolerates either form).
+  assertEquals(S.windowDaysFromSearch("window=90"), 90);
+});
+
+Deno.test("windowDaysFromSearch returns 180 for ?window=180", () => {
+  assertEquals(S.windowDaysFromSearch("?window=180"), 180);
+});
+
+Deno.test("windowDaysFromSearch ignores surrounding whitespace", () => {
+  assertEquals(S.windowDaysFromSearch("?window=%2090%20"), 90);
+});
+
+Deno.test("windowDaysFromSearch returns null when the param is absent", () => {
+  assertEquals(S.windowDaysFromSearch(""), null);
+  assertEquals(S.windowDaysFromSearch("?theme=dark"), null);
+  assertEquals(S.windowDaysFromSearch("?date=2026-03-23"), null);
+});
+
+Deno.test("windowDaysFromSearch returns null for a blank value", () => {
+  assertEquals(S.windowDaysFromSearch("?window="), null);
+  assertEquals(S.windowDaysFromSearch("?window=%20"), null);
+});
+
+Deno.test("windowDaysFromSearch returns null for a disallowed window", () => {
+  // Only 90 and 180 are permitted; anything else falls through to null so the
+  // caller keeps the saved/default choice.
+  assertEquals(S.windowDaysFromSearch("?window=45"), null);
+  assertEquals(S.windowDaysFromSearch("?window=360"), null);
+  assertEquals(S.windowDaysFromSearch("?window=abc"), null);
+  assertEquals(S.windowDaysFromSearch("?window=0"), null);
+});
+
+Deno.test("windowDaysFromSearch tolerates rubbish input without throwing", () => {
+  assertEquals(S.windowDaysFromSearch(null), null);
+  assertEquals(S.windowDaysFromSearch(undefined), null);
+  assertEquals(S.windowDaysFromSearch(123), null);
+});
+
+// --- effectiveWindowDays: visit-only precedence -----------------------------
+
+Deno.test("effectiveWindowDays: ?window=90 overrides a saved desktop 180", () => {
+  // Desktop acceptance: a shared 90-day link narrows the desktop window for the
+  // visit, even though the saved value is 180.
+  assertEquals(S.effectiveWindowDays("?window=90", 180), 90);
+});
+
+Deno.test("effectiveWindowDays: ?window=180 overrides a saved desktop 90", () => {
+  // A link can widen a saved desktop-90 choice back to 180 for the visit only.
+  assertEquals(S.effectiveWindowDays("?window=180", 90), 180);
+});
+
+Deno.test("effectiveWindowDays: absent ?window= keeps the saved value", () => {
+  assertEquals(S.effectiveWindowDays("", 180), 180);
+  assertEquals(S.effectiveWindowDays("?theme=dark", 90), 90);
+});
+
+Deno.test("effectiveWindowDays: invalid ?window= falls back to the saved value", () => {
+  assertEquals(S.effectiveWindowDays("?window=45", 180), 180);
+  assertEquals(S.effectiveWindowDays("?window=", 90), 90);
+});
+
+Deno.test("effectiveWindowDays: mobile default 90 is preserved when no override", () => {
+  // The mobile invariant: with no `?window=` the saved/default mobile 90 stands.
+  assertEquals(S.effectiveWindowDays("", 90), 90);
+  // A `?window=180` link is per-visit only — it returns 180 for the visit but
+  // writes nothing (this function is pure), so mobile's stored 90 is untouched.
+  assertEquals(S.effectiveWindowDays("?window=180", 90), 180);
+});


### PR DESCRIPTION
## Summary

Make a `?window=90` / `?window=180` deep link take effect **on desktop**
(and mobile), **visit-only**, so a shared link can switch the chart — and the
aligned Market Performance summary — to a 90- or 180-day window without writing
the saved per-device preference. Closes #467.

Parsing of `?window=` is owned by #450; since #450 has not merged yet, this PR
adds the **single shared parser** (`windowDaysFromSearch`) alongside the
existing window helpers so #450 can consume the same implementation — the
parameter is built **once**, not twice.

What changed:

- `docs/chart_window_settings.js` — adds two pure helpers on
  `globalThis.GRQChartWindow`, mirroring `theme.js`'s `preferenceFromSearch`:
  - `windowDaysFromSearch(search)` — the shared `?window=` parser. Returns `90`
    or `180` for a permitted value, else `null` (absent / blank / disallowed).
  - `effectiveWindowDays(search, savedWindowDays)` — the visit-only precedence
    resolver: a `?window=` URL override **wins** over the saved per-device
    choice, which wins over the device default. Pure — it writes nothing, so a
    URL-supplied window is honoured for the visit only.
- `docs/app.js` — `currentWindowDays()` now resolves the saved per-device value
  (mobile 90 / desktop 180) and then applies the transient `?window=` override
  through `effectiveWindowDays`. Because every window-sizing call site (chart,
  summary, cost-of-capital floor) already routes through this single accessor,
  a `?window=90` link narrows the chart **and** the summary together, ending on
  the same date (#367). The URL value is **never** persisted, so a reload
  without the param returns to the saved/180 window. Guarded so a missing helper
  degrades cleanly to the saved value.
- `README.md` — documents the new `?window=90|180` transient deep link.

### Precedence

```mermaid
flowchart LR
    A["?window=90|180<br/>(transient, #450 parser)"] -->|wins| R[currentWindowDays]
    B["saved per-device choice<br/>(grq.chart.*WindowDays)"] -->|fallback| R
    C["device default<br/>(desktop 180 / mobile 90)"] -->|fallback| R
    R --> D[chart]
    R --> E[Market Performance summary]
```

### Mobile invariant

A `?window=` value is per-visit only and writes nothing, so a desktop link
never changes mobile's stored 90 default. With no override, mobile still
resolves to its saved/90 value.

## Evidence

Backend/front-end logic change with no new visual chrome (the toggle UI and
styles ship under #466). Verified behaviourally via the Deno test suite — the
new parser and precedence resolver are exercised against the real shipped
helpers. Full suite green: `deno test --allow-read tests/*.ts` → `799 passed`.

## Test Plan

- Added `tests/chart_window_url_test.ts` (real-function behavioural tests):
  - `windowDaysFromSearch` — `?window=90`/`?window=180` parse to `90`/`180`;
    leading `?` optional; whitespace tolerated; absent / blank / disallowed /
    rubbish input → `null` (never throws).
  - `effectiveWindowDays` — `?window=90` overrides a saved desktop `180`;
    `?window=180` overrides a saved desktop `90`; absent/invalid falls back to
    the saved value; mobile's `90` default is preserved when no override is
    present (override is per-visit, writes nothing).
- Existing `tests/chart_window_settings_test.ts` and
  `tests/chart_window_toggle_test.ts` continue to pass unchanged (no persisted
  behaviour altered).
