### PR TITLE
Harden CI Node-tooling installs with --ignore-scripts and version pins (Issue #533)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -118,14 +118,25 @@ jobs:
           fi
           echo "Using browser at ${CHROME_BIN}"
           echo "PUPPETEER_EXECUTABLE_PATH=${CHROME_BIN}" >> "${GITHUB_ENV}"
-      # PUPPETEER_SKIP_DOWNLOAD stops puppeteer's install hook attempting a
-      # Chrome-for-Testing download we will not use; the scan launches the
-      # system Chrome resolved above via PUPPETEER_EXECUTABLE_PATH instead.
+      # Install pa11y-ci with a pinned exact version and install scripts
+      # disabled (Issue #533, supply-chain hardening per Issue #2184). Without
+      # --ignore-scripts the npm lifecycle hooks (preinstall/postinstall/
+      # prepare) of pa11y-ci AND its entire transitive tree run in CI against
+      # the checked-out workspace, and an unpinned spec floats to whatever the
+      # registry serves on each run — the exact install-time code-execution
+      # pivot exploited by the Shai-Hulud and Axios npm incidents. pa11y-ci's
+      # only build-time hook is puppeteer's postinstall Chrome download, which
+      # PUPPETEER_SKIP_DOWNLOAD already no-ops (the scan launches the runner's
+      # system Chrome via PUPPETEER_EXECUTABLE_PATH), so --ignore-scripts is
+      # safe and changes nothing functionally.
       - name: Install pa11y-ci
-        run: npm install --no-save pa11y-ci
+        run: npm install --no-save --ignore-scripts pa11y-ci@4.1.1
         env:
           PUPPETEER_SKIP_DOWNLOAD: "true"
       # pa11y-ci has no --standard CLI flag (that is a pa11y option); the
-      # standard and target URLs are configured in pa11yci.json instead.
+      # standard and target URLs are configured in pa11yci.json instead. Run the
+      # locally-installed, script-disabled binary directly rather than a second
+      # `npx pa11y-ci` fetch, so the audited copy is the one that executes
+      # (Issue #533).
       - name: Run pa11y-ci (WCAG 2.1 AA) over the dashboard pages
-        run: npx pa11y-ci --config pa11yci.json
+        run: ./node_modules/.bin/pa11y-ci --config pa11yci.json

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -27,8 +27,16 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "lts/*"
+      # Install markdownlint-cli2 with a pinned exact version and install
+      # scripts disabled (Issue #533, supply-chain hardening per Issue #2184).
+      # Without --ignore-scripts the npm lifecycle hooks of markdownlint-cli2
+      # and its entire transitive tree run in CI against the checked-out
+      # workspace, and an unpinned spec floats to whatever the registry serves
+      # each run — the install-time code-execution pivot of the Shai-Hulud and
+      # Axios npm incidents. markdownlint-cli2 is pure JS with no build step, so
+      # --ignore-scripts is safe and changes nothing functionally.
       - name: Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2
+        run: npm install -g --ignore-scripts markdownlint-cli2@0.22.1
       - name: Run markdownlint-cli2
         run: markdownlint-cli2
       # Optional: mirror the local check-mermaid quality gate when Deno

--- a/docs/archive/pr-summaries/pr-summary-533.md
+++ b/docs/archive/pr-summaries/pr-summary-533.md
@@ -1,0 +1,57 @@
+# Harden CI Node-tooling installs with `--ignore-scripts` and version pins
+
+## Summary
+
+Two CI workflows installed Node CLI tooling without `--ignore-scripts` and
+without a version pin, so npm lifecycle scripts (`preinstall`/`postinstall`/
+`prepare`) of the tool **and its entire transitive tree** executed in CI against
+the checked-out workspace, while the resolved version floated to whatever the
+registry served on each run — the same install-time code-execution pivot
+exploited by the Shai-Hulud and Axios npm incidents.
+
+Both tools are genuinely Node-only (accessibility and markdown linting, no
+Deno-native equivalent), so they legitimately stay on Node; only the install
+posture is hardened:
+
+- **`.github/workflows/a11y.yml`** — `npm install --no-save pa11y-ci` →
+  `npm install --no-save --ignore-scripts pa11y-ci@4.1.1`. The scan now runs the
+  locally-installed binary (`./node_modules/.bin/pa11y-ci --config pa11yci.json`)
+  instead of a second `npx pa11y-ci` fetch, so the audited, script-disabled copy
+  is the one that executes. The workflow already sets `PUPPETEER_SKIP_DOWNLOAD`
+  and points Puppeteer at the runner's system Chrome, so puppeteer's
+  `postinstall` Chrome download was already a no-op — disabling install scripts
+  changes nothing functionally.
+- **`.github/workflows/markdown-lint.yml`** — `npm install -g markdownlint-cli2`
+  → `npm install -g --ignore-scripts markdownlint-cli2@0.22.1`. `markdownlint-cli2`
+  is pure JS with no build step, so `--ignore-scripts` is safe directly.
+
+Versions are pinned to the current latest releases (both well over the 24h
+quarantine floor), which CI tests against.
+
+Closes #533.
+
+## Evidence
+
+Backend/CI change with no web interface to screenshot. Verified via the Deno
+workflow tests below (all 25 pass) and YAML validation of both workflow files.
+
+```mermaid
+flowchart LR
+    A["npm install pa11y-ci<br/>(unpinned, scripts run)"] -->|hardened| B["npm install --ignore-scripts<br/>pa11y-ci@4.1.1"]
+    B --> C["./node_modules/.bin/pa11y-ci<br/>(audited local copy)"]
+    D["npm install -g markdownlint-cli2<br/>(unpinned, scripts run)"] -->|hardened| E["npm install -g --ignore-scripts<br/>markdownlint-cli2@0.22.1"]
+```
+
+## Test Plan
+
+- Updated `tests/a11y_workflow_test.ts::a11y workflow runs pa11y-ci against the
+  dashboard pages` to assert the scan runs the locally-installed
+  `./node_modules/.bin/pa11y-ci` binary (the invocation changed from `npx`).
+- Added `tests/a11y_workflow_test.ts::a11y pa11y-ci install is hardened with
+  --ignore-scripts and an exact version pin`.
+- Added `tests/a11y_workflow_test.ts::a11y workflow does not run pa11y-ci via npx`
+  to guard the regression.
+- Added `tests/markdown_lint_workflow_test.ts::Markdown Lint install is hardened
+  with --ignore-scripts and an exact version pin`.
+- All 25 tests across both workflow test files pass; `deno lint` and `deno check`
+  are clean.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.2">
+    <meta name="app-version" content="1.1.3">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -513,6 +513,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.2"></script>
+    <script src="sw-register.js?v=1.1.3"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.2")
+    navigator.serviceWorker.register("./sw.js?v=1.1.3")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.2";
+const APP_VERSION = "1.1.3";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.2">
+    <meta name="app-version" content="1.1.3">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -207,6 +207,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.2"></script>
+    <script src="sw-register.js?v=1.1.3"></script>
   </body>
 </html>

--- a/tests/a11y_workflow_test.ts
+++ b/tests/a11y_workflow_test.ts
@@ -138,14 +138,51 @@ Deno.test("a11y workflow defines a job with a sane timeout", async () => {
 
 Deno.test("a11y workflow runs pa11y-ci against the dashboard pages", async () => {
   const doc = await loadWorkflow();
-  // Structured invariant (Issue #202): a step invokes pa11y-ci (here via npx),
-  // matched on tokens rather than grepping the run-step source text.
-  assert(invokesTool(allSteps(doc), "pa11y-ci"), "a job must run pa11y-ci");
+  // Structured invariant (Issue #202): a step invokes the locally-installed
+  // pa11y-ci binary (Issue #533 runs ./node_modules/.bin/pa11y-ci rather than a
+  // second `npx` fetch), matched on tokens rather than grepping source text.
+  assert(
+    invokesTool(allSteps(doc), "./node_modules/.bin/pa11y-ci"),
+    "a job must run the locally-installed pa11y-ci binary",
+  );
   // The target URLs live in pa11yci.json (passed via --config), not in the
   // workflow run command. The published dashboard page must be exercised.
   const config = await loadPa11yConfig();
   const urls = (config.urls ?? []).join("\n");
   assert(/index\.html/.test(urls), "pa11y-ci must check index.html");
+});
+
+// Issue #533: harden the CI Node-tooling install. The pa11y-ci install must
+// pass --ignore-scripts so the npm lifecycle hooks of pa11y-ci and its entire
+// transitive tree never execute against the checked-out workspace, and must
+// pin an exact version so the spec cannot float to whatever the registry
+// currently serves. Running a second `npx pa11y-ci` would re-fetch an
+// unhardened copy, so the scan must run the locally-installed binary instead.
+Deno.test("a11y pa11y-ci install is hardened with --ignore-scripts and an exact version pin", async () => {
+  const doc = await loadWorkflow();
+  const installStep = allSteps(doc).find((s) =>
+    /\bnpm install\b/.test(s.run ?? "") && /pa11y-ci/.test(s.run ?? "")
+  );
+  assert(installStep, "workflow must install pa11y-ci via npm");
+  const run = installStep.run ?? "";
+  assert(
+    /--ignore-scripts\b/.test(run),
+    "pa11y-ci install must pass --ignore-scripts to disable npm lifecycle scripts",
+  );
+  assert(
+    /pa11y-ci@\d+\.\d+\.\d+\b/.test(run),
+    `pa11y-ci install must pin an exact version (got: ${run.trim()})`,
+  );
+});
+
+// Issue #533: do not re-fetch pa11y-ci with `npx` at scan time — that bypasses
+// the audited, --ignore-scripts copy installed above. Guard the regression.
+Deno.test("a11y workflow does not run pa11y-ci via npx", async () => {
+  const doc = await loadWorkflow();
+  assert(
+    !invokesTool(allSteps(doc), "npx", { subcommand: "pa11y-ci" }),
+    "workflow must run the locally-installed pa11y-ci, not a fresh npx fetch",
+  );
 });
 
 Deno.test("a11y workflow enforces the WCAG2AA standard", async () => {

--- a/tests/markdown_lint_workflow_test.ts
+++ b/tests/markdown_lint_workflow_test.ts
@@ -70,6 +70,31 @@ Deno.test("Markdown Lint workflow runs markdownlint-cli2 in its job", async () =
   );
 });
 
+// Issue #533: harden the CI Node-tooling install. The markdownlint-cli2 install
+// must pass --ignore-scripts so the npm lifecycle hooks of the tool and its
+// entire transitive tree never execute against the checked-out workspace, and
+// must pin an exact version so the spec cannot float to whatever the registry
+// currently serves. markdownlint-cli2 is pure JS with no build step, so
+// disabling install scripts is functionally a no-op.
+Deno.test("Markdown Lint install is hardened with --ignore-scripts and an exact version pin", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as { jobs: Record<string, { steps?: Step[] }> };
+  const steps = doc.jobs?.markdownlint?.steps ?? [];
+  const installStep = steps.find((s) =>
+    /\bnpm install\b/.test(s.run ?? "") && /markdownlint-cli2/.test(s.run ?? "")
+  );
+  assert(installStep, "workflow must install markdownlint-cli2 via npm");
+  const run = installStep.run ?? "";
+  assert(
+    /--ignore-scripts\b/.test(run),
+    "markdownlint-cli2 install must pass --ignore-scripts to disable npm lifecycle scripts",
+  );
+  assert(
+    /markdownlint-cli2@\d+\.\d+\.\d+\b/.test(run),
+    `markdownlint-cli2 install must pin an exact version (got: ${run.trim()})`,
+  );
+});
+
 Deno.test("Markdown Lint workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   assertActionsPinnedToSha(text);


### PR DESCRIPTION
# Harden CI Node-tooling installs with `--ignore-scripts` and version pins

## Summary

Two CI workflows installed Node CLI tooling without `--ignore-scripts` and
without a version pin, so npm lifecycle scripts (`preinstall`/`postinstall`/
`prepare`) of the tool **and its entire transitive tree** executed in CI against
the checked-out workspace, while the resolved version floated to whatever the
registry served on each run — the same install-time code-execution pivot
exploited by the Shai-Hulud and Axios npm incidents.

Both tools are genuinely Node-only (accessibility and markdown linting, no
Deno-native equivalent), so they legitimately stay on Node; only the install
posture is hardened:

- **`.github/workflows/a11y.yml`** — `npm install --no-save pa11y-ci` →
  `npm install --no-save --ignore-scripts pa11y-ci@4.1.1`. The scan now runs the
  locally-installed binary (`./node_modules/.bin/pa11y-ci --config pa11yci.json`)
  instead of a second `npx pa11y-ci` fetch, so the audited, script-disabled copy
  is the one that executes. The workflow already sets `PUPPETEER_SKIP_DOWNLOAD`
  and points Puppeteer at the runner's system Chrome, so puppeteer's
  `postinstall` Chrome download was already a no-op — disabling install scripts
  changes nothing functionally.
- **`.github/workflows/markdown-lint.yml`** — `npm install -g markdownlint-cli2`
  → `npm install -g --ignore-scripts markdownlint-cli2@0.22.1`. `markdownlint-cli2`
  is pure JS with no build step, so `--ignore-scripts` is safe directly.

Versions are pinned to the current latest releases (both well over the 24h
quarantine floor), which CI tests against.

Closes #533.

## Evidence

Backend/CI change with no web interface to screenshot. Verified via the Deno
workflow tests below (all 25 pass) and YAML validation of both workflow files.

```mermaid
flowchart LR
    A["npm install pa11y-ci<br/>(unpinned, scripts run)"] -->|hardened| B["npm install --ignore-scripts<br/>pa11y-ci@4.1.1"]
    B --> C["./node_modules/.bin/pa11y-ci<br/>(audited local copy)"]
    D["npm install -g markdownlint-cli2<br/>(unpinned, scripts run)"] -->|hardened| E["npm install -g --ignore-scripts<br/>markdownlint-cli2@0.22.1"]
```

## Test Plan

- Updated `tests/a11y_workflow_test.ts::a11y workflow runs pa11y-ci against the
  dashboard pages` to assert the scan runs the locally-installed
  `./node_modules/.bin/pa11y-ci` binary (the invocation changed from `npx`).
- Added `tests/a11y_workflow_test.ts::a11y pa11y-ci install is hardened with
  --ignore-scripts and an exact version pin`.
- Added `tests/a11y_workflow_test.ts::a11y workflow does not run pa11y-ci via npx`
  to guard the regression.
- Added `tests/markdown_lint_workflow_test.ts::Markdown Lint install is hardened
  with --ignore-scripts and an exact version pin`.
- All 25 tests across both workflow test files pass; `deno lint` and `deno check`
  are clean.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqstjut9-6779bc`<!-- vibe-worker-issue-533 -->