### PR TITLE
feat: ?group=day|week|month|quarter deep-link for Trend-view grouping (visit-only) (#481)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-481.md
+++ b/docs/archive/pr-summaries/pr-summary-481.md
@@ -1,0 +1,71 @@
+## Summary
+
+Adds a transient `?group=day|week|month|quarter` deep-link to the **Prediction
+Trend** view (`docs/trend.html` / `docs/trend.js`), mirroring the existing
+`?theme=` transient-override model. A valid grouping in the URL overrides the
+saved `grq.trend.grouping` choice **for the current page load only** — it is
+read once on load (one-way), reflected in the grouping control, and **never**
+persisted to `localStorage`. Unknown / blank / absent values leave the
+saved/default grouping unchanged. Closes #481.
+
+Part of milestone #450 (URL parameters for more dashboard state).
+
+### What changed
+- **New `docs/trend_grouping_link.js`** — a pure, DOM-free classic `<script>`
+  (published on `globalThis.GRQTrendGroupingLink`, importable by Deno tests),
+  beside the existing trend settings. It exposes:
+  - `groupingFromSearch(search)` — returns a valid granularity or `null`,
+    reusing `GRQTrendSettings.GRANULARITIES` as the single source of truth for
+    what counts as a granularity.
+  - `effectiveGrouping(search, savedGrouping)` — a valid `?group=` override
+    wins; otherwise the saved grouping stands (normalised to the `month`
+    default via `GRQTrendSettings.normaliseGrouping`). Mirrors
+    `GRQChartWindow.effectiveWindowDays`.
+- **`docs/trend.js`** — boot now applies `effectiveGrouping(location.search, …)`
+  beside `readTrendSettings()`. The override flows into the grouping `<select>`
+  through the existing `buildGroupingControl()` (which only writes storage on a
+  user change), so the URL override is reflected **without** any storage write.
+- **`docs/trend.html`** / **`docs/sw.js`** — load and precache the new script.
+
+### Precedence (visit-only, never persisted)
+
+```mermaid
+flowchart LR
+    A["trend.html?group=week"] --> B{"valid ?group=?"}
+    B -- yes --> C["use URL grouping (this visit)"]
+    B -- "no / blank / absent" --> D["use saved grq.trend.grouping<br/>(or month default)"]
+    C --> E["reflect in grouping select<br/>(no localStorage write)"]
+    D --> E
+```
+
+## Evidence
+
+Playwright MCP was unavailable in this run, so the behaviour was verified
+headlessly against the **real** shipped helpers mounted in a `deno-dom`
+document — proving the end-to-end wiring (`?group=week` → grouping select),
+not just the pure functions:
+
+```
+saved grouping       : month
+?group=week effective: week
+select.value         : week
+localStorage writes  : 0 []
+```
+
+This demonstrates each acceptance criterion: `?group=week` groups by week for
+the visit, the grouping control reflects it, and **no** `localStorage` write
+occurs (so a reload without the param returns to the saved grouping).
+
+## Test Plan
+
+New `tests/trend_grouping_link_test.ts` (all passing; full suite: 825 passed):
+
+- `groupingFromSearch` extracts each valid granularity (`day`/`week`/`month`/
+  `quarter`), with/without a leading `?` and alongside other params.
+- `groupingFromSearch` returns `null` for absent, blank (`?group=`), whitespace,
+  and unknown (`?group=year`) values, plus `null`/`undefined` input.
+- `effectiveGrouping` — valid override wins over the saved grouping; absent/
+  invalid override keeps the saved grouping; a corrupt saved grouping falls back
+  to the `month` default.
+- Wiring guard — `trend.html` loads and `sw.js` precaches
+  `trend_grouping_link.js`.

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -46,6 +46,8 @@ const STATIC_ASSETS = [
   "./trend_series.js",
   "./index_overlay.js",
   "./trend_settings.js",
+  // Transient ?group= grouping deep-link for the Trend view (issue #481).
+  "./trend_grouping_link.js",
   // SRI-pinned CDN assets from docs/index.html (issue #79).
   // Bump APP_VERSION whenever these pins change so the integrity hashes are
   // re-validated.

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -183,6 +183,10 @@
     <!-- Trend-view persisted settings (issue #432) -->
     <script src="trend_settings.js"></script>
 
+    <!-- Transient ?group=day|week|month|quarter grouping deep-link (issue #481) —
+         after trend_settings.js (reuses its granularities), before trend.js. -->
+    <script src="trend_grouping_link.js"></script>
+
     <!-- Per-score-date prediction resolver (issue #430) -->
     <script src="trend_predictions.js"></script>
 

--- a/docs/trend.js
+++ b/docs/trend.js
@@ -68,6 +68,16 @@
             this.granularity = settings.grouping;
             this.toggles = settings.toggles;
 
+            // Visit-only `?group=day|week|month|quarter` deep-link (issue #481):
+            // a valid grouping in the URL overrides the saved choice for this
+            // page load only. Read on load, never written to localStorage.
+            if (globalThis.GRQTrendGroupingLink && typeof location !== "undefined") {
+                this.granularity = GRQTrendGroupingLink.effectiveGrouping(
+                    location.search,
+                    this.granularity,
+                );
+            }
+
             this.elements = {
                 loading: document.getElementById("trendLoading"),
                 error: document.getElementById("trendError"),

--- a/docs/trend_grouping_link.js
+++ b/docs/trend_grouping_link.js
@@ -1,0 +1,68 @@
+// Transient grouping deep-link for the Prediction Trend view (issue #481, part
+// of milestone #450 — URL parameters for more dashboard state).
+//
+// Adds a visit-only `?group=day|week|month|quarter` deep-link that overrides
+// the trend grouping granularity for the current page load, mirroring the
+// `?theme=` (docs/theme.js) transient-override model. The override is read on
+// page load only (one-way), takes precedence over the saved
+// `grq.trend.grouping` choice, and is NEVER persisted to localStorage.
+//
+// Like docs/theme.js, docs/view_selection.js and docs/trend_settings.js this
+// file is loaded as a classic <script> and is also imported by the Deno tests.
+// It uses no module syntax, publishes its helpers on
+// globalThis.GRQTrendGroupingLink, and touches no DOM, so it imports cleanly in
+// a non-browser (test) environment. It reuses GRQTrendSettings.GRANULARITIES /
+// normaliseGrouping as the single source of truth for what counts as a valid
+// granularity (resolved lazily so script load order does not matter).
+(function () {
+  "use strict";
+
+  // The trend settings module, when it has loaded — our source of truth for
+  // the granularities and the default grouping. Resolved lazily so this file
+  // parses and the helpers work regardless of <script> ordering.
+  function settings() {
+    return globalThis.GRQTrendSettings || null;
+  }
+
+  // Pure: extract a valid grouping granularity from a URL query string, e.g.
+  // `?group=week`. Returns the granularity ("day"/"week"/"month"/"quarter") or
+  // null when the parameter is absent, blank or unrecognised — so callers fall
+  // back to the saved/default grouping rather than guessing.
+  function groupingFromSearch(search) {
+    try {
+      const raw = new URLSearchParams(search || "").get("group");
+      if (raw === null) {
+        return null;
+      }
+      const value = raw.trim();
+      if (value === "") {
+        return null;
+      }
+      const s = settings();
+      const granularities = (s && s.GRANULARITIES) ||
+        ["day", "week", "month", "quarter"];
+      return granularities.includes(value) ? value : null;
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // The grouping that should apply for this visit: a valid `?group=` override
+  // wins (visit-only, never persisted); otherwise the saved/default grouping
+  // stands, normalised so a corrupt saved value falls back to the month
+  // default. Mirrors GRQChartWindow.effectiveWindowDays.
+  function effectiveGrouping(search, savedGrouping) {
+    const override = groupingFromSearch(search);
+    if (override !== null) {
+      return override;
+    }
+    const s = settings();
+    return s ? s.normaliseGrouping(savedGrouping) : savedGrouping;
+  }
+
+  // Publish the pure helpers for the Trend view and the tests.
+  globalThis.GRQTrendGroupingLink = {
+    groupingFromSearch,
+    effectiveGrouping,
+  };
+})();

--- a/tests/trend_grouping_link_test.ts
+++ b/tests/trend_grouping_link_test.ts
@@ -1,0 +1,84 @@
+// Behavioural tests for the transient Trend-view grouping deep-link helpers
+// (issue #481, part of milestone #450 — URL parameters for more dashboard
+// state).
+//
+// These import the REAL shipped helpers from docs/trend_grouping_link.js — the
+// same pure functions trend.js uses to honour a `?group=day|week|month|quarter`
+// URL parameter for the current visit only. The helper reuses
+// GRQTrendSettings.normaliseGrouping / GRANULARITIES as the single source of
+// truth for what counts as a granularity, so the settings module is imported
+// first. Both modules publish their helpers on globalThis and touch no DOM, so
+// they import cleanly under Deno.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/trend_settings.js";
+import "../docs/trend_grouping_link.js";
+
+const g = globalThis as unknown as {
+  GRQTrendGroupingLink: {
+    groupingFromSearch: (search: unknown) => string | null;
+    effectiveGrouping: (search: unknown, savedGrouping: unknown) => string;
+  };
+};
+const L = g.GRQTrendGroupingLink;
+
+Deno.test("GRQTrendGroupingLink is published on globalThis", () => {
+  assert(
+    L,
+    "trend_grouping_link.js should publish globalThis.GRQTrendGroupingLink",
+  );
+});
+
+Deno.test("groupingFromSearch extracts each valid granularity", () => {
+  assertEquals(L.groupingFromSearch("?group=day"), "day");
+  assertEquals(L.groupingFromSearch("?group=week"), "week");
+  assertEquals(L.groupingFromSearch("?group=month"), "month");
+  assertEquals(L.groupingFromSearch("?group=quarter"), "quarter");
+  // Leading "?" optional and works alongside other params.
+  assertEquals(L.groupingFromSearch("group=week"), "week");
+  assertEquals(L.groupingFromSearch("?theme=dark&group=quarter"), "quarter");
+});
+
+Deno.test("groupingFromSearch returns null when absent, blank or invalid", () => {
+  assertEquals(L.groupingFromSearch(""), null);
+  assertEquals(L.groupingFromSearch("?theme=dark"), null);
+  assertEquals(L.groupingFromSearch("?group="), null);
+  assertEquals(L.groupingFromSearch("?group=%20%20"), null);
+  assertEquals(L.groupingFromSearch("?group=year"), null);
+  assertEquals(L.groupingFromSearch("?group=fortnight"), null);
+  assertEquals(L.groupingFromSearch(null), null);
+  assertEquals(L.groupingFromSearch(undefined), null);
+});
+
+Deno.test("effectiveGrouping: a valid override wins over the saved grouping", () => {
+  assertEquals(L.effectiveGrouping("?group=week", "month"), "week");
+  assertEquals(L.effectiveGrouping("?group=day", "quarter"), "day");
+  // The override even overrides a saved value equal to the default.
+  assertEquals(L.effectiveGrouping("?group=quarter", "month"), "quarter");
+});
+
+Deno.test("effectiveGrouping: absent/invalid override keeps the saved grouping", () => {
+  assertEquals(L.effectiveGrouping("", "week"), "week");
+  assertEquals(L.effectiveGrouping("?theme=dark", "quarter"), "quarter");
+  assertEquals(L.effectiveGrouping("?group=year", "day"), "day");
+  assertEquals(L.effectiveGrouping("?group=", "week"), "week");
+});
+
+Deno.test("effectiveGrouping: a corrupt saved grouping falls back to the default", () => {
+  // No override + an unknown saved value normalises to the month default.
+  assertEquals(L.effectiveGrouping("", "fortnight"), "month");
+  assertEquals(L.effectiveGrouping("", null), "month");
+  assertEquals(L.effectiveGrouping("", undefined), "month");
+});
+
+Deno.test("trend.html and sw.js wire in the grouping deep-link helper", async () => {
+  const trendHtml = await Deno.readTextFile("docs/trend.html");
+  const sw = await Deno.readTextFile("docs/sw.js");
+  assert(
+    trendHtml.includes('src="trend_grouping_link.js"'),
+    "trend.html must load trend_grouping_link.js",
+  );
+  assert(
+    sw.includes('"./trend_grouping_link.js"'),
+    "sw.js STATIC_ASSETS must precache trend_grouping_link.js",
+  );
+});


### PR DESCRIPTION
## Summary

Adds a transient `?group=day|week|month|quarter` deep-link to the **Prediction
Trend** view (`docs/trend.html` / `docs/trend.js`), mirroring the existing
`?theme=` transient-override model. A valid grouping in the URL overrides the
saved `grq.trend.grouping` choice **for the current page load only** — it is
read once on load (one-way), reflected in the grouping control, and **never**
persisted to `localStorage`. Unknown / blank / absent values leave the
saved/default grouping unchanged. Closes #481.

Part of milestone #450 (URL parameters for more dashboard state).

### What changed
- **New `docs/trend_grouping_link.js`** — a pure, DOM-free classic `<script>`
  (published on `globalThis.GRQTrendGroupingLink`, importable by Deno tests),
  beside the existing trend settings. It exposes:
  - `groupingFromSearch(search)` — returns a valid granularity or `null`,
    reusing `GRQTrendSettings.GRANULARITIES` as the single source of truth for
    what counts as a granularity.
  - `effectiveGrouping(search, savedGrouping)` — a valid `?group=` override
    wins; otherwise the saved grouping stands (normalised to the `month`
    default via `GRQTrendSettings.normaliseGrouping`). Mirrors
    `GRQChartWindow.effectiveWindowDays`.
- **`docs/trend.js`** — boot now applies `effectiveGrouping(location.search, …)`
  beside `readTrendSettings()`. The override flows into the grouping `<select>`
  through the existing `buildGroupingControl()` (which only writes storage on a
  user change), so the URL override is reflected **without** any storage write.
- **`docs/trend.html`** / **`docs/sw.js`** — load and precache the new script.

### Precedence (visit-only, never persisted)

```mermaid
flowchart LR
    A["trend.html?group=week"] --> B{"valid ?group=?"}
    B -- yes --> C["use URL grouping (this visit)"]
    B -- "no / blank / absent" --> D["use saved grq.trend.grouping<br/>(or month default)"]
    C --> E["reflect in grouping select<br/>(no localStorage write)"]
    D --> E
```

## Evidence

Playwright MCP was unavailable in this run, so the behaviour was verified
headlessly against the **real** shipped helpers mounted in a `deno-dom`
document — proving the end-to-end wiring (`?group=week` → grouping select),
not just the pure functions:

```
saved grouping       : month
?group=week effective: week
select.value         : week
localStorage writes  : 0 []
```

This demonstrates each acceptance criterion: `?group=week` groups by week for
the visit, the grouping control reflects it, and **no** `localStorage` write
occurs (so a reload without the param returns to the saved grouping).

## Test Plan

New `tests/trend_grouping_link_test.ts` (all passing; full suite: 825 passed):

- `groupingFromSearch` extracts each valid granularity (`day`/`week`/`month`/
  `quarter`), with/without a leading `?` and alongside other params.
- `groupingFromSearch` returns `null` for absent, blank (`?group=`), whitespace,
  and unknown (`?group=year`) values, plus `null`/`undefined` input.
- `effectiveGrouping` — valid override wins over the saved grouping; absent/
  invalid override keeps the saved grouping; a corrupt saved grouping falls back
  to the `month` default.
- Wiring guard — `trend.html` loads and `sw.js` precaches
  `trend_grouping_link.js`.
