### PR TITLE
docs: document ?view/?indices/?group/?fullscreen deep-link params (#483)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Visit `http://localhost:8000` to access the dashboard.
 
 #### Deep-link URL parameters
 
-The dashboard reads five optional query parameters so a specific view can be
+The dashboard reads nine optional query parameters so a specific view can be
 linked directly (and so the automated accessibility check can audit each view
 deterministically — issue #281):
 
@@ -181,6 +181,37 @@ deterministically — issue #281):
   without the param returns to the saved window (desktop 180 / mobile 90). Both
   windows end on the same date (#367); an absent or invalid value falls back to
   the saved choice, then the device default.
+- `?view=portfolio|trend` — deep-link straight to a top-level view (issue #479).
+  `?view=trend` routes to the Prediction Trend page (`trend.html`);
+  `?view=portfolio` routes back to the aggregate dashboard (`index.html`). Like
+  `?theme=`, this is read on page load only (one-way) and is **never** persisted
+  to `localStorage`; an absent, blank or unrecognised value (or a value that
+  already matches the current page) leaves you where you are.
+- `?indices=sp500,nasdaq,russell2000` — on the Trend view, turn the listed
+  benchmark-index overlays **on** for this visit; any index **not** listed is
+  turned off (issue #480). The keys are the canonical index keys `sp500`,
+  `nasdaq` and `russell2000`; unknown keys are ignored and a present-but-empty
+  value (`?indices=`) turns every overlay off. A **transient / visit-only**
+  override that wins over the saved toggles but is **never** persisted; an
+  absent param leaves the saved/default toggles unchanged.
+- `?group=day|week|month|quarter` — on the Trend view, set the **Group by**
+  granularity for this visit (issue #481). A **transient / visit-only** override
+  that wins over the saved `grq.trend.grouping` choice but is **never**
+  persisted; an absent or unrecognised value falls back to the saved choice,
+  then the **month** default.
+- `?fullscreen=1` — **mobile-only**: open the chart pop-out (landscape,
+  maximised chart) on page load (issue #482). Only the exact value `1` triggers
+  it; it is a **no-op on desktop**, where the expand control is hidden. Like
+  `?theme=`, it is read once on load (one-way) and is **never** persisted.
+
+**Worked examples**
+
+- `index.html?date=2026-01-01&window=180&fullscreen=1` — 180 days from
+  1 January, landscape (maximised chart) on a phone.
+- `trend.html?group=week&indices=sp500,nasdaq` — the Trend view grouped by week
+  with the S&P 500 and NASDAQ overlays on (Russell 2000 off) for this visit.
+- `index.html?view=trend` — jump straight from the dashboard to the Prediction
+  Trend page.
 
 All views meet **WCAG 2 AA** colour contrast in both the light and dark themes;
 `pa11yci.json` scans the aggregate, single-stock and Trend views in both themes

--- a/docs/archive/pr-summaries/pr-summary-483.md
+++ b/docs/archive/pr-summaries/pr-summary-483.md
@@ -1,0 +1,67 @@
+## Summary
+
+Documentation-only change extending the README's **Deep-link URL parameters**
+section to cover the four parameters added under milestone #450 (URL parameters
+for more dashboard state), so the docs match shipped behaviour. Closes #483.
+
+Added documentation for:
+
+- `?view=portfolio|trend` (#479) — deep-link to a top-level view; routes between
+  `index.html` and `trend.html`; transient/visit-only, never persisted.
+- `?indices=sp500,nasdaq,russell2000` (#480) — Trend view: listed benchmark
+  overlays on, the rest off; unknown keys ignored; empty value turns all off;
+  visit-only, never persisted.
+- `?group=day|week|month|quarter` (#481) — Trend **Group by** granularity;
+  visit-only; absent/invalid falls back to the saved choice, then the **month**
+  default.
+- `?fullscreen=1` (#482) — **mobile-only**, opens the landscape pop-out on load;
+  **no-op on desktop**; visit-only.
+
+Also updated the lead-in count ("reads **nine** optional query parameters") and
+added a **Worked examples** list, including the canonical combined example
+`?date=2026-01-01&window=180&fullscreen=1` and a Trend example
+`trend.html?group=week&indices=sp500,nasdaq`.
+
+The allowed values, fallback behaviour and transient/visit-only semantics were
+taken directly from the shipped scripts (`docs/view_selection.js`,
+`docs/trend_indices_deeplink.js`, `docs/trend_grouping_link.js`,
+`docs/chart_popout.js`) so the prose matches actual behaviour.
+
+## Evidence
+
+This is a documentation/CLI-only change with no web UI to screenshot. It is
+verified by the new tests below, which tie the documented parameter keys to the
+values shipped in `docs/*.js`.
+
+```mermaid
+flowchart LR
+    A[docs/view_selection.js<br/>VALID_VIEWS] --> R[README deep-link section]
+    B[docs/trend_indices_deeplink.js<br/>INDEX_KEYS] --> R
+    C[docs/trend_grouping_link.js<br/>GRANULARITIES] --> R
+    D[docs/chart_popout.js<br/>fullscreen=1] --> R
+    R --> T[tests/deeplink_docs_test.ts<br/>asserts docs match source]
+```
+
+## Test Plan
+
+Added `tests/deeplink_docs_test.ts` (6 tests, all passing):
+
+- `?view=` values documented match `VALID_VIEWS` in `view_selection.js`.
+- `?indices=` overlay keys (`sp500`, `nasdaq`, `russell2000`) are documented.
+- `?group=` granularities (`day`/`week`/`month`/`quarter`) are documented.
+- `?fullscreen=1` is documented as mobile-only / no-op on desktop.
+- The canonical combined and Trend worked examples are present.
+- The lead-in count word matches the number of documented `?param=` bullets.
+
+The new tests were confirmed to fail against the pre-change README (5 of 6 fail)
+and pass after the change, acting as a regression guard against doc drift.
+
+### Pre-existing unrelated failures
+
+`./quality.sh` reports two failures in `tests/trend_view_wiring_test.ts`
+(`trend.html` not loading and `sw.js` not precaching `trend_indices_deeplink.js`).
+These pre-exist on the milestone base branch
+(`milestone/450-feat-url-parameters-for-more-dashboard-state-c`) — the `?indices=`
+wiring sub-issue (#480) has not yet landed its `trend.html`/`sw.js` wiring — and
+are unrelated to this documentation-only change. They are out of scope for #483
+and were not introduced here.

--- a/tests/deeplink_docs_test.ts
+++ b/tests/deeplink_docs_test.ts
@@ -1,0 +1,109 @@
+// Tests that README.md's "Deep-link URL parameters" section documents the
+// parameters added under milestone #450 (issue #483), and that the documented
+// parameter keys match the values actually shipped in docs/*.js.
+//
+// These assert *derivable relationships* between the README prose and the
+// source of truth in the dashboard scripts (the valid `?view=` values, the
+// `?indices=` overlay keys, the `?group=` granularities and the `?fullscreen=1`
+// trigger value), so the docs cannot silently drift from shipped behaviour.
+
+import { assert } from "@std/assert";
+
+const README = "README.md";
+
+async function readText(path: string): Promise<string> {
+  return await Deno.readTextFile(path);
+}
+
+// Pull the deep-link section out of the README so assertions are scoped to it
+// rather than matching coincidental text elsewhere in the file.
+async function deepLinkSection(): Promise<string> {
+  const text = await readText(README);
+  const start = text.indexOf("#### Deep-link URL parameters");
+  assert(start >= 0, "README must have a 'Deep-link URL parameters' section");
+  const rest = text.slice(start + 1);
+  const next = rest.indexOf("\n#### ");
+  return next >= 0 ? rest.slice(0, next) : rest;
+}
+
+Deno.test("README documents the ?view= values shipped by view_selection.js", async () => {
+  const section = await deepLinkSection();
+  const src = await readText("docs/view_selection.js");
+  const match = src.match(/VALID_VIEWS\s*=\s*\[([^\]]*)\]/);
+  assert(match, "view_selection.js must define VALID_VIEWS");
+  const views = [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  assert(views.length > 0, "expected at least one valid view");
+  assert(section.includes("?view="), "README must document ?view=");
+  for (const view of views) {
+    assert(
+      section.includes(view),
+      `README deep-link section must document the ?view= value "${view}"`,
+    );
+  }
+});
+
+Deno.test("README documents the ?indices= overlay keys", async () => {
+  const section = await deepLinkSection();
+  for (const key of ["sp500", "nasdaq", "russell2000"]) {
+    assert(
+      section.includes(key),
+      `README deep-link section must document the ?indices= key "${key}"`,
+    );
+  }
+  assert(section.includes("?indices="), "README must document ?indices=");
+});
+
+Deno.test("README documents the ?group= granularities", async () => {
+  const section = await deepLinkSection();
+  assert(section.includes("?group="), "README must document ?group=");
+  for (const g of ["day", "week", "month", "quarter"]) {
+    assert(
+      section.includes(g),
+      `README deep-link section must document the ?group= value "${g}"`,
+    );
+  }
+});
+
+Deno.test("README documents ?fullscreen=1 as mobile-only / no-op on desktop", async () => {
+  const section = await deepLinkSection();
+  assert(section.includes("?fullscreen=1"), "README must document ?fullscreen=1");
+  assert(
+    /no-op on desktop/i.test(section),
+    "README must note ?fullscreen=1 is a no-op on desktop",
+  );
+});
+
+Deno.test("README includes the canonical combined and Trend worked examples", async () => {
+  const section = await deepLinkSection();
+  assert(
+    section.includes("Worked examples"),
+    "README must include a 'Worked examples' list",
+  );
+  assert(
+    section.includes("?date=2026-01-01&window=180&fullscreen=1"),
+    "README must include the canonical combined worked example",
+  );
+  assert(
+    section.includes("?group=week&indices=sp500,nasdaq"),
+    "README must include the Trend worked example",
+  );
+});
+
+Deno.test("README lead-in count matches the number of documented parameters", async () => {
+  const section = await deepLinkSection();
+  // Count distinct `?param=` bullet definitions (lines that start a list item).
+  const params = new Set(
+    [...section.matchAll(/^- `\?(\w+)=/gm)].map((m) => m[1]),
+  );
+  assert(params.size > 0, "expected documented parameters");
+  const words = [
+    "zero", "one", "two", "three", "four", "five", "six", "seven", "eight",
+    "nine", "ten",
+  ];
+  const expected = words[params.size] ?? String(params.size);
+  assert(
+    section.includes(`reads ${expected} optional query parameters`),
+    `README lead-in must say it reads ${expected} optional query parameters ` +
+      `(found ${params.size} documented: ${[...params].join(", ")})`,
+  );
+});


### PR DESCRIPTION
## Summary

Documentation-only change extending the README's **Deep-link URL parameters**
section to cover the four parameters added under milestone #450 (URL parameters
for more dashboard state), so the docs match shipped behaviour. Closes #483.

Added documentation for:

- `?view=portfolio|trend` (#479) — deep-link to a top-level view; routes between
  `index.html` and `trend.html`; transient/visit-only, never persisted.
- `?indices=sp500,nasdaq,russell2000` (#480) — Trend view: listed benchmark
  overlays on, the rest off; unknown keys ignored; empty value turns all off;
  visit-only, never persisted.
- `?group=day|week|month|quarter` (#481) — Trend **Group by** granularity;
  visit-only; absent/invalid falls back to the saved choice, then the **month**
  default.
- `?fullscreen=1` (#482) — **mobile-only**, opens the landscape pop-out on load;
  **no-op on desktop**; visit-only.

Also updated the lead-in count ("reads **nine** optional query parameters") and
added a **Worked examples** list, including the canonical combined example
`?date=2026-01-01&window=180&fullscreen=1` and a Trend example
`trend.html?group=week&indices=sp500,nasdaq`.

The allowed values, fallback behaviour and transient/visit-only semantics were
taken directly from the shipped scripts (`docs/view_selection.js`,
`docs/trend_indices_deeplink.js`, `docs/trend_grouping_link.js`,
`docs/chart_popout.js`) so the prose matches actual behaviour.

## Evidence

This is a documentation/CLI-only change with no web UI to screenshot. It is
verified by the new tests below, which tie the documented parameter keys to the
values shipped in `docs/*.js`.

```mermaid
flowchart LR
    A[docs/view_selection.js<br/>VALID_VIEWS] --> R[README deep-link section]
    B[docs/trend_indices_deeplink.js<br/>INDEX_KEYS] --> R
    C[docs/trend_grouping_link.js<br/>GRANULARITIES] --> R
    D[docs/chart_popout.js<br/>fullscreen=1] --> R
    R --> T[tests/deeplink_docs_test.ts<br/>asserts docs match source]
```

## Test Plan

Added `tests/deeplink_docs_test.ts` (6 tests, all passing):

- `?view=` values documented match `VALID_VIEWS` in `view_selection.js`.
- `?indices=` overlay keys (`sp500`, `nasdaq`, `russell2000`) are documented.
- `?group=` granularities (`day`/`week`/`month`/`quarter`) are documented.
- `?fullscreen=1` is documented as mobile-only / no-op on desktop.
- The canonical combined and Trend worked examples are present.
- The lead-in count word matches the number of documented `?param=` bullets.

The new tests were confirmed to fail against the pre-change README (5 of 6 fail)
and pass after the change, acting as a regression guard against doc drift.

### Pre-existing unrelated failures

`./quality.sh` reports two failures in `tests/trend_view_wiring_test.ts`
(`trend.html` not loading and `sw.js` not precaching `trend_indices_deeplink.js`).
These pre-exist on the milestone base branch
(`milestone/450-feat-url-parameters-for-more-dashboard-state-c`) — the `?indices=`
wiring sub-issue (#480) has not yet landed its `trend.html`/`sw.js` wiring — and
are unrelated to this documentation-only change. They are out of scope for #483
and were not introduced here.
