### PR TITLE
Correct misleading "current price" label in show-working popover (#542)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Pages.
 > validation horizon** — the last market-data point on or before 90 days after
 > the prediction (score) date, or the latest available point when that 90-day
 > window is not yet complete. It deliberately **never** shows today's live price
-> beyond the 90-day horizon: a prediction is judged purely on how the stock moved
-> within its 90 days. The dashboard therefore labels this figure **"90-Day
-> Price"** (issue #539), not "Current Price", so it cannot be mistaken for a live
-> quote. A later rally or slump outside the window does not change a settled
-> 90-day result.
+> beyond the 90-day horizon: a prediction is judged purely on how the stock
+> moved within its 90 days. The dashboard therefore labels this figure **"90-Day
+> Price"** (issue #539), not "Current Price", so it cannot be mistaken for a
+> live quote. The "show the working" popovers use the same human-readable label
+> in their header — e.g. `Field: 90-Day Price`, never the raw `current-price` id
+> (issue #542). A later rally or slump outside the window does not change a
+> settled 90-day result.
 
 ## Features
 
@@ -194,8 +196,8 @@ deterministically — issue #281):
   override that is **not** persisted to `localStorage`).
 - `?window=90|180` — switch the chart (and aligned Market Performance summary)
   to a 90- or 180-day window for that page load, on **both** desktop and mobile
-  (issues #450, #467). Like `?theme=`, this is a **transient** override: it
-  wins over the saved per-device choice but is **never** persisted, so a reload
+  (issues #450, #467). Like `?theme=`, this is a **transient** override: it wins
+  over the saved per-device choice but is **never** persisted, so a reload
   without the param returns to the saved window (desktop 180 / mobile 90). Both
   windows end on the same date (#367); an absent or invalid value falls back to
   the saved choice, then the device default.
@@ -224,8 +226,8 @@ deterministically — issue #281):
 
 **Worked examples**
 
-- `index.html?date=2026-01-01&window=180&fullscreen=1` — 180 days from
-  1 January, landscape (maximised chart) on a phone.
+- `index.html?date=2026-01-01&window=180&fullscreen=1` — 180 days from 1
+  January, landscape (maximised chart) on a phone.
 - `trend.html?group=week&indices=sp500,nasdaq` — the Trend view grouped by week
   with the S&P 500 and NASDAQ overlays on (Russell 2000 off) for this visit.
 - `index.html?view=trend` — jump straight from the dashboard to the Prediction

--- a/docs/app.js
+++ b/docs/app.js
@@ -3941,9 +3941,13 @@ class GRQValidator {
         if (!stock) return "Stock not found";
 
         const scoreDate = this.getScoreDate(this.selectedFile);
-        const header = `Stock: ${stockSymbol} | Field: ${field} | Score Date: ${
-            scoreDate.toISOString().split("T")[0]
-        }\n\n`;
+        // Use the human-readable field label (issue #542) so the working header
+        // reads e.g. "Field: 90-Day Price" rather than the raw "current-price"
+        // id, which was misleading (it is never today's live price — issue #539).
+        const scoreDateISO = scoreDate.toISOString().split("T")[0];
+        const header = globalThis.GRQFieldLabel
+            ? globalThis.GRQFieldLabel.workingHeader(stockSymbol, field, scoreDateISO)
+            : `Stock: ${stockSymbol} | Field: ${field} | Score Date: ${scoreDateISO}\n\n`;
 
         switch (field) {
             case "buy-price":

--- a/docs/archive/pr-summaries/pr-summary-542.md
+++ b/docs/archive/pr-summaries/pr-summary-542.md
@@ -1,0 +1,57 @@
+# Correct the misleading "current price" label in the "show working" popover
+
+## Summary
+
+The "show the working" popovers rendered their header from the RAW internal
+field id, so the price working read **`Field: current-price`**. That label is
+wrong/misleading: the dashboard deliberately labels this figure **"90-Day
+Price"** (issue #539) and never shows today's live price beyond the 90-day
+horizon, so "current price" can be mistaken for a live quote.
+
+The fix maps each internal `data-field` id to the same human-readable display
+label the column headers and popover titles already use, and the working header
+now renders that label instead of the raw id — e.g. `Field: 90-Day Price`. The
+mapping lives in a new pure helper (`docs/field_label.js`, published on
+`globalThis.GRQFieldLabel`) so the browser dashboard (via `app.js`) and the Deno
+tests exercise the exact same code, mirroring `docs/color_key.js` /
+`docs/series_label_colour.js`. Display/labelling only — no figures or formulae
+change.
+
+Closes #542.
+
+## Evidence
+
+Playwright MCP was not available in this run, so the popover could not be
+screenshotted. The change is exercised through the real shipped helper instead.
+Before/after of the working-popover header (produced by calling the shipped
+`GRQFieldLabel.workingHeader`):
+
+```text
+BEFORE: Stock: NYSE:SCHW | Field: current-price | Score Date: 2025-01-15
+AFTER:  Stock: NYSE:SCHW | Field: 90-Day Price | Score Date: 2025-01-15
+```
+
+Data flow of the working header:
+
+```mermaid
+flowchart LR
+    A["clickable value<br/>data-field=current-price"] --> B["app.js getWorking()"]
+    B --> C["GRQFieldLabel.workingHeader()"]
+    C --> D["GRQFieldLabel.fieldLabel()<br/>current-price → 90-Day Price"]
+    D --> E["popover header:<br/>Field: 90-Day Price"]
+```
+
+## Test Plan
+
+- Added `tests/show_working_field_label_test.ts` (7 tests) covering:
+  - `fieldLabel("current-price")` returns `"90-Day Price"` (the bug fix).
+  - No label in the map uses the misleading "Current Price" wording.
+  - Every documented field id maps to its established display label.
+  - Unknown ids fall back to the raw id; empty/missing input returns `""`.
+  - `workingHeader(...)` renders the friendly label and never leaks the raw
+    `current-price` id, keeping the stock symbol and score date verbatim.
+- `app.js` now builds the working header via `GRQFieldLabel.workingHeader`, with
+  a literal-string fallback when the helper is absent.
+- Full Deno suite passes (`deno test --allow-read tests/*.ts` → 999 passed, 0
+  failed); `deno fmt`, `deno lint` and `deno check` are clean.
+- The Rust backend is untouched by this UI-only change.

--- a/docs/field_label.js
+++ b/docs/field_label.js
@@ -1,0 +1,65 @@
+// Human-readable labels for the "show the working" popover field id (issue #542).
+//
+// Each clickable dashboard value carries an internal `data-field` id (e.g.
+// "current-price"). The working popover used to print that RAW id in its header
+// — `Field: current-price` — which is wrong/misleading: the dashboard
+// deliberately labels that figure "90-Day Price" (issue #539), NOT "Current
+// Price", so it can never be mistaken for a live quote. This module maps each
+// field id to the SAME display label the column headers and popover titles use,
+// so the working header reads `Field: 90-Day Price`.
+//
+// Like docs/color_key.js and docs/series_label_colour.js this is a PURE classic
+// script: no module syntax, helpers published on `globalThis`, so the browser
+// dashboard (via app.js) and the Deno tests exercise the exact same code.
+
+// Field id -> display label. Labels mirror the column headers / popover titles
+// in docs/index.html and docs/app.js. The displayed price figure is the
+// "90-Day Price" (issue #539), never "Current Price".
+const FIELD_LABELS = {
+    "buy-price": "Buy Price",
+    "target": "90-Day Target",
+    "target-percentage": "Target Percentage",
+    "current-price": "90-Day Price",
+    "gain-loss": "Gain/Loss",
+    "progress-vs-cost": "Return above Cost of Capital",
+    "judgement": "Judgement",
+    "status-projection": "Status/Projection",
+    "intrinsic-basic": "Intrinsic Value (Basic)",
+    "intrinsic-adjusted": "Intrinsic Value (Adjusted)",
+    "avg-dividend": "Average Dividend (90-day)",
+    "total-dividend": "Total Dividends (90-day)",
+    "dividend-info": "Dividend Info",
+    "stars": "Stars",
+    "fair-value-range": "Fair Value Range",
+    "portfolio-target": "Portfolio Target",
+    "portfolio-actual": "Actual",
+    "portfolio-dividends": "Dividends",
+    "portfolio-return-above-cost-of-capital":
+        "Portfolio Return above Cost of Capital",
+};
+
+// Friendly display label for a field id. Unknown ids fall back to the raw id so
+// nothing silently disappears; empty/missing input yields "".
+function fieldLabel(field) {
+    if (typeof field !== "string" || field === "") return "";
+    return Object.prototype.hasOwnProperty.call(FIELD_LABELS, field)
+        ? FIELD_LABELS[field]
+        : field;
+}
+
+// Build the popover working header, using the friendly field label so the
+// header never leaks the raw internal id. `scoreDateISO` is the YYYY-MM-DD
+// score date already formatted by the caller.
+function workingHeader(stockSymbol, field, scoreDateISO) {
+    return `Stock: ${stockSymbol} | Field: ${
+        fieldLabel(field)
+    } | Score Date: ${scoreDateISO}\n\n`;
+}
+
+// Publish on globalThis so the browser dashboard (classic script) and the Deno
+// tests both reach the exact same helpers, mirroring docs/color_key.js.
+globalThis.GRQFieldLabel = {
+    FIELD_LABELS,
+    fieldLabel,
+    workingHeader,
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.6">
+    <meta name="app-version" content="1.1.7">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -517,6 +517,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.6"></script>
+    <script src="sw-register.js?v=1.1.7"></script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -508,6 +508,10 @@
          wires the footer button to the live selections via globalThis.GRQShare. -->
     <script src="share_link.js"></script>
 
+    <!-- "Show working" popover field labels (issue #542) — before app.js, which
+         reads globalThis.GRQFieldLabel to render the working header. -->
+    <script src="field_label.js"></script>
+
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
     <script src="dashboard_boot.js"></script>
 

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.6")
+    navigator.serviceWorker.register("./sw.js?v=1.1.7")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.6";
+const APP_VERSION = "1.1.7";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -24,6 +24,8 @@ const STATIC_ASSETS = [
   "./chart_window_settings.js",
   "./color_key.js",
   "./series_label_colour.js",
+  // "Show working" popover field labels (issue #542).
+  "./field_label.js",
   "./chart_theme.js",
   "./chart_title.js",
   "./format.js",

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.6">
+    <meta name="app-version" content="1.1.7">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -207,6 +207,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.6"></script>
+    <script src="sw-register.js?v=1.1.7"></script>
   </body>
 </html>

--- a/tests/show_working_field_label_test.ts
+++ b/tests/show_working_field_label_test.ts
@@ -1,0 +1,113 @@
+// Tests for the "show working" popover field label (issue #542).
+//
+// The popover header inside every "show the working" tooltip used to render the
+// RAW internal field id, e.g. `Field: current-price`. That is wrong/misleading:
+// the dashboard deliberately labels that figure "90-Day Price" (issue #539),
+// never "Current Price", so it cannot be mistaken for a live quote. This change
+// maps each internal field id to its human-readable display label so the
+// working header reads `Field: 90-Day Price`.
+//
+// The helper is a PURE classic script (docs/field_label.js) published on
+// globalThis, mirroring docs/color_key.js / docs/series_label_colour.js, so the
+// browser dashboard (via app.js) and these Deno tests exercise the SAME code.
+
+import { assert, assertEquals } from "@std/assert";
+import "../docs/field_label.js";
+
+const g = globalThis as unknown as {
+  GRQFieldLabel: {
+    FIELD_LABELS: Record<string, string>;
+    fieldLabel: (field: string) => string;
+    workingHeader: (
+      stockSymbol: string,
+      field: string,
+      scoreDateISO: string,
+    ) => string;
+  };
+};
+const GRQFieldLabel = g.GRQFieldLabel;
+
+// --- the bug fix: current-price must read as "90-Day Price" -----------------
+
+Deno.test('fieldLabel - "current-price" maps to "90-Day Price", not a live-quote label', () => {
+  assertEquals(GRQFieldLabel.fieldLabel("current-price"), "90-Day Price");
+});
+
+Deno.test('fieldLabel - never returns the misleading "Current Price" wording', () => {
+  for (const label of Object.values(GRQFieldLabel.FIELD_LABELS)) {
+    assert(
+      !/current\s*price/i.test(label),
+      `label "${label}" must not use the misleading "Current Price" wording`,
+    );
+  }
+});
+
+// --- the other known fields keep their established display labels -----------
+
+Deno.test("fieldLabel - maps the documented field ids to their display labels", () => {
+  const expected: Record<string, string> = {
+    "buy-price": "Buy Price",
+    "target": "90-Day Target",
+    "target-percentage": "Target Percentage",
+    "current-price": "90-Day Price",
+    "gain-loss": "Gain/Loss",
+    "progress-vs-cost": "Return above Cost of Capital",
+    "judgement": "Judgement",
+    "status-projection": "Status/Projection",
+    "intrinsic-basic": "Intrinsic Value (Basic)",
+    "intrinsic-adjusted": "Intrinsic Value (Adjusted)",
+    "avg-dividend": "Average Dividend (90-day)",
+    "total-dividend": "Total Dividends (90-day)",
+    "dividend-info": "Dividend Info",
+    "stars": "Stars",
+    "fair-value-range": "Fair Value Range",
+    "portfolio-target": "Portfolio Target",
+  };
+  for (const [field, label] of Object.entries(expected)) {
+    assertEquals(GRQFieldLabel.fieldLabel(field), label);
+  }
+});
+
+// --- robustness: unknown / empty ids fall back gracefully -------------------
+
+Deno.test("fieldLabel - unknown field id falls back to the raw id", () => {
+  assertEquals(GRQFieldLabel.fieldLabel("no-such-field"), "no-such-field");
+});
+
+Deno.test("fieldLabel - empty/missing input returns an empty string", () => {
+  assertEquals(GRQFieldLabel.fieldLabel(""), "");
+  assertEquals(
+    GRQFieldLabel.fieldLabel(undefined as unknown as string),
+    "",
+  );
+});
+
+// --- the working header uses the friendly label -----------------------------
+
+Deno.test("workingHeader - renders the friendly field label, not the raw id", () => {
+  const header = GRQFieldLabel.workingHeader(
+    "NYSE:SCHW",
+    "current-price",
+    "2025-01-15",
+  );
+  assertEquals(
+    header,
+    "Stock: NYSE:SCHW | Field: 90-Day Price | Score Date: 2025-01-15\n\n",
+  );
+  assert(
+    !header.includes("current-price"),
+    "working header must not leak the raw 'current-price' field id",
+  );
+});
+
+Deno.test("workingHeader - keeps the stock symbol and score date verbatim", () => {
+  const header = GRQFieldLabel.workingHeader(
+    "ASX:CBA",
+    "buy-price",
+    "2024-12-31",
+  );
+  assertEquals(
+    header,
+    "Stock: ASX:CBA | Field: Buy Price | Score Date: 2024-12-31\n\n",
+  );
+});


### PR DESCRIPTION
# Correct the misleading "current price" label in the "show working" popover

## Summary

The "show the working" popovers rendered their header from the RAW internal
field id, so the price working read **`Field: current-price`**. That label is
wrong/misleading: the dashboard deliberately labels this figure **"90-Day
Price"** (issue #539) and never shows today's live price beyond the 90-day
horizon, so "current price" can be mistaken for a live quote.

The fix maps each internal `data-field` id to the same human-readable display
label the column headers and popover titles already use, and the working header
now renders that label instead of the raw id — e.g. `Field: 90-Day Price`. The
mapping lives in a new pure helper (`docs/field_label.js`, published on
`globalThis.GRQFieldLabel`) so the browser dashboard (via `app.js`) and the Deno
tests exercise the exact same code, mirroring `docs/color_key.js` /
`docs/series_label_colour.js`. Display/labelling only — no figures or formulae
change.

Closes #542.

## Evidence

Playwright MCP was not available in this run, so the popover could not be
screenshotted. The change is exercised through the real shipped helper instead.
Before/after of the working-popover header (produced by calling the shipped
`GRQFieldLabel.workingHeader`):

```text
BEFORE: Stock: NYSE:SCHW | Field: current-price | Score Date: 2025-01-15
AFTER:  Stock: NYSE:SCHW | Field: 90-Day Price | Score Date: 2025-01-15
```

Data flow of the working header:

```mermaid
flowchart LR
    A["clickable value<br/>data-field=current-price"] --> B["app.js getWorking()"]
    B --> C["GRQFieldLabel.workingHeader()"]
    C --> D["GRQFieldLabel.fieldLabel()<br/>current-price → 90-Day Price"]
    D --> E["popover header:<br/>Field: 90-Day Price"]
```

## Test Plan

- Added `tests/show_working_field_label_test.ts` (7 tests) covering:
  - `fieldLabel("current-price")` returns `"90-Day Price"` (the bug fix).
  - No label in the map uses the misleading "Current Price" wording.
  - Every documented field id maps to its established display label.
  - Unknown ids fall back to the raw id; empty/missing input returns `""`.
  - `workingHeader(...)` renders the friendly label and never leaks the raw
    `current-price` id, keeping the stock symbol and score date verbatim.
- `app.js` now builds the working header via `GRQFieldLabel.workingHeader`, with
  a literal-string fallback when the helper is absent.
- Full Deno suite passes (`deno test --allow-read tests/*.ts` → 999 passed, 0
  failed); `deno fmt`, `deno lint` and `deno check` are clean.
- The Rust backend is untouched by this UI-only change.
