### PR TITLE
Serve docs/ via Deno helpers/server.ts in a11y workflow (Issue #532)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -69,14 +69,24 @@ jobs:
         with:
           # Track the current LTS rather than a pinned major: Node 20 reaches
           # end-of-life on GitHub-hosted runners (2026-09-16), so pinning it
-          # runs the toolchain (http-server, pa11y-ci) on an unsupported
-          # interpreter. lts/* keeps the gate on a maintained runtime, matching
-          # markdown-lint.yml (Issue #171).
+          # runs pa11y-ci on an unsupported interpreter. lts/* keeps the gate on
+          # a maintained runtime, matching markdown-lint.yml (Issue #171).
           node-version: "lts/*"
+      # denoland/setup-deno@v2 — needed to run the in-repo Deno static server
+      # below. Pinned to a 40-character commit SHA per the supply-chain rule,
+      # matching markdown-lint.yml (Issue #532).
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        with:
+          deno-version: v2.x
       - name: Serve docs/ dashboard and wait for it to come up
         run: |
           set -euo pipefail
-          npx --yes http-server docs -p 8080 --silent &
+          # Serve docs/ with the repo's own reviewed, tested, loopback-bound
+          # static server instead of fetching an unpinned npm `http-server` at
+          # run time (Issue #532). helpers/server.ts reads the port from
+          # Deno.args[0] (default 8000), so passing 8080 keeps the health check
+          # and pa11yci.json target URLs unchanged.
+          deno run --allow-net --allow-read helpers/server.ts 8080 &
           for i in $(seq 1 30); do
             if curl -sSf http://localhost:8080/index.html >/dev/null 2>&1; then
               echo "Static server is up"

--- a/docs/archive/pr-summaries/pr-summary-532.md
+++ b/docs/archive/pr-summaries/pr-summary-532.md
@@ -1,0 +1,70 @@
+## Summary
+
+The Accessibility (`a11y.yml`) workflow served the `docs/` dashboard for the
+pa11y scan by shelling out to an unpinned Node static server fetched at run
+time (`npx --yes http-server docs -p 8080`). This is a Deno repo
+(`deno.json`, `deno.lock` at the root) that already ships its own reviewed,
+tested, loopback-bound static server, `helpers/server.ts`. Pulling
+`http-server` (and its transitive tree) from npm on every CI run — with the
+checked-out repository in scope — both reintroduced a Node-tooling dependency
+the repo had eliminated and opened an unpinned supply-chain surface inside CI.
+
+This PR replaces that step with the in-repo Deno server, run via a
+SHA-pinned `denoland/setup-deno` action (mirroring `markdown-lint.yml`).
+`helpers/server.ts` reads the port from `Deno.args[0]` (default 8000), so
+passing `8080` keeps the existing `curl` health check and the `pa11yci.json`
+target URLs unchanged.
+
+Closes #532.
+
+### Deno regression avoided
+
+- Removed `npx --yes http-server` from CI and served `docs/` with the
+  in-repo Deno `helpers/server.ts` instead — no Node-only static server
+  fetched at run time.
+
+## Evidence
+
+This is a CI-workflow change with no web UI to screenshot. Verified locally
+that the in-repo Deno server serves the dashboard on the same port and paths
+the workflow and `pa11yci.json` expect:
+
+```
+$ deno run --allow-net --allow-read helpers/server.ts 8080 &
+UP after 2s
+index.html -> HTTP 200
+trend.html -> HTTP 200
+```
+
+Flow of the updated pa11y job:
+
+```mermaid
+flowchart LR
+    A[checkout] --> B[setup-node]
+    B --> C[setup-deno @SHA]
+    C --> D["deno run helpers/server.ts 8080 &<br/>curl readiness loop"]
+    D --> E[point Puppeteer at system Chrome]
+    E --> F[install pa11y-ci]
+    F --> G["pa11y-ci --config pa11yci.json<br/>(WCAG2AA)"]
+```
+
+## Test Plan
+
+Updated `tests/a11y_workflow_test.ts` (TDD — the three tests below failed
+against the old workflow and pass after the change):
+
+- `a11y workflow serves docs/ via the in-repo Deno server` — asserts a step
+  runs `deno run ... helpers/server.ts` (structural token match, not a
+  source-text grep).
+- `a11y workflow does not shell out to npx http-server` — regression guard
+  ensuring the unpinned npm server does not return.
+- `a11y workflow sets up Deno via a SHA-pinned action` — asserts a
+  `denoland/setup-deno@<40-char SHA>` step is present.
+
+All 13 tests in `tests/a11y_workflow_test.ts` pass; `deno fmt --check` and
+`deno lint` are clean on the modified file.
+
+Note: one pre-existing Rust unit test (`utils::tests::test_read_market_data`)
+fails locally because the current-quarter market-data file is absent in this
+environment. It fails identically on the unmodified branch and is unrelated
+to this change.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.1">
+    <meta name="app-version" content="1.1.2">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -513,6 +513,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.1"></script>
+    <script src="sw-register.js?v=1.1.2"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.1")
+    navigator.serviceWorker.register("./sw.js?v=1.1.2")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.1";
+const APP_VERSION = "1.1.2";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.1">
+    <meta name="app-version" content="1.1.2">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -207,6 +207,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.1"></script>
+    <script src="sw-register.js?v=1.1.2"></script>
   </body>
 </html>

--- a/tests/a11y_workflow_test.ts
+++ b/tests/a11y_workflow_test.ts
@@ -159,14 +159,46 @@ Deno.test("a11y workflow enforces the WCAG2AA standard", async () => {
   );
 });
 
-Deno.test("a11y workflow serves the docs/ directory before checking", async () => {
+Deno.test("a11y workflow serves docs/ via the in-repo Deno server", async () => {
   const doc = await loadWorkflow();
   // The dashboard is a static site; a local server must back the a11y check
-  // because pa11y loads pages over HTTP. Assert the http-server tool is
-  // invoked (Issue #202) rather than grepping the run-step source text.
+  // because pa11y loads pages over HTTP. This repo is a Deno repo and ships its
+  // own reviewed, tested, loopback-bound static server (helpers/server.ts), so
+  // serve via that rather than fetching an unpinned Node `http-server` from npm
+  // at run time (Issue #532). Assert the deno-run invocation structurally
+  // (Issue #202) rather than grepping the run-step source text.
   assert(
-    invokesTool(allSteps(doc), "http-server"),
-    "workflow must serve docs/ over a local HTTP server",
+    invokesTool(allSteps(doc), "deno", {
+      subcommand: "run",
+      args: ["helpers/server.ts"],
+    }),
+    "workflow must serve docs/ via `deno run ... helpers/server.ts`",
+  );
+});
+
+// Issue #532: a Deno repo serving docs/ with `npx http-server` is a regression
+// back onto ad-hoc Node tooling and pulls an unpinned npm package (and its
+// transitive tree) into CI on every run. Guard against the regression returning.
+Deno.test("a11y workflow does not shell out to npx http-server", async () => {
+  const doc = await loadWorkflow();
+  assert(
+    !invokesTool(allSteps(doc), "http-server"),
+    "workflow must not serve docs/ via the unpinned npm http-server",
+  );
+});
+
+// The Deno server needs the Deno runtime on the runner. Mirror markdown-lint.yml
+// by pinning denoland/setup-deno to a 40-character commit SHA (Issue #532).
+Deno.test("a11y workflow sets up Deno via a SHA-pinned action", async () => {
+  const doc = await loadWorkflow();
+  const setupDeno = allSteps(doc).find((s) =>
+    typeof s.uses === "string" && s.uses.startsWith("denoland/setup-deno@")
+  );
+  assert(setupDeno, "workflow must add a denoland/setup-deno step");
+  const ref = (setupDeno.uses as string).split("@")[1];
+  assert(
+    /^[0-9a-f]{40}$/.test(ref),
+    `denoland/setup-deno must be pinned to a 40-char commit SHA, got: ${ref}`,
   );
 });
 


### PR DESCRIPTION
## Summary

The Accessibility (`a11y.yml`) workflow served the `docs/` dashboard for the
pa11y scan by shelling out to an unpinned Node static server fetched at run
time (`npx --yes http-server docs -p 8080`). This is a Deno repo
(`deno.json`, `deno.lock` at the root) that already ships its own reviewed,
tested, loopback-bound static server, `helpers/server.ts`. Pulling
`http-server` (and its transitive tree) from npm on every CI run — with the
checked-out repository in scope — both reintroduced a Node-tooling dependency
the repo had eliminated and opened an unpinned supply-chain surface inside CI.

This PR replaces that step with the in-repo Deno server, run via a
SHA-pinned `denoland/setup-deno` action (mirroring `markdown-lint.yml`).
`helpers/server.ts` reads the port from `Deno.args[0]` (default 8000), so
passing `8080` keeps the existing `curl` health check and the `pa11yci.json`
target URLs unchanged.

Closes #532.

### Deno regression avoided

- Removed `npx --yes http-server` from CI and served `docs/` with the
  in-repo Deno `helpers/server.ts` instead — no Node-only static server
  fetched at run time.

## Evidence

This is a CI-workflow change with no web UI to screenshot. Verified locally
that the in-repo Deno server serves the dashboard on the same port and paths
the workflow and `pa11yci.json` expect:

```
$ deno run --allow-net --allow-read helpers/server.ts 8080 &
UP after 2s
index.html -> HTTP 200
trend.html -> HTTP 200
```

Flow of the updated pa11y job:

```mermaid
flowchart LR
    A[checkout] --> B[setup-node]
    B --> C[setup-deno @SHA]
    C --> D["deno run helpers/server.ts 8080 &<br/>curl readiness loop"]
    D --> E[point Puppeteer at system Chrome]
    E --> F[install pa11y-ci]
    F --> G["pa11y-ci --config pa11yci.json<br/>(WCAG2AA)"]
```

## Test Plan

Updated `tests/a11y_workflow_test.ts` (TDD — the three tests below failed
against the old workflow and pass after the change):

- `a11y workflow serves docs/ via the in-repo Deno server` — asserts a step
  runs `deno run ... helpers/server.ts` (structural token match, not a
  source-text grep).
- `a11y workflow does not shell out to npx http-server` — regression guard
  ensuring the unpinned npm server does not return.
- `a11y workflow sets up Deno via a SHA-pinned action` — asserts a
  `denoland/setup-deno@<40-char SHA>` step is present.

All 13 tests in `tests/a11y_workflow_test.ts` pass; `deno fmt --check` and
`deno lint` are clean on the modified file.

Note: one pre-existing Rust unit test (`utils::tests::test_read_market_data`)
fails locally because the current-quarter market-data file is absent in this
environment. It fails identically on the unmodified branch and is unrelated
to this change.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqstnmms-32c6b8`<!-- vibe-worker-issue-532 -->