### PR TITLE
Show fair-value freshness emoji beside table star rating (Issue #548)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3199,7 +3199,7 @@ class GRQValidator {
                 >${this.formatCurrency(buyPrice)}</span>
             </td>
             <td>
-                <span class="clickable-value" data-bs-toggle="popover" data-bs-trigger="click" data-bs-content="" data-bs-title="Stars - ${safeStock}" data-field="stars" data-stock="${safeStock}">${this.getStarRatingDisplay(stock.stock)}</span>
+                <span class="clickable-value" data-bs-toggle="popover" data-bs-trigger="click" data-bs-content="" data-bs-title="Stars - ${safeStock}" data-field="stars" data-stock="${safeStock}">${this.getStarRatingDisplay(stock.stock)}${this.getFreshnessIndicator(stock.stock) ? ` ${this.getFreshnessIndicator(stock.stock)}` : ""}</span>
             </td>
             <td>
             <span class="clickable-value ${this.getTargetPriceColor(target, currentPrice, buyPrice)}" data-bs-toggle="popover" data-bs-trigger="click" data-bs-content="" data-bs-title="90-Day Target - ${safeStock}" data-field="target" data-stock="${safeStock}">${this.formatCurrency(target)

--- a/docs/archive/pr-summaries/pr-summary-548.md
+++ b/docs/archive/pr-summaries/pr-summary-548.md
@@ -1,0 +1,68 @@
+## Summary
+
+Show the fair-value freshness emoji (issue #547's `getFreshnessIndicator()`)
+**beside** the existing star rating in the desktop/aggregate score **table**.
+The "Stars" `<td>` now appends the freshness indicator after the moon glyphs so
+the cell reads e.g. `🌕🌕🌕🌑 🌺`. The emoji accompanies the stars — it does not
+replace them. Closes #548.
+
+Behaviour:
+- **Fresh row** → moon glyphs then the freshness emoji, separated by one space
+  (e.g. `🌕🌕🌕🌕 🌹` for same-day analysis).
+- **N/A stars** → empty cell. Both `getStarRatingDisplay()` and
+  `getFreshnessIndicator()` return `''` for no-analysis / `avgStars === null`,
+  and the append is guarded so there is no stray space and no lone emoji.
+- **Negative-age row** → `⚠️` beside the stars (the helper surfaces the
+  pipeline invariant breach).
+
+### Change
+
+`docs/app.js` — aggregate-table "Stars" cell:
+
+```js
+${this.getStarRatingDisplay(stock.stock)}${this.getFreshnessIndicator(stock.stock) ? ` ${this.getFreshnessIndicator(stock.stock)}` : ""}
+```
+
+The freshness emoji is only appended (with its leading space) when the helper
+returns a non-empty value, keeping the N/A cell clean.
+
+```mermaid
+flowchart LR
+    A[stock row] --> B["getStarRatingDisplay()"]
+    A --> C["getFreshnessIndicator()"]
+    B --> D{stars empty?}
+    C --> E{freshness empty?}
+    D -- yes --> F["cell = '' (N/A, no emoji)"]
+    D -- no --> G[moon glyphs]
+    E -- no --> H["+ ' ' + emoji"]
+    E -- yes --> G
+    G --> I["🌕🌕🌕🌑 🌺"]
+    H --> I
+```
+
+## Evidence
+
+Playwright MCP was unavailable in this run, so visual capture was not possible.
+The combined cell output was verified directly across every scenario by running
+the exact app.js combine logic:
+
+| avgStars | signed age | rendered cell |
+|----------|-----------|---------------|
+| 3.1 | 3 days | `🌕🌕🌕🌑 🌺` |
+| 4.0 | 0 days | `🌕🌕🌕🌕 🌹` |
+| 3.0 | 12 days | `🌕🌕🌕 🍂` |
+| null | 5 days | `` (empty — N/A) |
+| 4.0 | -1 day | `🌕🌕🌕🌕 ⚠️` |
+
+## Test Plan
+
+Extended `tests/star_rating_test.ts` with four tests:
+- `Table Stars cell - freshness emoji renders beside the rating` — fresh rows
+  show the moon glyphs then the freshness emoji.
+- `Table Stars cell - N/A stars produce no emoji and no stray space` — null
+  stars give an empty cell, even with a negative age.
+- `Table Stars cell - negative age shows ⚠️ beside the rating`.
+- `app.js: table Stars cell wires freshness beside the star rating` — guards the
+  source wiring (fails against the pre-change `app.js`, confirming TDD).
+
+Full suite green via `./quality.sh`.

--- a/tests/star_rating_test.ts
+++ b/tests/star_rating_test.ts
@@ -415,6 +415,102 @@ Deno.test("Star Rating Calculation Details", () => {
   );
 });
 
+// --- Issue #548: freshness emoji beside the star rating in the table cell ---
+//
+// The aggregate-score table "Stars" cell appends the fair-value freshness
+// indicator (issue #547) after the moon glyphs, e.g. "🌕🌕🌕🌑 🌺". When the
+// stars are N/A both helpers return '' so the cell must be empty — no stray
+// space and no lone emoji. A negative-age row shows '⚠️' beside the stars.
+
+// Freshness indicator, mirrored from app.js getFreshnessIndicator (issue #547).
+const FRESHNESS_SCALE: ReadonlyArray<readonly [number, string]> = [
+  [0, "🌹"],
+  [2, "🌺"],
+  [4, "🥀"],
+  [7, "🍁"],
+  [10, "🍂"],
+  [14, "🕸"],
+];
+
+function getFreshnessIndicator(
+  avgStars: number | null,
+  signedDaysFromScore: number,
+): string {
+  if (avgStars === null) {
+    return "";
+  }
+  if (signedDaysFromScore < 0) {
+    return "⚠️";
+  }
+  let emoji = FRESHNESS_SCALE[0][1];
+  for (const [threshold, candidate] of FRESHNESS_SCALE) {
+    if (signedDaysFromScore >= threshold) {
+      emoji = candidate;
+    } else {
+      break;
+    }
+  }
+  return emoji;
+}
+
+// Build the "Stars" table cell exactly as app.js does: stars, then the
+// freshness emoji separated by a single space, with no marker when there is
+// no freshness emoji to show.
+function renderStarsCell(
+  avgStars: number | null,
+  signedDaysFromScore: number,
+): string {
+  const stars = getStarRatingDisplay(avgStars);
+  const freshness = getFreshnessIndicator(avgStars, signedDaysFromScore);
+  return `${stars}${freshness ? ` ${freshness}` : ""}`;
+}
+
+Deno.test("Table Stars cell - freshness emoji renders beside the rating", () => {
+  assertEquals(
+    renderStarsCell(3.1, 3),
+    "🌕🌕🌕🌑 🌺",
+    "fresh row shows moon glyphs then the freshness emoji",
+  );
+  assertEquals(
+    renderStarsCell(4.0, 0),
+    "🌕🌕🌕🌕 🌹",
+    "same-day analysis shows 🌹 beside four full moons",
+  );
+});
+
+Deno.test("Table Stars cell - N/A stars produce no emoji and no stray space", () => {
+  assertEquals(
+    renderStarsCell(null, 5),
+    "",
+    "no analysis stars → empty cell, no lone freshness emoji",
+  );
+  assertEquals(
+    renderStarsCell(null, -3),
+    "",
+    "null stars win even when the age is negative",
+  );
+});
+
+Deno.test("Table Stars cell - negative age shows ⚠️ beside the rating", () => {
+  assertEquals(
+    renderStarsCell(4.0, -1),
+    "🌕🌕🌕🌕 ⚠️",
+    "analysis dated after the score date surfaces ⚠️ beside the stars",
+  );
+});
+
+Deno.test("app.js: table Stars cell wires freshness beside the star rating", async () => {
+  const js = await Deno.readTextFile("docs/app.js");
+  // The Stars <td> must append getFreshnessIndicator after getStarRatingDisplay,
+  // guarded so an empty indicator adds no stray space (issue #548).
+  assertEquals(
+    /getStarRatingDisplay\(stock\.stock\)\}\$\{this\.getFreshnessIndicator\(stock\.stock\)\s*\?/
+      .test(js),
+    true,
+    "table cell must append a guarded getFreshnessIndicator(stock.stock) after the stars",
+  );
+});
+
 // Helper function for assertions (Deno doesn't have assertEquals by default)
 function assertEquals(actual: unknown, expected: unknown, message?: string) {
   if (actual !== expected) {


### PR DESCRIPTION
## Summary

Show the fair-value freshness emoji (issue #547's `getFreshnessIndicator()`)
**beside** the existing star rating in the desktop/aggregate score **table**.
The "Stars" `<td>` now appends the freshness indicator after the moon glyphs so
the cell reads e.g. `🌕🌕🌕🌑 🌺`. The emoji accompanies the stars — it does not
replace them. Closes #548.

Behaviour:
- **Fresh row** → moon glyphs then the freshness emoji, separated by one space
  (e.g. `🌕🌕🌕🌕 🌹` for same-day analysis).
- **N/A stars** → empty cell. Both `getStarRatingDisplay()` and
  `getFreshnessIndicator()` return `''` for no-analysis / `avgStars === null`,
  and the append is guarded so there is no stray space and no lone emoji.
- **Negative-age row** → `⚠️` beside the stars (the helper surfaces the
  pipeline invariant breach).

### Change

`docs/app.js` — aggregate-table "Stars" cell:

```js
${this.getStarRatingDisplay(stock.stock)}${this.getFreshnessIndicator(stock.stock) ? ` ${this.getFreshnessIndicator(stock.stock)}` : ""}
```

The freshness emoji is only appended (with its leading space) when the helper
returns a non-empty value, keeping the N/A cell clean.

```mermaid
flowchart LR
    A[stock row] --> B["getStarRatingDisplay()"]
    A --> C["getFreshnessIndicator()"]
    B --> D{stars empty?}
    C --> E{freshness empty?}
    D -- yes --> F["cell = '' (N/A, no emoji)"]
    D -- no --> G[moon glyphs]
    E -- no --> H["+ ' ' + emoji"]
    E -- yes --> G
    G --> I["🌕🌕🌕🌑 🌺"]
    H --> I
```

## Evidence

Playwright MCP was unavailable in this run, so visual capture was not possible.
The combined cell output was verified directly across every scenario by running
the exact app.js combine logic:

| avgStars | signed age | rendered cell |
|----------|-----------|---------------|
| 3.1 | 3 days | `🌕🌕🌕🌑 🌺` |
| 4.0 | 0 days | `🌕🌕🌕🌕 🌹` |
| 3.0 | 12 days | `🌕🌕🌕 🍂` |
| null | 5 days | `` (empty — N/A) |
| 4.0 | -1 day | `🌕🌕🌕🌕 ⚠️` |

## Test Plan

Extended `tests/star_rating_test.ts` with four tests:
- `Table Stars cell - freshness emoji renders beside the rating` — fresh rows
  show the moon glyphs then the freshness emoji.
- `Table Stars cell - N/A stars produce no emoji and no stray space` — null
  stars give an empty cell, even with a negative age.
- `Table Stars cell - negative age shows ⚠️ beside the rating`.
- `app.js: table Stars cell wires freshness beside the star rating` — guards the
  source wiring (fails against the pre-change `app.js`, confirming TDD).

Full suite green via `./quality.sh`.



## Milestone
This PR is part of the **#545 Show fair-value freshness indicator wherever star ratings appear** milestone and targets the `milestone/545-show-fair-value-freshness-indicator-wherever-s` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqu07ewa-471838`<!-- vibe-worker-issue-548 -->