### PR TITLE
Quantify Target/Actual dividend-basis bias (flat 1/4 vs windowed) (#553)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",

--- a/README.md
+++ b/README.md
@@ -424,7 +424,9 @@ GRQ-validation/
 │   ├── fetch_market_indices.ts    # Server-side benchmark-index fetcher
 │   ├── refresh_market_indices.ts  # Non-blocking daily-scorer wrapper (#238)
 │   ├── price_basis_diagnostic.ts  # mid-vs-low basis bias computation (#552)
-│   └── diagnose_price_basis.ts    # CLI report for the basis diagnostic (#552)
+│   ├── diagnose_price_basis.ts    # CLI report for the basis diagnostic (#552)
+│   ├── dividend_basis_diagnostic.ts # flat-1/4-vs-windowed dividend bias (#553)
+│   └── diagnose_dividend_basis.ts # CLI report for the dividend diagnostic (#553)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,8 @@
   "tasks": {
     "fetch-indices": "deno run --allow-net --allow-read --allow-write scripts/fetch_market_indices.ts",
     "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts",
-    "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts"
+    "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts",
+    "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/docs/archive/investigations/issue-553-dividend-basis-bias.md
+++ b/docs/archive/investigations/issue-553-dividend-basis-bias.md
@@ -1,0 +1,154 @@
+# Dividend-basis bias: flat training quarter vs windowed actual ex-dividends
+
+_Diagnostic for Issue #553 (sub-issue of #544 — one candidate source of the
+systematic Target-over-Actual measurement gap). The windowed credit lives in
+`GRQ-validation`; the flat training credit lives upstream in `GRQ`._
+
+## TL;DR
+
+GRQ training bakes a **flat** quarter of the trailing annual dividend,
+`core.yearOfDividends / 4`, into the total-return label for **every** stock —
+whether or not a dividend actually lands in the forward window
+(`GRQ/src/LearnUtil.ts:147-148`, built from `GRQ/src/CoreFeatures.ts`). The
+validation dashboard credits only the **actual ex-dividends inside the 90-day
+window** (`GRQ-validation/src/utils.rs` `calculate_dividends_for_period`,
+mirrored by the shipped JS kernels `filterDividendsWithin90Days` +
+`sumDividends`).
+
+Per matured row the diagnostic compares the two credits as a percentage of the
+buy price and aggregates the **mean difference and its sign**. Over the matured
+historical score set (274 score dates, 5 444 included stock-rows, as-of
+2026-06-26), `(flatCredit − windowedCredit) / buyPrice` is:
+
+| Statistic | Value |
+| --- | --- |
+| Mean (raw) | **+2.827 pp** |
+| Mean (1%-trimmed) | **+1.358 pp** |
+| Median | +0.000 pp |
+| Min | −116.652 pp (special distribution caught in-window, low-priced) |
+| Max | +277.778 pp (special distribution missed by the window, low-priced) |
+| Std dev | 20.174 pp |
+| Rows within ±1 pp | 86.4 % |
+
+| Dividend-return component (mean over included rows) | Value |
+| --- | --- |
+| Mean flat credit yield (`yearOfDividends / 4` / buy) | 3.656 % |
+| Mean realised in-window yield (dashboard Actual) | 0.829 % |
+| Included rows with **zero** in-window dividends | 45.2 % |
+
+**Sign and netting.** The mean difference is **positive (sign +)**: the flat
+training quarter is, on average, a **consistent over-credit** relative to the
+realised in-window dividends. Because the model's Target embeds the flat credit
+while the dashboard's Actual credits only realised in-window dividends, this
+dividend basis **contributes to (widens)** the Target-over-Actual gap — the
+**same** direction as the observed gap, unlike the price-basis candidate (#552),
+which *narrowed* it.
+
+The headline raw mean (+2.83 pp) is **lumpy and tail-driven**: 86.4 % of rows
+sit within ±1 pp and the median is exactly 0 (non-payers and quarterly payers
+roughly net out), but a handful of **special / liquidating distributions on
+low-priced stocks** (EQC, ELME, VISN) dominate both tails. The robust central
+estimate is therefore the **1%-trimmed mean ≈ +1.36 pp** (and the median 0).
+
+## Why the two sides diverge
+
+- **Cadence.** 45.2 % of included rows realise **no** dividend in their 90-day
+  window — semi-annual and annual payers contribute 0 to Actual in most windows
+  yet always receive the flat quarter in training. This is the dominant,
+  same-direction driver: their per-row difference is `+flatCredit/buy > 0`.
+- **Growth / cuts.** `yearOfDividends` is the trailing year, so it misses
+  forward dividend growth or cuts that the realised in-window figure captures.
+- **Specials.** One-off special and liquidating distributions are credited
+  realised-only on the validation side, but are diluted into (or excluded from)
+  the trailing-annual quarter on the training side. On low-priced stocks these
+  produce the extreme ± tails above and inflate the raw mean.
+
+## Acceptance criteria
+
+1. **Mean dividend-basis difference (pp) with sign** — **+2.827 pp** raw /
+   **+1.358 pp** (1%-trimmed), median 0; **sign +** (flat quarter is a
+   consistent over-credit).
+2. **Contributes to or offsets the gap** — it **contributes to (widens)** the
+   Target-over-Actual gap, because Target carries the larger flat credit while
+   Actual carries the smaller realised in-window credit. (Opposite to #552's
+   price basis, which masked the gap.)
+3. **Fix-vs-leave recommendation** — see below.
+
+## Recommendation: real, same-direction contributor — **fix the basis upstream in `GRQ`** (align training onto realised forward-window dividends)
+
+Unlike the price-basis candidate (#552, exonerated because it *hid* the gap),
+the dividend basis is a **genuine, same-direction contributor** of roughly
+**+1.4 pp (robust) to +2.8 pp (raw)**. It is worth correcting, and the correct
+direction is to **align both sides on realised dividends**:
+
+- The dashboard's realised in-window credit is the **defensible** "Actual": it
+  reflects the cash a holder actually received in the 90 days. Degrading it to a
+  fabricated flat quarter (to match training) would credit dividend income that
+  was never realised — strictly worse for a user-facing figure.
+- Therefore the clean fix lives **upstream in `GRQ`**: train/evaluate the label
+  on the dividends that actually fall in the forward 90-day window (the same
+  basis `calculate_dividends_for_period` uses), instead of a flat
+  `yearOfDividends / 4`. That removes the structural over-credit at source and
+  makes Target and Actual like-for-like on dividends.
+- The root-cause change is a **training-label** decision in `GRQ`, out of scope
+  for this `GRQ-validation` diagnostic issue (whose deliverable is the written
+  analysis + recommendation). It should be carried as a fix candidate under
+  milestone #544.
+
+**Net for the milestone:** keep this candidate as a **confirmed, modest,
+same-direction contributor** (~+1.4 to +2.8 pp) alongside genuine model optimism
+— but treat the raw +2.83 pp as an upper bound inflated by a few special-dividend
+outliers; the robust figure is ~+1.4 pp.
+
+## How this was measured (reproducible)
+
+Every per-stock figure is delegated to the **shipped** kernels so the windowed
+credit measured here is the dashboard's own credit, not a re-implementation:
+
+- `GRQTrendPredictions.resolvePredictionStocks` — split-aware `buyPrice`,
+  `currentPrice`, inclusion flag and the realised in-window `totalDividends`
+  (`sumDividends` ∘ `filterDividendsWithin90Days`) — the dashboard's Actual
+  dividend credit.
+- `GRQProjection.trailingAnnualDividends` — trailing-365-day dividend total as
+  of the score date; `/ 4` reproduces the model's flat training credit (added
+  for this diagnostic).
+- `GRQProjection.dividendBasisDifferencePercent` —
+  `(flatCredit − windowedCredit) / buyPrice * 100`.
+- `GRQProjection.isStockIncluded` — restricts to the same included set the
+  dashboard aggregates over.
+
+The flat credit is read from the full per-ticker dividend history in the
+sibling `../GRQ-dividends` tree (the same source `src/utils.rs` reads via
+`DIVIDEND_DATA_BASE_PATH`); the windowed credit is read from the committed
+per-score `*-dividends.csv` files.
+
+```bash
+deno task diagnose-dividend-basis              # docs/, today, ../GRQ-dividends
+# raw form (pin an as-of date + explicit history root for a reproducible report):
+deno run --allow-read scripts/diagnose_dividend_basis.ts docs 2026-06-26 ../GRQ-dividends
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv]
+    B --> C[resolvePredictionStocks<br/>buyPrice + realised in-window totalDividends]
+    A --> D[../GRQ-dividends<br/>full per-ticker history]
+    D --> E[trailingAnnualDividends / 4<br/>flat training credit]
+    C --> F[dividendBasisDifferencePercent<br/>= flat - windowed / buyPrice]
+    E --> F
+    F --> G[aggregate: mean / 1%-trimmed / median / dist<br/>+ sign vs observed gap]
+```
+
+## Code references
+
+- Flat training credit: `GRQ/src/LearnUtil.ts:147-148`
+  (`(targetPrice + core.yearOfDividends / 4) / core.monthsAgoPrice`),
+  `yearOfDividends` built in `GRQ/src/CoreFeatures.ts`.
+- Windowed actual credit: `GRQ-validation/src/utils.rs`
+  `calculate_dividends_for_period` (invoked at the 90-day window), mirrored by
+  `docs/projection.js` `filterDividendsWithin90Days` + `sumDividends`.
+- Trailing-annual basis + difference helper: `docs/projection.js`
+  `trailingAnnualDividends`, `dividendBasisDifferencePercent` (this issue).
+- Diagnostic: `scripts/diagnose_dividend_basis.ts`,
+  `scripts/dividend_basis_diagnostic.ts`;
+  tests `tests/dividend_basis_diagnostic_test.ts`.

--- a/docs/archive/pr-summaries/pr-summary-553.md
+++ b/docs/archive/pr-summaries/pr-summary-553.md
@@ -1,0 +1,98 @@
+## Summary
+
+Adds a written diagnostic and reproducible analysis quantifying the
+Target-over-Actual bias that comes purely from the **dividend basis** mismatch
+between training and the dashboard (milestone #544 candidate). GRQ training bakes
+a **flat** quarter of the trailing annual dividend, `core.yearOfDividends / 4`,
+into the total-return label for **every** stock
+(`GRQ/src/LearnUtil.ts:147-148`), whereas the validation side credits only the
+**actual ex-dividends inside the 90-day window**
+(`GRQ-validation/src/utils.rs` `calculate_dividends_for_period`, mirrored by the
+shipped JS kernels `filterDividendsWithin90Days` + `sumDividends`).
+
+Over the matured score set (274 score dates, 5 444 included stock-rows, as-of
+2026-06-26) the per-row difference `(flatCredit − windowedCredit) / buyPrice` is
+**+2.827 pp raw / +1.358 pp (1%-trimmed)**, median 0, **sign +**. The flat
+training quarter is a **consistent over-credit** relative to realised in-window
+dividends, so — because Target embeds the flat credit while Actual credits only
+realised dividends — this dividend basis **contributes to (widens)** the
+Target-over-Actual gap (the *opposite* of the price-basis candidate #552, which
+masked it). The raw mean is lumpy: 86.4 % of rows fall within ±1 pp and a few
+special/liquidating distributions on low-priced stocks (EQC, ELME, VISN)
+dominate the tails, so the robust contribution is ~+1.4 pp. The main
+same-direction driver is that **45.2 % of included rows realise zero in-window
+dividends yet still receive the flat quarter in training**.
+
+**Recommendation:** a genuine, modest, same-direction contributor worth fixing
+by **aligning both sides on realised in-window dividends** — the clean fix is
+upstream in `GRQ` (train/evaluate the label on the forward-window dividends
+rather than a flat `yearOfDividends / 4`), since degrading the dashboard's
+realised "Actual" to a fabricated flat quarter would credit dividends never
+received. The root-cause training-label change is out of scope for this
+`GRQ-validation` diagnostic and is carried as a fix candidate under #544.
+
+Closes #553.
+
+## Evidence
+
+Backend/CLI diagnostic — no web UI to screenshot. Verified by the new unit tests
+(below) and by running the reproducible report:
+
+```text
+$ deno run --allow-read scripts/diagnose_dividend_basis.ts docs 2026-06-26 ../GRQ-dividends
+Matured score dates:     274
+Included stock-rows:     5444
+Mean (raw):              +2.827 pp
+Mean (1%-trimmed):       +1.358 pp
+Median:                  +0.000 pp
+Within +/-1 pp:          86.4 %
+Mean flat credit yield:  3.656 %
+Mean windowed yield:     0.829 %
+Rows with 0 in-window:   45.2 %
+Gap contribution:        +2.827 pp
+```
+
+The full written diagnostic (mechanism, tables, mermaid flow, recommendation,
+acceptance criteria) lives in
+`docs/archive/investigations/issue-553-dividend-basis-bias.md`.
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv]
+    B --> C[resolvePredictionStocks<br/>buyPrice + realised in-window totalDividends]
+    A --> D[../GRQ-dividends<br/>full per-ticker history]
+    D --> E[trailingAnnualDividends / 4<br/>flat training credit]
+    C --> F[dividendBasisDifferencePercent<br/>= flat - windowed / buyPrice]
+    E --> F
+    F --> G[aggregate: mean / 1%-trimmed / median / dist<br/>+ sign vs observed gap]
+```
+
+## Test Plan
+
+- `tests/dividend_basis_diagnostic_test.ts` (new, 14 tests) exercises the real
+  shipped kernels and the real aggregation with synthetic data:
+  - `trailingAnnualDividends` trailing-year sum, boundary semantics
+    (`> scoreDate-365 && <= scoreDate`), and empty/invalid guards.
+  - `dividendBasisDifferencePercent` arithmetic, the offsetting (negative)
+    direction, and bad-input guards.
+  - `stripSymbol` exchange-prefix/dot normalisation matching
+    `extract_symbol_from_ticker`.
+  - `summariseDiffs` and `trimmedMean` statistics, including outlier robustness.
+  - `aggregateDate` for a semi-annual payer (flat > windowed, zero in-window)
+    and a quarterly payer (flat ≈ windowed, nets to ~0).
+  - `buildReport` contributing (+) and offsetting (−) verdicts and the
+    `within1ppSharePct` / `windowedZeroSharePct` aggregates.
+- All run read-only under `deno test --allow-read`; pure functions assert on
+  computed results, not source text.
+
+## Files
+
+- `docs/projection.js` — new shipped kernels `trailingAnnualDividends` and
+  `dividendBasisDifferencePercent` (published on `GRQProjection`).
+- `scripts/dividend_basis_diagnostic.ts` — pure aggregation + disk loader.
+- `scripts/diagnose_dividend_basis.ts` — CLI report (`deno task
+  diagnose-dividend-basis`).
+- `tests/dividend_basis_diagnostic_test.ts` — kernel + aggregation tests.
+- `docs/archive/investigations/issue-553-dividend-basis-bias.md` — written
+  diagnostic.
+- `deno.json`, `README.md` — task entry and script-tree documentation.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -622,6 +622,51 @@ function priceBasisOffsetPercent(buyPrice, midPrice, lowPrice) {
     return ((midPrice - lowPrice) / buyPrice) * 100;
 }
 
+// Trailing-365-day dividend total as of the score date — the quantity the GRQ
+// model turns into a FLAT training credit of `yearOfDividends / 4`
+// (GRQ/src/CoreFeatures.ts builds `yearOfDividends`; GRQ/src/LearnUtil.ts bakes
+// `yearOfDividends / 4` into the total-return label for EVERY stock). Sums the
+// cash amount of every dividend whose ex-dividend date falls in the year ending
+// at the score date (`scoreDate - 365 days < exDivDate <= scoreDate`). Mirrors
+// the shape `filterDividendsWithin90Days`/`sumDividends` consume so the
+// diagnostic measures the same dividend records the dashboard does. Pure given
+// its inputs; returns 0 for a missing/empty list (issue #553).
+function trailingAnnualDividends(dividends, scoreDate) {
+    if (!Array.isArray(dividends) || !(scoreDate instanceof Date)) {
+        return 0;
+    }
+    const yearStart = new Date(
+        scoreDate.getTime() - (365 * 24 * 60 * 60 * 1000),
+    );
+    return dividends
+        .filter((d) => d && d.exDivDate > yearStart && d.exDivDate <= scoreDate)
+        .reduce((sum, d) => sum + (d.amount || 0), 0);
+}
+
+// Dividend-basis difference between the model's FLAT training credit
+// (`yearOfDividends / 4`) and the dashboard's realised in-window dividends,
+// expressed as a percentage of the buy price (issue #553):
+// `(flatCredit - windowedCredit) / buyPrice * 100`. A POSITIVE value means the
+// flat training credit EXCEEDS the realised in-window dividends, so the model's
+// dividend-inflated Target sits above an Actual that credits only the dividends
+// that actually fell inside the 90-day window — i.e. it CONTRIBUTES to (widens)
+// the Target-over-Actual gap. A negative value means the realised in-window
+// dividends exceed the flat quarter, which NARROWS (masks) the gap. Returns null
+// when any input is missing or the buy price is not a positive number.
+function dividendBasisDifferencePercent(flatCredit, windowedCredit, buyPrice) {
+    if (
+        buyPrice === null || buyPrice === undefined || Number.isNaN(buyPrice) ||
+        buyPrice <= 0 ||
+        flatCredit === null || flatCredit === undefined ||
+        Number.isNaN(flatCredit) ||
+        windowedCredit === null || windowedCredit === undefined ||
+        Number.isNaN(windowedCredit)
+    ) {
+        return null;
+    }
+    return ((flatCredit - windowedCredit) / buyPrice) * 100;
+}
+
 // Target return as a percentage of the buy price. Returns null when either input
 // is missing, matching the dashboard's guard before reporting a target figure.
 function calculateTargetPercentage(buyPrice, adjustedTarget) {
@@ -1095,6 +1140,8 @@ globalThis.GRQProjection = {
     priceAtNinetyDayHorizon,
     lowPriceAtNinetyDayHorizon,
     priceBasisOffsetPercent,
+    trailingAnnualDividends,
+    dividendBasisDifferencePercent,
     calculateTargetPercentage,
     calculatePortfolioTargetPercentage,
     getFairValueRange,

--- a/scripts/diagnose_dividend_basis.ts
+++ b/scripts/diagnose_dividend_basis.ts
@@ -1,0 +1,76 @@
+// Diagnostic for issue #553 (milestone #544): quantify the Target/Actual bias
+// that comes purely from the DIVIDEND basis mismatch between training and the
+// dashboard.
+//
+//   - The GRQ model bakes a FLAT quarter of the trailing annual dividend,
+//     `core.yearOfDividends / 4`, into the total-return training label for EVERY
+//     stock (GRQ/src/LearnUtil.ts:147-148, GRQ/src/CoreFeatures.ts).
+//   - The dashboard/validation side credits only the ACTUAL ex-dividends inside
+//     the 90-day window (GRQ-validation/src/utils.rs
+//     `calculate_dividends_for_period`, mirrored by the shipped JS kernels
+//     `filterDividendsWithin90Days` + `sumDividends`).
+//
+// Per matured row this script compares the two credits and aggregates the mean
+// difference (in pp of buy price) and its SIGN, so we know whether the flat
+// quarter is a consistent over- or under-credit relative to realised dividends,
+// and whether it contributes to (or offsets) the Target-over-Actual gap.
+//
+// It reuses the SHIPPED kernels — GRQProjection.trailingAnnualDividends,
+// dividendBasisDifferencePercent, isStockIncluded, and the
+// GRQTrendPredictions resolver/parsers — so the windowed credit it reports is
+// computed on exactly the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_dividend_basis.ts \
+//        [docsPath] [asOf YYYY-MM-DD] [dividendsRoot]
+// (defaults: docsPath="docs", asOf=today, dividendsRoot="../GRQ-dividends").
+// Read-only; prints a Markdown-friendly report.
+
+import { computeDividendBasisDiagnostic } from "./dividend_basis_diagnostic.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+// "Today" governs which score dates have a complete 90-day window. Default to
+// the real clock; allow an override (second arg, YYYY-MM-DD) for reproducible
+// reports pinned to a specific as-of date.
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+const dividendsRoot = Deno.args[2] ?? "../GRQ-dividends";
+
+const report = await computeDividendBasisDiagnostic(
+  docsPath,
+  asOf,
+  dividendsRoot,
+);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(
+  `# Dividend-basis (flat 1/4 vs windowed) diagnostic — issue #553\n`,
+);
+console.log(`As-of date:              ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Dividend history root:   ${dividendsRoot}`);
+console.log(`Matured score dates:     ${report.maturedDates}`);
+console.log(`Included stock-rows:     ${report.rowCount}`);
+console.log("");
+console.log(
+  `## Per-row basis difference (flatCredit - windowedCredit) / buyPrice`,
+);
+console.log(`Mean (raw):              ${pp(report.meanDiffPp)}`);
+console.log(`Mean (1%-trimmed):       ${pp(report.trimmedMeanDiffPp)}`);
+console.log(`Median:                  ${pp(report.medianDiffPp)}`);
+console.log(`Min:                     ${pp(report.minDiffPp)}`);
+console.log(`Max:                     ${pp(report.maxDiffPp)}`);
+console.log(`Std dev:                 ${report.stdDevPp.toFixed(3)} pp`);
+console.log(
+  `Within +/-1 pp:          ${report.within1ppSharePct.toFixed(1)} %`,
+);
+console.log("");
+console.log(`## Dividend-return components (mean over included rows)`);
+console.log(`Mean flat credit yield:  ${report.meanFlatYieldPct.toFixed(3)} %`);
+console.log(
+  `Mean windowed yield:     ${report.meanWindowedYieldPct.toFixed(3)} %`,
+);
+console.log(
+  `Rows with 0 in-window:   ${report.windowedZeroSharePct.toFixed(1)} %`,
+);
+console.log(`Gap contribution:        ${pp(report.contributionPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/scripts/dividend_basis_diagnostic.ts
+++ b/scripts/dividend_basis_diagnostic.ts
@@ -1,0 +1,388 @@
+// Core computation for the issue #553 dividend-basis diagnostic.
+//
+// Quantifies the Target/Actual bias that comes from the DIVIDEND basis mismatch
+// between training and the dashboard:
+//
+//   - Training (GRQ/src/LearnUtil.ts:147-148) bakes a FLAT quarter of the
+//     trailing annual dividend, `core.yearOfDividends / 4`, into the
+//     total-return label for EVERY stock, whether or not a dividend actually
+//     falls in the forward window.
+//   - The dashboard/validation side credits only the ACTUAL ex-dividends that
+//     fall inside the 90-day window
+//     (GRQ-validation/src/utils.rs `calculate_dividends_for_period`, mirrored on
+//     the JS side by `filterDividendsWithin90Days` + `sumDividends`).
+//
+// Splits the pure aggregation (testable with synthetic rows, no disk) from the
+// file IO. Every per-stock figure is delegated to the SHIPPED kernels published
+// on globalThis by docs/projection.js and docs/trend_predictions.js, so the
+// windowed credit measured here is exactly the dashboard's own credit rather
+// than a re-implementation.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Summary statistics for a list of per-row differences (percentage points). */
+export interface DiffSummary {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  stdDev: number;
+}
+
+/** Pure stats over a list of numbers. Empty input yields all-zero summary. */
+export function summariseDiffs(values: number[]): DiffSummary {
+  const finite = values.filter((v) =>
+    typeof v === "number" && !Number.isNaN(v)
+  );
+  if (finite.length === 0) {
+    return { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 };
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  const sum = finite.reduce((t, v) => t + v, 0);
+  const mean = sum / finite.length;
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+  const variance = finite.reduce((t, v) => t + (v - mean) ** 2, 0) /
+    finite.length;
+  return {
+    count: finite.length,
+    mean,
+    median,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+// Strip an exchange prefix and normalise dots to hyphens, mirroring the Rust
+// `extract_symbol_from_ticker` so a score ticker ("NYSE:SEM", "HEI.A") maps to
+// the per-ticker dividend-history filename ("SEM", "HEI-A").
+export function stripSymbol(ticker: string): string {
+  const idx = ticker.lastIndexOf(":");
+  const sym = idx >= 0 ? ticker.slice(idx + 1) : ticker;
+  return sym.replace(/\./g, "-");
+}
+
+/** One matured score date's per-row dividend-basis differences. */
+export interface DateAggregate {
+  date: string;
+  /** Per included row: (flatCredit - windowedCredit) / buyPrice * 100. */
+  rowDiffsPp: number[];
+  /** Per included row: flat training credit as a % of buy price. */
+  flatYieldsPct: number[];
+  /** Per included row: realised in-window credit as a % of buy price. */
+  windowedYieldsPct: number[];
+  /** Included rows where the realised in-window dividend was exactly 0. */
+  windowedZeroCount: number;
+  /** Total included rows contributing to the figures above. */
+  includedCount: number;
+}
+
+// Build the per-row dividend-basis differences for one score date. Pure: the
+// caller supplies already-parsed score rows, the market-data map, the COMMITTED
+// in-window dividend map (the dashboard's Actual source), and the FULL trailing
+// dividend history keyed by stripped symbol (the training-credit source).
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  windowedDividends: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  fullHistory: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  // Shipped resolver: gives buyPrice, currentPrice, splitReliable and the
+  // realised in-window `totalDividends` — exactly the dashboard's Actual credit.
+  const stocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    windowedDividends,
+    scoreDate,
+  );
+
+  const rowDiffsPp: number[] = [];
+  const flatYieldsPct: number[] = [];
+  const windowedYieldsPct: number[] = [];
+  let windowedZeroCount = 0;
+  let includedCount = 0;
+
+  // deno-lint-ignore no-explicit-any
+  stocks.forEach((stock: any, i: number) => {
+    if (
+      !P.isStockIncluded(
+        stock.buyPrice,
+        stock.currentPrice,
+        stock.splitReliable,
+      )
+    ) {
+      return;
+    }
+    includedCount += 1;
+
+    const history = fullHistory[stripSymbol(scoreRows[i].stock)] || [];
+    const flatCredit = P.trailingAnnualDividends(history, scoreDate) / 4;
+    const windowedCredit = stock.totalDividends || 0;
+
+    const diff = P.dividendBasisDifferencePercent(
+      flatCredit,
+      windowedCredit,
+      stock.buyPrice,
+    );
+    if (diff === null) {
+      return;
+    }
+    rowDiffsPp.push(diff);
+    flatYieldsPct.push((flatCredit / stock.buyPrice) * 100);
+    windowedYieldsPct.push((windowedCredit / stock.buyPrice) * 100);
+    if (windowedCredit === 0) {
+      windowedZeroCount += 1;
+    }
+  });
+
+  return {
+    date,
+    rowDiffsPp,
+    flatYieldsPct,
+    windowedYieldsPct,
+    windowedZeroCount,
+    includedCount,
+  };
+}
+
+/** The full diagnostic result over the matured historical score set. */
+export interface DividendBasisReport {
+  maturedDates: number;
+  rowCount: number;
+  meanDiffPp: number;
+  medianDiffPp: number;
+  minDiffPp: number;
+  maxDiffPp: number;
+  stdDevPp: number;
+  /** Mean after dropping the most extreme `trimFraction` of each tail. */
+  trimmedMeanDiffPp: number;
+  /** Share of included rows whose difference sits within +/-1 pp. */
+  within1ppSharePct: number;
+  meanFlatYieldPct: number;
+  meanWindowedYieldPct: number;
+  windowedZeroSharePct: number;
+  /** Equal-weight per-row mean difference == portfolio-level gap contribution. */
+  contributionPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Mean after dropping the most extreme `trimFraction` of values at EACH tail.
+// The raw per-row mean is dominated by a handful of special/liquidating
+// distributions on low-priced stocks (e.g. EQC, ELME, VISN), so a trimmed mean
+// reports the robust central tendency alongside the lumpy raw figure.
+export function trimmedMean(values: number[], trimFraction: number): number {
+  const finite = values
+    .filter((v) => typeof v === "number" && !Number.isNaN(v))
+    .sort((a, b) => a - b);
+  if (finite.length === 0) return 0;
+  const k = Math.floor(finite.length * trimFraction);
+  const kept = finite.slice(k, finite.length - k);
+  return mean(kept.length > 0 ? kept : finite);
+}
+
+// Assemble the report from per-date aggregates. Pure so it can be unit-tested
+// with synthetic DateAggregate rows.
+export function buildReport(aggregates: DateAggregate[]): DividendBasisReport {
+  const allDiffs = aggregates.flatMap((a) => a.rowDiffsPp);
+  const stats = summariseDiffs(allDiffs);
+
+  const meanFlatYieldPct = mean(aggregates.flatMap((a) => a.flatYieldsPct));
+  const meanWindowedYieldPct = mean(
+    aggregates.flatMap((a) => a.windowedYieldsPct),
+  );
+  const totalIncluded = aggregates.reduce((t, a) => t + a.includedCount, 0);
+  const totalWindowedZero = aggregates.reduce(
+    (t, a) => t + a.windowedZeroCount,
+    0,
+  );
+  const windowedZeroSharePct = totalIncluded === 0
+    ? 0
+    : (totalWindowedZero / totalIncluded) * 100;
+
+  const trimmedMeanDiffPp = trimmedMean(allDiffs, 0.01);
+  const within1ppSharePct = stats.count === 0
+    ? 0
+    : (allDiffs.filter((d) => Math.abs(d) <= 1).length / stats.count) * 100;
+
+  // Under equal weighting the mean per-row (flat - windowed)/buy difference IS
+  // the amount the dividend basis moves the Target-over-Actual gap: Target
+  // carries the flat credit, Actual carries the windowed credit.
+  const contributionPp = stats.mean;
+  const direction = contributionPp >= 0
+    ? "CONTRIBUTES to (widens)"
+    : "OFFSETS (narrows)";
+
+  const verdict =
+    `VERDICT: the flat training credit (yearOfDividends / 4) exceeds the ` +
+    `realised in-window dividends by a mean ${stats.mean.toFixed(3)} pp of ` +
+    `buy price (median ${stats.median.toFixed(3)} pp; 1%-trimmed mean ` +
+    `${trimmedMeanDiffPp.toFixed(3)} pp). Because Target embeds the flat ` +
+    `credit while Actual credits only realised in-window dividends, this ` +
+    `dividend basis ${direction} the Target-over-Actual gap by ` +
+    `${Math.abs(contributionPp).toFixed(3)} pp. ` +
+    `${windowedZeroSharePct.toFixed(1)}% of included rows realised ZERO ` +
+    `in-window dividends yet still receive the flat quarter in training (the ` +
+    `same-direction driver), but the raw mean is lumpy: ` +
+    `${within1ppSharePct.toFixed(1)}% of rows fall within +/-1 pp and the ` +
+    `mean is dominated by a few special/liquidating distributions on ` +
+    `low-priced stocks, so the robust contribution is the smaller trimmed mean.`;
+
+  return {
+    maturedDates: aggregates.length,
+    rowCount: stats.count,
+    meanDiffPp: stats.mean,
+    medianDiffPp: stats.median,
+    minDiffPp: stats.min,
+    maxDiffPp: stats.max,
+    stdDevPp: stats.stdDev,
+    trimmedMeanDiffPp,
+    within1ppSharePct,
+    meanFlatYieldPct,
+    meanWindowedYieldPct,
+    windowedZeroSharePct,
+    contributionPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+interface DividendHistoryRecord {
+  ex_dividend_date?: string;
+  amount?: string | number;
+}
+
+// Load one ticker's FULL dividend history from the GRQ-dividends tree
+// (../GRQ-dividends/data/<L>/<SYM>.json) into the { exDivDate, amount } shape the
+// kernels consume. Returns [] when the file is absent or unparseable so a ticker
+// with no published history simply contributes a 0 flat credit.
+async function loadDividendHistory(
+  dividendsRoot: string,
+  strippedSymbol: string,
+): Promise<{ exDivDate: Date; amount: number }[]> {
+  if (!strippedSymbol) return [];
+  const letter = strippedSymbol.charAt(0).toUpperCase();
+  const path = `${dividendsRoot}/data/${letter}/${strippedSymbol}.json`;
+  let text: string;
+  try {
+    text = await Deno.readTextFile(path);
+  } catch {
+    return [];
+  }
+  let parsed: { data?: DividendHistoryRecord[] };
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  const records = Array.isArray(parsed.data) ? parsed.data : [];
+  const out: { exDivDate: Date; amount: number }[] = [];
+  for (const r of records) {
+    if (!r || typeof r.ex_dividend_date !== "string") continue;
+    const amount = typeof r.amount === "number"
+      ? r.amount
+      : parseFloat(String(r.amount));
+    if (Number.isNaN(amount)) continue;
+    out.push({
+      exDivDate: P.setDateToMidnight(new Date(r.ex_dividend_date)),
+      amount,
+    });
+  }
+  return out;
+}
+
+// Load the matured score set from disk and compute the full diagnostic.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+// `dividendsRoot` points at the GRQ-dividends history tree (default
+// "../GRQ-dividends", matching src/utils.rs DIVIDEND_DATA_BASE_PATH).
+export async function computeDividendBasisDiagnostic(
+  docsPath: string,
+  asOf: Date,
+  dividendsRoot = "../GRQ-dividends",
+): Promise<DividendBasisReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const historyCache = new Map<string, { exDivDate: Date; amount: number }[]>();
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    const scoreRows = TP.parseScoreTsv(tsvText);
+    const marketData = TP.parseMarketCsv(csvText);
+    const windowedDividends = TP.parseDividendCsv(divText);
+
+    // Full trailing history per ticker on this date (cached across dates).
+    // deno-lint-ignore no-explicit-any
+    const fullHistory: Record<string, any[]> = {};
+    for (const row of scoreRows) {
+      const sym = stripSymbol(row.stock);
+      if (!historyCache.has(sym)) {
+        historyCache.set(sym, await loadDividendHistory(dividendsRoot, sym));
+      }
+      fullHistory[sym] = historyCache.get(sym) as {
+        exDivDate: Date;
+        amount: number;
+      }[];
+    }
+
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        scoreRows,
+        marketData,
+        windowedDividends,
+        fullHistory,
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReport(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/tests/dividend_basis_diagnostic_test.ts
+++ b/tests/dividend_basis_diagnostic_test.ts
@@ -1,0 +1,279 @@
+// Tests for the issue #553 dividend-basis (flat 1/4 vs windowed) diagnostic.
+//
+// These exercise the REAL shipped kernels (docs/projection.js) and the real
+// aggregation in scripts/dividend_basis_diagnostic.ts with synthetic data,
+// asserting on computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReport,
+  type DateAggregate,
+  stripSymbol,
+  summariseDiffs,
+  trimmedMean,
+} from "../scripts/dividend_basis_diagnostic.ts";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+Deno.test("trailingAnnualDividends sums the year ending at the score date", () => {
+  const scoreDate = midnight("2026-01-01");
+  const divs = [
+    { exDivDate: midnight("2025-02-15"), amount: 0.25 }, // in trailing year
+    { exDivDate: midnight("2025-05-15"), amount: 0.25 }, // in trailing year
+    { exDivDate: midnight("2025-08-15"), amount: 0.25 }, // in trailing year
+    { exDivDate: midnight("2025-11-15"), amount: 0.25 }, // in trailing year
+    { exDivDate: midnight("2026-02-15"), amount: 0.30 }, // after score date
+    { exDivDate: midnight("2024-06-15"), amount: 0.20 }, // before the year
+  ];
+  assertAlmostEquals(P.trailingAnnualDividends(divs, scoreDate), 1.0, 1e-9);
+});
+
+Deno.test("trailingAnnualDividends boundaries: includes score date, excludes -365", () => {
+  const scoreDate = midnight("2026-01-01");
+  // exactly 365 days before score date -> excluded (strictly greater than).
+  const onYearStart = { exDivDate: midnight("2025-01-01"), amount: 1 };
+  // on the score date -> included.
+  const onScoreDate = { exDivDate: midnight("2026-01-01"), amount: 2 };
+  assertAlmostEquals(
+    P.trailingAnnualDividends([onYearStart, onScoreDate], scoreDate),
+    2,
+    1e-9,
+  );
+});
+
+Deno.test("trailingAnnualDividends returns 0 for empty/invalid input", () => {
+  assertEquals(P.trailingAnnualDividends([], midnight("2026-01-01")), 0);
+  assertEquals(P.trailingAnnualDividends(null, midnight("2026-01-01")), 0);
+  assertEquals(P.trailingAnnualDividends([{ amount: 1 }], "nope"), 0);
+});
+
+Deno.test("dividendBasisDifferencePercent computes (flat - windowed)/buy*100", () => {
+  // buy 100, flat 0.50, windowed 0.25 -> (0.25)/100*100 = 0.25 pp.
+  assertAlmostEquals(P.dividendBasisDifferencePercent(0.5, 0.25, 100), 0.25);
+  // flat == windowed -> zero difference.
+  assertEquals(P.dividendBasisDifferencePercent(0.4, 0.4, 100), 0);
+  // windowed exceeds flat -> negative (the offsetting direction).
+  assertAlmostEquals(P.dividendBasisDifferencePercent(0.2, 0.6, 100), -0.4);
+});
+
+Deno.test("dividendBasisDifferencePercent guards bad inputs", () => {
+  assertEquals(P.dividendBasisDifferencePercent(0.5, 0.25, 0), null);
+  assertEquals(P.dividendBasisDifferencePercent(0.5, 0.25, -5), null);
+  assertEquals(P.dividendBasisDifferencePercent(null, 0.25, 100), null);
+  assertEquals(P.dividendBasisDifferencePercent(0.5, NaN, 100), null);
+});
+
+Deno.test("stripSymbol drops the exchange prefix and normalises dots", () => {
+  assertEquals(stripSymbol("NYSE:SEM"), "SEM");
+  assertEquals(stripSymbol("NASDAQ:IBKR"), "IBKR");
+  assertEquals(stripSymbol("HEI.A"), "HEI-A");
+  assertEquals(stripSymbol("PLAIN"), "PLAIN");
+});
+
+Deno.test("summariseDiffs computes mean/median/min/max/stdDev", () => {
+  const s = summariseDiffs([1, 2, 3, 4]);
+  assertEquals(s.count, 4);
+  assertAlmostEquals(s.mean, 2.5);
+  assertAlmostEquals(s.median, 2.5);
+  assertEquals(s.min, 1);
+  assertEquals(s.max, 4);
+  assertAlmostEquals(s.stdDev, Math.sqrt(1.25));
+});
+
+Deno.test("summariseDiffs handles empty input", () => {
+  const s = summariseDiffs([]);
+  assertEquals(s, { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 });
+});
+
+Deno.test("trimmedMean drops the extreme tails so a single outlier cannot dominate", () => {
+  // Without trimming the +100 outlier dominates; trimming 10% each side at this
+  // size drops exactly the min and max, leaving a robust central mean of 0.
+  const values = [-100, 0, 0, 0, 0, 0, 0, 0, 0, 100];
+  assertAlmostEquals(trimmedMean(values, 0.0), 0); // 10 values, mean 0 anyway
+  assertAlmostEquals(trimmedMean(values, 0.1), 0); // drops -100 and +100
+  // A right-skewed set: raw mean is pulled up, trimmed mean is lower.
+  const skew = [0, 0, 0, 0, 0, 0, 0, 0, 0, 50];
+  assert(trimmedMean(skew, 0.0) > trimmedMean(skew, 0.1));
+});
+
+Deno.test("trimmedMean handles empty input", () => {
+  assertEquals(trimmedMean([], 0.01), 0);
+});
+
+Deno.test("aggregateDate measures flat-vs-windowed difference for a semi-annual payer", () => {
+  const scoreDate = midnight("2026-01-01");
+  // One stock, buy ~100. Pays semi-annually: trailing year has two 0.50
+  // dividends (annual 1.00 -> flat quarter 0.25). The forward 90-day window
+  // catches NONE of its dividends (next pays in 2026-06), so windowed = 0.
+  const scoreRows = [{
+    stock: "NYSE:X",
+    target: 130,
+    score: 1,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    "NYSE:X": [
+      {
+        date: midnight("2026-01-02"),
+        high: 101,
+        low: 99,
+        open: 100,
+        close: 100,
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 120,
+        low: 100,
+        open: 110,
+        close: 115,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  // Committed in-window dividend CSV: empty for X over this window.
+  const windowedDividends = {};
+  // Full trailing history keyed by STRIPPED symbol.
+  const fullHistory = {
+    X: [
+      { exDivDate: midnight("2025-06-15"), amount: 0.5 },
+      { exDivDate: midnight("2025-12-15"), amount: 0.5 },
+    ],
+  };
+  const agg = aggregateDate(
+    "2026-01-01",
+    scoreRows,
+    marketData,
+    windowedDividends,
+    fullHistory,
+    scoreDate,
+  );
+  // buyPrice = mid of 2026-01-02 = 100. flat = 1.00/4 = 0.25, windowed = 0.
+  // diff = (0.25 - 0)/100 * 100 = 0.25 pp.
+  assertEquals(agg.includedCount, 1);
+  assertEquals(agg.rowDiffsPp.length, 1);
+  assertAlmostEquals(agg.rowDiffsPp[0], 0.25, 1e-9);
+  assertEquals(agg.windowedZeroCount, 1);
+  assertAlmostEquals(agg.flatYieldsPct[0], 0.25, 1e-9);
+  assertAlmostEquals(agg.windowedYieldsPct[0], 0, 1e-9);
+});
+
+Deno.test("aggregateDate: a quarterly payer with one in-window dividend nets near zero", () => {
+  const scoreDate = midnight("2026-01-01");
+  const scoreRows = [{
+    stock: "NYSE:Q",
+    target: 130,
+    score: 1,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    "NYSE:Q": [
+      {
+        date: midnight("2026-01-02"),
+        high: 101,
+        low: 99,
+        open: 100,
+        close: 100,
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 110,
+        low: 100,
+        open: 105,
+        close: 108,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  // One realised in-window dividend of 0.25 (ex-div 2026-02-15 <= horizon).
+  const windowedDividends = {
+    "NYSE:Q": [{ exDivDate: midnight("2026-02-15"), amount: 0.25 }],
+  };
+  // Trailing year: four 0.25 quarterly dividends -> flat quarter 0.25.
+  const fullHistory = {
+    Q: [
+      { exDivDate: midnight("2025-02-15"), amount: 0.25 },
+      { exDivDate: midnight("2025-05-15"), amount: 0.25 },
+      { exDivDate: midnight("2025-08-15"), amount: 0.25 },
+      { exDivDate: midnight("2025-11-15"), amount: 0.25 },
+    ],
+  };
+  const agg = aggregateDate(
+    "2026-01-01",
+    scoreRows,
+    marketData,
+    windowedDividends,
+    fullHistory,
+    scoreDate,
+  );
+  // flat 0.25, windowed 0.25 -> diff 0.
+  assertEquals(agg.rowDiffsPp.length, 1);
+  assertAlmostEquals(agg.rowDiffsPp[0], 0, 1e-9);
+  assertEquals(agg.windowedZeroCount, 0);
+});
+
+Deno.test("buildReport: positive mean difference contributes to (widens) the gap", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      rowDiffsPp: [0.25, 0.10],
+      flatYieldsPct: [0.25, 0.10],
+      windowedYieldsPct: [0, 0],
+      windowedZeroCount: 2,
+      includedCount: 2,
+    },
+    {
+      date: "2026-02-01",
+      rowDiffsPp: [0.05, -0.05],
+      flatYieldsPct: [0.30, 0.20],
+      windowedYieldsPct: [0.25, 0.25],
+      windowedZeroCount: 0,
+      includedCount: 2,
+    },
+  ];
+  const r = buildReport(aggregates);
+  assertEquals(r.maturedDates, 2);
+  assertEquals(r.rowCount, 4);
+  assertAlmostEquals(r.meanDiffPp, (0.25 + 0.10 + 0.05 - 0.05) / 4); // 0.0875
+  // Equal-weight per-row mean is the portfolio-level contribution.
+  assertAlmostEquals(r.contributionPp, r.meanDiffPp);
+  assert(r.contributionPp > 0, "flat > windowed should WIDEN the gap");
+  // 2 of 4 rows realised zero in-window dividends.
+  assertAlmostEquals(r.windowedZeroSharePct, 50);
+  // All four rows are within +/-1 pp here.
+  assertAlmostEquals(r.within1ppSharePct, 100);
+  assert(Number.isFinite(r.trimmedMeanDiffPp), "trimmed mean is reported");
+  assert(
+    r.verdict.includes("CONTRIBUTES") && r.verdict.includes("flat training"),
+    "verdict states the contributing direction",
+  );
+});
+
+Deno.test("buildReport: realised dividends exceeding the flat quarter OFFSET the gap", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      rowDiffsPp: [-0.40, -0.20],
+      flatYieldsPct: [0.20, 0.10],
+      windowedYieldsPct: [0.60, 0.30],
+      windowedZeroCount: 0,
+      includedCount: 2,
+    },
+  ];
+  const r = buildReport(aggregates);
+  assert(r.contributionPp < 0);
+  assert(
+    r.verdict.includes("OFFSETS"),
+    "verdict states the offsetting direction",
+  );
+});


### PR DESCRIPTION
## Summary

Adds a written diagnostic and reproducible analysis quantifying the
Target-over-Actual bias that comes purely from the **dividend basis** mismatch
between training and the dashboard (milestone #544 candidate). GRQ training bakes
a **flat** quarter of the trailing annual dividend, `core.yearOfDividends / 4`,
into the total-return label for **every** stock
(`GRQ/src/LearnUtil.ts:147-148`), whereas the validation side credits only the
**actual ex-dividends inside the 90-day window**
(`GRQ-validation/src/utils.rs` `calculate_dividends_for_period`, mirrored by the
shipped JS kernels `filterDividendsWithin90Days` + `sumDividends`).

Over the matured score set (274 score dates, 5 444 included stock-rows, as-of
2026-06-26) the per-row difference `(flatCredit − windowedCredit) / buyPrice` is
**+2.827 pp raw / +1.358 pp (1%-trimmed)**, median 0, **sign +**. The flat
training quarter is a **consistent over-credit** relative to realised in-window
dividends, so — because Target embeds the flat credit while Actual credits only
realised dividends — this dividend basis **contributes to (widens)** the
Target-over-Actual gap (the *opposite* of the price-basis candidate #552, which
masked it). The raw mean is lumpy: 86.4 % of rows fall within ±1 pp and a few
special/liquidating distributions on low-priced stocks (EQC, ELME, VISN)
dominate the tails, so the robust contribution is ~+1.4 pp. The main
same-direction driver is that **45.2 % of included rows realise zero in-window
dividends yet still receive the flat quarter in training**.

**Recommendation:** a genuine, modest, same-direction contributor worth fixing
by **aligning both sides on realised in-window dividends** — the clean fix is
upstream in `GRQ` (train/evaluate the label on the forward-window dividends
rather than a flat `yearOfDividends / 4`), since degrading the dashboard's
realised "Actual" to a fabricated flat quarter would credit dividends never
received. The root-cause training-label change is out of scope for this
`GRQ-validation` diagnostic and is carried as a fix candidate under #544.

Closes #553.

## Evidence

Backend/CLI diagnostic — no web UI to screenshot. Verified by the new unit tests
(below) and by running the reproducible report:

```text
$ deno run --allow-read scripts/diagnose_dividend_basis.ts docs 2026-06-26 ../GRQ-dividends
Matured score dates:     274
Included stock-rows:     5444
Mean (raw):              +2.827 pp
Mean (1%-trimmed):       +1.358 pp
Median:                  +0.000 pp
Within +/-1 pp:          86.4 %
Mean flat credit yield:  3.656 %
Mean windowed yield:     0.829 %
Rows with 0 in-window:   45.2 %
Gap contribution:        +2.827 pp
```

The full written diagnostic (mechanism, tables, mermaid flow, recommendation,
acceptance criteria) lives in
`docs/archive/investigations/issue-553-dividend-basis-bias.md`.

```mermaid
flowchart LR
    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv]
    B --> C[resolvePredictionStocks<br/>buyPrice + realised in-window totalDividends]
    A --> D[../GRQ-dividends<br/>full per-ticker history]
    D --> E[trailingAnnualDividends / 4<br/>flat training credit]
    C --> F[dividendBasisDifferencePercent<br/>= flat - windowed / buyPrice]
    E --> F
    F --> G[aggregate: mean / 1%-trimmed / median / dist<br/>+ sign vs observed gap]
```

## Test Plan

- `tests/dividend_basis_diagnostic_test.ts` (new, 14 tests) exercises the real
  shipped kernels and the real aggregation with synthetic data:
  - `trailingAnnualDividends` trailing-year sum, boundary semantics
    (`> scoreDate-365 && <= scoreDate`), and empty/invalid guards.
  - `dividendBasisDifferencePercent` arithmetic, the offsetting (negative)
    direction, and bad-input guards.
  - `stripSymbol` exchange-prefix/dot normalisation matching
    `extract_symbol_from_ticker`.
  - `summariseDiffs` and `trimmedMean` statistics, including outlier robustness.
  - `aggregateDate` for a semi-annual payer (flat > windowed, zero in-window)
    and a quarterly payer (flat ≈ windowed, nets to ~0).
  - `buildReport` contributing (+) and offsetting (−) verdicts and the
    `within1ppSharePct` / `windowedZeroSharePct` aggregates.
- All run read-only under `deno test --allow-read`; pure functions assert on
  computed results, not source text.

## Files

- `docs/projection.js` — new shipped kernels `trailingAnnualDividends` and
  `dividendBasisDifferencePercent` (published on `GRQProjection`).
- `scripts/dividend_basis_diagnostic.ts` — pure aggregation + disk loader.
- `scripts/diagnose_dividend_basis.ts` — CLI report (`deno task
  diagnose-dividend-basis`).
- `tests/dividend_basis_diagnostic_test.ts` — kernel + aggregation tests.
- `docs/archive/investigations/issue-553-dividend-basis-bias.md` — written
  diagnostic.
- `deno.json`, `README.md` — task entry and script-tree documentation.



## Milestone
This PR is part of the **#544 Diagnose systematic Target-over-Actual gap in validation's measurement basis** milestone and targets the `milestone/544-diagnose-systematic-target-over-actual-gap-in` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqu36d3b-727e00`<!-- vibe-worker-issue-553 -->