### PR TITLE
feat: ?indices= deep-link for Trend-view benchmark indices (visit-only) (#480)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Pages.
   Refresh it with `deno task fetch-indices`; the write is safe for unattended
   daily runs (fails fast on an empty response, refuses to overwrite committed
   history with a regressed payload, and skips the write when nothing changed).
-  The external daily scorer job refreshes it in lockstep with the scores via
-  the non-blocking `deno task refresh-indices` wrapper (see _Daily benchmark
+  The external daily scorer job refreshes it in lockstep with the scores via the
+  non-blocking `deno task refresh-indices` wrapper (see _Daily benchmark
   refresh_ below).
 - **Split-Aware Returns** — the backend reads each day's `split_coefficient` and
   reconciles any stock split inside the 90-day window. A trustworthy split
@@ -58,9 +58,9 @@ flowchart LR
 ```
 
 The dashboard reads every input from its own origin: per-score market CSVs, the
-score index, and the benchmark-index file. Benchmark data is fetched
-server-side and committed, so a visitor's browser never calls an untrusted
-third-party relay (issue #93).
+score index, and the benchmark-index file. Benchmark data is fetched server-side
+and committed, so a visitor's browser never calls an untrusted third-party relay
+(issue #93).
 
 ### Daily benchmark refresh (in lockstep with the scores)
 
@@ -111,8 +111,8 @@ date in `docs/market-indices.json` against the newest date in the actuals
 (`docs/USDAUD.json`) and fails when the indices lag by more than
 `FRESHNESS_TOLERANCE_TRADING_DAYS` (3) trading days. The gap is measured in
 trading days (weekends skipped), so the acceptable one-trading-day end-of-day
-publishing lag — and an intervening public holiday — never raises a false
-alarm. When the guard trips it names both newest dates and the gap, e.g.
+publishing lag — and an intervening public holiday — never raises a false alarm.
+When the guard trips it names both newest dates and the gap, e.g.
 `benchmark indices are stale: newest index date 2026-06-08 lags the newest
 actuals date 2026-06-18 by 7 trading days (tolerance is 3 trading days)`.
 
@@ -159,7 +159,7 @@ Visit `http://localhost:8000` to access the dashboard.
 
 #### Deep-link URL parameters
 
-The dashboard reads five optional query parameters so a specific view can be
+The dashboard reads six optional query parameters so a specific view can be
 linked directly (and so the automated accessibility check can audit each view
 deterministically — issue #281):
 
@@ -182,6 +182,13 @@ deterministically — issue #281):
   Read on load only and **not** persisted to `localStorage`; an absent or
   unknown value falls back to the current default. (Single-stock is already
   reachable via `?stock=`, so `?view=` does not duplicate it.)
+- `?indices=sp500,nasdaq,russell2000` — on the **Prediction Trend** page
+  (`docs/trend.html`), turn the listed benchmark-index overlays **ON** for that
+  visit; any index not listed is **OFF** (issue #480). Keys are the canonical
+  overlay keys `sp500`, `nasdaq`, `russell2000`; unknown keys are ignored. Read
+  on load only and **not** persisted to `localStorage` — reloading without the
+  param restores the saved choice. An absent param leaves the saved/default
+  toggles unchanged.
 
 All views meet **WCAG 2 AA** colour contrast in both the light and dark themes;
 `pa11yci.json` scans the aggregate, single-stock and Trend views in both themes
@@ -216,35 +223,34 @@ flowchart LR
 
 ## CI/CD Pipeline
 
-This repository ships a set of GitHub Actions workflows in
-`.github/workflows/` covering continuous integration, security scanning, and
-dependency hygiene.
+This repository ships a set of GitHub Actions workflows in `.github/workflows/`
+covering continuous integration, security scanning, and dependency hygiene.
 
 ### Workflows
 
 1. **CI** (`ci.yml`) — main continuous integration: build, test, formatting,
-   linting, and artifact upload. Runs on pushes and pull requests to `main`
-   and to `milestone/**` integration branches, so the Rust quality gate
+   linting, and artifact upload. Runs on pushes and pull requests to `main` and
+   to `milestone/**` integration branches, so the Rust quality gate
    (`cargo fmt`/`clippy`/`check`/`test`) also guards milestone PRs. The
-   `deploy-pages` job stays `main`-only, so milestone branches never publish
-   the GitHub Pages dashboard.
+   `deploy-pages` job stays `main`-only, so milestone branches never publish the
+   GitHub Pages dashboard.
 2. **Cargo Audit** (`cargo-audit.yml`) — runs `cargo audit` on every pull
    request and on a weekly schedule to catch newly disclosed advisories.
-3. **Deno Outdated** (`deno-outdated.yml`) — checks for outdated JSR/npm
-   imports used by the TypeScript dashboard tests.
+3. **Deno Outdated** (`deno-outdated.yml`) — checks for outdated JSR/npm imports
+   used by the TypeScript dashboard tests.
 4. **Deno Quality** (`deno-quality.yml`) — runs `deno fmt`, `deno lint`,
-   `deno check`, `deno audit`, and `deno test` against `tests/` on every
-   pull request and on a weekly schedule. `deno audit` scans the resolved
-   JSR/`@std` dependency graph for known vulnerabilities — the Deno-side
-   counterpart to `cargo audit`.
-5. **Dependency Review** (`dependency-review.yml`) — reviews dependency
-   changes on pull requests for known vulnerabilities and licence issues.
+   `deno check`, `deno audit`, and `deno test` against `tests/` on every pull
+   request and on a weekly schedule. `deno audit` scans the resolved JSR/`@std`
+   dependency graph for known vulnerabilities — the Deno-side counterpart to
+   `cargo audit`.
+5. **Dependency Review** (`dependency-review.yml`) — reviews dependency changes
+   on pull requests for known vulnerabilities and licence issues.
 6. **Gitleaks** (`gitleaks.yml`) — scans the repository for accidentally
    committed secrets.
 7. **Markdown Lint** (`markdown-lint.yml`) — enforces the rules in
    `.markdownlint-cli2.jsonc` against every Markdown file.
-8. **Semgrep** (`semgrep.yml`) — runs Semgrep static analysis for security
-   and correctness issues.
+8. **Semgrep** (`semgrep.yml`) — runs Semgrep static analysis for security and
+   correctness issues.
 9. **Shellcheck** (`shellcheck.yml`) — lints every `*.sh` script in the
    repository.
 10. **Accessibility** (`a11y.yml`) — runs `pa11y-ci` against the rendered
@@ -252,13 +258,12 @@ dependency hygiene.
     build on WCAG 2.1 AA violations so accessibility regressions are caught on
     the PR that introduces them.
 11. **Dependency Quarantine Gate** (`bump-quarantine-gate.yml`) — deterministic
-    supply-chain backstop that, on every pull request, blocks an external
-    Cargo crate or GitHub Action bump whose upstream release is younger than
-    24 hours (see _Automated dependency updates_ below).
+    supply-chain backstop that, on every pull request, blocks an external Cargo
+    crate or GitHub Action bump whose upstream release is younger than 24 hours
+    (see _Automated dependency updates_ below).
 12. **Version Bump** (`version-bump.yml`) — on every pull request, runs
-    `scripts/bump_version.ts` to increment the dashboard app version and
-    commits the change back to the PR branch (see _Dashboard versioning_
-    below).
+    `scripts/bump_version.ts` to increment the dashboard app version and commits
+    the change back to the PR branch (see _Dashboard versioning_ below).
 
 ### Dashboard versioning
 
@@ -270,11 +275,11 @@ the `app-version` meta and `sw-register.js?v=` script tag in `docs/index.html`.
 
 The **Version Bump** workflow keeps this automatic and reliable: on every pull
 request it runs `scripts/bump_version.ts`, which increments the patch component
-across all four locations and commits the result back to the PR branch. The
-bump is idempotent — it compares the branch version against the base branch and
-skips when the branch has already been bumped — so re-runs do not ratchet the
-version. This replaced an unreliable local pre-commit hook that only fired when
-a contributor had installed it.
+across all four locations and commits the result back to the PR branch. The bump
+is idempotent — it compares the branch version against the base branch and skips
+when the branch has already been bumped — so re-runs do not ratchet the version.
+This replaced an unreliable local pre-commit hook that only fired when a
+contributor had installed it.
 
 ```mermaid
 flowchart LR
@@ -323,13 +328,13 @@ flowchart TD
 
 The CI pipeline (`ci.yml`) complements this by building the **committed,
 reviewed `Cargo.lock`** rather than floating dependencies: every `cargo`
-build/test/check step runs with `--locked`, so a stale lockfile fails the
-build instead of silently resolving (and executing the `build.rs` /
-proc-macros of) a freshly-published, unquarantined crate. CI tool installs
-(`cargo-tarpaulin`, `cargo-cyclonedx`, `cargo-audit`) are pinned to explicit
-versions with `--locked` so they do not compile an arbitrary newest
-tool-dependency tree on each run. Crate bumps therefore arrive only through
-the quarantined Dependabot PRs above, never inline on a PR build.
+build/test/check step runs with `--locked`, so a stale lockfile fails the build
+instead of silently resolving (and executing the `build.rs` / proc-macros of) a
+freshly-published, unquarantined crate. CI tool installs (`cargo-tarpaulin`,
+`cargo-cyclonedx`, `cargo-audit`) are pinned to explicit versions with
+`--locked` so they do not compile an arbitrary newest tool-dependency tree on
+each run. Crate bumps therefore arrive only through the quarantined Dependabot
+PRs above, never inline on a PR build.
 
 ### Setup
 

--- a/docs/archive/pr-summaries/pr-summary-480.md
+++ b/docs/archive/pr-summaries/pr-summary-480.md
@@ -1,0 +1,79 @@
+# feat: `?indices=` deep-link for Trend-view benchmark indices (visit-only)
+
+## Summary
+
+Adds a transient `?indices=` deep-link to the **Prediction Trend** view
+(`docs/trend.html`), part of milestone #450 (URL parameters for more dashboard
+state). `trend.html?indices=sp500,nasdaq,russell2000` turns the listed benchmark
+indices **ON** for that visit; any index not listed is **OFF**. Keys are the
+canonical overlay keys (`sp500`, `nasdaq`, `russell2000`); unknown keys are
+ignored and an **absent** param leaves the saved/default toggles unchanged.
+
+Precedence mirrors the existing `?theme=` / `?view=` transient-override model:
+the URL value wins over the saved `grq.trend.indices` choice for this visit but
+is **never persisted** to `localStorage`, and is read on page load only
+(one-way). Reloading without the param returns to the saved choice.
+
+Closes #480
+
+### Design
+
+- **New pure helper** `docs/trend_indices_deeplink.js`
+  (`globalThis.GRQTrendDeepLink`), a classic `<script>` with no DOM and no
+  storage, importable by the Deno tests:
+  - `togglesFromSearch(search)` — parses `?indices=`, returning a normalised
+    boolean map (listed keys ON, the rest OFF) or `null` when the param is
+    absent. Reuses `GRQTrendSettings.normaliseToggles` so the shape matches
+    exactly what the chart consumes; unknown keys are dropped.
+  - `effectiveToggles(search, savedToggles)` — resolver mirroring
+    `GRQChartWindow.effectiveWindowDays`: the URL override wins for this visit,
+    otherwise the saved toggles are used.
+- **Wired into `trend.js` boot**: on construction the view applies the URL
+  override on top of the saved toggles via `effectiveToggles(...)`, which the
+  overlay checkbox UI reflects directly — **without** writing storage.
+- **Loaded in `trend.html`** after `trend_settings.js` (whose `normaliseToggles`
+  it reuses) and before `trend.js`, and **precached in `sw.js`**.
+- README documents the new parameter alongside the other deep-links.
+
+### Boot flow
+
+```mermaid
+flowchart LR
+    A["trend.html?indices=sp500,nasdaq"] --> B["GRQTrendSettings.readTrendSettings()<br/>saved toggles"]
+    A --> C["GRQTrendDeepLink.togglesFromSearch(location.search)"]
+    B --> D["effectiveToggles(search, saved)"]
+    C --> D
+    D -->|"URL present → override wins"| E["this.toggles for this visit"]
+    D -->|"URL absent → null"| B
+    E --> F["overlay checkboxes reflect toggles<br/>(no localStorage write)"]
+```
+
+## Evidence
+
+No browser screenshot: Playwright MCP was unavailable in this run (no
+`browser_*` tools resolvable). The change is pure-logic plus boot wiring,
+verified by behavioural Deno tests that call the real shipped helpers, and the
+script was confirmed served and referenced by `trend.html`:
+
+- `trend.html` includes `<script src="trend_indices_deeplink.js"></script>`
+  (HTTP 200 when served from `docs/`).
+- Manual expectation: `trend.html?indices=sp500,nasdaq` shows only the S&P 500
+  and NASDAQ overlays for that visit; reloading without the param restores the
+  saved choice; no `localStorage` writes occur on load.
+
+## Test Plan
+
+- **New** `tests/trend_indices_deeplink_test.ts` (17 cases) covering:
+  - valid input — single / multiple / all keys, trimming + case-insensitivity,
+    no leading `?`;
+  - invalid input — unknown keys ignored, only-unknown and present-but-empty
+    values yield an all-off map;
+  - absent input — missing param / empty search return `null`;
+  - `effectiveToggles` precedence — URL wins, absent falls back to (and
+    normalises) the saved map, present-but-empty overrides to all-off, never
+    mutates the saved argument, always returns a full map.
+- **Updated** `tests/trend_view_wiring_test.ts` — pins `trend_indices_deeplink.js`
+  in both the `trend.html` script list and the `sw.js` precache list.
+- **Updated** `tests/js_syntax_test.ts` — parses the new production script.
+- Full suite: `deno test --allow-read tests/*.ts` → 836 passed, 0 failed;
+  `deno fmt --check`, `deno lint`, `deno check` all clean.

--- a/docs/trend.js
+++ b/docs/trend.js
@@ -66,7 +66,17 @@
                 ? GRQTrendSettings.readTrendSettings()
                 : { grouping: "month", toggles: {} };
             this.granularity = settings.grouping;
-            this.toggles = settings.toggles;
+            // `?indices=` deep-link (issue #480): a transient URL override of
+            // the benchmark-index overlays wins for this visit but is never
+            // persisted; an absent param keeps the saved toggles. Read on page
+            // load only — the toggle UI reflects the result without writing
+            // storage.
+            this.toggles = globalThis.GRQTrendDeepLink
+                ? GRQTrendDeepLink.effectiveToggles(
+                    typeof location !== "undefined" ? location.search : "",
+                    settings.toggles,
+                )
+                : settings.toggles;
 
             // Visit-only `?group=day|week|month|quarter` deep-link (issue #481):
             // a valid grouping in the URL overrides the saved choice for this

--- a/docs/trend_indices_deeplink.js
+++ b/docs/trend_indices_deeplink.js
@@ -1,0 +1,92 @@
+// Transient `?indices=` deep-link for the Trend view's benchmark-index overlays
+// (issue #480, part of milestone #450 — URL parameters for more dashboard
+// state).
+//
+// `trend.html?indices=sp500,nasdaq,russell2000` turns the listed benchmark
+// indices ON for this visit; any index NOT listed is OFF. The keys are the
+// canonical index keys defined in docs/trend_settings.js (GRQTrendSettings) /
+// GRQIndexOverlay.OVERLAY_INDICES: `sp500`, `nasdaq`, `russell2000`. Unknown
+// keys are ignored; an ABSENT param leaves the saved/default toggles unchanged.
+//
+// Precedence mirrors `?theme=` (docs/theme.js) and `?view=`
+// (docs/view_selection.js): the URL value wins for this visit but is NEVER
+// persisted to localStorage — read on page load only, one-way.
+//
+// Like docs/trend_settings.js and docs/view_selection.js this file is loaded as
+// a classic <script> and is also imported by the Deno tests. It uses no module
+// syntax, publishes its helpers on `globalThis.GRQTrendDeepLink`, and touches no
+// DOM, so it imports cleanly in a non-browser (test) environment. It reuses
+// `GRQTrendSettings.normaliseToggles` (the single source of truth for the toggle
+// shape) at call time, falling back to a local normaliser only when that helper
+// has not loaded — so the parsed map always matches what the chart consumes.
+(function () {
+  "use strict";
+
+  // The benchmark indices whose toggles a `?indices=` link can drive, reusing
+  // the overlay engine's single source of truth when present, else a local
+  // fallback list (so this module parses and tests independently).
+  const INDEX_KEYS =
+    (globalThis.GRQIndexOverlay && globalThis.GRQIndexOverlay.OVERLAY_INDICES &&
+      globalThis.GRQIndexOverlay.OVERLAY_INDICES.map((i) => i.key)) ||
+    ["sp500", "nasdaq", "russell2000"];
+
+  // Coerce a (possibly partial) toggle object into a full boolean map. Delegates
+  // to GRQTrendSettings.normaliseToggles when present (one source of truth) so
+  // the shape matches exactly what the chart consumes; otherwise applies the
+  // same all-off default locally. Unknown keys are dropped.
+  function normaliseToggles(toggles) {
+    if (
+      globalThis.GRQTrendSettings &&
+      typeof globalThis.GRQTrendSettings.normaliseToggles === "function"
+    ) {
+      return globalThis.GRQTrendSettings.normaliseToggles(toggles);
+    }
+    const source = toggles && typeof toggles === "object" ? toggles : {};
+    const result = {};
+    for (const key of INDEX_KEYS) {
+      result[key] = key in source ? Boolean(source[key]) : false;
+    }
+    return result;
+  }
+
+  // Parse a transient `?indices=` override from a URL query string. Returns a
+  // normalised boolean map (listed canonical keys ON, the rest OFF) when the
+  // param is present, or `null` when it is ABSENT so callers fall back to the
+  // saved/default toggles. Unknown / blank keys are ignored; a present-but-empty
+  // value (`?indices=`) therefore turns every overlay OFF for this visit. Pure:
+  // no DOM, no storage, never throws.
+  function togglesFromSearch(search) {
+    try {
+      const value = new URLSearchParams(search || "").get("indices");
+      if (value === null) {
+        return null;
+      }
+      const source = {};
+      for (const token of value.split(",")) {
+        const key = token.trim().toLowerCase();
+        if (key) {
+          source[key] = true;
+        }
+      }
+      return normaliseToggles(source);
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // Resolve the toggles to apply for this visit, mirroring
+  // GRQChartWindow.effectiveWindowDays: a `?indices=` URL override wins for the
+  // current page load; otherwise the saved toggles are used. The result is
+  // always a full normalised boolean map. Never writes storage.
+  function effectiveToggles(search, savedToggles) {
+    const fromUrl = togglesFromSearch(search);
+    return fromUrl !== null ? fromUrl : normaliseToggles(savedToggles);
+  }
+
+  // Publish the pure helpers for the Trend view and the tests.
+  globalThis.GRQTrendDeepLink = {
+    INDEX_KEYS,
+    togglesFromSearch,
+    effectiveToggles,
+  };
+})();

--- a/tests/js_syntax_test.ts
+++ b/tests/js_syntax_test.ts
@@ -99,6 +99,14 @@ Deno.test("checkJsSyntax - production docs/trend_settings.js parses cleanly", as
   assertEquals(result.valid, true, result.error);
 });
 
+Deno.test("checkJsSyntax - production docs/trend_indices_deeplink.js parses cleanly", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../docs/trend_indices_deeplink.js", import.meta.url),
+  );
+  const result = checkJsSyntax(source);
+  assertEquals(result.valid, true, result.error);
+});
+
 Deno.test("checkJsSyntax - production docs/trend_predictions.js parses cleanly", async () => {
   const source = await Deno.readTextFile(
     new URL("../docs/trend_predictions.js", import.meta.url),

--- a/tests/trend_indices_deeplink_test.ts
+++ b/tests/trend_indices_deeplink_test.ts
@@ -1,0 +1,147 @@
+// Behavioural tests for the Trend-view `?indices=` deep-link helper
+// (issue #480, part of milestone #450).
+//
+// These import the REAL shipped helpers from docs/trend_indices_deeplink.js —
+// the same pure functions trend.js uses to turn benchmark-index overlays ON/OFF
+// from a `?indices=` URL parameter for a single visit. The module publishes its
+// helpers on globalThis.GRQTrendDeepLink and reuses
+// GRQTrendSettings.normaliseToggles, so we import the settings module first to
+// give it that single source of truth (mirroring the load order in trend.html).
+//
+// The helpers are pure: no DOM, no storage. Tests assert on the returned
+// normalised boolean maps for valid / invalid / absent input.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/trend_settings.js";
+import "../docs/trend_indices_deeplink.js";
+
+const g = globalThis as unknown as {
+  GRQTrendDeepLink: {
+    INDEX_KEYS: string[];
+    togglesFromSearch: (
+      search: string,
+    ) => Record<string, boolean> | null;
+    effectiveToggles: (
+      search: string,
+      savedToggles: unknown,
+    ) => Record<string, boolean>;
+  };
+};
+
+const { togglesFromSearch, effectiveToggles, INDEX_KEYS } = g.GRQTrendDeepLink;
+
+const ALL_OFF = { sp500: false, nasdaq: false, russell2000: false };
+
+Deno.test("INDEX_KEYS exposes the three canonical benchmark keys", () => {
+  assertEquals([...INDEX_KEYS].sort(), ["nasdaq", "russell2000", "sp500"]);
+});
+
+// --- togglesFromSearch: valid input --------------------------------------
+
+Deno.test("togglesFromSearch - single key turns only that index ON", () => {
+  assertEquals(togglesFromSearch("?indices=sp500"), {
+    sp500: true,
+    nasdaq: false,
+    russell2000: false,
+  });
+});
+
+Deno.test("togglesFromSearch - multiple keys turn each listed index ON", () => {
+  assertEquals(togglesFromSearch("?indices=sp500,nasdaq"), {
+    sp500: true,
+    nasdaq: true,
+    russell2000: false,
+  });
+});
+
+Deno.test("togglesFromSearch - all three keys turn every overlay ON", () => {
+  assertEquals(togglesFromSearch("?indices=sp500,nasdaq,russell2000"), {
+    sp500: true,
+    nasdaq: true,
+    russell2000: true,
+  });
+});
+
+Deno.test("togglesFromSearch - keys are trimmed and case-insensitive", () => {
+  assertEquals(togglesFromSearch("?indices= SP500 , NasDaq "), {
+    sp500: true,
+    nasdaq: true,
+    russell2000: false,
+  });
+});
+
+Deno.test("togglesFromSearch - works without a leading '?'", () => {
+  assertEquals(togglesFromSearch("indices=russell2000"), {
+    sp500: false,
+    nasdaq: false,
+    russell2000: true,
+  });
+});
+
+// --- togglesFromSearch: invalid input ------------------------------------
+
+Deno.test("togglesFromSearch - unknown keys are ignored", () => {
+  assertEquals(togglesFromSearch("?indices=sp500,dogecoin"), {
+    sp500: true,
+    nasdaq: false,
+    russell2000: false,
+  });
+});
+
+Deno.test("togglesFromSearch - only-unknown keys yield an all-off map", () => {
+  assertEquals(togglesFromSearch("?indices=bogus,unknown"), ALL_OFF);
+});
+
+Deno.test("togglesFromSearch - present-but-empty value turns all overlays OFF", () => {
+  assertEquals(togglesFromSearch("?indices="), ALL_OFF);
+});
+
+// --- togglesFromSearch: absent input -------------------------------------
+
+Deno.test("togglesFromSearch - absent param returns null", () => {
+  assertEquals(togglesFromSearch("?theme=dark"), null);
+});
+
+Deno.test("togglesFromSearch - empty search returns null", () => {
+  assertEquals(togglesFromSearch(""), null);
+});
+
+// --- effectiveToggles: precedence ----------------------------------------
+
+Deno.test("effectiveToggles - URL override wins over saved toggles", () => {
+  const saved = { sp500: false, nasdaq: false, russell2000: true };
+  assertEquals(effectiveToggles("?indices=sp500,nasdaq", saved), {
+    sp500: true,
+    nasdaq: true,
+    russell2000: false,
+  });
+});
+
+Deno.test("effectiveToggles - absent param falls back to saved toggles", () => {
+  const saved = { sp500: true, nasdaq: false, russell2000: true };
+  assertEquals(effectiveToggles("", saved), saved);
+});
+
+Deno.test("effectiveToggles - absent param normalises a partial saved map", () => {
+  assertEquals(effectiveToggles("?theme=dark", { sp500: true }), {
+    sp500: true,
+    nasdaq: false,
+    russell2000: false,
+  });
+});
+
+Deno.test("effectiveToggles - present-but-empty URL value overrides saved to all-off", () => {
+  const saved = { sp500: true, nasdaq: true, russell2000: true };
+  assertEquals(effectiveToggles("?indices=", saved), ALL_OFF);
+});
+
+Deno.test("effectiveToggles - never mutates the saved toggles argument", () => {
+  const saved = { sp500: true, nasdaq: false, russell2000: false };
+  const snapshot = { ...saved };
+  effectiveToggles("?indices=nasdaq", saved);
+  assertEquals(saved, snapshot);
+});
+
+Deno.test("effectiveToggles - returns a full normalised map for all inputs", () => {
+  const result = effectiveToggles("?indices=sp500", null);
+  assert("sp500" in result && "nasdaq" in result && "russell2000" in result);
+});

--- a/tests/trend_view_wiring_test.ts
+++ b/tests/trend_view_wiring_test.ts
@@ -33,6 +33,7 @@ Deno.test("trend.html loads the shared engines and the controller", () => {
       "trend_series.js",
       "index_overlay.js",
       "trend_settings.js",
+      "trend_indices_deeplink.js",
       "trend_predictions.js",
       "trend.js",
     ]
@@ -66,6 +67,7 @@ Deno.test("sw.js precaches the Trend view assets", () => {
       "./trend_series.js",
       "./index_overlay.js",
       "./trend_settings.js",
+      "./trend_indices_deeplink.js",
     ]
   ) {
     assert(


### PR DESCRIPTION
# feat: `?indices=` deep-link for Trend-view benchmark indices (visit-only)

## Summary

Adds a transient `?indices=` deep-link to the **Prediction Trend** view
(`docs/trend.html`), part of milestone #450 (URL parameters for more dashboard
state). `trend.html?indices=sp500,nasdaq,russell2000` turns the listed benchmark
indices **ON** for that visit; any index not listed is **OFF**. Keys are the
canonical overlay keys (`sp500`, `nasdaq`, `russell2000`); unknown keys are
ignored and an **absent** param leaves the saved/default toggles unchanged.

Precedence mirrors the existing `?theme=` / `?view=` transient-override model:
the URL value wins over the saved `grq.trend.indices` choice for this visit but
is **never persisted** to `localStorage`, and is read on page load only
(one-way). Reloading without the param returns to the saved choice.

Closes #480

### Design

- **New pure helper** `docs/trend_indices_deeplink.js`
  (`globalThis.GRQTrendDeepLink`), a classic `<script>` with no DOM and no
  storage, importable by the Deno tests:
  - `togglesFromSearch(search)` — parses `?indices=`, returning a normalised
    boolean map (listed keys ON, the rest OFF) or `null` when the param is
    absent. Reuses `GRQTrendSettings.normaliseToggles` so the shape matches
    exactly what the chart consumes; unknown keys are dropped.
  - `effectiveToggles(search, savedToggles)` — resolver mirroring
    `GRQChartWindow.effectiveWindowDays`: the URL override wins for this visit,
    otherwise the saved toggles are used.
- **Wired into `trend.js` boot**: on construction the view applies the URL
  override on top of the saved toggles via `effectiveToggles(...)`, which the
  overlay checkbox UI reflects directly — **without** writing storage.
- **Loaded in `trend.html`** after `trend_settings.js` (whose `normaliseToggles`
  it reuses) and before `trend.js`, and **precached in `sw.js`**.
- README documents the new parameter alongside the other deep-links.

### Boot flow

```mermaid
flowchart LR
    A["trend.html?indices=sp500,nasdaq"] --> B["GRQTrendSettings.readTrendSettings()<br/>saved toggles"]
    A --> C["GRQTrendDeepLink.togglesFromSearch(location.search)"]
    B --> D["effectiveToggles(search, saved)"]
    C --> D
    D -->|"URL present → override wins"| E["this.toggles for this visit"]
    D -->|"URL absent → null"| B
    E --> F["overlay checkboxes reflect toggles<br/>(no localStorage write)"]
```

## Evidence

No browser screenshot: Playwright MCP was unavailable in this run (no
`browser_*` tools resolvable). The change is pure-logic plus boot wiring,
verified by behavioural Deno tests that call the real shipped helpers, and the
script was confirmed served and referenced by `trend.html`:

- `trend.html` includes `<script src="trend_indices_deeplink.js"></script>`
  (HTTP 200 when served from `docs/`).
- Manual expectation: `trend.html?indices=sp500,nasdaq` shows only the S&P 500
  and NASDAQ overlays for that visit; reloading without the param restores the
  saved choice; no `localStorage` writes occur on load.

## Test Plan

- **New** `tests/trend_indices_deeplink_test.ts` (17 cases) covering:
  - valid input — single / multiple / all keys, trimming + case-insensitivity,
    no leading `?`;
  - invalid input — unknown keys ignored, only-unknown and present-but-empty
    values yield an all-off map;
  - absent input — missing param / empty search return `null`;
  - `effectiveToggles` precedence — URL wins, absent falls back to (and
    normalises) the saved map, present-but-empty overrides to all-off, never
    mutates the saved argument, always returns a full map.
- **Updated** `tests/trend_view_wiring_test.ts` — pins `trend_indices_deeplink.js`
  in both the `trend.html` script list and the `sw.js` precache list.
- **Updated** `tests/js_syntax_test.ts` — parses the new production script.
- Full suite: `deno test --allow-read tests/*.ts` → 836 passed, 0 failed;
  `deno fmt --check`, `deno lint`, `deno check` all clean.
