### PR TITLE
fix: wire footer Share button to clipboard deep-link (#515)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -71,6 +71,6 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/index.html docs/sw.js docs/sw-register.js
+          git add docs/index.html docs/sw.js docs/sw-register.js docs/trend.html
           git commit -m "Auto-increment app version (Issue #323)"
           git push origin "HEAD:${HEAD_REF}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to
   desktop 180). The helper stays pure — the caller supplies the value — and the
   allow-list constant is renamed `PERMITTED_WINDOW_DAYS` (Issue #464).
 
+### Fixed
+
+- Footer **🔗 Share** button now copies a deep-link to the clipboard. The
+  link-builder and clipboard/fallback handling shipped in `docs/share_link.js`
+  (Issue #495) but the dashboard never called `GRQShare.initShareButton(...)`,
+  so a tap did nothing — no copy, no confirmation. `docs/app.js` now wires the
+  button to the live selections via `shareState()` on init (Issue #515).
+
 ### Removed
 
 - Dead `[dependencies]` `walkdir` and `thiserror`, which were declared but never

--- a/docs/app.js
+++ b/docs/app.js
@@ -203,9 +203,30 @@ class GRQValidator {
         });
     }
 
+    // Wire the footer "Share" button (issue #515). The deep-link builder and
+    // clipboard/select-the-text fallback live in docs/share_link.js (issue
+    // #495); the dashboard only has to supply the live selections via
+    // shareState(). Without this call the button has no click handler, so a tap
+    // does nothing — the exact bug #515 fixes. Guarded so a missing helper
+    // degrades cleanly (the footer simply stays inert) and is read-only.
+    initShareButton() {
+        if (
+            typeof GRQShare === "undefined" ||
+            typeof GRQShare.initShareButton !== "function"
+        ) {
+            return;
+        }
+        GRQShare.initShareButton({
+            getState: () => this.shareState(),
+        });
+    }
+
     initializeEventListeners() {
         // 90/180-day chart window toggle, now on every device (issue #449, #466).
         this.initChartWindowToggle();
+
+        // Footer "Share" deep-link button (issue #515 wires #495's builder).
+        this.initShareButton();
 
         document
             .getElementById("scoreFileSelect")

--- a/docs/archive/pr-summaries/pr-summary-515.md
+++ b/docs/archive/pr-summaries/pr-summary-515.md
@@ -1,0 +1,86 @@
+# PR Summary — Issue #515
+
+## Summary
+
+The footer **🔗 Share** button did nothing when tapped — no clipboard copy, no
+"Link copied to clipboard" confirmation. The deep-link builder, clipboard write,
+and select-the-text fallback all shipped in `docs/share_link.js` (Issue #495),
+and the dashboard already exposed the live selections via
+`GRQValidator.shareState()`. The missing piece was the wiring: `docs/app.js`
+never called `GRQShare.initShareButton(...)`, so the button had **no click
+handler**.
+
+This PR adds a small `initShareButton()` method to `GRQValidator` and calls it
+from `initializeEventListeners()`, feeding the live selections to the existing
+builder via `getState: () => this.shareState()`. The call is guarded so a missing
+helper degrades cleanly (the footer simply stays inert) and remains read-only —
+sharing never mutates saved settings. The existing select-the-text fallback for
+blocked-clipboard contexts is preserved.
+
+Closes #515.
+
+## Mermaid — before vs after
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Footer as Footer 🔗 Share
+    participant App as app.js (GRQValidator)
+    participant Share as share_link.js (GRQShare)
+    participant Clip as Clipboard
+
+    Note over Footer,Share: BEFORE — no handler wired
+    User->>Footer: tap
+    Footer--xUser: nothing happens
+
+    Note over Footer,Share: AFTER — wired on init
+    App->>Share: initShareButton({ getState: shareState })
+    User->>Footer: tap
+    Footer->>Share: click handler
+    Share->>App: getState() → live selections
+    Share->>Share: buildShareUrl(currentPageUrl, state)
+    Share->>Clip: writeText(url)
+    Clip-->>User: "Link copied to clipboard"
+    Note right of Share: clipboard blocked → reveal<br/>select-the-text fallback
+```
+
+## Evidence
+
+Playwright MCP browser tools were not available in this environment, so a live
+screenshot could not be captured. The behaviour is covered by an automated
+behavioural test that drives the **real** DOM-wiring in `docs/share_link.js`
+with a fake document: a tap reads `getState()`, builds the deep-link URL, and
+surfaces it (via the fallback path, since the headless test has no Clipboard
+API), flashing a status message. A companion assertion pins that `docs/app.js`
+invokes `GRQShare.initShareButton` and feeds it `shareState()`.
+
+The wiring assertion was confirmed to **fail before** the `app.js` change
+(reproducing the reported bug) and **pass after** it. Full Deno suite: 939
+tests passing.
+
+## Test Plan
+
+- Added `tests/share_button_wiring_test.ts`:
+  - `share_link.js publishes the DOM-wiring entry point` — `initShareButton` is
+    published once a document exists.
+  - `a tap reads getState and surfaces the deep-link (fallback path)` — clicking
+    the footer button reads the live selections and writes the encoded deep-link
+    (`file`, `stock`, `window`) into the fallback control with a status message.
+    Reproduces the user-facing flow.
+  - `initShareButton is inert when the footer button is absent` — no throw when
+    the control is missing.
+  - `app.js wires the footer Share button to shareState (issue #515)` — pins the
+    `GRQShare.initShareButton` + `shareState()` wiring in `docs/app.js` (which
+    bootstraps a live `new GRQValidator()` at import and cannot be imported
+    headless — mirrors the source-structure checks in
+    `chart_window_toggle_test.ts`). This test fails on the unfixed `app.js`.
+- Existing `tests/share_link_test.ts` (pure builder helpers) continues to pass.
+- `deno fmt --check`, `deno lint`, `deno check`, and the full `deno test` suite
+  (939 passing) all green.
+
+## Files changed
+
+- `docs/app.js` — add `initShareButton()` and call it from
+  `initializeEventListeners()`.
+- `tests/share_button_wiring_test.ts` — new behavioural + wiring tests.
+- `CHANGELOG.md` — note the fix under a new **Fixed** section.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.217">
+    <meta name="app-version" content="1.0.218">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -477,6 +477,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.0.217"></script>
+    <script src="sw-register.js?v=1.0.218"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.0.217")
+    navigator.serviceWorker.register("./sw.js?v=1.0.218")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.0.217";
+const APP_VERSION = "1.0.218";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.0.217">
+    <meta name="app-version" content="1.0.218">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -202,6 +202,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.0.217"></script>
+    <script src="sw-register.js?v=1.0.218"></script>
   </body>
 </html>

--- a/tests/share_button_wiring_test.ts
+++ b/tests/share_button_wiring_test.ts
@@ -1,0 +1,153 @@
+// Tests for wiring the footer "Share" button (issue #515).
+//
+// The deep-link builder + clipboard/fallback handling shipped in
+// docs/share_link.js (issue #495), but the dashboard never called
+// GRQShare.initShareButton(...), so a tap did nothing — no copy, no message
+// (the bug reported in #515). These tests pin two things:
+//
+//   1. BEHAVIOUR — drive the REAL DOM-wiring in docs/share_link.js with a tiny
+//      fake document: a tap reads the live selections via getState, builds the
+//      deep-link URL and surfaces it (here through the select-the-text fallback,
+//      since the headless test has no Clipboard API), flashing a status message.
+//
+//   2. WIRING — assert docs/app.js actually invokes GRQShare.initShareButton and
+//      feeds it shareState(). app.js bootstraps a live `new GRQValidator()` at
+//      import time and touches dozens of real DOM nodes, so it cannot be
+//      imported headless; this mirrors the source-structure checks already used
+//      for app.js wiring in chart_window_toggle_test.ts.
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+
+// ---------------------------------------------------------------------------
+// Minimal fake DOM — only the surface share_link.js actually touches.
+// ---------------------------------------------------------------------------
+class FakeClassList {
+  private set = new Set<string>();
+  add(c: string) {
+    this.set.add(c);
+  }
+  remove(c: string) {
+    this.set.delete(c);
+  }
+  contains(c: string) {
+    return this.set.has(c);
+  }
+}
+
+class FakeElement {
+  value = "";
+  textContent = "";
+  classList = new FakeClassList();
+  attrs: Record<string, string> = {};
+  // deno-lint-ignore no-explicit-any
+  _grqClearTimer: any = null;
+  private clickHandlers: Array<() => void> = [];
+  constructor(public id = "") {}
+  addEventListener(type: string, fn: () => void) {
+    if (type === "click") this.clickHandlers.push(fn);
+  }
+  click() {
+    for (const fn of this.clickHandlers) fn();
+  }
+  setAttribute(k: string, v: string) {
+    this.attrs[k] = v;
+  }
+  removeAttribute(k: string) {
+    delete this.attrs[k];
+  }
+  focus() {}
+  select() {}
+}
+
+class FakeDocument {
+  els = new Map<string, FakeElement>();
+  add(id: string) {
+    const el = new FakeElement(id);
+    this.els.set(id, el);
+    return el;
+  }
+  getElementById(id: string) {
+    return this.els.get(id) ?? null;
+  }
+}
+
+// share_link.js only publishes the DOM-wiring (initShareButton) when a global
+// `document` exists at import time. Define one BEFORE importing the module, then
+// import dynamically so the wiring branch of the IIFE runs.
+const doc = new FakeDocument();
+const button = doc.add("shareButton");
+const statusEl = doc.add("shareStatus");
+const fallbackInput = doc.add("shareFallback");
+(globalThis as unknown as { document: unknown }).document = doc;
+
+await import("../docs/share_link.js");
+
+const g = globalThis as unknown as {
+  GRQShare: {
+    initShareButton: (opts: {
+      document?: unknown;
+      getState?: () => unknown;
+    }) => void;
+  };
+};
+const S = g.GRQShare;
+
+Deno.test("share_link.js publishes the DOM-wiring entry point", () => {
+  assertEquals(typeof S.initShareButton, "function");
+});
+
+Deno.test("a tap reads getState and surfaces the deep-link (fallback path)", async () => {
+  let stateReads = 0;
+  S.initShareButton({
+    document: doc,
+    getState: () => {
+      stateReads += 1;
+      return { file: "2026/March/23.tsv", stock: "NASDAQ:MGRC", window: 180 };
+    },
+  });
+
+  // Before the tap there is no link and no status — the bug state.
+  assertEquals(fallbackInput.value, "");
+  assertEquals(statusEl.textContent, "");
+
+  button.click();
+  // Let the clipboard promise reject (no Clipboard API headless) so the
+  // select-the-text fallback runs.
+  await new Promise((r) => setTimeout(r, 0));
+
+  assertEquals(stateReads, 1, "the tap must read the live selections");
+  assertStringIncludes(fallbackInput.value, "file=2026%2FMarch%2F23.tsv");
+  assertStringIncludes(fallbackInput.value, "stock=NASDAQ%3AMGRC");
+  assertStringIncludes(fallbackInput.value, "window=180");
+  assert(!fallbackInput.classList.contains("visually-hidden"));
+  assert(
+    statusEl.textContent.length > 0,
+    "a confirmation/fallback message must be shown",
+  );
+
+  clearTimeout(statusEl._grqClearTimer);
+});
+
+Deno.test("initShareButton is inert when the footer button is absent", () => {
+  // A page without the footer control must not throw.
+  const bare = new FakeDocument();
+  S.initShareButton({ document: bare, getState: () => ({}) });
+});
+
+// --- wiring: docs/app.js must call the builder with shareState ---------------
+
+const appJs = await Deno.readTextFile("docs/app.js");
+
+Deno.test("app.js wires the footer Share button to shareState (issue #515)", () => {
+  assert(
+    appJs.includes("GRQShare.initShareButton"),
+    "app.js must call GRQShare.initShareButton to wire the footer button",
+  );
+  assert(
+    /getState[\s\S]{0,80}this\.shareState\(\)/.test(appJs),
+    "app.js must feed the live selections via shareState() as getState",
+  );
+  assert(
+    appJs.includes("this.initShareButton()"),
+    "initializeEventListeners must invoke the Share-button wiring on init",
+  );
+});


### PR DESCRIPTION
# PR Summary — Issue #515

## Summary

The footer **🔗 Share** button did nothing when tapped — no clipboard copy, no
"Link copied to clipboard" confirmation. The deep-link builder, clipboard write,
and select-the-text fallback all shipped in `docs/share_link.js` (Issue #495),
and the dashboard already exposed the live selections via
`GRQValidator.shareState()`. The missing piece was the wiring: `docs/app.js`
never called `GRQShare.initShareButton(...)`, so the button had **no click
handler**.

This PR adds a small `initShareButton()` method to `GRQValidator` and calls it
from `initializeEventListeners()`, feeding the live selections to the existing
builder via `getState: () => this.shareState()`. The call is guarded so a missing
helper degrades cleanly (the footer simply stays inert) and remains read-only —
sharing never mutates saved settings. The existing select-the-text fallback for
blocked-clipboard contexts is preserved.

Closes #515.

## Mermaid — before vs after

```mermaid
sequenceDiagram
    actor User
    participant Footer as Footer 🔗 Share
    participant App as app.js (GRQValidator)
    participant Share as share_link.js (GRQShare)
    participant Clip as Clipboard

    Note over Footer,Share: BEFORE — no handler wired
    User->>Footer: tap
    Footer--xUser: nothing happens

    Note over Footer,Share: AFTER — wired on init
    App->>Share: initShareButton({ getState: shareState })
    User->>Footer: tap
    Footer->>Share: click handler
    Share->>App: getState() → live selections
    Share->>Share: buildShareUrl(currentPageUrl, state)
    Share->>Clip: writeText(url)
    Clip-->>User: "Link copied to clipboard"
    Note right of Share: clipboard blocked → reveal<br/>select-the-text fallback
```

## Evidence

Playwright MCP browser tools were not available in this environment, so a live
screenshot could not be captured. The behaviour is covered by an automated
behavioural test that drives the **real** DOM-wiring in `docs/share_link.js`
with a fake document: a tap reads `getState()`, builds the deep-link URL, and
surfaces it (via the fallback path, since the headless test has no Clipboard
API), flashing a status message. A companion assertion pins that `docs/app.js`
invokes `GRQShare.initShareButton` and feeds it `shareState()`.

The wiring assertion was confirmed to **fail before** the `app.js` change
(reproducing the reported bug) and **pass after** it. Full Deno suite: 939
tests passing.

## Test Plan

- Added `tests/share_button_wiring_test.ts`:
  - `share_link.js publishes the DOM-wiring entry point` — `initShareButton` is
    published once a document exists.
  - `a tap reads getState and surfaces the deep-link (fallback path)` — clicking
    the footer button reads the live selections and writes the encoded deep-link
    (`file`, `stock`, `window`) into the fallback control with a status message.
    Reproduces the user-facing flow.
  - `initShareButton is inert when the footer button is absent` — no throw when
    the control is missing.
  - `app.js wires the footer Share button to shareState (issue #515)` — pins the
    `GRQShare.initShareButton` + `shareState()` wiring in `docs/app.js` (which
    bootstraps a live `new GRQValidator()` at import and cannot be imported
    headless — mirrors the source-structure checks in
    `chart_window_toggle_test.ts`). This test fails on the unfixed `app.js`.
- Existing `tests/share_link_test.ts` (pure builder helpers) continues to pass.
- `deno fmt --check`, `deno lint`, `deno check`, and the full `deno test` suite
  (939 passing) all green.

## Files changed

- `docs/app.js` — add `initShareButton()` and call it from
  `initializeEventListeners()`.
- `tests/share_button_wiring_test.ts` — new behavioural + wiring tests.
- `CHANGELOG.md` — note the fix under a new **Fixed** section.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqrzrnhl-55711c`<!-- vibe-worker-issue-515 -->