### PR TITLE
Stars popover: show exact analysis age + date (#550)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -4400,9 +4400,21 @@ class GRQValidator {
                 if (remainderStars > 0) {
                     moonPhaseStep = `\n= Moon phase: ${moonPhase}`;
                 }
-                
+
+                // Freshness section (issue #550): the exact analysis date plus
+                // the whole-day age relative to the VIEWED score date — the
+                // precise number behind the inline freshness emoji (issue #547).
+                const starAnalysis = this.analysisData[stockSymbol];
+                let freshnessStep = '';
+                if (starAnalysis && globalThis.GRQFreshness) {
+                    freshnessStep = globalThis.GRQFreshness.freshnessSection(
+                        starAnalysis.date,
+                        starAnalysis.signedDaysFromScore,
+                    );
+                }
+
                 return header +
-                    `Stars working:\n${calculationSteps}${roundingSteps}${moonPhaseStep}\n= Display: ${display}`;
+                    `Stars working:\n${calculationSteps}${roundingSteps}${moonPhaseStep}\n= Display: ${display}${freshnessStep}`;
             case "fair-value-range":
                 const fairValueRange = this.getFairValueRange(stockSymbol);
                 if (!fairValueRange) {

--- a/docs/archive/pr-summaries/pr-summary-550.md
+++ b/docs/archive/pr-summaries/pr-summary-550.md
@@ -1,0 +1,118 @@
+# Stars click-popover: show exact analysis age + date (#550)
+
+## Summary
+
+The Stars "show the working" click-popover now appends a **freshness section**
+giving the **exact analysis date** and the **whole-day age of that analysis
+relative to the viewed score date** — the precise number behind the inline
+freshness emoji (issue #547). For example:
+
+```
+Analysis freshness:
+= Analysed: 20 Jun 2026
+= 5 days before score date
+```
+
+The age is **always measured against the viewed score date, never against
+today** — the dashboard judges how good the prediction was on the chosen date.
+
+Edge cases handled:
+
+- **Singular vs plural** — `1 day before score date` vs `N days before score date`.
+- **Same day** — age `0` → `same day as score date`.
+- **Negative age** (analysis dated *after* the score date, a data-pipeline
+  invariant violation) → the age line is replaced with
+  `⚠️ analysed AFTER the score date (data-pipeline error — should never happen)`,
+  mirroring the inline `⚠️` from #547.
+- **No analysis data** — the existing
+  `No analysis data available for this stock` branch is unchanged (the
+  freshness section is only appended when an analysis row exists).
+
+Closes #550.
+
+## Design
+
+The age/date formatting lives in a new **pure classic script**
+`docs/freshness_text.js`, published on `globalThis.GRQFreshness`, mirroring
+`docs/field_label.js` (#542). This lets the browser dashboard (`docs/app.js`)
+and the Deno tests exercise **exactly the same code**. The date is formatted
+manually (`20 Jun 2026`) rather than via `toLocaleDateString`, because Deno's
+ICU build renders the `"short"` month as the full name (`June`) — the manual
+short-month table is deterministic in both the browser and the tests.
+
+`docs/app.js` `case "stars":` reads `this.analysisData[stockSymbol]` (its
+`date` and signed `signedDaysFromScore` fields from #547) and appends
+`GRQFreshness.freshnessSection(...)` to the working text.
+
+The new script is loaded before `app.js` in both `docs/index.html` and
+`docs/trend.html`, added to the service-worker precache list in `docs/sw.js`,
+and the app version is bumped `1.1.7 → 1.1.8` so existing clients re-precache.
+
+```mermaid
+flowchart LR
+    A["analysisData[stock]<br/>(date, signedDaysFromScore #547)"] --> B["GRQFreshness.freshnessSection()"]
+    B --> C{"signedDaysFromScore"}
+    C -->|"&lt; 0"| D["⚠️ analysed AFTER<br/>the score date"]
+    C -->|"= 0"| E["same day as score date"]
+    C -->|"= 1"| F["1 day before score date"]
+    C -->|"&gt; 1"| G["N days before score date"]
+    D --> H["Stars popover text"]
+    E --> H
+    F --> H
+    G --> H
+```
+
+## Evidence
+
+Playwright MCP was unavailable in this run, so UI evidence is the **actual
+rendered popover text** produced by the real shared module
+(`docs/freshness_text.js`) driven from the same inputs the dashboard supplies:
+
+```
+Stock: NYSE:SCHW | Field: Stars | Score Date: 2026-06-25
+
+Stars working:
+= MorningStar: 4 stars
+= Tips Stars: 6 stars (normalized to 3.0 stars)
+= Average: (4 stars + 3.0 stars) / 2 = 3.50 stars
+
+Rounding to nearest quarter:
+= 3.50 × 20 = 70.0
+= Rounded to 70 twentieths
+= Full stars: 70 ÷ 20 = 3
+= Remainder: 70 - (3 × 20) = 10 twentieths
+= Partial stars: 10 ÷ 5 = 2.0 → 2 quarters
+= Moon phase: 🌓 (half moon)
+= Display: 🌟🌟🌟🌓
+
+Analysis freshness:
+= Analysed: 20 Jun 2026
+= 5 days before score date
+```
+
+Edge-case sections (same inputs, different ages):
+
+```
+= Analysed: 25 Jun 2026
+= same day as score date
+---
+= Analysed: 24 Jun 2026
+= 1 day before score date
+---
+= Analysed: 27 Jun 2026
+= ⚠️ analysed AFTER the score date (data-pipeline error — should never happen)
+```
+
+## Test Plan
+
+- **New** `tests/stars_popover_freshness_test.ts` — exercises the shared
+  `GRQFreshness` helpers:
+  - `formatAnalysisDate` — `20 Jun 2026` / `1 Jan 2025` / `31 Dec 2024`, and
+    `''` for invalid/missing dates.
+  - `analysisAgeLine` — plural, singular, zero (same-day) and negative
+    (⚠️ pipeline error) cases, asserting the negative case never reads as an
+    ordinary age line.
+  - `freshnessSection` — date + age appear together for plural, same-day and
+    negative inputs.
+- Full suite green: `deno test` → **995 passed, 0 failed**.
+- `./quality.sh` passes cleanly (lint, type-check, Rust, Deno tests).

--- a/docs/freshness_text.js
+++ b/docs/freshness_text.js
@@ -1,0 +1,70 @@
+// Stars click-popover freshness text helpers (issue #550).
+//
+// The Stars "show the working" popover appends the EXACT analysis date and the
+// whole-day age of that analysis relative to the VIEWED score date. The inline
+// emoji (issue #547) is the at-a-glance signal; this section gives the precise
+// number — e.g. `Analysed: 20 Jun 2026` / `5 days before score date`.
+//
+// Like docs/field_label.js and docs/color_key.js this is a PURE classic script:
+// no module syntax, helpers published on `globalThis`, so the browser dashboard
+// (via app.js) and the Deno tests exercise the exact same code.
+
+// Short month names. We format the date ourselves rather than via
+// toLocaleDateString so the output is `20 Jun 2026` deterministically in both
+// the browser and Deno (whose ICU build renders the "short" month as "June").
+const SHORT_MONTHS = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+];
+
+// Format an analysis date as `20 Jun 2026` (day / short month / year).
+// Invalid or missing dates yield "" so nothing misleading is shown.
+function formatAnalysisDate(date) {
+    if (!(date instanceof Date) || isNaN(date.getTime())) return "";
+    return `${date.getDate()} ${SHORT_MONTHS[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+// Describe the signed whole-day analysis age relative to the viewed score date.
+// Always measured against the score date, never against today (issue #550).
+//   n > 1  → "N days before score date"
+//   n = 1  → "1 day before score date"   (singular)
+//   n = 0  → "same day as score date"
+//   n < 0  → ⚠️ analysis dated AFTER the score date (a data-pipeline error)
+function analysisAgeLine(signedDaysFromScore) {
+    const n = signedDaysFromScore;
+    if (n < 0) {
+        return "⚠️ analysed AFTER the score date (data-pipeline error — should never happen)";
+    }
+    if (n === 0) {
+        return "same day as score date";
+    }
+    const unit = n === 1 ? "day" : "days";
+    return `${n} ${unit} before score date`;
+}
+
+// Build the freshness section appended to the Stars working text: the analysis
+// date plus the exact age line. A leading blank line separates it from the
+// star maths above.
+function freshnessSection(date, signedDaysFromScore) {
+    return `\n\nAnalysis freshness:\n= Analysed: ${
+        formatAnalysisDate(date)
+    }\n= ${analysisAgeLine(signedDaysFromScore)}`;
+}
+
+// Publish on globalThis so the browser dashboard (classic script) and the Deno
+// tests both reach the exact same helpers, mirroring docs/field_label.js.
+globalThis.GRQFreshness = {
+    formatAnalysisDate,
+    analysisAgeLine,
+    freshnessSection,
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.7">
+    <meta name="app-version" content="1.1.8">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -512,11 +512,15 @@
          reads globalThis.GRQFieldLabel to render the working header. -->
     <script src="field_label.js"></script>
 
+    <!-- Stars popover freshness text (issue #550) — before app.js, which reads
+         globalThis.GRQFreshness to append the analysis date + age. -->
+    <script src="freshness_text.js"></script>
+
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
     <script src="dashboard_boot.js"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.7"></script>
+    <script src="sw-register.js?v=1.1.8"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.7")
+    navigator.serviceWorker.register("./sw.js?v=1.1.8")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.7";
+const APP_VERSION = "1.1.8";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;
@@ -26,6 +26,8 @@ const STATIC_ASSETS = [
   "./series_label_colour.js",
   // "Show working" popover field labels (issue #542).
   "./field_label.js",
+  // Stars popover freshness text (issue #550).
+  "./freshness_text.js",
   "./chart_theme.js",
   "./chart_title.js",
   "./format.js",

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.7">
+    <meta name="app-version" content="1.1.8">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -207,6 +207,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.7"></script>
+    <script src="sw-register.js?v=1.1.8"></script>
   </body>
 </html>

--- a/tests/stars_popover_freshness_test.ts
+++ b/tests/stars_popover_freshness_test.ts
@@ -1,0 +1,100 @@
+// Stars click-popover freshness section (issue #550).
+//
+// The Stars "show the working" popover now appends the exact analysis date and
+// the whole-day age of that analysis RELATIVE TO THE VIEWED SCORE DATE — the
+// inline emoji (issue #547) is the at-a-glance signal, this is the precise
+// number. e.g. `Analysed: 20 Jun 2026` / `5 days before score date`.
+//
+// The age helpers live in docs/freshness_text.js, a PURE classic script
+// published on globalThis (mirroring docs/field_label.js), so the browser
+// dashboard (via app.js) and these Deno tests exercise the SAME code.
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import "../docs/freshness_text.js";
+
+const g = globalThis as unknown as {
+  GRQFreshness: {
+    formatAnalysisDate: (date: Date) => string;
+    analysisAgeLine: (signedDaysFromScore: number) => string;
+    freshnessSection: (date: Date, signedDaysFromScore: number) => string;
+  };
+};
+const GRQFreshness = g.GRQFreshness;
+
+// --- date formatting: `20 Jun 2026` (day / short-month / year) --------------
+
+Deno.test("formatAnalysisDate - day, short month and year", () => {
+  assertEquals(
+    GRQFreshness.formatAnalysisDate(new Date(2026, 5, 20)),
+    "20 Jun 2026",
+  );
+  assertEquals(
+    GRQFreshness.formatAnalysisDate(new Date(2025, 0, 1)),
+    "1 Jan 2025",
+  );
+  assertEquals(
+    GRQFreshness.formatAnalysisDate(new Date(2024, 11, 31)),
+    "31 Dec 2024",
+  );
+});
+
+Deno.test("formatAnalysisDate - invalid/missing date returns ''", () => {
+  assertEquals(GRQFreshness.formatAnalysisDate(new Date("nonsense")), "");
+  assertEquals(
+    GRQFreshness.formatAnalysisDate(undefined as unknown as Date),
+    "",
+  );
+});
+
+// --- the age line: singular / plural / same-day / negative ------------------
+
+Deno.test("analysisAgeLine - plural days before score date", () => {
+  assertEquals(
+    GRQFreshness.analysisAgeLine(5),
+    "5 days before score date",
+  );
+});
+
+Deno.test("analysisAgeLine - singular day", () => {
+  assertEquals(
+    GRQFreshness.analysisAgeLine(1),
+    "1 day before score date",
+  );
+});
+
+Deno.test("analysisAgeLine - zero is the same-day case", () => {
+  assertEquals(
+    GRQFreshness.analysisAgeLine(0),
+    "same day as score date",
+  );
+});
+
+Deno.test("analysisAgeLine - negative age explains the ⚠️ pipeline error", () => {
+  const line = GRQFreshness.analysisAgeLine(-1);
+  assertStringIncludes(line, "⚠️");
+  assertStringIncludes(line, "AFTER the score date");
+  // Must NOT pretend it is an ordinary age line.
+  assert(!line.includes("before score date"));
+});
+
+// --- the full appended section ----------------------------------------------
+
+Deno.test("freshnessSection - date + plural age relative to score date", () => {
+  const section = GRQFreshness.freshnessSection(new Date(2026, 5, 20), 5);
+  assertStringIncludes(section, "20 Jun 2026");
+  assertStringIncludes(section, "5 days before score date");
+});
+
+Deno.test("freshnessSection - same-day case", () => {
+  const section = GRQFreshness.freshnessSection(new Date(2026, 5, 25), 0);
+  assertStringIncludes(section, "25 Jun 2026");
+  assertStringIncludes(section, "same day as score date");
+});
+
+Deno.test("freshnessSection - negative age shows the ⚠️ explanation", () => {
+  const section = GRQFreshness.freshnessSection(new Date(2026, 5, 30), -3);
+  assertStringIncludes(section, "30 Jun 2026");
+  assertStringIncludes(section, "⚠️");
+  assertStringIncludes(section, "AFTER the score date");
+  assert(!section.includes("before score date"));
+});


### PR DESCRIPTION
# Stars click-popover: show exact analysis age + date (#550)

## Summary

The Stars "show the working" click-popover now appends a **freshness section**
giving the **exact analysis date** and the **whole-day age of that analysis
relative to the viewed score date** — the precise number behind the inline
freshness emoji (issue #547). For example:

```
Analysis freshness:
= Analysed: 20 Jun 2026
= 5 days before score date
```

The age is **always measured against the viewed score date, never against
today** — the dashboard judges how good the prediction was on the chosen date.

Edge cases handled:

- **Singular vs plural** — `1 day before score date` vs `N days before score date`.
- **Same day** — age `0` → `same day as score date`.
- **Negative age** (analysis dated *after* the score date, a data-pipeline
  invariant violation) → the age line is replaced with
  `⚠️ analysed AFTER the score date (data-pipeline error — should never happen)`,
  mirroring the inline `⚠️` from #547.
- **No analysis data** — the existing
  `No analysis data available for this stock` branch is unchanged (the
  freshness section is only appended when an analysis row exists).

Closes #550.

## Design

The age/date formatting lives in a new **pure classic script**
`docs/freshness_text.js`, published on `globalThis.GRQFreshness`, mirroring
`docs/field_label.js` (#542). This lets the browser dashboard (`docs/app.js`)
and the Deno tests exercise **exactly the same code**. The date is formatted
manually (`20 Jun 2026`) rather than via `toLocaleDateString`, because Deno's
ICU build renders the `"short"` month as the full name (`June`) — the manual
short-month table is deterministic in both the browser and the tests.

`docs/app.js` `case "stars":` reads `this.analysisData[stockSymbol]` (its
`date` and signed `signedDaysFromScore` fields from #547) and appends
`GRQFreshness.freshnessSection(...)` to the working text.

The new script is loaded before `app.js` in both `docs/index.html` and
`docs/trend.html`, added to the service-worker precache list in `docs/sw.js`,
and the app version is bumped `1.1.7 → 1.1.8` so existing clients re-precache.

```mermaid
flowchart LR
    A["analysisData[stock]<br/>(date, signedDaysFromScore #547)"] --> B["GRQFreshness.freshnessSection()"]
    B --> C{"signedDaysFromScore"}
    C -->|"&lt; 0"| D["⚠️ analysed AFTER<br/>the score date"]
    C -->|"= 0"| E["same day as score date"]
    C -->|"= 1"| F["1 day before score date"]
    C -->|"&gt; 1"| G["N days before score date"]
    D --> H["Stars popover text"]
    E --> H
    F --> H
    G --> H
```

## Evidence

Playwright MCP was unavailable in this run, so UI evidence is the **actual
rendered popover text** produced by the real shared module
(`docs/freshness_text.js`) driven from the same inputs the dashboard supplies:

```
Stock: NYSE:SCHW | Field: Stars | Score Date: 2026-06-25

Stars working:
= MorningStar: 4 stars
= Tips Stars: 6 stars (normalized to 3.0 stars)
= Average: (4 stars + 3.0 stars) / 2 = 3.50 stars

Rounding to nearest quarter:
= 3.50 × 20 = 70.0
= Rounded to 70 twentieths
= Full stars: 70 ÷ 20 = 3
= Remainder: 70 - (3 × 20) = 10 twentieths
= Partial stars: 10 ÷ 5 = 2.0 → 2 quarters
= Moon phase: 🌓 (half moon)
= Display: 🌟🌟🌟🌓

Analysis freshness:
= Analysed: 20 Jun 2026
= 5 days before score date
```

Edge-case sections (same inputs, different ages):

```
= Analysed: 25 Jun 2026
= same day as score date
---
= Analysed: 24 Jun 2026
= 1 day before score date
---
= Analysed: 27 Jun 2026
= ⚠️ analysed AFTER the score date (data-pipeline error — should never happen)
```

## Test Plan

- **New** `tests/stars_popover_freshness_test.ts` — exercises the shared
  `GRQFreshness` helpers:
  - `formatAnalysisDate` — `20 Jun 2026` / `1 Jan 2025` / `31 Dec 2024`, and
    `''` for invalid/missing dates.
  - `analysisAgeLine` — plural, singular, zero (same-day) and negative
    (⚠️ pipeline error) cases, asserting the negative case never reads as an
    ordinary age line.
  - `freshnessSection` — date + age appear together for plural, same-day and
    negative inputs.
- Full suite green: `deno test` → **995 passed, 0 failed**.
- `./quality.sh` passes cleanly (lint, type-check, Rust, Deno tests).
