### PR TITLE
Quantify Target/Actual price-basis bias: training low vs dashboard mid (#552)

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,9 @@ GRQ-validation/
 ├── scripts/                # Utility scripts
 │   ├── bump_version.ts            # CI app-version incrementer (#323)
 │   ├── fetch_market_indices.ts    # Server-side benchmark-index fetcher
-│   └── refresh_market_indices.ts  # Non-blocking daily-scorer wrapper (#238)
+│   ├── refresh_market_indices.ts  # Non-blocking daily-scorer wrapper (#238)
+│   ├── price_basis_diagnostic.ts  # mid-vs-low basis bias computation (#552)
+│   └── diagnose_price_basis.ts    # CLI report for the basis diagnostic (#552)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,8 @@
 {
   "tasks": {
     "fetch-indices": "deno run --allow-net --allow-read --allow-write scripts/fetch_market_indices.ts",
-    "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts"
+    "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts",
+    "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/docs/archive/investigations/issue-552-price-basis-bias.md
+++ b/docs/archive/investigations/issue-552-price-basis-bias.md
@@ -1,0 +1,121 @@
+# Price-basis bias: training intraday-low vs dashboard midpoint
+
+_Diagnostic for Issue #552 (sub-issue of #544 — one candidate source of the
+systematic Target-over-Actual measurement gap). Measurement lives in
+`GRQ-validation`; the root price-basis decision lives upstream in `GRQ`._
+
+## TL;DR
+
+The GRQ model is trained on a return label measured at the **intraday low** of
+the trading day 90 days ahead, but the validation dashboard measures **Actual**
+at the **midpoint** `(high + low) / 2` of the horizon row. Because `mid >= low`
+on every row, the mid basis **lifts** the measured Actual.
+
+Over the matured historical score set (274 score dates, 5 444 included
+stock-rows, as-of 2026-06-26) the basis offset `(mid - low) / buyPrice` is:
+
+| Statistic | Value |
+| --- | --- |
+| Mean | **+2.235 pp** |
+| Median | +1.546 pp |
+| Min | +0.000 pp |
+| Max | +93.273 pp (thin, low-priced outlier) |
+| Std dev | 3.216 pp |
+
+**Sign and netting.** The offset is **non-negative on every row** (sign **+**).
+Measuring Actual at the higher mid makes Actual larger, which **narrows / masks**
+the Target-over-Actual gap — the *opposite* direction to the observed gap. So
+this candidate **offsets** the gap rather than causing it:
+
+| Quantity (mean over matured dates) | Value |
+| --- | --- |
+| Mean Target % | 28.916 % |
+| Mean Actual % (mid — current dashboard) | 10.447 % |
+| Mean Actual % (low — trained basis) | 8.204 % |
+| **Observed gap** (Target − Actual, mid) | **+18.470 pp** |
+| Gap on the trained low basis | +20.712 pp |
+| **Basis contribution** (low − mid gap) | **+2.242 pp** |
+
+Restating Actual onto the basis the model was trained on (intraday low) would
+**widen** the apparent gap by ~**2.24 pp**, from ~18.5 pp to ~20.7 pp. Genuine
+model optimism (and the remaining candidates in #544) must therefore explain a
+gap that is *larger* than the headline figure, not smaller.
+
+> The per-row equal-weight mean (+2.235 pp) and the per-date portfolio-level
+> contribution (+2.242 pp) agree to within rounding, confirming the offset is a
+> broad, structural feature rather than an artefact of a few dates.
+
+## Acceptance criteria
+
+1. **Numeric aggregate contribution (pp) with sign** — mean basis offset
+   **+2.235 pp** (per row) / **+2.242 pp** (portfolio-level); always `>= 0`.
+2. **Widens or narrows the observed gap** — the mid basis **narrows (masks)**
+   the gap; switching to the trained low basis **widens** it by ~2.24 pp.
+3. **Fix-vs-leave recommendation** — see below.
+
+## Recommendation: confirm the asymmetry, but **leave the dashboard basis as-is**
+for now (low-priority hygiene fix only)
+
+A real, structural asymmetry **is** confirmed (a consistent, same-direction
+~2.2 pp offset), so a fix is *justifiable* on like-for-like grounds. However:
+
+- Correcting it **does not close** the Target-over-Actual gap — it **widens**
+  it. This candidate is therefore **exonerated as a cause** of the reported
+  symptom; it was partially *hiding* the gap.
+- The mid basis is also the more defensible figure to **show a user** as the
+  "Actual" return: the midpoint is an unbiased intraday estimate, whereas the
+  intraday low systematically understates what a holder realised. Switching the
+  user-facing Actual to the low purely to match a training artefact would make
+  the dashboard's headline returns look worse than reality.
+
+**Therefore:** the milestone should keep chasing genuine model optimism and the
+other #544 candidates (dividend timing, buy-price denominator, score decoding)
+as the real drivers. If a fully like-for-like trend comparison is later wanted,
+the cleaner fix is to **restate the model Target onto the midpoint basis**
+(upstream in `GRQ`) — i.e. train/evaluate both series on one consistent basis —
+rather than degrade the dashboard's user-facing Actual to the intraday low. That
+is a separate, low-priority piece of measurement hygiene, not a gap-closing fix.
+
+## How this was measured (reproducible)
+
+Every per-stock figure is delegated to the **shipped** kernels so the diagnostic
+measures the dashboard's own basis, not a re-implementation:
+
+- `GRQProjection.getBuyPrice` — split-adjusted midpoint buy price.
+- `GRQProjection.priceAtNinetyDayHorizon` — Actual on the **mid** basis.
+- `GRQProjection.lowPriceAtNinetyDayHorizon` — Actual on the **low** basis
+  (added for this diagnostic; mirrors the mid helper's horizon selection so both
+  pick the same row).
+- `GRQProjection.priceBasisOffsetPercent` — `(mid - low) / buyPrice * 100`.
+- `GRQProjection.isStockIncluded` — restricts to the same included set the
+  dashboard aggregates over.
+
+```bash
+deno task diagnose-price-basis            # against docs/, as-of today
+# raw form (pin an as-of date for a reproducible report):
+deno run --allow-read scripts/diagnose_price_basis.ts docs 2026-06-26
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>split-adjusted mid]
+    B --> D[priceAtNinetyDayHorizon<br/>Actual = mid]
+    B --> E[lowPriceAtNinetyDayHorizon<br/>Actual = low]
+    D --> F[priceBasisOffsetPercent<br/>= mid - low / buyPrice]
+    E --> F
+    C --> F
+    F --> G[aggregate: mean/median/dist<br/>+ net vs observed gap]
+```
+
+## Code references
+
+- Training label (intraday low, 90 days ahead): `GRQ/src/LearnUtil.ts`
+  (`market.lowPrice(symbol, targetDate)`).
+- Dashboard Actual (midpoint): `GRQ-validation/docs/projection.js`
+  — `currentPriceFromLatest`, `priceAtNinetyDayHorizon`.
+- Matching low basis + offset helper: `GRQ-validation/docs/projection.js`
+  — `lowPriceAtNinetyDayHorizon`, `priceBasisOffsetPercent` (this issue).
+- Diagnostic: `scripts/diagnose_price_basis.ts`,
+  `scripts/price_basis_diagnostic.ts`;
+  tests `tests/price_basis_diagnostic_test.ts`.

--- a/docs/archive/pr-summaries/pr-summary-552.md
+++ b/docs/archive/pr-summaries/pr-summary-552.md
@@ -1,0 +1,84 @@
+## Summary
+
+Quantifies the Target/Actual measurement bias that comes purely from the **price
+basis** mismatch between training and the dashboard (one candidate source in the
+#544 milestone breakdown). The GRQ model is trained on the **intraday low** of
+the trading day 90 days ahead, while the dashboard measures **Actual** at the
+**midpoint** `(high + low) / 2`. Because `mid >= low` on every row this is a
+structural, same-direction offset.
+
+The deliverable is a **written diagnostic** plus a reproducible analysis, both
+computed with the dashboard's own shipped kernels. Over the matured historical
+score set (274 score dates, 5 444 included stock-rows, as-of 2026-06-26):
+
+- Mean per-row basis offset `(mid - low) / buyPrice` = **+2.235 pp** (median
+  +1.546 pp, std dev 3.216 pp); **non-negative on every row** (sign **+**).
+- The mid basis **narrows / masks** the gap rather than causing it: the observed
+  Target-over-Actual gap is **+18.470 pp** on the mid basis and **+20.712 pp** on
+  the trained low basis — restating Actual onto the trained basis **widens** the
+  gap by **+2.242 pp**.
+- **Recommendation:** the asymmetry is real but this candidate is **exonerated as
+  a cause** — correcting it widens, not closes, the gap. Leave the dashboard's
+  user-facing Actual on the (unbiased) midpoint; if a fully like-for-like
+  comparison is later wanted, restate the *Target* onto the midpoint basis
+  upstream in `GRQ`. Genuine model optimism and the other #544 candidates remain
+  the drivers to chase.
+
+Full write-up: `docs/archive/investigations/issue-552-price-basis-bias.md`.
+
+Closes #552.
+
+### Deno regression avoided
+
+This is a Deno repo; the diagnostic ships as Deno-native TypeScript run via
+`deno task diagnose-price-basis` (and `deno test`), with no Node tooling
+introduced.
+
+## Evidence
+
+Backend/CLI diagnostic — no web UI to screenshot. Verified by the new test
+suite and by running the diagnostic against the committed score data:
+
+```text
+$ deno task diagnose-price-basis docs 2026-06-26
+Matured score dates:   274
+Included stock-rows:   5444
+## Per-row basis offset (mid - low) / buyPrice
+Mean:                  +2.235 pp
+Median:                +1.546 pp
+Min:                   +0.000 pp
+Max:                   +93.273 pp
+Std dev:               3.216 pp
+Observed gap (T-A,mid):+18.470 pp
+Gap on low basis:      +20.712 pp
+Basis contribution:    +2.242 pp
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>split-adjusted mid]
+    B --> D[priceAtNinetyDayHorizon<br/>Actual = mid]
+    B --> E[lowPriceAtNinetyDayHorizon<br/>Actual = low]
+    C --> F[priceBasisOffsetPercent<br/>= mid - low / buyPrice]
+    D --> F
+    E --> F
+    F --> G[aggregate + net vs observed gap]
+```
+
+## Test Plan
+
+New tests in `tests/price_basis_diagnostic_test.ts` (all exercise real shipped
+kernels / aggregation with synthetic data — no source-text grepping):
+
+- `lowPriceAtNinetyDayHorizon` returns the in-window low, picks the **same row**
+  as `priceAtNinetyDayHorizon`, and guards empty/null data.
+- `priceBasisOffsetPercent` computes `(mid - low) / buyPrice * 100`, is always
+  `>= 0` when `mid >= low`, and guards bad inputs.
+- `summariseOffsets` mean/median/min/max/stdDev plus the empty case.
+- `aggregateDate` measures the per-row offset over included stocks and confirms
+  the mid-vs-low Actual difference equals the offset.
+- `buildReport` confirms the basis contribution **widens** the gap and the
+  verdict states the masking sign.
+
+Existing suite unchanged: `deno test --allow-read tests/*.ts` → 1010 passed.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -582,6 +582,46 @@ function priceAtNinetyDayHorizon(marketData, scoreDate) {
     return (lastData.high + lastData.low) / 2;
 }
 
+// Intraday LOW of the last market-data point on or before the 90-day horizon —
+// the price basis the GRQ model is TRAINED on (GRQ/src/LearnUtil.ts uses
+// `market.lowPrice(symbol, targetDate)` for the 90-day return label). The
+// dashboard measures Actual at the midpoint (priceAtNinetyDayHorizon); this
+// helper exposes the matching low so a like-for-like, same-basis comparison can
+// be made (issue #552). Mirrors priceAtNinetyDayHorizon's horizon selection
+// exactly so the two pick the SAME row. Returns null when there is no usable
+// data on or before the horizon.
+function lowPriceAtNinetyDayHorizon(marketData, scoreDate) {
+    if (!marketData || marketData.length === 0) return null;
+    const ninetyDayDate = new Date(
+        scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+    );
+    const within90Days = marketData.filter((point) =>
+        point.date <= ninetyDayDate
+    );
+    if (within90Days.length === 0) return null;
+    return within90Days[within90Days.length - 1].low;
+}
+
+// Price-basis offset between the dashboard's midpoint Actual and the model's
+// trained intraday-low basis, expressed as a percentage of the buy price
+// (issue #552): `(mid - low) / buyPrice * 100`. This is the amount the measured
+// Actual % is LIFTED by reading the horizon at the midpoint rather than the low
+// the model was trained to hit. Because `mid >= low` on every row the offset is
+// always >= 0, so it NARROWS (masks) any Target-over-Actual gap rather than
+// causing it. Returns null when any input is missing or the buy price is not a
+// positive number.
+function priceBasisOffsetPercent(buyPrice, midPrice, lowPrice) {
+    if (
+        buyPrice === null || buyPrice === undefined || Number.isNaN(buyPrice) ||
+        buyPrice <= 0 ||
+        midPrice === null || midPrice === undefined || Number.isNaN(midPrice) ||
+        lowPrice === null || lowPrice === undefined || Number.isNaN(lowPrice)
+    ) {
+        return null;
+    }
+    return ((midPrice - lowPrice) / buyPrice) * 100;
+}
+
 // Target return as a percentage of the buy price. Returns null when either input
 // is missing, matching the dashboard's guard before reporting a target figure.
 function calculateTargetPercentage(buyPrice, adjustedTarget) {
@@ -1053,6 +1093,8 @@ globalThis.GRQProjection = {
     getBuyPrice,
     currentPriceFromLatest,
     priceAtNinetyDayHorizon,
+    lowPriceAtNinetyDayHorizon,
+    priceBasisOffsetPercent,
     calculateTargetPercentage,
     calculatePortfolioTargetPercentage,
     getFairValueRange,

--- a/scripts/diagnose_price_basis.ts
+++ b/scripts/diagnose_price_basis.ts
@@ -1,0 +1,55 @@
+// Diagnostic for issue #552 (milestone #544): quantify the Target/Actual bias
+// that comes purely from the price BASIS mismatch between training and the
+// dashboard.
+//
+//   - The GRQ model is trained on the intraday LOW of the trading day 90 days
+//     ahead (GRQ/src/LearnUtil.ts -> market.lowPrice(symbol, targetDate)).
+//   - The dashboard measures Actual at the MIDPOINT (high + low) / 2 of the last
+//     point on or before the 90-day horizon (docs/projection.js).
+//
+// Because mid >= low on every row, reading Actual at the mid LIFTS the measured
+// Actual %, which NARROWS (masks) any Target-over-Actual gap. This script
+// quantifies that offset over the matured historical score set so we know how
+// much of the residual gap genuine model optimism still has to explain.
+//
+// It reuses the SHIPPED kernels — GRQProjection.getBuyPrice,
+// priceAtNinetyDayHorizon, lowPriceAtNinetyDayHorizon, priceBasisOffsetPercent
+// and isStockIncluded, plus the GRQTrendPredictions CSV/TSV parsers — so the
+// numbers it reports are computed on exactly the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_price_basis.ts [docsPath]
+// (default docsPath = "docs"). Read-only; prints a Markdown-friendly report.
+
+import { computePriceBasisDiagnostic } from "./price_basis_diagnostic.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+// "Today" governs which score dates have a complete 90-day window. Default to
+// the real clock; allow an override (second arg, YYYY-MM-DD) for reproducible
+// reports pinned to a specific as-of date.
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+
+const report = await computePriceBasisDiagnostic(docsPath, asOf);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(`# Price-basis (mid vs low) diagnostic — issue #552\n`);
+console.log(`As-of date:            ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Matured score dates:   ${report.maturedDates}`);
+console.log(`Included stock-rows:   ${report.rowCount}`);
+console.log("");
+console.log(`## Per-row basis offset (mid - low) / buyPrice`);
+console.log(`Mean:                  ${pp(report.meanOffsetPp)}`);
+console.log(`Median:                ${pp(report.medianOffsetPp)}`);
+console.log(`Min:                   ${pp(report.minOffsetPp)}`);
+console.log(`Max:                   ${pp(report.maxOffsetPp)}`);
+console.log(`Std dev:               ${report.stdDevPp.toFixed(3)} pp`);
+console.log("");
+console.log(`## Per-date portfolio aggregates (mean over matured dates)`);
+console.log(`Mean Target %:         ${report.meanTargetPct.toFixed(3)} %`);
+console.log(`Mean Actual % (mid):   ${report.meanActualMidPct.toFixed(3)} %`);
+console.log(`Mean Actual % (low):   ${report.meanActualLowPct.toFixed(3)} %`);
+console.log(`Observed gap (T-A,mid):${pp(report.observedGapPp)}`);
+console.log(`Gap on low basis:      ${pp(report.gapOnLowBasisPp)}`);
+console.log(`Basis contribution:    ${pp(report.basisContributionPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/scripts/price_basis_diagnostic.ts
+++ b/scripts/price_basis_diagnostic.ts
@@ -1,0 +1,240 @@
+// Core computation for the issue #552 price-basis diagnostic.
+//
+// Splits the pure aggregation (testable with synthetic rows, no disk) from the
+// file IO. Every per-stock figure is delegated to the SHIPPED kernels published
+// on globalThis by docs/projection.js and docs/trend_predictions.js, so the
+// diagnostic measures the dashboard's own basis rather than a re-implementation.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Summary statistics for a list of per-row basis offsets (percentage points). */
+export interface OffsetSummary {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  stdDev: number;
+}
+
+/** Pure stats over a list of numbers. Empty input yields all-zero summary. */
+export function summariseOffsets(values: number[]): OffsetSummary {
+  const finite = values.filter((v) =>
+    typeof v === "number" && !Number.isNaN(v)
+  );
+  if (finite.length === 0) {
+    return { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 };
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  const sum = finite.reduce((t, v) => t + v, 0);
+  const mean = sum / finite.length;
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+  const variance = finite.reduce((t, v) => t + (v - mean) ** 2, 0) /
+    finite.length;
+  return {
+    count: finite.length,
+    mean,
+    median,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+/** One matured score date's portfolio figures on both price bases. */
+export interface DateAggregate {
+  date: string;
+  targetPct: number | null;
+  actualMidPct: number | null;
+  actualLowPct: number | null;
+  rowOffsetsPp: number[];
+}
+
+// Build the mid-basis and low-basis per-stock inputs for one score date and
+// compute the portfolio Target %, Actual % (mid) and Actual % (low), plus the
+// per-row (mid - low) / buyPrice offsets over the INCLUDED stocks. Pure: the
+// caller supplies already-parsed score rows and the market-data map.
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  dividendData: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  const midStocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+
+  const rowOffsetsPp: number[] = [];
+  // deno-lint-ignore no-explicit-any
+  const lowStocks = midStocks.map((stock: any, i: number) => {
+    const points = marketData[scoreRows[i].stock];
+    const low = P.lowPriceAtNinetyDayHorizon(points, scoreDate);
+    const offset = P.priceBasisOffsetPercent(
+      stock.buyPrice,
+      stock.currentPrice,
+      low,
+    );
+    const included = P.isStockIncluded(
+      stock.buyPrice,
+      stock.currentPrice,
+      stock.splitReliable,
+    );
+    if (included && offset !== null) {
+      rowOffsetsPp.push(offset);
+    }
+    // Same stock, Actual measured at the trained low basis instead of mid.
+    return { ...stock, currentPrice: low };
+  });
+
+  return {
+    date,
+    targetPct: P.calculatePortfolioTargetPercentage(midStocks),
+    actualMidPct: P.calculateIncludedPortfolioPerformance(midStocks),
+    actualLowPct: P.calculateIncludedPortfolioPerformance(lowStocks),
+    rowOffsetsPp,
+  };
+}
+
+/** The full diagnostic result over the matured historical score set. */
+export interface PriceBasisReport {
+  maturedDates: number;
+  rowCount: number;
+  meanOffsetPp: number;
+  medianOffsetPp: number;
+  minOffsetPp: number;
+  maxOffsetPp: number;
+  stdDevPp: number;
+  meanTargetPct: number;
+  meanActualMidPct: number;
+  meanActualLowPct: number;
+  observedGapPp: number;
+  gapOnLowBasisPp: number;
+  basisContributionPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Assemble the report from per-date aggregates. Pure so it can be unit-tested
+// with synthetic DateAggregate rows.
+export function buildReport(aggregates: DateAggregate[]): PriceBasisReport {
+  const allOffsets = aggregates.flatMap((a) => a.rowOffsetsPp);
+  const stats = summariseOffsets(allOffsets);
+
+  const withFigures = aggregates.filter((a) =>
+    a.targetPct !== null && a.actualMidPct !== null &&
+    a.actualLowPct !== null
+  );
+  const meanTargetPct = mean(withFigures.map((a) => a.targetPct as number));
+  const meanActualMidPct = mean(
+    withFigures.map((a) => a.actualMidPct as number),
+  );
+  const meanActualLowPct = mean(
+    withFigures.map((a) => a.actualLowPct as number),
+  );
+  const observedGapPp = meanTargetPct - meanActualMidPct;
+  const gapOnLowBasisPp = meanTargetPct - meanActualLowPct;
+  const basisContributionPp = gapOnLowBasisPp - observedGapPp;
+
+  const verdict =
+    `VERDICT: the midpoint basis lifts Actual by a mean ${
+      stats.mean.toFixed(3)
+    } pp versus the trained intraday-low basis. The offset is >= 0 on every ` +
+    `row, so it NARROWS (masks) the Target-over-Actual gap; restating Actual ` +
+    `onto the trained low basis would WIDEN the observed gap by ` +
+    `${basisContributionPp.toFixed(3)} pp. This candidate therefore offsets, ` +
+    `rather than causes, the gap — genuine model optimism must exceed the ` +
+    `raw observed gap by this amount.`;
+
+  return {
+    maturedDates: aggregates.length,
+    rowCount: stats.count,
+    meanOffsetPp: stats.mean,
+    medianOffsetPp: stats.median,
+    minOffsetPp: stats.min,
+    maxOffsetPp: stats.max,
+    stdDevPp: stats.stdDev,
+    meanTargetPct,
+    meanActualMidPct,
+    meanActualLowPct,
+    observedGapPp,
+    gapOnLowBasisPp,
+    basisContributionPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+// Load the matured score set from disk and compute the full diagnostic.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+export async function computePriceBasisDiagnostic(
+  docsPath: string,
+  asOf: Date,
+): Promise<PriceBasisReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    const scoreRows = TP.parseScoreTsv(tsvText);
+    const marketData = TP.parseMarketCsv(csvText);
+    const dividendData = TP.parseDividendCsv(divText);
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        scoreRows,
+        marketData,
+        dividendData,
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReport(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/tests/price_basis_diagnostic_test.ts
+++ b/tests/price_basis_diagnostic_test.ts
@@ -1,0 +1,181 @@
+// Tests for the issue #552 price-basis (mid vs low) diagnostic.
+//
+// These exercise the REAL shipped kernels (docs/projection.js) and the real
+// aggregation in scripts/price_basis_diagnostic.ts with synthetic market data,
+// asserting on computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReport,
+  type DateAggregate,
+  summariseOffsets,
+} from "../scripts/price_basis_diagnostic.ts";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+Deno.test("lowPriceAtNinetyDayHorizon returns the low of the last in-window point", () => {
+  const scoreDate = midnight("2026-01-01");
+  const market = [
+    { date: midnight("2026-01-02"), high: 10, low: 9 },
+    { date: midnight("2026-03-30"), high: 12, low: 11 }, // within 90 days
+    { date: midnight("2026-05-30"), high: 20, low: 19 }, // beyond horizon
+  ];
+  assertEquals(P.lowPriceAtNinetyDayHorizon(market, scoreDate), 11);
+});
+
+Deno.test("lowPriceAtNinetyDayHorizon picks the SAME row as priceAtNinetyDayHorizon", () => {
+  const scoreDate = midnight("2026-01-01");
+  const market = [
+    { date: midnight("2026-02-01"), high: 12, low: 8 },
+    { date: midnight("2026-03-15"), high: 16, low: 10 },
+  ];
+  const low = P.lowPriceAtNinetyDayHorizon(market, scoreDate);
+  const mid = P.priceAtNinetyDayHorizon(market, scoreDate);
+  assertEquals(low, 10);
+  assertEquals(mid, (16 + 10) / 2);
+});
+
+Deno.test("lowPriceAtNinetyDayHorizon returns null with no usable data", () => {
+  assertEquals(P.lowPriceAtNinetyDayHorizon([], midnight("2026-01-01")), null);
+  assertEquals(
+    P.lowPriceAtNinetyDayHorizon(null, midnight("2026-01-01")),
+    null,
+  );
+});
+
+Deno.test("priceBasisOffsetPercent computes (mid - low) / buyPrice * 100", () => {
+  // buyPrice 100, mid 110, low 105 -> 5%
+  assertAlmostEquals(P.priceBasisOffsetPercent(100, 110, 105), 5);
+  // mid == low -> zero offset (the only-in-aggregate, same-direction case)
+  assertEquals(P.priceBasisOffsetPercent(100, 110, 110), 0);
+});
+
+Deno.test("priceBasisOffsetPercent is always >= 0 when mid >= low", () => {
+  for (
+    const [buy, mid, low] of [[50, 60, 55], [10, 10.1, 9.9], [200, 200, 200]]
+  ) {
+    const offset = P.priceBasisOffsetPercent(buy, mid, low);
+    assert(offset !== null && offset >= 0, `offset ${offset} should be >= 0`);
+  }
+});
+
+Deno.test("priceBasisOffsetPercent guards bad inputs", () => {
+  assertEquals(P.priceBasisOffsetPercent(0, 10, 9), null);
+  assertEquals(P.priceBasisOffsetPercent(-5, 10, 9), null);
+  assertEquals(P.priceBasisOffsetPercent(100, null, 9), null);
+  assertEquals(P.priceBasisOffsetPercent(100, 10, NaN), null);
+});
+
+Deno.test("summariseOffsets computes mean/median/min/max/stdDev", () => {
+  const s = summariseOffsets([1, 2, 3, 4]);
+  assertEquals(s.count, 4);
+  assertAlmostEquals(s.mean, 2.5);
+  assertAlmostEquals(s.median, 2.5);
+  assertEquals(s.min, 1);
+  assertEquals(s.max, 4);
+  assertAlmostEquals(s.stdDev, Math.sqrt(1.25));
+});
+
+Deno.test("summariseOffsets handles empty input", () => {
+  const s = summariseOffsets([]);
+  assertEquals(s, { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 });
+});
+
+Deno.test("aggregateDate measures the per-row mid-vs-low offset over included stocks", () => {
+  const scoreDate = midnight("2026-01-01");
+  // One stock: buy near 100 (mid of first day), horizon mid 110, low 100.
+  const scoreRows = [{
+    stock: "X",
+    target: 130,
+    score: 0.5,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    X: [
+      {
+        date: midnight("2026-01-02"),
+        high: 101,
+        low: 99,
+        open: 100,
+        close: 100,
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 120,
+        low: 100,
+        open: 110,
+        close: 115,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, scoreDate);
+  // buyPrice = mid of 2026-01-02 = 100; horizon mid = 110, low = 100.
+  // offset = (110 - 100) / 100 * 100 = 10 pp.
+  assertEquals(agg.rowOffsetsPp.length, 1);
+  assertAlmostEquals(agg.rowOffsetsPp[0], 10, 1e-9);
+  // Actual(mid) uses 110 -> +10%; Actual(low) uses 100 -> 0%. Difference 10 pp.
+  assert(agg.actualMidPct !== null && agg.actualLowPct !== null);
+  assertAlmostEquals(
+    (agg.actualMidPct as number) - (agg.actualLowPct as number),
+    10,
+    1e-9,
+  );
+});
+
+Deno.test("buildReport: basis contribution widens the gap and verdict states the sign", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetPct: 25,
+      actualMidPct: 10,
+      actualLowPct: 6,
+      rowOffsetsPp: [3, 5],
+    },
+    {
+      date: "2026-02-01",
+      targetPct: 15,
+      actualMidPct: 8,
+      actualLowPct: 6,
+      rowOffsetsPp: [1, 3],
+    },
+  ];
+  const r = buildReport(aggregates);
+  assertEquals(r.maturedDates, 2);
+  assertEquals(r.rowCount, 4);
+  assertAlmostEquals(r.meanOffsetPp, 3); // (3+5+1+3)/4
+  // mean Target 20, mean Actual(mid) 9 -> observed gap 11; Actual(low) 6 -> 14.
+  assertAlmostEquals(r.observedGapPp, 11);
+  assertAlmostEquals(r.gapOnLowBasisPp, 14);
+  assertAlmostEquals(r.basisContributionPp, 3); // 14 - 11
+  assert(r.basisContributionPp > 0, "low basis should WIDEN the gap");
+  assert(
+    r.verdict.includes("NARROWS") && r.verdict.includes("WIDEN"),
+    "verdict states the masking sign",
+  );
+});
+
+Deno.test("buildReport: all offsets non-negative implies a non-negative mean", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetPct: 20,
+      actualMidPct: 10,
+      actualLowPct: 8,
+      rowOffsetsPp: [0, 2, 4],
+    },
+  ];
+  const r = buildReport(aggregates);
+  assert(r.meanOffsetPp >= 0);
+  assert(r.basisContributionPp >= 0);
+});


### PR DESCRIPTION
## Summary

Quantifies the Target/Actual measurement bias that comes purely from the **price
basis** mismatch between training and the dashboard (one candidate source in the
\#544 milestone breakdown). The GRQ model is trained on the **intraday low** of
the trading day 90 days ahead, while the dashboard measures **Actual** at the
**midpoint** `(high + low) / 2`. Because `mid >= low` on every row this is a
structural, same-direction offset.

The deliverable is a **written diagnostic** plus a reproducible analysis, both
computed with the dashboard's own shipped kernels. Over the matured historical
score set (274 score dates, 5 444 included stock-rows, as-of 2026-06-26):

- Mean per-row basis offset `(mid - low) / buyPrice` = **+2.235 pp** (median
  +1.546 pp, std dev 3.216 pp); **non-negative on every row** (sign **+**).
- The mid basis **narrows / masks** the gap rather than causing it: the observed
  Target-over-Actual gap is **+18.470 pp** on the mid basis and **+20.712 pp** on
  the trained low basis — restating Actual onto the trained basis **widens** the
  gap by **+2.242 pp**.
- **Recommendation:** the asymmetry is real but this candidate is **exonerated as
  a cause** — correcting it widens, not closes, the gap. Leave the dashboard's
  user-facing Actual on the (unbiased) midpoint; if a fully like-for-like
  comparison is later wanted, restate the *Target* onto the midpoint basis
  upstream in `GRQ`. Genuine model optimism and the other #544 candidates remain
  the drivers to chase.

Full write-up: `docs/archive/investigations/issue-552-price-basis-bias.md`.

Closes #552.

### Deno regression avoided

This is a Deno repo; the diagnostic ships as Deno-native TypeScript run via
`deno task diagnose-price-basis` (and `deno test`), with no Node tooling
introduced.

## Evidence

Backend/CLI diagnostic — no web UI to screenshot. Verified by the new test
suite and by running the diagnostic against the committed score data:

```text
$ deno task diagnose-price-basis docs 2026-06-26
Matured score dates:   274
Included stock-rows:   5444
## Per-row basis offset (mid - low) / buyPrice
Mean:                  +2.235 pp
Median:                +1.546 pp
Min:                   +0.000 pp
Max:                   +93.273 pp
Std dev:               3.216 pp
Observed gap (T-A,mid):+18.470 pp
Gap on low basis:      +20.712 pp
Basis contribution:    +2.242 pp
```

```mermaid
flowchart LR
    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv/dividends]
    B --> C[getBuyPrice<br/>split-adjusted mid]
    B --> D[priceAtNinetyDayHorizon<br/>Actual = mid]
    B --> E[lowPriceAtNinetyDayHorizon<br/>Actual = low]
    C --> F[priceBasisOffsetPercent<br/>= mid - low / buyPrice]
    D --> F
    E --> F
    F --> G[aggregate + net vs observed gap]
```

## Test Plan

New tests in `tests/price_basis_diagnostic_test.ts` (all exercise real shipped
kernels / aggregation with synthetic data — no source-text grepping):

- `lowPriceAtNinetyDayHorizon` returns the in-window low, picks the **same row**
  as `priceAtNinetyDayHorizon`, and guards empty/null data.
- `priceBasisOffsetPercent` computes `(mid - low) / buyPrice * 100`, is always
  `>= 0` when `mid >= low`, and guards bad inputs.
- `summariseOffsets` mean/median/min/max/stdDev plus the empty case.
- `aggregateDate` measures the per-row offset over included stocks and confirms
  the mid-vs-low Actual difference equals the offset.
- `buildReport` confirms the basis contribution **widens** the gap and the
  verdict states the masking sign.

Existing suite unchanged: `deno test --allow-read tests/*.ts` → 1010 passed.



## Milestone
This PR is part of the **#544 Diagnose systematic Target-over-Actual gap in validation's measurement basis** milestone and targets the `milestone/544-diagnose-systematic-target-over-actual-gap-in` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqu36d3b-727e00`<!-- vibe-worker-issue-552 -->