### PR TITLE
feat: ?view=portfolio|trend deep-link to select the dashboard view (#479)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Visit `http://localhost:8000` to access the dashboard.
 
 #### Deep-link URL parameters
 
-The dashboard reads four optional query parameters so a specific view can be
+The dashboard reads five optional query parameters so a specific view can be
 linked directly (and so the automated accessibility check can audit each view
 deterministically — issue #281):
 
@@ -174,6 +174,14 @@ deterministically — issue #281):
   `?stock=NASDAQ%3AMGRC`. An unknown symbol falls back to the aggregate view.
 - `?theme=auto|light|dark` — force a theme for that page load (a transient
   override that is **not** persisted to `localStorage`).
+- `?view=portfolio|trend` — select which top-level view loads (issue #479).
+  `?view=trend` routes to the **Prediction Trend** page (`docs/trend.html`);
+  `?view=portfolio` shows the default aggregate view. Because the Trend view is
+  a separate page, `index.html?view=trend` redirects to `trend.html` and
+  `trend.html?view=portfolio` redirects back, mirroring the on-page nav links.
+  Read on load only and **not** persisted to `localStorage`; an absent or
+  unknown value falls back to the current default. (Single-stock is already
+  reachable via `?stock=`, so `?view=` does not duplicate it.)
 
 All views meet **WCAG 2 AA** colour contrast in both the light and dark themes;
 `pa11yci.json` scans the aggregate, single-stock and Trend views in both themes

--- a/docs/app.js
+++ b/docs/app.js
@@ -8,7 +8,30 @@ const RETURN_ABOVE_COST_OF_CAPITAL_DEFINITION =
     "Return above the 10% annualised cost-of-capital hurdle, pro-rated by days elapsed. Positive = beating the hurdle.";
 
 class GRQValidator {
+    // View deep-link routing (?view=portfolio|trend, issue #479). When the URL
+    // requests the Trend view, navigate to the separate trend.html page before
+    // any setup. Visit-only and one-way: reads the URL on load, never rewrites
+    // it and never writes localStorage. Returns true when it has navigated away.
+    static applyViewRoutingFromUrl() {
+        if (typeof location === "undefined" || !globalThis.GRQViewSelection) {
+            return false;
+        }
+        const target = globalThis.GRQViewSelection.viewRedirectTarget(
+            location.pathname,
+            location.search,
+        );
+        if (target) {
+            location.replace(target);
+            return true;
+        }
+        return false;
+    }
+
     constructor() {
+        // Honour ?view=trend before doing any work — it redirects to trend.html.
+        if (GRQValidator.applyViewRoutingFromUrl()) {
+            return;
+        }
         this.scoreData = null;
         this.marketData = null;
         this.dividendData = null;

--- a/docs/archive/pr-summaries/pr-summary-479.md
+++ b/docs/archive/pr-summaries/pr-summary-479.md
@@ -1,0 +1,75 @@
+# feat: `?view=portfolio|trend` deep-link to select the dashboard view
+
+## Summary
+
+Adds a transient `?view=` deep-link parameter that selects which top-level view
+loads, mirroring the existing `?date=` (#436), `?stock=` (#281) and `?theme=`
+(#233) helpers. Part of #450. Closes #479.
+
+- `index.html?view=trend` → routes to the **Prediction Trend** page
+  (`docs/trend.html`).
+- `index.html?view=portfolio` (or absent / invalid) → the default aggregate
+  ("portfolio") view.
+- For symmetry, `trend.html?view=portfolio` routes back to `index.html`.
+
+The Trend view is a **separate page** (`docs/trend.html`), not an in-page
+toggle, so `?view=` is applied as a one-way redirect on page load — mirroring
+the existing `#trendViewLink` nav anchor. Single-stock detail stays reachable
+via `?stock=`, so `?view=` does not duplicate it.
+
+Behaviour follows the same precedence model as `?theme=`: **read on page load
+only** (one-way, the URL is never rewritten as the user navigates) and
+**visit-only** (never writes `localStorage`). An absent, blank or unrecognised
+value falls back to the current default.
+
+### Implementation
+
+- **`docs/view_selection.js`** — new classic `<script>` helper (no module
+  syntax, no DOM coupling) published on `globalThis.GRQViewSelection`, matching
+  the shape of `stock_selection.js` / `date_selection.js`. Pure functions:
+  - `viewFromSearch(search)` → `"portfolio"` / `"trend"` / `null`.
+  - `currentPageFromPath(pathname)` → `"index"` / `"trend"`.
+  - `viewRedirectTarget(pathname, search)` → the page to navigate to, or `null`.
+- Loaded **before `app.js`** in `docs/index.html`, and before `trend.js` in
+  `docs/trend.html`.
+- `docs/app.js` and `docs/trend.js` call the pure resolver on load and, when a
+  redirect is required, `location.replace()` to the target page before doing any
+  other setup. Both call sites are guarded so the Deno tests (no DOM) are
+  unaffected.
+- Registered in `docs/sw.js` `STATIC_ASSETS` (PWA precache). `APP_VERSION`
+  bumped `1.0.214` → `1.0.215` across `sw.js`, `sw-register.js`,
+  `index.html` and `trend.html` so the new shell is re-fetched.
+
+## Evidence
+
+Playwright MCP was not available in this environment, so no browser screenshot
+could be captured. The redirect logic is pure and fully covered by the Deno
+unit tests below (valid / invalid / absent + both routing directions), and the
+script wiring (load order in both HTML pages + `sw.js` precache) is verified by
+the existing `trend_view_wiring` and `sw_precache_list` suites, which pass.
+
+Routing on page load:
+
+```mermaid
+flowchart TD
+    A["index.html?view=trend"] -->|viewRedirectTarget| B{redirect?}
+    B -->|trend.html| C["Prediction Trend page"]
+    D["trend.html?view=portfolio"] -->|viewRedirectTarget| E{redirect?}
+    E -->|index.html| F["Aggregate portfolio view"]
+    G["?view=portfolio on index<br/>?view=trend on trend<br/>absent / invalid"] -->|null| H["Stay on current page (default)"]
+```
+
+## Test Plan
+
+- Added `tests/view_selection_test.ts`, mirroring `tests/stock_selection_test.ts`:
+  - `viewFromSearch` extracts valid views (case-insensitive, whitespace-tolerant,
+    alongside other params).
+  - `viewFromSearch` returns `null` for absent / blank / invalid values and
+    non-string inputs.
+  - `currentPageFromPath` distinguishes the index vs trend page (incl. `/`,
+    empty and sub-path cases).
+  - `viewRedirectTarget` routes index → trend and trend → portfolio, and returns
+    `null` when already on the requested view or for absent / invalid values.
+- Full Deno suite: **818 tests pass** (`deno test --allow-read tests/*.ts`),
+  including the updated `trend_view_wiring` and `sw_precache_list` version
+  alignment checks.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.214">
+    <meta name="app-version" content="1.0.215">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -417,6 +417,10 @@
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
     <script src="date_selection.js"></script>
 
+    <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
+         before app.js, which routes ?view=trend to trend.html on load. -->
+    <script src="view_selection.js"></script>
+
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
     <script src="popover_dismiss.js"></script>
 
@@ -434,6 +438,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.214"></script>
+    <script src="sw-register.js?v=1.0.215"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.214")
+    navigator.serviceWorker.register("./sw.js?v=1.0.215")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.214";
+const APP_VERSION = "1.0.215";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;
@@ -27,6 +27,8 @@ const STATIC_ASSETS = [
   "./format.js",
   "./market_index.js",
   "./escape.js",
+  // View deep-link (?view=portfolio|trend) selection helpers (issue #479).
+  "./view_selection.js",
   "./popover_cleanup.js",
   // Mobile chart pop-out overlay engine (issue #451).
   "./chart_popout.js",

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.214">
+    <meta name="app-version" content="1.0.215">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -186,10 +186,14 @@
     <!-- Per-score-date prediction resolver (issue #430) -->
     <script src="trend_predictions.js"></script>
 
+    <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
+         before trend.js, which routes ?view=portfolio back to index.html. -->
+    <script src="view_selection.js"></script>
+
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.0.213"></script>
+    <script src="sw-register.js?v=1.0.215"></script>
   </body>
 </html>

--- a/docs/trend.js
+++ b/docs/trend.js
@@ -402,6 +402,19 @@
     }
 
     function start() {
+        // View deep-link routing (?view=portfolio, issue #479): when the URL
+        // requests the aggregate view, navigate back to index.html before any
+        // setup. Visit-only and one-way — never writes the URL or localStorage.
+        if (globalThis.GRQViewSelection) {
+            const target = globalThis.GRQViewSelection.viewRedirectTarget(
+                location.pathname,
+                location.search,
+            );
+            if (target) {
+                location.replace(target);
+                return;
+            }
+        }
         new GRQTrendView().init();
     }
 

--- a/docs/view_selection.js
+++ b/docs/view_selection.js
@@ -1,0 +1,76 @@
+// View deep-link selection helpers (issue #479).
+//
+// The dashboard can be deep-linked to a specific top-level view with a
+// `?view=portfolio|trend` query parameter:
+//   - `index.html?view=trend`     → the Prediction Trend page (trend.html).
+//   - `index.html?view=portfolio` → the default aggregate ("portfolio") view.
+// The Trend view is the SEPARATE page docs/trend.html (reached via the
+// `#trendViewLink` nav anchor), not an in-page toggle, so `?view=trend` on
+// index.html routes to trend.html; for symmetry `trend.html?view=portfolio`
+// routes back. Single-stock detail is already reachable via `?stock=`, so
+// `?view=` does not duplicate it.
+//
+// Mirrors the precedence model of `?theme=` (issue #233): read on page load
+// only (one-way), applies for the current load, and never writes localStorage.
+//
+// Like docs/escape.js, docs/projection.js, docs/theme.js,
+// docs/stock_selection.js and docs/date_selection.js, this file is loaded as a
+// classic <script> in docs/index.html and is also imported by the Deno tests.
+// It uses no module syntax, publishes its helpers on
+// `globalThis.GRQViewSelection`, and touches no DOM, so it imports cleanly in a
+// non-browser (test) environment.
+(function () {
+  "use strict";
+
+  const VALID_VIEWS = ["portfolio", "trend"];
+
+  // Extract the requested view from a URL query string. Returns "portfolio" or
+  // "trend" (lower-cased, trimmed), or null when the parameter is absent,
+  // blank or unrecognised — so callers fall back to the current default rather
+  // than guessing.
+  function viewFromSearch(search) {
+    try {
+      const value = new URLSearchParams(search || "").get("view");
+      if (value === null) {
+        return null;
+      }
+      const normalised = value.trim().toLowerCase();
+      return VALID_VIEWS.includes(normalised) ? normalised : null;
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // Identify the current top-level page from a URL pathname. Returns "trend"
+  // for the Prediction Trend page (trend.html), else "index" (the aggregate
+  // portfolio page, which is also the default for "/" and unknown paths).
+  function currentPageFromPath(pathname) {
+    const path = typeof pathname === "string" ? pathname.toLowerCase() : "";
+    return path.endsWith("trend.html") ? "trend" : "index";
+  }
+
+  // Resolve a `?view=` request for the current page into the page to navigate
+  // to. Returns "trend.html" or "index.html" when a redirect is required, or
+  // null when the view is absent/invalid or already matches the current page
+  // (so no navigation happens). Pure: performs no navigation itself.
+  function viewRedirectTarget(pathname, search) {
+    const requested = viewFromSearch(search);
+    if (requested === null) {
+      return null;
+    }
+    const current = currentPageFromPath(pathname);
+    if (requested === "trend" && current !== "trend") {
+      return "trend.html";
+    }
+    if (requested === "portfolio" && current !== "index") {
+      return "index.html";
+    }
+    return null;
+  }
+
+  globalThis.GRQViewSelection = {
+    viewFromSearch,
+    currentPageFromPath,
+    viewRedirectTarget,
+  };
+})();

--- a/tests/view_selection_test.ts
+++ b/tests/view_selection_test.ts
@@ -1,0 +1,105 @@
+// Behavioural tests for the view deep-link helpers (issue #479).
+//
+// These import the REAL shipped helpers from docs/view_selection.js — the same
+// pure functions the dashboard uses to honour a `?view=portfolio|trend` URL
+// parameter and route between the aggregate ("portfolio") view of
+// docs/index.html and the separate Prediction Trend page docs/trend.html.
+// The module publishes its helpers on globalThis and touches no DOM, so it
+// imports cleanly under Deno.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/view_selection.js";
+
+const g = globalThis as unknown as {
+  GRQViewSelection: {
+    viewFromSearch: (search: unknown) => string | null;
+    currentPageFromPath: (pathname: unknown) => string;
+    viewRedirectTarget: (pathname: unknown, search: unknown) => string | null;
+  };
+};
+const GRQViewSelection = g.GRQViewSelection;
+
+Deno.test("GRQViewSelection is published on globalThis", () => {
+  assert(
+    GRQViewSelection,
+    "view_selection.js should publish globalThis.GRQViewSelection",
+  );
+});
+
+Deno.test("viewFromSearch extracts a valid view", () => {
+  assertEquals(GRQViewSelection.viewFromSearch("?view=portfolio"), "portfolio");
+  assertEquals(GRQViewSelection.viewFromSearch("?view=trend"), "trend");
+  assertEquals(GRQViewSelection.viewFromSearch("view=trend"), "trend");
+  // Works alongside other params.
+  assertEquals(
+    GRQViewSelection.viewFromSearch("?theme=dark&view=trend"),
+    "trend",
+  );
+  // Case-insensitive and whitespace-tolerant.
+  assertEquals(GRQViewSelection.viewFromSearch("?view=TREND"), "trend");
+  assertEquals(
+    GRQViewSelection.viewFromSearch("?view=%20portfolio%20"),
+    "portfolio",
+  );
+});
+
+Deno.test("viewFromSearch returns null when absent, blank or invalid", () => {
+  assertEquals(GRQViewSelection.viewFromSearch(""), null);
+  assertEquals(GRQViewSelection.viewFromSearch("?theme=dark"), null);
+  assertEquals(GRQViewSelection.viewFromSearch("?view="), null);
+  assertEquals(GRQViewSelection.viewFromSearch("?view=%20%20"), null);
+  assertEquals(GRQViewSelection.viewFromSearch("?view=single"), null);
+  assertEquals(GRQViewSelection.viewFromSearch(null), null);
+  assertEquals(GRQViewSelection.viewFromSearch(undefined), null);
+});
+
+Deno.test("currentPageFromPath identifies the index vs trend page", () => {
+  assertEquals(GRQViewSelection.currentPageFromPath("/index.html"), "index");
+  assertEquals(GRQViewSelection.currentPageFromPath("/"), "index");
+  assertEquals(GRQViewSelection.currentPageFromPath(""), "index");
+  assertEquals(GRQViewSelection.currentPageFromPath("/GRQ/"), "index");
+  assertEquals(GRQViewSelection.currentPageFromPath("/trend.html"), "trend");
+  assertEquals(
+    GRQViewSelection.currentPageFromPath("/sub/trend.html"),
+    "trend",
+  );
+});
+
+Deno.test("viewRedirectTarget routes index -> trend and trend -> portfolio", () => {
+  // On index, ?view=trend routes to the Trend page.
+  assertEquals(
+    GRQViewSelection.viewRedirectTarget("/index.html", "?view=trend"),
+    "trend.html",
+  );
+  // On trend, ?view=portfolio routes back to the aggregate page.
+  assertEquals(
+    GRQViewSelection.viewRedirectTarget("/trend.html", "?view=portfolio"),
+    "index.html",
+  );
+});
+
+Deno.test("viewRedirectTarget returns null when already on the requested view", () => {
+  // Already on the portfolio (index) page.
+  assertEquals(
+    GRQViewSelection.viewRedirectTarget("/index.html", "?view=portfolio"),
+    null,
+  );
+  // Already on the trend page.
+  assertEquals(
+    GRQViewSelection.viewRedirectTarget("/trend.html", "?view=trend"),
+    null,
+  );
+});
+
+Deno.test("viewRedirectTarget returns null for absent or invalid view", () => {
+  assertEquals(GRQViewSelection.viewRedirectTarget("/index.html", ""), null);
+  assertEquals(
+    GRQViewSelection.viewRedirectTarget("/index.html", "?view=single"),
+    null,
+  );
+  assertEquals(
+    GRQViewSelection.viewRedirectTarget("/trend.html", "?theme=dark"),
+    null,
+  );
+  // Defensive: non-string inputs never throw.
+  assertEquals(GRQViewSelection.viewRedirectTarget(null, null), null);
+});


### PR DESCRIPTION
# feat: `?view=portfolio|trend` deep-link to select the dashboard view

## Summary

Adds a transient `?view=` deep-link parameter that selects which top-level view
loads, mirroring the existing `?date=` (#436), `?stock=` (#281) and `?theme=`
(#233) helpers. Part of #450. Closes #479.

- `index.html?view=trend` → routes to the **Prediction Trend** page
  (`docs/trend.html`).
- `index.html?view=portfolio` (or absent / invalid) → the default aggregate
  ("portfolio") view.
- For symmetry, `trend.html?view=portfolio` routes back to `index.html`.

The Trend view is a **separate page** (`docs/trend.html`), not an in-page
toggle, so `?view=` is applied as a one-way redirect on page load — mirroring
the existing `#trendViewLink` nav anchor. Single-stock detail stays reachable
via `?stock=`, so `?view=` does not duplicate it.

Behaviour follows the same precedence model as `?theme=`: **read on page load
only** (one-way, the URL is never rewritten as the user navigates) and
**visit-only** (never writes `localStorage`). An absent, blank or unrecognised
value falls back to the current default.

### Implementation

- **`docs/view_selection.js`** — new classic `<script>` helper (no module
  syntax, no DOM coupling) published on `globalThis.GRQViewSelection`, matching
  the shape of `stock_selection.js` / `date_selection.js`. Pure functions:
  - `viewFromSearch(search)` → `"portfolio"` / `"trend"` / `null`.
  - `currentPageFromPath(pathname)` → `"index"` / `"trend"`.
  - `viewRedirectTarget(pathname, search)` → the page to navigate to, or `null`.
- Loaded **before `app.js`** in `docs/index.html`, and before `trend.js` in
  `docs/trend.html`.
- `docs/app.js` and `docs/trend.js` call the pure resolver on load and, when a
  redirect is required, `location.replace()` to the target page before doing any
  other setup. Both call sites are guarded so the Deno tests (no DOM) are
  unaffected.
- Registered in `docs/sw.js` `STATIC_ASSETS` (PWA precache). `APP_VERSION`
  bumped `1.0.214` → `1.0.215` across `sw.js`, `sw-register.js`,
  `index.html` and `trend.html` so the new shell is re-fetched.

## Evidence

Playwright MCP was not available in this environment, so no browser screenshot
could be captured. The redirect logic is pure and fully covered by the Deno
unit tests below (valid / invalid / absent + both routing directions), and the
script wiring (load order in both HTML pages + `sw.js` precache) is verified by
the existing `trend_view_wiring` and `sw_precache_list` suites, which pass.

Routing on page load:

```mermaid
flowchart TD
    A["index.html?view=trend"] -->|viewRedirectTarget| B{redirect?}
    B -->|trend.html| C["Prediction Trend page"]
    D["trend.html?view=portfolio"] -->|viewRedirectTarget| E{redirect?}
    E -->|index.html| F["Aggregate portfolio view"]
    G["?view=portfolio on index<br/>?view=trend on trend<br/>absent / invalid"] -->|null| H["Stay on current page (default)"]
```

## Test Plan

- Added `tests/view_selection_test.ts`, mirroring `tests/stock_selection_test.ts`:
  - `viewFromSearch` extracts valid views (case-insensitive, whitespace-tolerant,
    alongside other params).
  - `viewFromSearch` returns `null` for absent / blank / invalid values and
    non-string inputs.
  - `currentPageFromPath` distinguishes the index vs trend page (incl. `/`,
    empty and sub-path cases).
  - `viewRedirectTarget` routes index → trend and trend → portfolio, and returns
    `null` when already on the requested view or for absent / invalid values.
- Full Deno suite: **818 tests pass** (`deno test --allow-read tests/*.ts`),
  including the updated `trend_view_wiring` and `sw_precache_list` version
  alignment checks.
