### PR TITLE
Quantify Target/Actual buy-price denominator bias (close vs midpoint) (#554)

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,9 @@ GRQ-validation/
 │   ├── price_basis_diagnostic.ts  # mid-vs-low basis bias computation (#552)
 │   ├── diagnose_price_basis.ts    # CLI report for the basis diagnostic (#552)
 │   ├── dividend_basis_diagnostic.ts # flat-1/4-vs-windowed dividend bias (#553)
-│   └── diagnose_dividend_basis.ts # CLI report for the dividend diagnostic (#553)
+│   ├── diagnose_dividend_basis.ts # CLI report for the dividend diagnostic (#553)
+│   ├── buy_price_denominator_diagnostic.ts # midpoint-vs-close denominator bias (#554)
+│   └── diagnose_buy_price_denominator.ts # CLI report for the denominator diagnostic (#554)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,8 @@
     "fetch-indices": "deno run --allow-net --allow-read --allow-write scripts/fetch_market_indices.ts",
     "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts",
     "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts",
-    "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts"
+    "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts",
+    "diagnose-buy-price-denominator": "deno run --allow-read scripts/diagnose_buy_price_denominator.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/docs/archive/investigations/issue-554-buy-price-denominator-bias.md
+++ b/docs/archive/investigations/issue-554-buy-price-denominator-bias.md
@@ -1,0 +1,166 @@
+# Buy-price denominator bias: training close vs dashboard midpoint
+
+_Diagnostic for Issue #554 (sub-issue of #544 — one candidate source of the
+systematic Target-over-Actual measurement gap). Measurement lives in
+`GRQ-validation`; the root denominator decision lives upstream in `GRQ`._
+
+## TL;DR
+
+The GRQ model is trained on a 90-day return whose **denominator** is
+`monthsAgoPrice` — the **close** on the score date. The validation dashboard
+divides **both** Target and Actual by `buyPrice` — the **split-adjusted
+midpoint** `(high + low) / 2` of the first usable point. Because the dashboard
+applies the *same* `buyPrice` to Target and Actual, the denominator choice
+**cannot desynchronise** them: it only rescales the (Target − Actual) gap by
+`buyPrice / close`.
+
+Over the matured historical score set (274 score dates, 5 444 included
+stock-rows, as-of 2026-06-26) the denominator offset
+`(buyPrice − close) / buyPrice` is:
+
+| Statistic | Value |
+| --- | --- |
+| Mean | **+0.046 pp** |
+| Median | +0.000 pp |
+| Min | −11.868 pp |
+| Max | +9.886 pp |
+| Std dev | 1.418 pp |
+
+**Sign and netting.** Unlike the price-basis offset of #552 (which is `>= 0` on
+every row), the midpoint-vs-close offset is **roughly symmetric around zero**
+(median 0.000, mean **+0.046 pp**, sign **+** but tiny). The close sits inside
+`[low, high]`, so on any given day it may be above or below the midpoint; across
+5 444 rows the two nearly cancel, leaving a negligible upward bias in `buyPrice`.
+
+| Quantity (mean over matured dates) | Value |
+| --- | --- |
+| Mean Target % (mid — current dashboard) | 28.916 % |
+| Mean Actual % (mid — current dashboard) | 10.447 % |
+| Mean Target % (close — trained basis) | 29.019 % |
+| Mean Actual % (close — trained basis) | 10.502 % |
+| **Observed gap** (Target − Actual, mid) | **+18.470 pp** |
+| Gap on the trained close basis | +18.517 pp |
+| **Basis contribution** (close − mid gap) | **+0.048 pp** |
+
+Restating **both** series onto the trained close denominator moves the apparent
+gap by ~**0.05 pp**, from ~18.47 pp to ~18.52 pp — three orders of magnitude
+smaller than the gap itself.
+
+> The per-row equal-weight mean (+0.046 pp) and the per-date portfolio-level
+> contribution (+0.048 pp) agree to within rounding, confirming the offset is a
+> broad, structural near-zero rather than an artefact of a few dates.
+
+## Acceptance criteria
+
+1. **Numeric denominator offset (pp) with sign** — mean **+0.046 pp** (per row)
+   / **+0.048 pp** (portfolio-level); roughly symmetric (median 0.000 pp).
+2. **A clear yes/no on whether Target vs Actual are desynchronised by the
+   denominator choice** — **NO.** The dashboard divides **both**
+   `calculatePortfolioTargetPercentage` and
+   `calculateIncludedPortfolioPerformance` by the **same** per-stock
+   `buyPrice`, so the denominator is shared. It rescales any existing gap by
+   `buyPrice / close`; it does not split Target and Actual onto different bases.
+3. **Fix-vs-leave recommendation** — see below.
+
+## Tracing the denominators (part 2)
+
+```mermaid
+flowchart TD
+    subgraph GRQ[Training — GRQ]
+        A[closePrices0 = close on score date] --> B[monthsAgoPrice]
+        B --> C["percentage = targetPrice + div/4 / monthsAgoPrice - 1"]
+    end
+    subgraph DASH[Dashboard — GRQ-validation]
+        D["getBuyPrice = split-adjusted high+low/2"] --> E[buyPrice]
+        E --> F[Target % = adjustedTarget - buyPrice / buyPrice]
+        E --> G[Actual % = currentPrice + div - buyPrice / buyPrice]
+    end
+    C -. emits absolute target price .-> F
+```
+
+- **Training denominator:** `GRQ/src/CoreFeatures.ts` sets
+  `monthsAgoPrice = closePrices[0]` (the close on the score date);
+  `GRQ/src/LearnUtil.ts:147-148` divides the labelled return by it, and
+  `:218` persists it with the train item.
+- **Dashboard denominator:** `GRQ-validation/docs/projection.js`
+  `getBuyPrice` (lines ~522-546) resolves the split-adjusted midpoint of the
+  first usable point; **both** `calculateTargetPercentage` /
+  `calculatePortfolioTargetPercentage` and `calculatePerformanceReturn` /
+  `calculateIncludedPortfolioPerformance` divide by that **one** `buyPrice`.
+- **Mixed basis?** Only at the level of the model's *emitted absolute target
+  price*: the network learned that price relative to the close, but the
+  dashboard expresses the (target − buyPrice) spread over `buyPrice`. Since
+  Actual is expressed over the *same* `buyPrice`, the choice rescales both
+  identically — it never measures Target and Actual on different denominators.
+
+## Aggregate contribution to the gap (part 3)
+
+**+0.048 pp** (portfolio-level), i.e. essentially nil. The denominator is a
+second-order rescale of an ~18.5 pp gap, not a driver of it.
+
+## Recommendation: **leave the dashboard denominator as-is** — exonerated
+
+- The denominator offset is **near-zero and symmetric** (mean +0.046 pp), so it
+  contributes a negligible **+0.048 pp** to the gap.
+- Target and Actual **already share** the denominator, so there is no
+  desynchronisation to fix — the property the issue asked us to confirm holds.
+- The midpoint `buyPrice` is also the more defensible figure to show a user as
+  the cost basis (an unbiased intraday estimate), and it is already split-aware,
+  which the raw training close is not.
+
+**Therefore:** this candidate is **exonerated as a cause** of the
+Target-over-Actual gap. The milestone (#544) should keep chasing genuine model
+optimism and the remaining candidates (price basis #552 — the dominant
+~2.2 pp masking term; dividend basis #553; score decoding). If a fully
+like-for-like trend comparison is ever wanted, the cleaner fix is to align the
+*price basis* (#552) upstream in `GRQ`, not to swap the dashboard's shared
+denominator for the training close.
+
+## How this was measured (reproducible)
+
+Every per-stock figure is delegated to the **shipped** kernels so the diagnostic
+measures the dashboard's own denominator, not a re-implementation:
+
+- `GRQProjection.getBuyPrice` — split-adjusted midpoint buy price (dashboard).
+- `GRQProjection.buyPriceCloseBasis` — split-adjusted close of the **same**
+  first point (the trained `monthsAgoPrice` basis; added for this diagnostic).
+- `GRQProjection.denominatorBasisOffsetPercent` —
+  `(buyPrice − close) / buyPrice * 100`.
+- `GRQProjection.calculatePortfolioTargetPercentage` /
+  `calculateIncludedPortfolioPerformance` — Target % and Actual % on each
+  denominator over the same included set.
+
+```bash
+deno task diagnose-buy-price-denominator   # against docs/, as-of today
+# raw form (pin an as-of date for a reproducible report):
+deno run --allow-read scripts/diagnose_buy_price_denominator.ts docs 2026-06-26
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>split-adjusted mid]
+    B --> D[buyPriceCloseBasis<br/>split-adjusted close]
+    C --> E[denominatorBasisOffsetPercent<br/>= buyPrice - close / buyPrice]
+    D --> E
+    C --> F[Target%/Actual% on mid basis]
+    D --> G[Target%/Actual% on close basis]
+    E --> H[aggregate: mean/median/dist<br/>+ gap rescale]
+    F --> H
+    G --> H
+```
+
+## Code references
+
+- Training denominator (close on score date): `GRQ/src/CoreFeatures.ts`
+  (`monthsAgoPrice = closePrices[0]`), `GRQ/src/LearnUtil.ts:147-148` (divides
+  by it), `:218` (persists it).
+- Dashboard denominator (shared midpoint): `GRQ-validation/docs/projection.js`
+  — `getBuyPrice`; consumed by `calculateTargetPercentage` /
+  `calculatePortfolioTargetPercentage` and `calculatePerformanceReturn` /
+  `calculateIncludedPortfolioPerformance`.
+- Matching close basis + offset helper: `GRQ-validation/docs/projection.js`
+  — `buyPriceCloseBasis`, `denominatorBasisOffsetPercent` (this issue).
+- Diagnostic: `scripts/diagnose_buy_price_denominator.ts`,
+  `scripts/buy_price_denominator_diagnostic.ts`;
+  tests `tests/buy_price_denominator_diagnostic_test.ts`.

--- a/docs/archive/pr-summaries/pr-summary-554.md
+++ b/docs/archive/pr-summaries/pr-summary-554.md
@@ -1,0 +1,102 @@
+## Summary
+
+Diagnostic for issue #554 (sub-issue of milestone #544): quantify the
+Target/Actual bias that comes purely from the **buy-price denominator**
+mismatch — training divides the 90-day return by `monthsAgoPrice` (the **close**
+on the score date), while the dashboard divides **both** Target and Actual by
+`buyPrice` (the split-adjusted **midpoint** of the first usable point).
+
+The headline finding: because the dashboard applies the **same** `buyPrice` to
+Target and Actual, the denominator choice **cannot desynchronise** them — it
+only rescales the existing gap by `buyPrice / close`. Over the matured
+historical score set the denominator offset is **near-zero and symmetric**
+(mean **+0.046 pp**, median 0.000 pp), contributing a negligible **+0.048 pp**
+to the ~18.5 pp gap. This candidate is **exonerated** as a cause of the gap;
+recommendation is to **leave** the dashboard denominator as-is.
+
+Closes #554.
+
+### Acceptance criteria
+
+- **Numeric denominator offset (pp) with sign** — mean **+0.046 pp** per row /
+  **+0.048 pp** portfolio-level; roughly symmetric (median 0.000 pp, min
+  −11.868 pp, max +9.886 pp, σ 1.418 pp) over 274 matured dates, 5 444 rows
+  (as-of 2026-06-26).
+- **Yes/no — are Target vs Actual desynchronised by the denominator choice?**
+  **NO.** `calculatePortfolioTargetPercentage` and
+  `calculateIncludedPortfolioPerformance` both divide by the **same** per-stock
+  `buyPrice`; the only mixed-basis level is the model's emitted absolute target
+  price (trained against the close), but since Actual uses the same `buyPrice`
+  the choice rescales both identically.
+- **Fix-vs-leave recommendation** — **leave**: the offset is negligible and the
+  denominator is already shared; the midpoint buy price is also the more
+  defensible, split-aware cost basis. The dominant masking term is the price
+  basis (#552), not the denominator.
+
+## Evidence
+
+Backend/CLI diagnostic — no web UI change, so no screenshot. Reproduce with:
+
+```bash
+deno task diagnose-buy-price-denominator            # against docs/, as-of today
+deno run --allow-read scripts/diagnose_buy_price_denominator.ts docs 2026-06-26
+```
+
+Output (as-of 2026-06-26):
+
+```
+## Per-row denominator offset (buyPrice - close) / buyPrice
+Mean:                  +0.046 pp
+Median:                +0.000 pp
+Min:                   -11.868 pp
+Max:                   +9.886 pp
+Std dev:               1.418 pp
+
+Observed gap (mid):    +18.470 pp
+Gap on close basis:    +18.517 pp
+Basis contribution:    +0.048 pp
+```
+
+Full write-up: `docs/archive/investigations/issue-554-buy-price-denominator-bias.md`.
+
+```mermaid
+flowchart TD
+    subgraph GRQ[Training — GRQ]
+        A[closePrices0 = close on score date] --> B[monthsAgoPrice]
+        B --> C["return / monthsAgoPrice - 1"]
+    end
+    subgraph DASH[Dashboard — GRQ-validation]
+        D["getBuyPrice = split-adjusted high+low/2"] --> E[buyPrice]
+        E --> F[Target % over buyPrice]
+        E --> G[Actual % over buyPrice]
+    end
+    C -. emits absolute target price .-> F
+```
+
+## Test Plan
+
+Added `tests/buy_price_denominator_diagnostic_test.ts` (11 tests), exercising
+the real shipped kernels and aggregation with synthetic data:
+
+- `buyPriceCloseBasis` — returns the split-adjusted close of the first usable
+  point; picks the **same** row as `getBuyPrice`; null on no data.
+- `denominatorBasisOffsetPercent` — `(buyPrice − close) / buyPrice * 100`,
+  including the negative-offset (close above midpoint) case and input guards.
+- `summariseOffsets` — mean/median/min/max/stdDev and empty input.
+- `aggregateDate` — per-row offset; and that a smaller denominator inflates
+  **both** Target and Actual together (the no-desync property).
+- `buildReport` — gap rescale, basis contribution, and verdict wording
+  (states "does NOT desynchronise"; renders a negative mean sign).
+
+All 1035 Deno tests pass; `deno fmt`, `deno lint` and `deno check` clean.
+
+## Files
+
+- `docs/projection.js` — new shipped kernels `buyPriceCloseBasis`,
+  `denominatorBasisOffsetPercent` (exported on `GRQProjection`).
+- `scripts/buy_price_denominator_diagnostic.ts` — pure aggregation + disk loader.
+- `scripts/diagnose_buy_price_denominator.ts` — CLI report runner.
+- `tests/buy_price_denominator_diagnostic_test.ts` — tests.
+- `deno.json` — `diagnose-buy-price-denominator` task.
+- `README.md` — scripts listing.
+- `docs/archive/investigations/issue-554-buy-price-denominator-bias.md` — write-up.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -622,6 +622,66 @@ function priceBasisOffsetPercent(buyPrice, midPrice, lowPrice) {
     return ((midPrice - lowPrice) / buyPrice) * 100;
 }
 
+// Buy-price denominator on the model's TRAINED basis: the split-adjusted
+// CLOSE of the first usable market-data point on or within five days after the
+// score date (issue #554). The GRQ training label divides the 90-day return by
+// `core.monthsAgoPrice`, which is `closePrices[0]` — the close on the score date
+// (GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts). The dashboard instead
+// divides by `getBuyPrice`, the split-adjusted MIDPOINT `(high + low) / 2` of
+// the same first point. This helper mirrors `getBuyPrice`'s point selection and
+// split adjustment EXACTLY — only the close replaces the midpoint — so a
+// like-for-like denominator comparison isolates the midpoint-vs-close basis (the
+// shared split factor cancels in the ratio). Returns `{ price, dateUsed,
+// reliable }`, or null when no market data falls in that window.
+function buyPriceCloseBasis(marketData, scoreDate) {
+    if (!marketData) return null;
+
+    const { reliable } = computeSplitAdjustment(marketData, scoreDate);
+
+    for (let offset = 0; offset <= 5; offset++) {
+        const candidateDate = new Date(scoreDate.getTime());
+        candidateDate.setDate(candidateDate.getDate() + offset);
+        const candidateData = marketData.find((point) => {
+            const pointDate = new Date(
+                point.date.getFullYear(),
+                point.date.getMonth(),
+                point.date.getDate(),
+            );
+            return pointDate.getTime() === candidateDate.getTime();
+        });
+        if (candidateData) {
+            const adjustedPrice = adjustHistoricalPriceToCurrent(
+                candidateData.close,
+                marketData,
+                scoreDate,
+            );
+            return { price: adjustedPrice, dateUsed: candidateDate, reliable };
+        }
+    }
+    return null;
+}
+
+// Denominator-basis offset between the dashboard's midpoint buy price and the
+// model's trained close basis, as a percentage of the dashboard buy price
+// (issue #554): `(buyPrice - buyPriceClose) / buyPrice * 100`. This is how much
+// LARGER (sign +) or smaller (sign -) the dashboard denominator is than the
+// close the model was trained to divide by. Because the dashboard applies the
+// SAME `buyPrice` to BOTH Target and Actual, this offset does not desynchronise
+// them — it rescales any existing Target-over-Actual gap by `buyPrice /
+// buyPriceClose`. Returns null when any input is missing or a price is not a
+// positive number.
+function denominatorBasisOffsetPercent(buyPrice, buyPriceClose) {
+    if (
+        buyPrice === null || buyPrice === undefined || Number.isNaN(buyPrice) ||
+        buyPrice <= 0 ||
+        buyPriceClose === null || buyPriceClose === undefined ||
+        Number.isNaN(buyPriceClose) || buyPriceClose <= 0
+    ) {
+        return null;
+    }
+    return ((buyPrice - buyPriceClose) / buyPrice) * 100;
+}
+
 // Trailing-365-day dividend total as of the score date — the quantity the GRQ
 // model turns into a FLAT training credit of `yearOfDividends / 4`
 // (GRQ/src/CoreFeatures.ts builds `yearOfDividends`; GRQ/src/LearnUtil.ts bakes
@@ -1140,6 +1200,8 @@ globalThis.GRQProjection = {
     priceAtNinetyDayHorizon,
     lowPriceAtNinetyDayHorizon,
     priceBasisOffsetPercent,
+    buyPriceCloseBasis,
+    denominatorBasisOffsetPercent,
     trailingAnnualDividends,
     dividendBasisDifferencePercent,
     calculateTargetPercentage,

--- a/scripts/buy_price_denominator_diagnostic.ts
+++ b/scripts/buy_price_denominator_diagnostic.ts
@@ -1,0 +1,270 @@
+// Core computation for the issue #554 buy-price denominator diagnostic.
+//
+// Splits the pure aggregation (testable with synthetic rows, no disk) from the
+// file IO. Every per-stock figure is delegated to the SHIPPED kernels published
+// on globalThis by docs/projection.js and docs/trend_predictions.js, so the
+// diagnostic measures the dashboard's own denominator rather than a
+// re-implementation.
+//
+// The question: training divides the 90-day return by `monthsAgoPrice` (the
+// CLOSE on the score date — GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts),
+// while the dashboard divides BOTH Target and Actual by `buyPrice` (the
+// split-adjusted MIDPOINT of the first usable point). This module quantifies the
+// denominator offset and the gap it contributes when Target and Actual are
+// restated onto the trained close basis.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Summary statistics for a list of per-row denominator offsets (pp). */
+export interface OffsetSummary {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  stdDev: number;
+}
+
+/** Pure stats over a list of numbers. Empty input yields all-zero summary. */
+export function summariseOffsets(values: number[]): OffsetSummary {
+  const finite = values.filter((v) =>
+    typeof v === "number" && !Number.isNaN(v)
+  );
+  if (finite.length === 0) {
+    return { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 };
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  const sum = finite.reduce((t, v) => t + v, 0);
+  const mean = sum / finite.length;
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+  const variance = finite.reduce((t, v) => t + (v - mean) ** 2, 0) /
+    finite.length;
+  return {
+    count: finite.length,
+    mean,
+    median,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+/** One matured score date's portfolio figures on both buy-price bases. */
+export interface DateAggregate {
+  date: string;
+  // Dashboard basis (denominator = midpoint buyPrice).
+  targetMidPct: number | null;
+  actualMidPct: number | null;
+  // Trained basis (denominator = split-adjusted close).
+  targetClosePct: number | null;
+  actualClosePct: number | null;
+  rowOffsetsPp: number[];
+}
+
+// Build the dashboard (midpoint-denominator) and trained (close-denominator)
+// per-stock inputs for one score date and compute the portfolio Target % and
+// Actual % on each basis, plus the per-row `(buyPrice - buyPriceClose) /
+// buyPrice` denominator offsets over the INCLUDED stocks. Pure: the caller
+// supplies already-parsed score rows and the market-data map.
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  dividendData: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  const midStocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+
+  const rowOffsetsPp: number[] = [];
+  // deno-lint-ignore no-explicit-any
+  const closeStocks = midStocks.map((stock: any, i: number) => {
+    const points = marketData[scoreRows[i].stock];
+    const closeObj = P.buyPriceCloseBasis(points, scoreDate);
+    const buyPriceClose = closeObj ? closeObj.price : null;
+    const offset = P.denominatorBasisOffsetPercent(
+      stock.buyPrice,
+      buyPriceClose,
+    );
+    const included = P.isStockIncluded(
+      stock.buyPrice,
+      stock.currentPrice,
+      stock.splitReliable,
+    );
+    if (included && offset !== null) {
+      rowOffsetsPp.push(offset);
+    }
+    // Same stock, both Target and Actual measured on the trained close
+    // denominator instead of the midpoint buy price. Only the denominator
+    // changes; numerators (adjustedTarget, currentPrice, dividends) are shared.
+    return { ...stock, buyPrice: buyPriceClose };
+  });
+
+  return {
+    date,
+    targetMidPct: P.calculatePortfolioTargetPercentage(midStocks),
+    actualMidPct: P.calculateIncludedPortfolioPerformance(midStocks),
+    targetClosePct: P.calculatePortfolioTargetPercentage(closeStocks),
+    actualClosePct: P.calculateIncludedPortfolioPerformance(closeStocks),
+    rowOffsetsPp,
+  };
+}
+
+/** The full diagnostic result over the matured historical score set. */
+export interface DenominatorReport {
+  maturedDates: number;
+  rowCount: number;
+  meanOffsetPp: number;
+  medianOffsetPp: number;
+  minOffsetPp: number;
+  maxOffsetPp: number;
+  stdDevPp: number;
+  meanTargetMidPct: number;
+  meanActualMidPct: number;
+  meanTargetClosePct: number;
+  meanActualClosePct: number;
+  observedGapPp: number;
+  gapOnCloseBasisPp: number;
+  basisContributionPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Assemble the report from per-date aggregates. Pure so it can be unit-tested
+// with synthetic DateAggregate rows.
+export function buildReport(aggregates: DateAggregate[]): DenominatorReport {
+  const allOffsets = aggregates.flatMap((a) => a.rowOffsetsPp);
+  const stats = summariseOffsets(allOffsets);
+
+  const withFigures = aggregates.filter((a) =>
+    a.targetMidPct !== null && a.actualMidPct !== null &&
+    a.targetClosePct !== null && a.actualClosePct !== null
+  );
+  const meanTargetMidPct = mean(
+    withFigures.map((a) => a.targetMidPct as number),
+  );
+  const meanActualMidPct = mean(
+    withFigures.map((a) => a.actualMidPct as number),
+  );
+  const meanTargetClosePct = mean(
+    withFigures.map((a) => a.targetClosePct as number),
+  );
+  const meanActualClosePct = mean(
+    withFigures.map((a) => a.actualClosePct as number),
+  );
+  // Both bases divide Target and Actual by the SAME denominator, so each basis
+  // is internally self-consistent; the gap on each is Target - Actual.
+  const observedGapPp = meanTargetMidPct - meanActualMidPct;
+  const gapOnCloseBasisPp = meanTargetClosePct - meanActualClosePct;
+  const basisContributionPp = gapOnCloseBasisPp - observedGapPp;
+
+  const sign = stats.mean >= 0 ? "+" : "-";
+  const widthWord = basisContributionPp >= 0 ? "WIDEN" : "NARROW";
+  const verdict =
+    `VERDICT: the dashboard divides BOTH Target and Actual by the same ` +
+    `midpoint buyPrice, so the denominator choice does NOT desynchronise ` +
+    `Target vs Actual — it rescales any existing gap by buyPrice/close. The ` +
+    `midpoint buyPrice runs a mean ${sign}${
+      Math.abs(stats.mean).toFixed(3)
+    } pp versus the trained close denominator. Restating BOTH series onto the ` +
+    `trained close basis would ${widthWord} the observed gap by ${
+      Math.abs(basisContributionPp).toFixed(3)
+    } pp (from ${observedGapPp.toFixed(3)} to ${
+      gapOnCloseBasisPp.toFixed(3)
+    } pp). The denominator is therefore a second-order rescale, not a cause of ` +
+    `the Target-over-Actual gap.`;
+
+  return {
+    maturedDates: aggregates.length,
+    rowCount: stats.count,
+    meanOffsetPp: stats.mean,
+    medianOffsetPp: stats.median,
+    minOffsetPp: stats.min,
+    maxOffsetPp: stats.max,
+    stdDevPp: stats.stdDev,
+    meanTargetMidPct,
+    meanActualMidPct,
+    meanTargetClosePct,
+    meanActualClosePct,
+    observedGapPp,
+    gapOnCloseBasisPp,
+    basisContributionPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+// Load the matured score set from disk and compute the full diagnostic.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+export async function computeDenominatorDiagnostic(
+  docsPath: string,
+  asOf: Date,
+): Promise<DenominatorReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    const scoreRows = TP.parseScoreTsv(tsvText);
+    const marketData = TP.parseMarketCsv(csvText);
+    const dividendData = TP.parseDividendCsv(divText);
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        scoreRows,
+        marketData,
+        dividendData,
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReport(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/scripts/diagnose_buy_price_denominator.ts
+++ b/scripts/diagnose_buy_price_denominator.ts
@@ -1,0 +1,61 @@
+// Diagnostic for issue #554 (milestone #544): quantify the Target/Actual bias
+// that comes purely from the buy-price DENOMINATOR mismatch between training and
+// the dashboard.
+//
+//   - The GRQ model is trained on a 90-day return divided by `monthsAgoPrice`,
+//     which is the CLOSE on the score date (GRQ/src/CoreFeatures.ts builds
+//     `monthsAgoPrice = closePrices[0]`; GRQ/src/LearnUtil.ts divides by it).
+//   - The dashboard divides BOTH Target and Actual by `buyPrice`, the
+//     split-adjusted MIDPOINT (high + low) / 2 of the first usable point
+//     (docs/projection.js -> getBuyPrice).
+//
+// Because the dashboard uses the SAME buyPrice for Target and Actual, the
+// denominator choice cannot desynchronise them — it only rescales any existing
+// gap by buyPrice/close. This script quantifies that offset and the gap it
+// contributes when both series are restated onto the trained close basis.
+//
+// It reuses the SHIPPED kernels — GRQProjection.getBuyPrice,
+// buyPriceCloseBasis, denominatorBasisOffsetPercent, isStockIncluded,
+// calculatePortfolioTargetPercentage and calculateIncludedPortfolioPerformance,
+// plus the GRQTrendPredictions CSV/TSV parsers — so the numbers it reports are
+// computed on exactly the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_buy_price_denominator.ts [docsPath] [asOf]
+// (default docsPath = "docs"). Read-only; prints a Markdown-friendly report.
+
+import { computeDenominatorDiagnostic } from "./buy_price_denominator_diagnostic.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+// "Today" governs which score dates have a complete 90-day window. Default to
+// the real clock; allow an override (second arg, YYYY-MM-DD) for reproducible
+// reports pinned to a specific as-of date.
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+
+const report = await computeDenominatorDiagnostic(docsPath, asOf);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(
+  `# Buy-price denominator (midpoint vs close) diagnostic — issue #554\n`,
+);
+console.log(`As-of date:            ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Matured score dates:   ${report.maturedDates}`);
+console.log(`Included stock-rows:   ${report.rowCount}`);
+console.log("");
+console.log(`## Per-row denominator offset (buyPrice - close) / buyPrice`);
+console.log(`Mean:                  ${pp(report.meanOffsetPp)}`);
+console.log(`Median:                ${pp(report.medianOffsetPp)}`);
+console.log(`Min:                   ${pp(report.minOffsetPp)}`);
+console.log(`Max:                   ${pp(report.maxOffsetPp)}`);
+console.log(`Std dev:               ${report.stdDevPp.toFixed(3)} pp`);
+console.log("");
+console.log(`## Per-date portfolio aggregates (mean over matured dates)`);
+console.log(`Mean Target % (mid):   ${report.meanTargetMidPct.toFixed(3)} %`);
+console.log(`Mean Actual % (mid):   ${report.meanActualMidPct.toFixed(3)} %`);
+console.log(`Mean Target % (close): ${report.meanTargetClosePct.toFixed(3)} %`);
+console.log(`Mean Actual % (close): ${report.meanActualClosePct.toFixed(3)} %`);
+console.log(`Observed gap (mid):    ${pp(report.observedGapPp)}`);
+console.log(`Gap on close basis:    ${pp(report.gapOnCloseBasisPp)}`);
+console.log(`Basis contribution:    ${pp(report.basisContributionPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/tests/buy_price_denominator_diagnostic_test.ts
+++ b/tests/buy_price_denominator_diagnostic_test.ts
@@ -1,0 +1,234 @@
+// Tests for the issue #554 buy-price denominator (midpoint vs close) diagnostic.
+//
+// These exercise the REAL shipped kernels (docs/projection.js) and the real
+// aggregation in scripts/buy_price_denominator_diagnostic.ts with synthetic
+// market data, asserting on computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReport,
+  type DateAggregate,
+  summariseOffsets,
+} from "../scripts/buy_price_denominator_diagnostic.ts";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+Deno.test("buyPriceCloseBasis returns the split-adjusted close of the first usable point", () => {
+  const scoreDate = midnight("2026-01-01");
+  const market = [
+    {
+      date: midnight("2026-01-02"),
+      high: 12,
+      low: 8,
+      open: 9,
+      close: 11,
+      splitCoefficient: 1,
+    },
+  ];
+  const obj = P.buyPriceCloseBasis(market, scoreDate);
+  // No split -> adjusted close == raw close 11.
+  assertEquals(obj.price, 11);
+  assertEquals(obj.reliable, true);
+});
+
+Deno.test("buyPriceCloseBasis picks the SAME first point as getBuyPrice (close vs midpoint)", () => {
+  const scoreDate = midnight("2026-01-01");
+  const market = [
+    {
+      date: midnight("2026-01-03"), // 2 days forward — both must use this row
+      high: 20,
+      low: 10,
+      open: 12,
+      close: 18,
+      splitCoefficient: 1,
+    },
+  ];
+  const close = P.buyPriceCloseBasis(market, scoreDate);
+  const buy = P.getBuyPrice(market, scoreDate);
+  assertEquals(close.price, 18); // close
+  assertEquals(buy.price, (20 + 10) / 2); // midpoint = 15
+  assertEquals(close.dateUsed.getTime(), buy.dateUsed.getTime());
+});
+
+Deno.test("buyPriceCloseBasis returns null with no usable data", () => {
+  assertEquals(P.buyPriceCloseBasis([], midnight("2026-01-01")), null);
+  assertEquals(P.buyPriceCloseBasis(null, midnight("2026-01-01")), null);
+});
+
+Deno.test("denominatorBasisOffsetPercent computes (buyPrice - close) / buyPrice * 100", () => {
+  // buyPrice 100, close 95 -> +5 pp (midpoint above close)
+  assertAlmostEquals(P.denominatorBasisOffsetPercent(100, 95), 5);
+  // close above midpoint -> negative offset
+  assertAlmostEquals(P.denominatorBasisOffsetPercent(100, 105), -5);
+  // equal -> zero
+  assertEquals(P.denominatorBasisOffsetPercent(100, 100), 0);
+});
+
+Deno.test("denominatorBasisOffsetPercent guards bad inputs", () => {
+  assertEquals(P.denominatorBasisOffsetPercent(0, 9), null);
+  assertEquals(P.denominatorBasisOffsetPercent(-5, 9), null);
+  assertEquals(P.denominatorBasisOffsetPercent(100, 0), null);
+  assertEquals(P.denominatorBasisOffsetPercent(100, NaN), null);
+  assertEquals(P.denominatorBasisOffsetPercent(null, 9), null);
+});
+
+Deno.test("summariseOffsets computes mean/median/min/max/stdDev", () => {
+  const s = summariseOffsets([1, 2, 3, 4]);
+  assertEquals(s.count, 4);
+  assertAlmostEquals(s.mean, 2.5);
+  assertAlmostEquals(s.median, 2.5);
+  assertEquals(s.min, 1);
+  assertEquals(s.max, 4);
+  assertAlmostEquals(s.stdDev, Math.sqrt(1.25));
+});
+
+Deno.test("summariseOffsets handles empty input", () => {
+  const s = summariseOffsets([]);
+  assertEquals(s, { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 });
+});
+
+Deno.test("aggregateDate measures the per-row midpoint-vs-close denominator offset", () => {
+  const scoreDate = midnight("2026-01-01");
+  const scoreRows = [{
+    stock: "X",
+    target: 130,
+    score: 0.5,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    X: [
+      {
+        date: midnight("2026-01-02"),
+        high: 110, // midpoint = 100
+        low: 90,
+        open: 95,
+        close: 95, // trained close basis
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 120,
+        low: 100, // midpoint = 110 -> Actual numerator
+        open: 110,
+        close: 115,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, scoreDate);
+  // buyPrice = mid of first day = 100; close = 95.
+  // offset = (100 - 95) / 100 * 100 = 5 pp.
+  assertEquals(agg.rowOffsetsPp.length, 1);
+  assertAlmostEquals(agg.rowOffsetsPp[0], 5, 1e-9);
+  // Actual numerator = horizon mid 110. On mid basis: (110-100)/100 = +10%.
+  // On close basis: (110-95)/95 = +15.789%.
+  assert(agg.actualMidPct !== null && agg.actualClosePct !== null);
+  assertAlmostEquals(agg.actualMidPct as number, 10, 1e-9);
+  assertAlmostEquals(
+    agg.actualClosePct as number,
+    ((110 - 95) / 95) * 100,
+    1e-9,
+  );
+  // Target adjustedTarget = 130. mid: (130-100)/100 = 30%; close: (130-95)/95.
+  assertAlmostEquals(agg.targetMidPct as number, 30, 1e-9);
+  assertAlmostEquals(
+    agg.targetClosePct as number,
+    ((130 - 95) / 95) * 100,
+    1e-9,
+  );
+});
+
+Deno.test("aggregateDate: a smaller denominator inflates BOTH Target and Actual together", () => {
+  // When close < buyPrice, dividing by the smaller close lifts both the Target
+  // and the Actual percentages — confirming the denominator does NOT
+  // desynchronise the two (it rescales both).
+  const scoreDate = midnight("2026-01-01");
+  const scoreRows = [{
+    stock: "Y",
+    target: 150,
+    score: 0.5,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    Y: [
+      {
+        date: midnight("2026-01-02"),
+        high: 110,
+        low: 90, // mid = 100
+        open: 95,
+        close: 80, // close well below midpoint
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 130,
+        low: 110, // mid = 120
+        open: 120,
+        close: 125,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, scoreDate);
+  assert((agg.targetClosePct as number) > (agg.targetMidPct as number));
+  assert((agg.actualClosePct as number) > (agg.actualMidPct as number));
+});
+
+Deno.test("buildReport: rescales the gap and verdict states no desync", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetMidPct: 25,
+      actualMidPct: 10,
+      targetClosePct: 27,
+      actualClosePct: 11,
+      rowOffsetsPp: [3, 5],
+    },
+    {
+      date: "2026-02-01",
+      targetMidPct: 15,
+      actualMidPct: 8,
+      targetClosePct: 16,
+      actualClosePct: 8.5,
+      rowOffsetsPp: [1, 3],
+    },
+  ];
+  const r = buildReport(aggregates);
+  assertEquals(r.maturedDates, 2);
+  assertEquals(r.rowCount, 4);
+  assertAlmostEquals(r.meanOffsetPp, 3); // (3+5+1+3)/4
+  // mean Target(mid) 20, Actual(mid) 9 -> observed gap 11.
+  assertAlmostEquals(r.observedGapPp, 11);
+  // mean Target(close) 21.5, Actual(close) 9.75 -> gap 11.75.
+  assertAlmostEquals(r.gapOnCloseBasisPp, 11.75);
+  assertAlmostEquals(r.basisContributionPp, 0.75); // 11.75 - 11
+  assert(
+    r.verdict.includes("does NOT desynchronise"),
+    "verdict states Target/Actual share the denominator",
+  );
+});
+
+Deno.test("buildReport: negative mean offset reported with sign", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetMidPct: 20,
+      actualMidPct: 10,
+      targetClosePct: 18,
+      actualClosePct: 9,
+      rowOffsetsPp: [-2, -4],
+    },
+  ];
+  const r = buildReport(aggregates);
+  assert(r.meanOffsetPp < 0);
+  assert(r.verdict.includes("-"), "negative mean sign rendered");
+});


### PR DESCRIPTION
## Summary

Diagnostic for issue #554 (sub-issue of milestone #544): quantify the
Target/Actual bias that comes purely from the **buy-price denominator**
mismatch — training divides the 90-day return by `monthsAgoPrice` (the **close**
on the score date), while the dashboard divides **both** Target and Actual by
`buyPrice` (the split-adjusted **midpoint** of the first usable point).

The headline finding: because the dashboard applies the **same** `buyPrice` to
Target and Actual, the denominator choice **cannot desynchronise** them — it
only rescales the existing gap by `buyPrice / close`. Over the matured
historical score set the denominator offset is **near-zero and symmetric**
(mean **+0.046 pp**, median 0.000 pp), contributing a negligible **+0.048 pp**
to the ~18.5 pp gap. This candidate is **exonerated** as a cause of the gap;
recommendation is to **leave** the dashboard denominator as-is.

Closes #554.

### Acceptance criteria

- **Numeric denominator offset (pp) with sign** — mean **+0.046 pp** per row /
  **+0.048 pp** portfolio-level; roughly symmetric (median 0.000 pp, min
  −11.868 pp, max +9.886 pp, σ 1.418 pp) over 274 matured dates, 5 444 rows
  (as-of 2026-06-26).
- **Yes/no — are Target vs Actual desynchronised by the denominator choice?**
  **NO.** `calculatePortfolioTargetPercentage` and
  `calculateIncludedPortfolioPerformance` both divide by the **same** per-stock
  `buyPrice`; the only mixed-basis level is the model's emitted absolute target
  price (trained against the close), but since Actual uses the same `buyPrice`
  the choice rescales both identically.
- **Fix-vs-leave recommendation** — **leave**: the offset is negligible and the
  denominator is already shared; the midpoint buy price is also the more
  defensible, split-aware cost basis. The dominant masking term is the price
  basis (#552), not the denominator.

## Evidence

Backend/CLI diagnostic — no web UI change, so no screenshot. Reproduce with:

```bash
deno task diagnose-buy-price-denominator            # against docs/, as-of today
deno run --allow-read scripts/diagnose_buy_price_denominator.ts docs 2026-06-26
```

Output (as-of 2026-06-26):

```
## Per-row denominator offset (buyPrice - close) / buyPrice
Mean:                  +0.046 pp
Median:                +0.000 pp
Min:                   -11.868 pp
Max:                   +9.886 pp
Std dev:               1.418 pp

Observed gap (mid):    +18.470 pp
Gap on close basis:    +18.517 pp
Basis contribution:    +0.048 pp
```

Full write-up: `docs/archive/investigations/issue-554-buy-price-denominator-bias.md`.

```mermaid
flowchart TD
    subgraph GRQ[Training — GRQ]
        A[closePrices0 = close on score date] --> B[monthsAgoPrice]
        B --> C["return / monthsAgoPrice - 1"]
    end
    subgraph DASH[Dashboard — GRQ-validation]
        D["getBuyPrice = split-adjusted high+low/2"] --> E[buyPrice]
        E --> F[Target % over buyPrice]
        E --> G[Actual % over buyPrice]
    end
    C -. emits absolute target price .-> F
```

## Test Plan

Added `tests/buy_price_denominator_diagnostic_test.ts` (11 tests), exercising
the real shipped kernels and aggregation with synthetic data:

- `buyPriceCloseBasis` — returns the split-adjusted close of the first usable
  point; picks the **same** row as `getBuyPrice`; null on no data.
- `denominatorBasisOffsetPercent` — `(buyPrice − close) / buyPrice * 100`,
  including the negative-offset (close above midpoint) case and input guards.
- `summariseOffsets` — mean/median/min/max/stdDev and empty input.
- `aggregateDate` — per-row offset; and that a smaller denominator inflates
  **both** Target and Actual together (the no-desync property).
- `buildReport` — gap rescale, basis contribution, and verdict wording
  (states "does NOT desynchronise"; renders a negative mean sign).

All 1035 Deno tests pass; `deno fmt`, `deno lint` and `deno check` clean.

## Files

- `docs/projection.js` — new shipped kernels `buyPriceCloseBasis`,
  `denominatorBasisOffsetPercent` (exported on `GRQProjection`).
- `scripts/buy_price_denominator_diagnostic.ts` — pure aggregation + disk loader.
- `scripts/diagnose_buy_price_denominator.ts` — CLI report runner.
- `tests/buy_price_denominator_diagnostic_test.ts` — tests.
- `deno.json` — `diagnose-buy-price-denominator` task.
- `README.md` — scripts listing.
- `docs/archive/investigations/issue-554-buy-price-denominator-bias.md` — write-up.



## Milestone
This PR is part of the **#544 Diagnose systematic Target-over-Actual gap in validation's measurement basis** milestone and targets the `milestone/544-diagnose-systematic-target-over-actual-gap-in` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqu36d3b-727e00`<!-- vibe-worker-issue-554 -->