### PR TITLE
Freshness foundation: signed analysis age + emoji-mapping helper (#547)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -723,7 +723,13 @@ class GRQValidator {
                         
                         // Check if analysis is within 30 days of score date
                         const daysDiff = Math.abs((analysisDate.getTime() - scoreDate.getTime()) / (1000 * 60 * 60 * 24));
-                        
+
+                        // Signed, whole-day analysis age (issue #547). Negative when the
+                        // analysis is dated *after* the score date — an invariant the
+                        // pipeline must never violate. Do NOT collapse with Math.abs.
+                        const oneDay = 1000 * 60 * 60 * 24;
+                        const signedDaysFromScore = Math.floor((analysisDate.getTime() - scoreDate.getTime()) / oneDay);
+
                         if (daysDiff <= 30) {
                             // Parse star ratings
                             const msStars = msIndex !== -1 && values[msIndex] ? parseFloat(values[msIndex]) : null;
@@ -760,6 +766,7 @@ class GRQValidator {
                         tipsStars: tipsStars,
                         avgStars: avgStars,
                         daysFromScore: daysDiff,
+                        signedDaysFromScore: signedDaysFromScore,
                         msFairValue: msFairValue,
                         tipsTarget: tipsTarget
                     };
@@ -905,6 +912,47 @@ class GRQValidator {
         }
         
         return display;
+    }
+
+    // Fair-value freshness indicator (issue #547). Maps the signed, whole-day
+    // analysis age onto the Google-Sheet emoji scale via a VLOOKUP-style
+    // approximate match (largest threshold ≤ age):
+    //   0–1 🌹 · 2–3 🌺 · 4–6 🥀 · 7–9 🍁 · 10–13 🍂 · 14+ 🕸
+    // Returns '' when there is no analysis row or stars show N/A, and '⚠️' when
+    // the age is negative (analysis dated after the score date — surface the bug).
+    getFreshnessIndicator(stockSymbol) {
+        if (!this.analysisData || !this.analysisData[stockSymbol]) {
+            return '';
+        }
+
+        const analysis = this.analysisData[stockSymbol];
+        if (analysis.avgStars === null) {
+            return '';
+        }
+
+        if (analysis.signedDaysFromScore < 0) {
+            return '⚠️';
+        }
+
+        // Ascending [threshold, emoji] pairs — pick the largest threshold ≤ age.
+        const scale = [
+            [0, '🌹'],
+            [2, '🌺'],
+            [4, '🥀'],
+            [7, '🍁'],
+            [10, '🍂'],
+            [14, '🕸'],
+        ];
+
+        let emoji = scale[0][1];
+        for (const [threshold, candidate] of scale) {
+            if (analysis.signedDaysFromScore >= threshold) {
+                emoji = candidate;
+            } else {
+                break;
+            }
+        }
+        return emoji;
     }
 
     getFairValueRange(stockSymbol) {

--- a/docs/archive/pr-summaries/pr-summary-547.md
+++ b/docs/archive/pr-summaries/pr-summary-547.md
@@ -1,0 +1,66 @@
+# Freshness foundation: signed analysis age + emoji-mapping helper
+
+## Summary
+
+Adds the shared foundation for the fair-value freshness indicator (sub-issue of
+#545). Closes #547.
+
+Two changes in `docs/app.js`:
+
+1. **Signed, whole-day analysis age.** `loadAnalysisData()` now stores
+   `signedDaysFromScore = Math.floor((analysisDate − scoreDate) / oneDay)` on
+   each analysis row alongside the existing absolute `daysFromScore`. The value
+   is **negative** when the analysis is dated *after* the score date — an
+   invariant the pipeline must never violate. It is deliberately **not**
+   collapsed with `Math.abs`, so the violation is no longer masked. The existing
+   absolute `daysFromScore` and the 30-day load-window filter are left
+   unchanged (out of scope).
+
+2. **`getFreshnessIndicator(stockSymbol)` helper.** Maps the signed whole-day
+   age onto the Google-Sheet emoji scale using a VLOOKUP-style approximate match
+   (largest threshold ≤ age):
+
+   | age (whole days) | emoji |
+   |---|---|
+   | 0–1 | 🌹 |
+   | 2–3 | 🌺 |
+   | 4–6 | 🥀 |
+   | 7–9 | 🍁 |
+   | 10–13 | 🍂 |
+   | 14+ | 🕸 |
+
+   Returns `''` when there is no analysis row or `avgStars === null` (stars show
+   N/A → no emoji), and `'⚠️'` when the signed age is negative.
+
+Wiring the emoji into the table column, mobile card, and click-popover is
+handled by the dependent display sub-issues — this change adds the data field,
+helper, and tests only.
+
+```mermaid
+flowchart LR
+    A[analysisDate − scoreDate] --> B[signedDaysFromScore<br/>Math.floor, whole days]
+    B --> C{getFreshnessIndicator}
+    C -->|no row / avgStars null| D['']
+    C -->|age &lt; 0| E[⚠️]
+    C -->|approx match| F[🌹 🌺 🥀 🍁 🍂 🕸]
+```
+
+## Evidence
+
+Backend/logic change with no standalone UI to screenshot (display wiring is in
+dependent sub-issues). Verified via unit tests — full Deno suite green
+(`1004 passed | 0 failed`).
+
+## Test Plan
+
+Added `tests/freshness_indicator_test.ts` mirroring `tests/star_rating_test.ts`:
+
+- **Bucket boundaries** — ages 0, 1, 2, 3, 4, 6, 7, 9, 10, 13, 14 each map to
+  the expected emoji.
+- **Large age** — 21 and 30 days stay in the 🕸 bucket.
+- **Negative age** — −1 and −5 return `⚠️`.
+- **No analysis data** — missing stock returns `''`.
+- **avgStars null** — returns `''`, including when age is also negative.
+
+All tests pass; `deno lint`, `deno check`, and the full `deno test` suite remain
+green.

--- a/tests/freshness_indicator_test.ts
+++ b/tests/freshness_indicator_test.ts
@@ -1,0 +1,133 @@
+// Fair-value freshness indicator helper (copied from app.js) — issue #547.
+//
+// Mirrors the Google-Sheet VLOOKUP-style approximate-match scale that turns a
+// signed, whole-day analysis age into a freshness emoji:
+//
+//   age (whole days) | emoji
+//   0–1              | 🌹
+//   2–3              | 🌺
+//   4–6              | 🥀
+//   7–9              | 🍁
+//   10–13            | 🍂
+//   14+              | 🕸
+//
+// Special cases:
+//   - no analysis row / avgStars === null → '' (no emoji)
+//   - signed age negative (analysis dated after the score date) → '⚠️'
+
+// Ascending [threshold, emoji] pairs — pick the largest threshold ≤ age.
+const FRESHNESS_SCALE: ReadonlyArray<readonly [number, string]> = [
+  [0, "🌹"],
+  [2, "🌺"],
+  [4, "🥀"],
+  [7, "🍁"],
+  [10, "🍂"],
+  [14, "🕸"],
+];
+
+interface AnalysisRow {
+  avgStars: number | null;
+  signedDaysFromScore: number;
+}
+
+function getFreshnessIndicator(
+  analysisData: Record<string, AnalysisRow>,
+  stockSymbol: string,
+): string {
+  const analysis = analysisData?.[stockSymbol];
+
+  // No analysis row, or stars show N/A → no emoji.
+  if (!analysis || analysis.avgStars === null) {
+    return "";
+  }
+
+  // Analysis dated after the score date — an invariant the pipeline must
+  // never violate. Surface the bug instead of a freshness emoji.
+  if (analysis.signedDaysFromScore < 0) {
+    return "⚠️";
+  }
+
+  // VLOOKUP-style approximate match: largest threshold ≤ age.
+  let emoji = FRESHNESS_SCALE[0][1];
+  for (const [threshold, candidate] of FRESHNESS_SCALE) {
+    if (analysis.signedDaysFromScore >= threshold) {
+      emoji = candidate;
+    } else {
+      break;
+    }
+  }
+  return emoji;
+}
+
+// Convenience wrapper so tests read like the data scenarios they describe.
+function freshnessFor(
+  avgStars: number | null,
+  signedDaysFromScore: number,
+): string {
+  return getFreshnessIndicator(
+    { "NYSE:TEST": { avgStars, signedDaysFromScore } },
+    "NYSE:TEST",
+  );
+}
+
+Deno.test("Freshness Indicator - bucket boundaries", () => {
+  const cases: { age: number; expected: string }[] = [
+    { age: 0, expected: "🌹" },
+    { age: 1, expected: "🌹" },
+    { age: 2, expected: "🌺" },
+    { age: 3, expected: "🌺" },
+    { age: 4, expected: "🥀" },
+    { age: 6, expected: "🥀" },
+    { age: 7, expected: "🍁" },
+    { age: 9, expected: "🍁" },
+    { age: 10, expected: "🍂" },
+    { age: 13, expected: "🍂" },
+    { age: 14, expected: "🕸" },
+  ];
+
+  for (const { age, expected } of cases) {
+    assertEquals(
+      freshnessFor(3.0, age),
+      expected,
+      `age ${age} → ${expected}`,
+    );
+  }
+});
+
+Deno.test("Freshness Indicator - large age stays in 🕸 bucket", () => {
+  assertEquals(freshnessFor(3.0, 21), "🕸", "21 days → 🕸");
+  assertEquals(freshnessFor(3.0, 30), "🕸", "30 days → 🕸");
+});
+
+Deno.test("Freshness Indicator - negative age surfaces ⚠️", () => {
+  assertEquals(freshnessFor(3.0, -1), "⚠️", "analysis dated after score date");
+  assertEquals(freshnessFor(3.0, -5), "⚠️", "well after score date");
+});
+
+Deno.test("Freshness Indicator - no analysis data returns ''", () => {
+  assertEquals(
+    getFreshnessIndicator({}, "NYSE:MISSING"),
+    "",
+    "missing stock → no emoji",
+  );
+});
+
+Deno.test("Freshness Indicator - avgStars null returns ''", () => {
+  assertEquals(freshnessFor(null, 0), "", "stars N/A → no emoji");
+  assertEquals(
+    freshnessFor(null, -3),
+    "",
+    "null stars wins over negative age",
+  );
+});
+
+// Helper function for assertions (matches tests/star_rating_test.ts style).
+function assertEquals(actual: unknown, expected: unknown, message?: string) {
+  if (actual !== expected) {
+    throw new Error(
+      `Assertion failed: ${message || "Values are not equal"}\n` +
+        `Expected: ${JSON.stringify(expected)}\n` +
+        `Actual: ${JSON.stringify(actual)}`,
+    );
+  }
+}


### PR DESCRIPTION
# Freshness foundation: signed analysis age + emoji-mapping helper

## Summary

Adds the shared foundation for the fair-value freshness indicator (sub-issue
of #545). Closes #547.

Two changes in `docs/app.js`:

1. **Signed, whole-day analysis age.** `loadAnalysisData()` now stores
   `signedDaysFromScore = Math.floor((analysisDate − scoreDate) / oneDay)` on
   each analysis row alongside the existing absolute `daysFromScore`. The value
   is **negative** when the analysis is dated *after* the score date — an
   invariant the pipeline must never violate. It is deliberately **not**
   collapsed with `Math.abs`, so the violation is no longer masked. The existing
   absolute `daysFromScore` and the 30-day load-window filter are left
   unchanged (out of scope).

2. **`getFreshnessIndicator(stockSymbol)` helper.** Maps the signed whole-day
   age onto the Google-Sheet emoji scale using a VLOOKUP-style approximate match
   (largest threshold ≤ age):

   | age (whole days) | emoji |
   |---|---|
   | 0–1 | 🌹 |
   | 2–3 | 🌺 |
   | 4–6 | 🥀 |
   | 7–9 | 🍁 |
   | 10–13 | 🍂 |
   | 14+ | 🕸 |

   Returns `''` when there is no analysis row or `avgStars === null` (stars show
   N/A → no emoji), and `'⚠️'` when the signed age is negative.

Wiring the emoji into the table column, mobile card, and click-popover is
handled by the dependent display sub-issues — this change adds the data field,
helper, and tests only.

```mermaid
flowchart LR
    A[analysisDate − scoreDate] --> B[signedDaysFromScore<br/>Math.floor, whole days]
    B --> C{getFreshnessIndicator}
    C -->|no row / avgStars null| D['']
    C -->|age &lt; 0| E[⚠️]
    C -->|approx match| F[🌹 🌺 🥀 🍁 🍂 🕸]
```

## Evidence

Backend/logic change with no standalone UI to screenshot (display wiring is in
dependent sub-issues). Verified via unit tests — full Deno suite green
(`1004 passed | 0 failed`).

## Test Plan

Added `tests/freshness_indicator_test.ts` mirroring `tests/star_rating_test.ts`:

- **Bucket boundaries** — ages 0, 1, 2, 3, 4, 6, 7, 9, 10, 13, 14 each map to
  the expected emoji.
- **Large age** — 21 and 30 days stay in the 🕸 bucket.
- **Negative age** — −1 and −5 return `⚠️`.
- **No analysis data** — missing stock returns `''`.
- **avgStars null** — returns `''`, including when age is also negative.

All tests pass; `deno lint`, `deno check`, and the full `deno test` suite remain
green.



## Milestone
This PR is part of the **#545 Show fair-value freshness indicator wherever star ratings appear** milestone and targets the `milestone/545-show-fair-value-freshness-indicator-wherever-s` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqu07ewa-471838`<!-- vibe-worker-issue-547 -->