### PR TITLE
Audit market-data timing & corporate-action parity (Issue #555)

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,9 @@ GRQ-validation/
 │   ├── dividend_basis_diagnostic.ts # flat-1/4-vs-windowed dividend bias (#553)
 │   ├── diagnose_dividend_basis.ts # CLI report for the dividend diagnostic (#553)
 │   ├── buy_price_denominator_diagnostic.ts # midpoint-vs-close denominator bias (#554)
-│   └── diagnose_buy_price_denominator.ts # CLI report for the denominator diagnostic (#554)
+│   ├── diagnose_buy_price_denominator.ts # CLI report for the denominator diagnostic (#554)
+│   ├── horizon_split_parity_diagnostic.ts # horizon as-of split-basis parity (#555)
+│   └── diagnose_horizon_split_parity.ts # CLI report for the timing/split parity audit (#555)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,8 @@
     "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts",
     "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts",
     "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts",
-    "diagnose-buy-price-denominator": "deno run --allow-read scripts/diagnose_buy_price_denominator.ts"
+    "diagnose-buy-price-denominator": "deno run --allow-read scripts/diagnose_buy_price_denominator.ts",
+    "diagnose-horizon-split-parity": "deno run --allow-read scripts/diagnose_horizon_split_parity.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/docs/archive/investigations/issue-555-market-data-timing-corporate-action-parity.md
+++ b/docs/archive/investigations/issue-555-market-data-timing-corporate-action-parity.md
@@ -1,0 +1,203 @@
+# Market-data timing & corporate-action parity: training vs dashboard
+
+_Parity audit for Issue #555 (sub-issue of #544 — one candidate source of the
+systematic Target-over-Actual measurement gap). User-raised candidate. The
+training timing/adjustment lives upstream in `GRQ`; the dashboard
+timing/adjustment lives in `GRQ-validation`._
+
+## TL;DR
+
+Of the four timing/corporate-action decisions the issue asked us to confirm,
+**three are aligned** between training and the dashboard and **one is
+divergent**:
+
+1. **Horizon-date selection — aligned.** Training takes the trading day on or
+   before `asOf + 90*DAY`; the dashboard takes the last market-data point on or
+   before `scoreDate + 90 days`. On the stock's own daily series these resolve
+   to the **same row**.
+2. **OHLC field — divergent, but already owned upstream.** Training reads the
+   intraday **low** at the horizon and the **close** at the score date; the
+   dashboard reads the **midpoint** `(high + low) / 2` at both. These are the
+   #552 (horizon field, ~+2.2 pp masking) and #554 (buy-price field, ~+0.05 pp)
+   findings — not re-quantified here.
+3. **Split/merge adjustment convention — aligned.** Both sides work on
+   split-adjusted prices and restate a historical price into current
+   (end-of-series) terms by dividing out the cumulative split factor for splits
+   **after** that date.
+4. **As-of split basis of the Actual horizon price — DIVERGENT (this audit's
+   finding).** The dashboard restates the **buy price** and the **model target**
+   into current terms, but reads the **Actual horizon price RAW**. When a
+   reconcilable split falls **between the 90-day horizon and the end of the data
+   series**, the Actual sits on a different split basis than the buy price it is
+   divided by.
+
+Measured over the matured historical score set (274 score dates, 5 444 included
+stock-rows, as-of 2026-06-26): **123 rows** carry a reconcilable post-horizon
+split. Restating their Actual onto the buy price's current basis moves the
+portfolio gap by **+0.482 pp** (a forward split inflates Actual, _masking_ the
+gap), while the per-row distortion is large and two-sided:
+
+| Statistic (per-row offset `(rawHorizon − currentBasis) / buyPrice`) | Value |
+| --- | --- |
+| Mean | **+0.565 pp** |
+| Median | +0.000 pp |
+| Min | −316.116 pp |
+| Max | +1395.893 pp |
+| Std dev | 51.437 pp |
+
+| Quantity (mean over 274 matured dates) | Value |
+| --- | --- |
+| Mean Target % | 28.916 % |
+| Mean Actual % (raw horizon — current dashboard) | 10.447 % |
+| Mean Actual % (split-consistent horizon) | 9.965 % |
+| **Observed gap** (Target − Actual, raw) | **+18.470 pp** |
+| Gap on the split-consistent basis | +18.952 pp |
+| **As-of-basis contribution** (consistent − raw gap) | **+0.482 pp** |
+
+> The mean raw Actual (10.447 %) reproduces the #554 audit's dashboard Actual
+> figure exactly, confirming this diagnostic measures the **shipped** Actual,
+> not a re-implementation.
+
+## Parity table
+
+Training (`GRQ`) vs dashboard (`GRQ-validation`), each row marked **aligned** or
+**divergent**:
+
+| # | Decision | Training (GRQ) | Dashboard (GRQ-validation) | Status | Direction if divergent |
+| --- | --- | --- | --- | --- | --- |
+| 1 | **Horizon-date selection** | `lowPrice` at `rewindToTradingDay(asOf + 90*DAY)` — trading day on/before exactly 90 days out (`GRQ/src/LearnUtil.ts:138-140`, `GRQ/src/Market.ts:241`) | last point with `date <= scoreDate + 90 days` (`priceAtNinetyDayHorizon` / `currentPriceWithinWindow`) | **Aligned** | — (same row on the stock's own daily series) |
+| 2 | **OHLC field — horizon** | intraday **low** (`market.lowPrice`) | **midpoint** `(high + low) / 2` | **Divergent** | mid ≥ low ⇒ Actual lifted ⇒ **masks** the gap; ~+2.2 pp — **owned by #552** |
+| 3 | **OHLC field — buy/score point** | **close** (`monthsAgoPrice = closePrices[0]`, `GRQ/src/CoreFeatures.ts`) | **midpoint** `(high + low) / 2` (`getBuyPrice`) | **Divergent** | symmetric ~+0.05 pp — **owned by #554** |
+| 4 | **Split/merge adjustment convention** | adjusted series; cumulative factor from each date to the data end (`GRQ/src/History.ts` accumulates `adj /= split` backwards) | on-the-fly restate-to-current via `computeSplitAdjustment` / `adjustHistoricalPriceToCurrent`, reconciliation-gated (`docs/projection.js:433-520`) | **Aligned** | — (same convention; reconciliation only _excludes_ a stock, it does not skew an included one) |
+| 5 | **As-of split basis of the Actual horizon price** | both `monthsAgoPrice` (score close) and `targetPrice` (horizon low) carry the data-end `adj`; the post-horizon factor **cancels** in `targetPrice / monthsAgoPrice` | **buy price** & **target** restated to current terms, but the **Actual horizon price read RAW** (`getStockReturnBreakdown` app.js:4458, `currentPriceWithinWindow`) | **Divergent** | forward post-horizon split inflates Actual ⇒ **masks** (+0.482 pp portfolio); reverse split widens; ±extreme per-row (−316 → +1396 pp on 123/5 444 rows) |
+
+## Why row 5 diverges (the mechanics)
+
+Let `S_in` be the cumulative split factor for splits **between** the score date
+and the horizon, and `S_after` for splits **between** the horizon and the end of
+the data series.
+
+- **Training** restates both the score close and the horizon low onto the
+  data-end basis. The return ratio `targetPrice / monthsAgoPrice` reduces to
+  `raw_low_horizon · S_in / raw_close_score` — the post-horizon factor `S_after`
+  appears in both numerator and denominator and **cancels**. Economically
+  correct: a split after the horizon does not change wealth.
+- **Dashboard** computes `buyPrice = raw_mid_score / (S_in · S_after)` (restated
+  to current terms by `getBuyPrice`) but `currentPrice = raw_mid_horizon`
+  (**unadjusted**, already post-`S_in` because the split actually happened by the
+  horizon). The Actual ratio becomes `raw_mid_horizon · S_in · S_after /
+  raw_mid_score` — an **extra factor of `S_after`**. A 2:1 forward split after
+  the horizon roughly **doubles** the displayed Actual for that stock; a reverse
+  split deflates it.
+
+**Target % is unaffected.** `calculateTargetPercentage` divides both
+`adjustedTarget` and `buyPrice` by the same `S_in · S_after`, so the split
+cancels: `(adjustedTarget − buyPrice) / buyPrice` is invariant to the
+post-horizon split. The divergence therefore shifts **only** the Actual side.
+
+```mermaid
+flowchart TD
+    subgraph GRQ[Training — GRQ]
+        A["monthsAgoPrice = close@score · adj_dataEnd"] --> R["ratio = targetPrice / monthsAgoPrice<br/>S_after cancels ✓"]
+        B["targetPrice = low@horizon · adj_dataEnd"] --> R
+    end
+    subgraph DASH[Dashboard — GRQ-validation]
+        C["buyPrice = mid@score / (S_in·S_after)<br/>restated to current"] --> P["Actual = (currentPrice − buyPrice)/buyPrice<br/>extra factor S_after ✗"]
+        D["currentPrice = mid@horizon RAW<br/>post-S_in only"] --> P
+        E["adjustedTarget = target / (S_in·S_after)"] --> T["Target % invariant — S_after cancels ✓"]
+        C --> T
+    end
+```
+
+## Fix recommendations & ruled-out notes
+
+- **Row 1 — Horizon-date selection: ruled out.** The dashboard's "last point on
+  or before `scoreDate + 90 days`" and training's `rewindToTradingDay(asOf +
+  90*DAY)` pick the same trading day on the stock's own daily series. The only
+  residual is training's `lowPrice` scan-back not crossing a **year boundary**
+  (a rare exclusion, not a directional skew). **No change recommended.**
+- **Row 2 / Row 3 — OHLC field: ruled out here; tracked in #552 / #554.** The
+  field mismatch is real but already enumerated and quantified by the sibling
+  audits. **No new action in this issue.**
+- **Row 4 — Split/merge convention: ruled out.** Both sides use the same
+  restate-to-current convention; the dashboard's reconciliation gate only drops
+  a stock it cannot trust (`reliable === false`), it never skews an included
+  row's adjustment relative to training. **No change recommended.**
+- **Row 5 — As-of split basis of the Actual horizon price: FIX RECOMMENDED.**
+  Read the Actual horizon price on the **same** current basis as the buy price,
+  i.e. divide the raw horizon midpoint by `postHorizonSplitFactor` (the new
+  `GRQProjection.horizonPriceCurrentBasis` helper). This removes the spurious
+  `S_after` factor, brings Actual onto the buy price's basis, and matches
+  training's cancellation. The portfolio-level effect is modest (**+0.482 pp**,
+  a _masking_ term that means genuine model optimism must exceed the raw gap by
+  this much), but the **per-row** distortion is large (up to +1 396 pp), so the
+  fix is primarily a **correctness** improvement for individual stocks that split
+  after their horizon. This is a behaviour change to the displayed Actual and
+  should land as its own focused PR (with UI evidence), not inside this audit.
+
+## Aggregate contribution to the gap
+
+**+0.482 pp** (portfolio-level), a _masking_ term: forward post-horizon splits
+dominate, so the shipped raw Actual is slightly **inflated**, and restating onto
+the split-consistent basis would **widen** the observed Target-over-Actual gap
+from 18.470 pp to 18.952 pp. Like #552 and #554, this candidate _offsets_
+rather than causes the gap — but unlike them it also flags a genuine per-row
+correctness bug worth fixing on its own merits.
+
+## How this was measured (reproducible)
+
+Every per-stock figure is delegated to the **shipped** kernels so the diagnostic
+measures the dashboard's own basis, not a re-implementation:
+
+- `GRQProjection.getBuyPrice` — split-adjusted midpoint buy price (current basis).
+- `GRQProjection.priceAtNinetyDayHorizon` — raw midpoint Actual (shipped basis).
+- `GRQProjection.horizonPointDate` — the date of the row the Actual is read from.
+- `GRQProjection.postHorizonSplitFactor` — `S_after` (reliable splits after the
+  horizon), added for this diagnostic.
+- `GRQProjection.horizonPriceCurrentBasis` — the horizon midpoint restated onto
+  the buy price's current basis.
+- `GRQProjection.horizonAsOfBasisOffsetPercent` —
+  `(rawHorizon − currentBasis) / buyPrice * 100`.
+- `GRQProjection.calculatePortfolioTargetPercentage` /
+  `calculateIncludedPortfolioPerformance` — Target % and Actual % on each basis
+  over the same included set.
+
+```bash
+deno task diagnose-horizon-split-parity            # against docs/, as-of today
+# raw form (pin an as-of date for a reproducible report):
+deno run --allow-read scripts/diagnose_horizon_split_parity.ts docs 2026-06-26
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>current basis]
+    B --> D[priceAtNinetyDayHorizon<br/>raw mid]
+    B --> E[horizonPriceCurrentBasis<br/>raw mid / S_after]
+    C --> F[horizonAsOfBasisOffsetPercent]
+    D --> F
+    E --> F
+    C --> G[Target%/Actual% raw basis]
+    C --> H[Target%/Actual% consistent basis]
+    F --> I[aggregate: mean/median/dist<br/>+ gap rescale + affected-row count]
+    G --> I
+    H --> I
+```
+
+## Code references
+
+- Training horizon & adjustment: `GRQ/src/LearnUtil.ts:138-148`
+  (`rewindToTradingDay`, `lowPrice`, `restrictHistoryTo`), `GRQ/src/Market.ts:194`
+  (`lowPrice`), `:241` (`rewindToTradingDay`), `GRQ/src/CoreFeatures.ts`
+  (`monthsAgoPrice = closePrices[0]`), `GRQ/src/History.ts` (split-adjusted load).
+- Dashboard horizon & adjustment: `GRQ-validation/docs/projection.js` —
+  `priceAtNinetyDayHorizon`, `getBuyPrice`, `computeSplitAdjustment`,
+  `adjustHistoricalPriceToCurrent`; `docs/app.js:4443-4490`
+  (`getStockReturnBreakdown`, raw horizon price); `docs/trend_predictions.js`
+  (`currentPriceWithinWindow`, `resolvePredictionStocks`).
+- New parity helpers: `GRQ-validation/docs/projection.js` — `horizonPointDate`,
+  `postHorizonSplitFactor`, `horizonPriceCurrentBasis`,
+  `horizonAsOfBasisOffsetPercent` (this issue).
+- Diagnostic: `scripts/diagnose_horizon_split_parity.ts`,
+  `scripts/horizon_split_parity_diagnostic.ts`;
+  tests `tests/horizon_split_parity_diagnostic_test.ts`.

--- a/docs/archive/pr-summaries/pr-summary-555.md
+++ b/docs/archive/pr-summaries/pr-summary-555.md
@@ -1,0 +1,87 @@
+## Summary
+
+Audited **market-data timing & corporate-action parity** between GRQ training
+and the GRQ-validation dashboard, as requested by the milestone #544 breakdown.
+The audit enumerates each timing/adjustment decision on both sides, marks it
+**aligned** or **divergent**, and — for the one divergent row — quantifies its
+aggregate contribution to the Target-over-Actual gap using the dashboard's own
+shipped kernels. Closes #555.
+
+**Finding.** Three of four decisions are aligned; one is divergent:
+
+| # | Decision | Status |
+| --- | --- | --- |
+| 1 | Horizon-date selection (trading day on/before `+90d` vs last point `<= +90d`) | **Aligned** — same row on the stock's daily series |
+| 2 | OHLC field at the horizon (low vs midpoint) | **Divergent** — owned by #552 (~+2.2 pp) |
+| 3 | OHLC field at the buy point (close vs midpoint) | **Divergent** — owned by #554 (~+0.05 pp) |
+| 4 | Split/merge adjustment convention (restate-to-current, reconciliation-gated) | **Aligned** |
+| 5 | **As-of split basis of the Actual horizon price** | **DIVERGENT (this audit)** |
+
+Row 5: the dashboard restates the **buy price** and the **model target** into
+current (end-of-series) split terms but reads the **Actual horizon price RAW**.
+When a reconcilable split falls between the 90-day horizon and the data-series
+end, the Actual carries a spurious post-horizon split factor `S_after` that
+training (and the economically-correct return) cancels. Target % is unaffected
+(both `adjustedTarget` and `buyPrice` divide by the same factor).
+
+**Measured (as-of 2026-06-26, 274 matured dates, 5 444 included rows):** 123
+rows carry a reconcilable post-horizon split; restating their Actual onto the
+buy price's basis moves the portfolio gap by **+0.482 pp** (a *masking* term —
+forward splits dominate), with large two-sided per-row distortion (−316 →
++1 396 pp). Like #552/#554 the candidate *offsets* rather than causes the gap,
+but it also flags a genuine per-row correctness bug. **Recommendation:** read
+the horizon price through the new `horizonPriceCurrentBasis` so Actual shares
+the buy price's basis — landed as its own focused PR with UI evidence (this PR
+is the audit + measurement only, matching the sibling diagnostics).
+
+## Evidence
+
+CLI/analysis change — no UI was modified, so no screenshot. Verified by the new
+unit tests and the reproducible diagnostic run below (delegating to the shipped
+`GRQProjection` kernels, so it measures the dashboard's own basis):
+
+```
+$ deno run --allow-read scripts/diagnose_horizon_split_parity.ts docs 2026-06-26
+Matured score dates:      274
+Included stock-rows:      5444
+Post-horizon split rows:  123
+Mean Target %:            28.916 %
+Mean Actual % (raw):      10.447 %   # reproduces the #554 dashboard Actual exactly
+Mean Actual % (current):  9.965 %
+Observed gap (T-A,raw):   +18.470 pp
+Gap on current basis:     +18.952 pp
+Basis contribution:       +0.482 pp
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>current basis]
+    B --> D[priceAtNinetyDayHorizon<br/>raw mid]
+    B --> E[horizonPriceCurrentBasis<br/>raw mid / S_after]
+    C --> F[horizonAsOfBasisOffsetPercent]
+    D --> F
+    E --> F
+    F --> G[aggregate: dist + gap rescale<br/>+ affected-row count]
+```
+
+Full written parity audit (table, mechanics, fix/ruled-out notes):
+`docs/archive/investigations/issue-555-market-data-timing-corporate-action-parity.md`.
+
+## Test Plan
+
+- `tests/horizon_split_parity_diagnostic_test.ts` (18 cases) — exercises the new
+  shipped kernels and the real aggregation with synthetic market data:
+  - `horizonPointDate` row selection (happy / empty / all-after-horizon).
+  - `postHorizonSplitFactor` — no split (1.0), reconcilable forward split (2.0),
+    reverse split (0.5), and a split **on/before** the horizon ignored.
+  - `horizonPriceCurrentBasis` — raw mid ÷ factor; coincides with the raw mid
+    when no split follows; null on no usable point.
+  - `horizonAsOfBasisOffsetPercent` — formula, forward (+) / reverse (−) sign,
+    and input guards (zero/negative buy price, NaN).
+  - `aggregateDate` — a post-horizon split desynchronises Actual but not Target;
+    the two Actual bases coincide with no split.
+  - `buildReport` — forward-split contribution widens the consistent-basis gap;
+    zero affected rows ⇒ DORMANT verdict / 0 pp; `summariseOffsets` stats.
+- Full suite green: `deno test --allow-read tests/*.ts` → **1053 passed**.
+- New `deno task diagnose-horizon-split-parity` registered in `deno.json`.

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -682,6 +682,79 @@ function denominatorBasisOffsetPercent(buyPrice, buyPriceClose) {
     return ((buyPrice - buyPriceClose) / buyPrice) * 100;
 }
 
+// The DATE of the last market-data point on or before the 90-day horizon — the
+// row priceAtNinetyDayHorizon / currentPriceWithinWindow read the Actual price
+// from (issue #555). Exposed so the as-of split basis of that row can be judged
+// against the buy price (which getBuyPrice has already restated to current
+// terms). Returns null when no point falls on or before the horizon.
+function horizonPointDate(marketData, scoreDate) {
+    if (!marketData || marketData.length === 0) return null;
+    const ninetyDayDate = new Date(
+        scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+    );
+    let last = null;
+    for (const point of marketData) {
+        if (point && point.date instanceof Date && point.date <= ninetyDayDate) {
+            last = point;
+        }
+    }
+    return last ? last.date : null;
+}
+
+// Cumulative RELIABLE split factor for splits strictly AFTER the 90-day horizon
+// up to the end of the series (issue #555): `getSplitAdjustment` evaluated at the
+// horizon point's own date. 1.0 means there is no reconcilable post-horizon
+// split, so the raw horizon price the shipped Actual reads already sits on the
+// current (end-of-series) basis its buy price uses. A FORWARD split gives a
+// factor > 1; a REVERSE split gives a factor < 1. Returns 1.0 when there is no
+// horizon point (no adjustment to make). Mirrors the `reliable`-gated factor, so
+// an unreconcilable series yields 1.0 rather than a silently wrong factor.
+function postHorizonSplitFactor(marketData, scoreDate) {
+    const date = horizonPointDate(marketData, scoreDate);
+    if (date === null) return 1.0;
+    return getSplitAdjustment(marketData, date);
+}
+
+// Midpoint at the 90-day horizon restated onto the CURRENT (end-of-series) split
+// basis — the SAME as-of basis getBuyPrice uses for the buy price (issue #555).
+// The shipped Actual (getStockReturnBreakdown / currentPriceWithinWindow) reads
+// this row's midpoint RAW while dividing by a buy price that getBuyPrice has
+// already restated to current terms; when a split falls between the horizon and
+// the series end the two sit on different split bases. Dividing the raw midpoint
+// by `postHorizonSplitFactor` puts the horizon price on the buy price's basis so
+// a like-for-like, same-basis Actual can be measured. Returns null when no point
+// falls on or before the horizon.
+function horizonPriceCurrentBasis(marketData, scoreDate) {
+    const rawMid = priceAtNinetyDayHorizon(marketData, scoreDate);
+    if (rawMid === null) return null;
+    return rawMid / postHorizonSplitFactor(marketData, scoreDate);
+}
+
+// As-of-basis offset the shipped Actual carries by reading the horizon midpoint
+// RAW instead of on the current basis its buy price uses (issue #555), as a
+// percentage of the buy price: `(rawHorizonMid - currentBasisHorizonMid) /
+// buyPrice * 100`. Sign: a FORWARD post-horizon split makes the raw price LARGER
+// than the current-basis price, INFLATING the measured Actual -> NARROWS (masks)
+// the Target-over-Actual gap; a REVERSE split deflates Actual -> WIDENS it. 0
+// when there is no post-horizon split (the two prices coincide). Because Target%
+// divides both adjustedTarget and buyPrice by the same factor, the post-horizon
+// split cancels there — so this offset shifts ONLY the Actual side. Returns null
+// when any input is missing or the buy price is not positive.
+function horizonAsOfBasisOffsetPercent(buyPrice, rawHorizonMid, currentBasisHorizonMid) {
+    if (
+        buyPrice === null || buyPrice === undefined || Number.isNaN(buyPrice) ||
+        buyPrice <= 0 ||
+        rawHorizonMid === null || rawHorizonMid === undefined ||
+        Number.isNaN(rawHorizonMid) ||
+        currentBasisHorizonMid === null ||
+        currentBasisHorizonMid === undefined ||
+        Number.isNaN(currentBasisHorizonMid)
+    ) {
+        return null;
+    }
+    return ((rawHorizonMid - currentBasisHorizonMid) / buyPrice) * 100;
+}
+
 // Trailing-365-day dividend total as of the score date — the quantity the GRQ
 // model turns into a FLAT training credit of `yearOfDividends / 4`
 // (GRQ/src/CoreFeatures.ts builds `yearOfDividends`; GRQ/src/LearnUtil.ts bakes
@@ -1202,6 +1275,10 @@ globalThis.GRQProjection = {
     priceBasisOffsetPercent,
     buyPriceCloseBasis,
     denominatorBasisOffsetPercent,
+    horizonPointDate,
+    postHorizonSplitFactor,
+    horizonPriceCurrentBasis,
+    horizonAsOfBasisOffsetPercent,
     trailingAnnualDividends,
     dividendBasisDifferencePercent,
     calculateTargetPercentage,

--- a/scripts/diagnose_horizon_split_parity.ts
+++ b/scripts/diagnose_horizon_split_parity.ts
@@ -1,0 +1,68 @@
+// Diagnostic for issue #555 (milestone #544): audit the market-data TIMING and
+// CORPORATE-ACTION parity between GRQ training and the GRQ-validation dashboard,
+// and quantify the one divergence that is measurable on the dashboard's data —
+// the as-of split basis of the Actual horizon price.
+//
+//   - Horizon ROW selection: training takes lowPrice at
+//     rewindToTradingDay(asOf + 90*DAY); the dashboard takes the last point on
+//     or before scoreDate + 90 days. On the stock's own daily series these
+//     resolve to the SAME row, so the horizon DATE is aligned.
+//   - Split-adjusted series: both sides work on split-adjusted prices. The
+//     dashboard restates the buy price AND the model's target into CURRENT
+//     (end-of-series) terms, but reads the Actual horizon price RAW. When a
+//     reconcilable split falls between the horizon and the series end, the
+//     Actual sits on a different split basis than the buy price it is divided
+//     by — a forward split inflates Actual (masking the gap), a reverse split
+//     deflates it (widening the gap). Target % is invariant (it divides both
+//     adjustedTarget and buyPrice by the same factor).
+//
+// This script measures that as-of-basis offset over the matured historical
+// score set, reusing the SHIPPED kernels — GRQProjection.horizonPriceCurrentBasis,
+// postHorizonSplitFactor, horizonAsOfBasisOffsetPercent, getBuyPrice,
+// calculatePortfolioTargetPercentage, calculateIncludedPortfolioPerformance and
+// isStockIncluded, plus the GRQTrendPredictions CSV/TSV parsers — so the numbers
+// it reports are computed on exactly the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_horizon_split_parity.ts [docsPath] [asOf]
+// (default docsPath = "docs", asOf = today). Read-only; prints a Markdown report.
+
+import { computeHorizonSplitParityDiagnostic } from "./horizon_split_parity_diagnostic.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+// "Today" governs which score dates have a complete 90-day window. Default to
+// the real clock; allow an override (second arg, YYYY-MM-DD) for reproducible
+// reports pinned to a specific as-of date.
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+
+const report = await computeHorizonSplitParityDiagnostic(docsPath, asOf);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(`# Horizon split-basis parity diagnostic — issue #555\n`);
+console.log(`As-of date:               ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Matured score dates:      ${report.maturedDates}`);
+console.log(`Included stock-rows:      ${report.rowCount}`);
+console.log(`Post-horizon split rows:  ${report.splitAffectedRows}`);
+console.log("");
+console.log(
+  `## Per-row as-of-basis offset (rawHorizon - currentBasis) / buyPrice`,
+);
+console.log(`Mean:                     ${pp(report.meanOffsetPp)}`);
+console.log(`Median:                   ${pp(report.medianOffsetPp)}`);
+console.log(`Min:                      ${pp(report.minOffsetPp)}`);
+console.log(`Max:                      ${pp(report.maxOffsetPp)}`);
+console.log(`Std dev:                  ${report.stdDevPp.toFixed(3)} pp`);
+console.log("");
+console.log(`## Per-date portfolio aggregates (mean over matured dates)`);
+console.log(`Mean Target %:            ${report.meanTargetPct.toFixed(3)} %`);
+console.log(
+  `Mean Actual % (raw):      ${report.meanActualRawPct.toFixed(3)} %`,
+);
+console.log(
+  `Mean Actual % (current):  ${report.meanActualCurrentBasisPct.toFixed(3)} %`,
+);
+console.log(`Observed gap (T-A,raw):   ${pp(report.observedGapPp)}`);
+console.log(`Gap on current basis:     ${pp(report.gapOnCurrentBasisPp)}`);
+console.log(`Basis contribution:       ${pp(report.basisContributionPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/scripts/horizon_split_parity_diagnostic.ts
+++ b/scripts/horizon_split_parity_diagnostic.ts
@@ -1,0 +1,280 @@
+// Core computation for the issue #555 market-data timing & corporate-action
+// parity diagnostic (milestone #544).
+//
+// The training label and the dashboard agree on the 90-day horizon ROW (both
+// take the last point on or before scoreDate + 90 days) and on a split-adjusted
+// series. They diverge on ONE as-of basis: the dashboard restates the buy price
+// and the model's target into CURRENT (end-of-series) split terms, but reads the
+// Actual horizon price RAW. When a reconcilable split falls between the horizon
+// and the series end, the Actual sits on a different split basis than the buy
+// price it is divided by — a forward split inflates Actual (masking the
+// Target-over-Actual gap), a reverse split deflates it (widening the gap).
+//
+// This module quantifies that as-of-basis offset over the matured historical
+// score set. Every per-stock figure is delegated to the SHIPPED kernels
+// published on globalThis by docs/projection.js and docs/trend_predictions.js,
+// so the diagnostic measures the dashboard's own basis, not a re-implementation.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Summary statistics for a list of per-row basis offsets (percentage points). */
+export interface OffsetSummary {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  stdDev: number;
+}
+
+/** Pure stats over a list of numbers. Empty input yields an all-zero summary. */
+export function summariseOffsets(values: number[]): OffsetSummary {
+  const finite = values.filter((v) =>
+    typeof v === "number" && !Number.isNaN(v)
+  );
+  if (finite.length === 0) {
+    return { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 };
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  const sum = finite.reduce((t, v) => t + v, 0);
+  const mean = sum / finite.length;
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+  const variance = finite.reduce((t, v) => t + (v - mean) ** 2, 0) /
+    finite.length;
+  return {
+    count: finite.length,
+    mean,
+    median,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+/** One matured score date's portfolio figures on both Actual bases. */
+export interface DateAggregate {
+  date: string;
+  targetPct: number | null;
+  actualRawPct: number | null;
+  actualCurrentBasisPct: number | null;
+  rowOffsetsPp: number[];
+  /** Included rows whose horizon price carries a reconcilable post-horizon split. */
+  splitAffectedRows: number;
+  /** Included rows considered (denominator for the affected-row share). */
+  includedRows: number;
+}
+
+// Build the per-stock inputs for one score date and compute the portfolio
+// Target %, Actual % on the shipped RAW horizon basis and Actual % on the
+// current (split-consistent) horizon basis, plus the per-row as-of-basis offsets
+// over the INCLUDED stocks. Pure: the caller supplies already-parsed score rows
+// and the market-data map.
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  dividendData: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  const rawStocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+
+  const rowOffsetsPp: number[] = [];
+  let splitAffectedRows = 0;
+  let includedRows = 0;
+  // deno-lint-ignore no-explicit-any
+  const currentBasisStocks = rawStocks.map((stock: any, i: number) => {
+    const points = marketData[scoreRows[i].stock];
+    const currentBasisMid = P.horizonPriceCurrentBasis(points, scoreDate);
+    const offset = P.horizonAsOfBasisOffsetPercent(
+      stock.buyPrice,
+      stock.currentPrice,
+      currentBasisMid,
+    );
+    const included = P.isStockIncluded(
+      stock.buyPrice,
+      stock.currentPrice,
+      stock.splitReliable,
+    );
+    if (included) {
+      includedRows++;
+      if (offset !== null) {
+        rowOffsetsPp.push(offset);
+        if (Math.abs(offset) > 0) splitAffectedRows++;
+      }
+    }
+    // Same stock, Actual measured on the buy price's current split basis.
+    return { ...stock, currentPrice: currentBasisMid };
+  });
+
+  return {
+    date,
+    targetPct: P.calculatePortfolioTargetPercentage(rawStocks),
+    actualRawPct: P.calculateIncludedPortfolioPerformance(rawStocks),
+    actualCurrentBasisPct: P.calculateIncludedPortfolioPerformance(
+      currentBasisStocks,
+    ),
+    rowOffsetsPp,
+    splitAffectedRows,
+    includedRows,
+  };
+}
+
+/** The full diagnostic result over the matured historical score set. */
+export interface HorizonSplitParityReport {
+  maturedDates: number;
+  rowCount: number;
+  splitAffectedRows: number;
+  meanOffsetPp: number;
+  medianOffsetPp: number;
+  minOffsetPp: number;
+  maxOffsetPp: number;
+  stdDevPp: number;
+  meanTargetPct: number;
+  meanActualRawPct: number;
+  meanActualCurrentBasisPct: number;
+  observedGapPp: number;
+  gapOnCurrentBasisPp: number;
+  basisContributionPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Assemble the report from per-date aggregates. Pure so it can be unit-tested
+// with synthetic DateAggregate rows.
+export function buildReport(
+  aggregates: DateAggregate[],
+): HorizonSplitParityReport {
+  const allOffsets = aggregates.flatMap((a) => a.rowOffsetsPp);
+  const stats = summariseOffsets(allOffsets);
+  const splitAffectedRows = aggregates.reduce(
+    (t, a) => t + a.splitAffectedRows,
+    0,
+  );
+
+  const withFigures = aggregates.filter((a) =>
+    a.targetPct !== null && a.actualRawPct !== null &&
+    a.actualCurrentBasisPct !== null
+  );
+  const meanTargetPct = mean(withFigures.map((a) => a.targetPct as number));
+  const meanActualRawPct = mean(
+    withFigures.map((a) => a.actualRawPct as number),
+  );
+  const meanActualCurrentBasisPct = mean(
+    withFigures.map((a) => a.actualCurrentBasisPct as number),
+  );
+  const observedGapPp = meanTargetPct - meanActualRawPct;
+  const gapOnCurrentBasisPp = meanTargetPct - meanActualCurrentBasisPct;
+  const basisContributionPp = gapOnCurrentBasisPp - observedGapPp;
+
+  const direction = splitAffectedRows === 0
+    ? "NO matured row carries a reconcilable post-horizon split, so the " +
+      "as-of-basis divergence is DORMANT on the current data — it contributes " +
+      "0 pp in practice"
+    : `${splitAffectedRows} matured row(s) carry a reconcilable post-horizon ` +
+      `split; restating their Actual onto the buy price's current split basis ` +
+      `moves the observed gap by ${basisContributionPp.toFixed(3)} pp`;
+
+  const verdict =
+    `VERDICT: the horizon row and the split-adjusted series are ALIGNED ` +
+    `between training and the dashboard; the only divergence is the as-of ` +
+    `split basis of the Actual horizon price (read RAW) versus the buy price ` +
+    `(restated to current terms). ${direction}. A forward post-horizon split ` +
+    `inflates Actual (MASKING the gap); a reverse split deflates it (WIDENING ` +
+    `the gap). The fix is to read the horizon price through ` +
+    `horizonPriceCurrentBasis so Actual shares the buy price's basis.`;
+
+  return {
+    maturedDates: aggregates.length,
+    rowCount: stats.count,
+    splitAffectedRows,
+    meanOffsetPp: stats.mean,
+    medianOffsetPp: stats.median,
+    minOffsetPp: stats.min,
+    maxOffsetPp: stats.max,
+    stdDevPp: stats.stdDev,
+    meanTargetPct,
+    meanActualRawPct,
+    meanActualCurrentBasisPct,
+    observedGapPp,
+    gapOnCurrentBasisPp,
+    basisContributionPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+// Load the matured score set from disk and compute the full diagnostic.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+export async function computeHorizonSplitParityDiagnostic(
+  docsPath: string,
+  asOf: Date,
+): Promise<HorizonSplitParityReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    const scoreRows = TP.parseScoreTsv(tsvText);
+    const marketData = TP.parseMarketCsv(csvText);
+    const dividendData = TP.parseDividendCsv(divText);
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        scoreRows,
+        marketData,
+        dividendData,
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReport(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/tests/horizon_split_parity_diagnostic_test.ts
+++ b/tests/horizon_split_parity_diagnostic_test.ts
@@ -1,0 +1,223 @@
+// Tests for the issue #555 market-data timing & corporate-action parity
+// diagnostic.
+//
+// These exercise the REAL shipped kernels (docs/projection.js,
+// docs/trend_predictions.js) and the real aggregation in
+// scripts/horizon_split_parity_diagnostic.ts with synthetic market data,
+// asserting on computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReport,
+  type DateAggregate,
+  summariseOffsets,
+} from "../scripts/horizon_split_parity_diagnostic.ts";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+// A flat OHLC point with an optional split coefficient (mid = price).
+function pt(date: string, price: number, splitCoefficient = 1.0) {
+  return {
+    date: midnight(date),
+    high: price,
+    low: price,
+    open: price,
+    close: price,
+    splitCoefficient,
+  };
+}
+
+// Score 2026-01-01 -> horizon 2026-04-01. A clean 2:1 forward split on 05-15
+// (after the horizon): mid halves 120 -> 60, so the price-ratio cross-check
+// reconciles (120 / 60 == 2).
+function marketWithPostHorizonSplit() {
+  return [
+    pt("2026-01-02", 100), // buy point
+    pt("2026-03-30", 120), // horizon point (last <= 2026-04-01)
+    pt("2026-05-15", 60, 2.0), // post-horizon 2:1 forward split
+  ];
+}
+
+const SCORE = midnight("2026-01-01");
+
+Deno.test("horizonPointDate returns the DATE of the last point on/before the horizon", () => {
+  const date = P.horizonPointDate(marketWithPostHorizonSplit(), SCORE);
+  assertEquals(date.getTime(), midnight("2026-03-30").getTime());
+});
+
+Deno.test("horizonPointDate returns null when no point falls on/before the horizon", () => {
+  assertEquals(P.horizonPointDate([], SCORE), null);
+  assertEquals(P.horizonPointDate(null, SCORE), null);
+  // Only points AFTER the horizon -> null.
+  assertEquals(P.horizonPointDate([pt("2026-09-01", 10)], SCORE), null);
+});
+
+Deno.test("postHorizonSplitFactor is 1.0 when there is no post-horizon split", () => {
+  const market = [pt("2026-01-02", 100), pt("2026-03-30", 120)];
+  assertEquals(P.postHorizonSplitFactor(market, SCORE), 1.0);
+});
+
+Deno.test("postHorizonSplitFactor captures a reconcilable forward split after the horizon", () => {
+  assertAlmostEquals(
+    P.postHorizonSplitFactor(marketWithPostHorizonSplit(), SCORE),
+    2.0,
+  );
+});
+
+Deno.test("postHorizonSplitFactor ignores a split ON/BEFORE the horizon (already in the raw price)", () => {
+  // Split lands on the horizon row itself -> not strictly after it.
+  const market = [pt("2026-01-02", 100), pt("2026-03-30", 60, 2.0)];
+  assertEquals(P.postHorizonSplitFactor(market, SCORE), 1.0);
+});
+
+Deno.test("postHorizonSplitFactor handles a reverse split (factor < 1)", () => {
+  // 1:2 reverse split on 05-15: mid doubles 120 -> 240, ratio 120/240 = 0.5.
+  const market = [
+    pt("2026-01-02", 100),
+    pt("2026-03-30", 120),
+    pt("2026-05-15", 240, 0.5),
+  ];
+  assertAlmostEquals(P.postHorizonSplitFactor(market, SCORE), 0.5);
+});
+
+Deno.test("horizonPriceCurrentBasis = raw horizon mid / post-horizon split factor", () => {
+  // raw mid 120, factor 2.0 -> 60 (the buy-price's current basis).
+  assertAlmostEquals(
+    P.horizonPriceCurrentBasis(marketWithPostHorizonSplit(), SCORE),
+    60,
+  );
+});
+
+Deno.test("horizonPriceCurrentBasis equals the raw horizon mid when no split follows", () => {
+  const market = [pt("2026-01-02", 100), pt("2026-03-30", 120)];
+  assertEquals(
+    P.horizonPriceCurrentBasis(market, SCORE),
+    P.priceAtNinetyDayHorizon(market, SCORE),
+  );
+});
+
+Deno.test("horizonPriceCurrentBasis returns null with no usable horizon point", () => {
+  assertEquals(P.horizonPriceCurrentBasis([], SCORE), null);
+});
+
+Deno.test("horizonAsOfBasisOffsetPercent computes (raw - currentBasis) / buyPrice * 100", () => {
+  // buyPrice 50, raw 120, currentBasis 60 -> (120-60)/50*100 = 120 pp.
+  assertAlmostEquals(P.horizonAsOfBasisOffsetPercent(50, 120, 60), 120);
+  // No post-horizon split: raw == currentBasis -> zero offset.
+  assertEquals(P.horizonAsOfBasisOffsetPercent(50, 120, 120), 0);
+});
+
+Deno.test("horizonAsOfBasisOffsetPercent is positive for forward, negative for reverse splits", () => {
+  // Forward: currentBasis < raw -> positive (Actual inflated, masks the gap).
+  assert(P.horizonAsOfBasisOffsetPercent(50, 120, 60) > 0);
+  // Reverse: currentBasis > raw -> negative (Actual deflated, widens the gap).
+  assert(P.horizonAsOfBasisOffsetPercent(100, 120, 240) < 0);
+});
+
+Deno.test("horizonAsOfBasisOffsetPercent guards bad inputs", () => {
+  assertEquals(P.horizonAsOfBasisOffsetPercent(0, 120, 60), null);
+  assertEquals(P.horizonAsOfBasisOffsetPercent(-5, 120, 60), null);
+  assertEquals(P.horizonAsOfBasisOffsetPercent(50, null, 60), null);
+  assertEquals(P.horizonAsOfBasisOffsetPercent(50, 120, NaN), null);
+});
+
+Deno.test("aggregateDate: a post-horizon split desynchronises Actual but not Target", () => {
+  const scoreRows = [{ stock: "AAA", target: 130 }];
+  const marketData = { AAA: marketWithPostHorizonSplit() };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, SCORE);
+
+  // One included row carrying a reconcilable post-horizon split.
+  assertEquals(agg.includedRows, 1);
+  assertEquals(agg.splitAffectedRows, 1);
+  assertEquals(agg.rowOffsetsPp.length, 1);
+  // buyPrice = 100/2 = 50; raw horizon 120; currentBasis 60 -> 120 pp.
+  assertAlmostEquals(agg.rowOffsetsPp[0], 120);
+
+  // The shipped (raw) Actual sits far above the split-consistent Actual.
+  assert(
+    (agg.actualRawPct as number) > (agg.actualCurrentBasisPct as number),
+  );
+  // Target % is invariant to the post-horizon split (same factor cancels).
+  assert(agg.targetPct !== null);
+});
+
+Deno.test("aggregateDate: no post-horizon split -> the two Actual bases coincide", () => {
+  const scoreRows = [{ stock: "AAA", target: 130 }];
+  const marketData = {
+    AAA: [pt("2026-01-02", 100), pt("2026-03-30", 120)],
+  };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, SCORE);
+  assertEquals(agg.splitAffectedRows, 0);
+  assertAlmostEquals(agg.rowOffsetsPp[0], 0);
+  assertAlmostEquals(
+    agg.actualRawPct as number,
+    agg.actualCurrentBasisPct as number,
+  );
+});
+
+Deno.test("buildReport: forward-split contribution WIDENS the gap on the consistent basis", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetPct: 30,
+      actualRawPct: 25, // inflated by the post-horizon forward split
+      actualCurrentBasisPct: 10, // split-consistent
+      rowOffsetsPp: [15],
+      splitAffectedRows: 1,
+      includedRows: 1,
+    },
+  ];
+  const report = buildReport(aggregates);
+  assertEquals(report.splitAffectedRows, 1);
+  assertAlmostEquals(report.observedGapPp, 5); // 30 - 25
+  assertAlmostEquals(report.gapOnCurrentBasisPp, 20); // 30 - 10
+  assertAlmostEquals(report.basisContributionPp, 15); // masking term
+  assert(report.verdict.includes("ALIGNED"));
+});
+
+Deno.test("buildReport: zero affected rows -> DORMANT verdict and 0 pp contribution", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetPct: 30,
+      actualRawPct: 12,
+      actualCurrentBasisPct: 12,
+      rowOffsetsPp: [0, 0],
+      splitAffectedRows: 0,
+      includedRows: 2,
+    },
+  ];
+  const report = buildReport(aggregates);
+  assertEquals(report.splitAffectedRows, 0);
+  assertAlmostEquals(report.basisContributionPp, 0);
+  assert(report.verdict.includes("DORMANT"));
+});
+
+Deno.test("summariseOffsets over a known list", () => {
+  const s = summariseOffsets([0, 10, 20]);
+  assertEquals(s.count, 3);
+  assertAlmostEquals(s.mean, 10);
+  assertAlmostEquals(s.median, 10);
+  assertEquals(s.min, 0);
+  assertEquals(s.max, 20);
+});
+
+Deno.test("summariseOffsets on empty input is all-zero", () => {
+  assertEquals(summariseOffsets([]), {
+    count: 0,
+    mean: 0,
+    median: 0,
+    min: 0,
+    max: 0,
+    stdDev: 0,
+  });
+});


### PR DESCRIPTION
## Summary

Audited **market-data timing & corporate-action parity** between GRQ training
and the GRQ-validation dashboard, as requested by the milestone #544 breakdown.
The audit enumerates each timing/adjustment decision on both sides, marks it
**aligned** or **divergent**, and — for the one divergent row — quantifies its
aggregate contribution to the Target-over-Actual gap using the dashboard's own
shipped kernels. Closes #555.

**Finding.** Three of four decisions are aligned; one is divergent:

| # | Decision | Status |
| --- | --- | --- |
| 1 | Horizon-date selection (trading day on/before `+90d` vs last point `<= +90d`) | **Aligned** — same row on the stock's daily series |
| 2 | OHLC field at the horizon (low vs midpoint) | **Divergent** — owned by #552 (~+2.2 pp) |
| 3 | OHLC field at the buy point (close vs midpoint) | **Divergent** — owned by #554 (~+0.05 pp) |
| 4 | Split/merge adjustment convention (restate-to-current, reconciliation-gated) | **Aligned** |
| 5 | **As-of split basis of the Actual horizon price** | **DIVERGENT (this audit)** |

Row 5: the dashboard restates the **buy price** and the **model target** into
current (end-of-series) split terms but reads the **Actual horizon price RAW**.
When a reconcilable split falls between the 90-day horizon and the data-series
end, the Actual carries a spurious post-horizon split factor `S_after` that
training (and the economically-correct return) cancels. Target % is unaffected
(both `adjustedTarget` and `buyPrice` divide by the same factor).

**Measured (as-of 2026-06-26, 274 matured dates, 5 444 included rows):** 123
rows carry a reconcilable post-horizon split; restating their Actual onto the
buy price's basis moves the portfolio gap by **+0.482 pp** (a *masking* term —
forward splits dominate), with large two-sided per-row distortion (−316 →
+1 396 pp). Like #552/#554 the candidate *offsets* rather than causes the gap,
but it also flags a genuine per-row correctness bug. **Recommendation:** read
the horizon price through the new `horizonPriceCurrentBasis` so Actual shares
the buy price's basis — landed as its own focused PR with UI evidence (this PR
is the audit + measurement only, matching the sibling diagnostics).

## Evidence

CLI/analysis change — no UI was modified, so no screenshot. Verified by the new
unit tests and the reproducible diagnostic run below (delegating to the shipped
`GRQProjection` kernels, so it measures the dashboard's own basis):

```
$ deno run --allow-read scripts/diagnose_horizon_split_parity.ts docs 2026-06-26
Matured score dates:      274
Included stock-rows:      5444
Post-horizon split rows:  123
Mean Target %:            28.916 %
Mean Actual % (raw):      10.447 %   # reproduces the #554 dashboard Actual exactly
Mean Actual % (current):  9.965 %
Observed gap (T-A,raw):   +18.470 pp
Gap on current basis:     +18.952 pp
Basis contribution:       +0.482 pp
```

```mermaid
flowchart LR
    A[scores/index.json<br/>matured dates] --> B[parse tsv/csv/dividends]
    B --> C[getBuyPrice<br/>current basis]
    B --> D[priceAtNinetyDayHorizon<br/>raw mid]
    B --> E[horizonPriceCurrentBasis<br/>raw mid / S_after]
    C --> F[horizonAsOfBasisOffsetPercent]
    D --> F
    E --> F
    F --> G[aggregate: dist + gap rescale<br/>+ affected-row count]
```

Full written parity audit (table, mechanics, fix/ruled-out notes):
`docs/archive/investigations/issue-555-market-data-timing-corporate-action-parity.md`.

## Test Plan

- `tests/horizon_split_parity_diagnostic_test.ts` (18 cases) — exercises the new
  shipped kernels and the real aggregation with synthetic market data:
  - `horizonPointDate` row selection (happy / empty / all-after-horizon).
  - `postHorizonSplitFactor` — no split (1.0), reconcilable forward split (2.0),
    reverse split (0.5), and a split **on/before** the horizon ignored.
  - `horizonPriceCurrentBasis` — raw mid ÷ factor; coincides with the raw mid
    when no split follows; null on no usable point.
  - `horizonAsOfBasisOffsetPercent` — formula, forward (+) / reverse (−) sign,
    and input guards (zero/negative buy price, NaN).
  - `aggregateDate` — a post-horizon split desynchronises Actual but not Target;
    the two Actual bases coincide with no split.
  - `buildReport` — forward-split contribution widens the consistent-basis gap;
    zero affected rows ⇒ DORMANT verdict / 0 pp; `summariseOffsets` stats.
- Full suite green: `deno test --allow-read tests/*.ts` → **1053 passed**.
- New `deno task diagnose-horizon-split-parity` registered in `deno.json`.



## Milestone
This PR is part of the **#544 Diagnose systematic Target-over-Actual gap in validation's measurement basis** milestone and targets the `milestone/544-diagnose-systematic-target-over-actual-gap-in` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqu62ykg-60bb92`<!-- vibe-worker-issue-555 -->