### PR TITLE
Default the prediction date to match the selected chart window (Issue #534)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -377,14 +377,19 @@ class GRQValidator {
                 }
 
                 // Fallback: select the nearest available score date ON OR
-                // BEFORE 90 days ago (issue #275). Delegates to the shared,
-                // unit-tested helper so the browser and Deno tests agree.
+                // BEFORE the active chart window (issue #534, extends #275):
+                // a 180-day window defaults to ~180 days ago, a 90-day window
+                // to ~90 days ago. Delegates to the shared, unit-tested helper
+                // so the browser and Deno tests agree. Initial default only —
+                // toggling the 90/180 control does not re-pick the date.
+                const windowDays = this.currentWindowDays();
                 const closestScore = GRQProjection.selectDefaultScore(
                     indexData.scores,
                     new Date(),
+                    windowDays,
                 );
 
-                console.log(`Auto-selecting score file on or before 90 days ago: ${closestScore.date} (${closestScore.month} ${closestScore.day})`);
+                console.log(`Auto-selecting score file on or before ${windowDays} days ago: ${closestScore.date} (${closestScore.month} ${closestScore.day})`);
 
                 this.selectedFile = closestScore.file;
                 select.value = this.selectedFile;

--- a/docs/archive/pr-summaries/pr-summary-534.md
+++ b/docs/archive/pr-summaries/pr-summary-534.md
@@ -1,0 +1,71 @@
+# Default the prediction date to match the selected chart window (90/180)
+
+## Summary
+
+On load, the dashboard's **Prediction Date** defaulted to the nearest score
+on/before ~90 days ago even when the active chart window was 180 days (the
+desktop default). This change ties the *initial* default prediction-date offset
+to the resolved active chart window: a 180-day window defaults to the nearest
+score on/before 180 days ago, a 90-day window keeps the ~90-days-ago default.
+The general rule applies on both mobile and desktop, to the initial default
+selection only — a `?date=`/`?file=` deep link still wins, and toggling the
+90/180 control does not re-pick the date. The 90/180 window defaults themselves
+(mobile 90, desktop 180) are unchanged.
+
+Frontend only. `Closes #534`.
+
+### Changes
+
+- **`docs/projection.js`** — `selectDefaultScore(scores, today, windowDays = 90)`
+  now derives the "on or before N days ago" target from `windowDays` instead of a
+  hardcoded 90. The argument defaults to 90 so existing callers/tests are
+  unaffected; a non-finite or non-positive value falls back to 90 so a bad input
+  can never widen the offset unexpectedly. The "latest score on/before the
+  target, else earliest" semantics are retained.
+- **`docs/app.js`** — the fallback after the `?file=`/`?date=` deep-link branch
+  threads `this.currentWindowDays()` (the resolved effective window from
+  `chart_window_settings.js`: `?window=` > saved per-device choice > device
+  default) into `selectDefaultScore`.
+
+```mermaid
+flowchart TD
+    A[Load dashboard] --> B{?file= or ?date=?}
+    B -- yes --> C[Deep link wins<br/>return early]
+    B -- no --> D[windowDays = currentWindowDays<br/>90 mobile / 180 desktop default]
+    D --> E[selectDefaultScore scores, today, windowDays]
+    E --> F[nearest score on/before<br/>windowDays days ago]
+    F -- none old enough --> G[fallback: earliest score]
+```
+
+## Evidence
+
+Playwright MCP was unavailable in this environment, so visual capture was not
+possible. The behaviour is verified deterministically against the real
+production `docs/scores/index.json` (reference date 2026-06-25):
+
+| Active window | Default prediction date | Score file |
+|---------------|-------------------------|------------|
+| 90 days       | 2026-03-27 (~90 days back)  | `2026/March/27.tsv` |
+| 180 days (desktop default) | 2025-12-27 (~180 days back) | `2025/December/27.tsv` |
+
+Before this change, the desktop 180-day view also defaulted to `2026-03-27`
+(the ~90-days-ago date), mismatching its chart window. It now defaults to
+`2025-12-27`.
+
+## Test Plan
+
+Extended `tests/score_selection_test.ts` (all pass; 986 Deno tests pass overall):
+
+- `90-day window keeps the ~90-days-ago default`
+- `180-day window picks the nearest score on/before 180 days ago`
+- `180-day window chooses the LATEST date on/before 180 days ago`
+- `180-day window falls back to EARLIEST when none ≥ 180 days old`
+- `omitted window argument defaults to the 90-day offset` (back-compat)
+
+The existing #275 regression tests (unchanged) continue to guard the 90-day
+behaviour.
+
+> Note: the Rust unit test `utils::tests::test_read_market_data` fails in this
+> environment due to a missing market-data fixture file. This failure is
+> pre-existing (reproduced on a clean checkout with no changes) and unrelated to
+> this frontend-only change.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.3">
+    <meta name="app-version" content="1.1.4">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -513,6 +513,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.3"></script>
+    <script src="sw-register.js?v=1.1.4"></script>
   </body>
 </html>

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -85,17 +85,22 @@ function windowShowsActualsAfter90(isMobile, windowDays) {
 
 // Choose the default score file for the dashboard (issue #275).
 //
-// By default we select the nearest available score date ON OR BEFORE 90 days
-// ago (the latest scoreDate <= today - 90 days). This deliberately avoids the
-// old absolute-nearest logic, where a score a few days MORE recent than the
-// 90-day target (e.g. 87 days ago) could wrongly win over the correct earlier
-// date (e.g. 90/93 days ago).
+// By default we select the nearest available score date ON OR BEFORE the
+// `windowDays`-day target (the latest scoreDate <= today - windowDays). This
+// deliberately avoids the old absolute-nearest logic, where a score a few days
+// MORE recent than the target (e.g. 87 days ago for a 90-day window) could
+// wrongly win over the correct earlier date (e.g. 90/93 days ago).
+//
+// `windowDays` ties the default prediction-date offset to the active chart
+// window (issue #534): a 180-day window defaults to the nearest score on/before
+// 180 days ago, a 90-day window keeps the ~90-days-ago default. It defaults to
+// 90 so existing callers (and a missing/invalid value) behave exactly as before.
 //
 // Only when no score date is on/before the target do we fall back to the
 // earliest available date. `today` is passed in explicitly so the function is
 // pure and deterministic (and unit-testable without a browser). Returns the
 // chosen score object, or null when the list is empty/invalid.
-function selectDefaultScore(scores, today) {
+function selectDefaultScore(scores, today, windowDays = 90) {
     if (!Array.isArray(scores) || scores.length === 0) {
         return null;
     }
@@ -116,10 +121,14 @@ function selectDefaultScore(scores, today) {
         return setDateToMidnight(new Date(value)).getTime();
     };
 
-    // Target = 90 days ago, normalised to local midnight for a date-only
-    // "on or before" comparison.
+    // Target = `windowDays` days ago, normalised to local midnight for a
+    // date-only "on or before" comparison. A non-finite or non-positive value
+    // falls back to 90 so a bad input can never widen the offset unexpectedly.
+    const offsetDays = Number.isFinite(windowDays) && windowDays > 0
+        ? windowDays
+        : 90;
     const target = setDateToMidnight(today);
-    target.setDate(target.getDate() - 90); // 90 days ago
+    target.setDate(target.getDate() - offsetDays);
     const targetTime = target.getTime();
 
     let selected = null;

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.3")
+    navigator.serviceWorker.register("./sw.js?v=1.1.4")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.3";
+const APP_VERSION = "1.1.4";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.3">
+    <meta name="app-version" content="1.1.4">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -207,6 +207,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.3"></script>
+    <script src="sw-register.js?v=1.1.4"></script>
   </body>
 </html>

--- a/tests/score_selection_test.ts
+++ b/tests/score_selection_test.ts
@@ -17,6 +17,7 @@ const g = globalThis as unknown as {
     selectDefaultScore: (
       scores: ScoreEntry[],
       today: Date,
+      windowDays?: number,
     ) => ScoreEntry | null;
   };
 };
@@ -112,4 +113,61 @@ Deno.test("selectDefaultScore: single date on/before target is chosen", () => {
   const chosen = selectDefaultScore(scores, TODAY);
   assert(chosen !== null);
   assertEquals(chosen?.file, "f200.tsv");
+});
+
+// Issue #534: the default prediction-date offset follows the active chart
+// window — a 180-day window defaults to the nearest score on/before 180 days
+// ago, a 90-day window keeps the ~90-days-ago default.
+
+Deno.test("selectDefaultScore: 90-day window keeps the ~90-days-ago default (issue #534)", () => {
+  const scores: ScoreEntry[] = [
+    { file: "f80.tsv", date: ymd(daysBefore(TODAY, 80)) },
+    { file: "f90.tsv", date: ymd(daysBefore(TODAY, 90)) },
+    { file: "f180.tsv", date: ymd(daysBefore(TODAY, 180)) },
+  ];
+  const chosen = selectDefaultScore(scores, TODAY, 90);
+  assertEquals(chosen?.file, "f90.tsv");
+});
+
+Deno.test("selectDefaultScore: 180-day window picks the nearest score on/before 180 days ago (issue #534)", () => {
+  const scores: ScoreEntry[] = [
+    { file: "f90.tsv", date: ymd(daysBefore(TODAY, 90)) },
+    { file: "f175.tsv", date: ymd(daysBefore(TODAY, 175)) },
+    { file: "f180.tsv", date: ymd(daysBefore(TODAY, 180)) },
+    { file: "f200.tsv", date: ymd(daysBefore(TODAY, 200)) },
+  ];
+  const chosen = selectDefaultScore(scores, TODAY, 180);
+  assertEquals(chosen?.file, "f180.tsv");
+});
+
+Deno.test("selectDefaultScore: 180-day window chooses the LATEST date on/before 180 days ago (issue #534)", () => {
+  const scores: ScoreEntry[] = [
+    { file: "f100.tsv", date: ymd(daysBefore(TODAY, 100)) },
+    { file: "f185.tsv", date: ymd(daysBefore(TODAY, 185)) },
+    { file: "f210.tsv", date: ymd(daysBefore(TODAY, 210)) },
+  ];
+  const chosen = selectDefaultScore(scores, TODAY, 180);
+  assertEquals(chosen?.file, "f185.tsv");
+});
+
+Deno.test("selectDefaultScore: 180-day window falls back to EARLIEST when none ≥ 180 days old (issue #534)", () => {
+  // Every score is more recent than 180 days ago — fall back to the earliest.
+  const scores: ScoreEntry[] = [
+    { file: "f90.tsv", date: ymd(daysBefore(TODAY, 90)) },
+    { file: "f150.tsv", date: ymd(daysBefore(TODAY, 150)) },
+    { file: "f120.tsv", date: ymd(daysBefore(TODAY, 120)) },
+  ];
+  const chosen = selectDefaultScore(scores, TODAY, 180);
+  assertEquals(chosen?.file, "f150.tsv");
+});
+
+Deno.test("selectDefaultScore: omitted window argument defaults to the 90-day offset (issue #534)", () => {
+  // Existing callers that pass no window must behave exactly as before.
+  const scores: ScoreEntry[] = [
+    { file: "f80.tsv", date: ymd(daysBefore(TODAY, 80)) },
+    { file: "f90.tsv", date: ymd(daysBefore(TODAY, 90)) },
+    { file: "f180.tsv", date: ymd(daysBefore(TODAY, 180)) },
+  ];
+  const chosen = selectDefaultScore(scores, TODAY);
+  assertEquals(chosen?.file, "f90.tsv");
 });


### PR DESCRIPTION
# Default the prediction date to match the selected chart window (90/180)

## Summary

On load, the dashboard's **Prediction Date** defaulted to the nearest score
on/before ~90 days ago even when the active chart window was 180 days (the
desktop default). This change ties the *initial* default prediction-date offset
to the resolved active chart window: a 180-day window defaults to the nearest
score on/before 180 days ago, a 90-day window keeps the ~90-days-ago default.
The general rule applies on both mobile and desktop, to the initial default
selection only — a `?date=`/`?file=` deep link still wins, and toggling the
90/180 control does not re-pick the date. The 90/180 window defaults themselves
(mobile 90, desktop 180) are unchanged.

Frontend only. `Closes #534`.

### Changes

- **`docs/projection.js`** — `selectDefaultScore(scores, today, windowDays = 90)`
  now derives the "on or before N days ago" target from `windowDays` instead of a
  hardcoded 90. The argument defaults to 90 so existing callers/tests are
  unaffected; a non-finite or non-positive value falls back to 90 so a bad input
  can never widen the offset unexpectedly. The "latest score on/before the
  target, else earliest" semantics are retained.
- **`docs/app.js`** — the fallback after the `?file=`/`?date=` deep-link branch
  threads `this.currentWindowDays()` (the resolved effective window from
  `chart_window_settings.js`: `?window=` > saved per-device choice > device
  default) into `selectDefaultScore`.

```mermaid
flowchart TD
    A[Load dashboard] --> B{?file= or ?date=?}
    B -- yes --> C[Deep link wins<br/>return early]
    B -- no --> D[windowDays = currentWindowDays<br/>90 mobile / 180 desktop default]
    D --> E[selectDefaultScore scores, today, windowDays]
    E --> F[nearest score on/before<br/>windowDays days ago]
    F -- none old enough --> G[fallback: earliest score]
```

## Evidence

Playwright MCP was unavailable in this environment, so visual capture was not
possible. The behaviour is verified deterministically against the real
production `docs/scores/index.json` (reference date 2026-06-25):

| Active window | Default prediction date | Score file |
|---------------|-------------------------|------------|
| 90 days       | 2026-03-27 (~90 days back)  | `2026/March/27.tsv` |
| 180 days (desktop default) | 2025-12-27 (~180 days back) | `2025/December/27.tsv` |

Before this change, the desktop 180-day view also defaulted to `2026-03-27`
(the ~90-days-ago date), mismatching its chart window. It now defaults to
`2025-12-27`.

## Test Plan

Extended `tests/score_selection_test.ts` (all pass; 986 Deno tests pass overall):

- `90-day window keeps the ~90-days-ago default`
- `180-day window picks the nearest score on/before 180 days ago`
- `180-day window chooses the LATEST date on/before 180 days ago`
- `180-day window falls back to EARLIEST when none ≥ 180 days old`
- `omitted window argument defaults to the 90-day offset` (back-compat)

The existing #275 regression tests (unchanged) continue to guard the 90-day
behaviour.

> Note: the Rust unit test `utils::tests::test_read_market_data` fails in this
> environment due to a missing market-data fixture file. This failure is
> pre-existing (reproduced on a clean checkout with no changes) and unrelated to
> this frontend-only change.
