### PR TITLE
Whole-application sweep + residual-gap reconciliation (Issue #557)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,9 @@ GRQ-validation/
 │   ├── horizon_split_parity_diagnostic.ts # horizon as-of split-basis parity (#555)
 │   ├── diagnose_horizon_split_parity.ts # CLI report for the timing/split parity audit (#555)
 │   ├── score_target_decoding_diagnostic.ts # reverseProfitRecommend round-trip bias (#556)
-│   └── diagnose_score_target_decoding.ts # CLI report for the score→target decode audit (#556)
+│   ├── diagnose_score_target_decoding.ts # CLI report for the score→target decode audit (#556)
+│   ├── residual_gap_reconciliation.ts # whole-app sweep + residual-gap reconciliation (#557)
+│   └── diagnose_residual_gap.ts      # CLI report for the catch-all sweep / reconciliation (#557)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,8 @@
     "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts",
     "diagnose-buy-price-denominator": "deno run --allow-read scripts/diagnose_buy_price_denominator.ts",
     "diagnose-horizon-split-parity": "deno run --allow-read scripts/diagnose_horizon_split_parity.ts",
-    "diagnose-score-target-decoding": "deno run --allow-read scripts/diagnose_score_target_decoding.ts"
+    "diagnose-score-target-decoding": "deno run --allow-read scripts/diagnose_score_target_decoding.ts",
+    "diagnose-residual-gap": "deno run --allow-read scripts/diagnose_residual_gap.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/docs/archive/investigations/issue-557-whole-application-sweep.md
+++ b/docs/archive/investigations/issue-557-whole-application-sweep.md
@@ -1,0 +1,193 @@
+# Whole-application sweep + residual-gap reconciliation
+
+_Catch-all audit for Issue #557 (sub-issue of milestone #544 — the systematic
+Target-over-Actual measurement gap). User-raised: "anywhere in this
+application". This is the final sub-issue: after the targeted candidates
+(#552–#556) were quantified, it sweeps the rest of the validation pipeline for
+any other same-direction asymmetry and reconciles the residual gap._
+
+## TL;DR
+
+The aggregation layer is **symmetric**: Target and Actual are aggregated by the
+**same equal-weight rule** over the **same `isStockIncluded` gate**, through the
+**same shared kernels**. The sweep found exactly one residual aggregation-layer
+asymmetry — the **target-availability denominator skew** (priceable stocks with
+a missing target are counted in Actual but dropped from Target) — and it is
+**immaterial and masking, not inflating** (−0.062 pp over 131 of 5 444 included
+rows).
+
+Reconciling the observed gap against every quantified #544 candidate:
+
+| Candidate (sign: + inflates the apparent gap, − masks it) | pp |
+| --- | --- |
+| #552 price-basis (mid vs low horizon) | **−2.242** |
+| #553 dividend-basis (flat quarter vs windowed) | **+1.358** |
+| #554 buy-price denominator (mid vs close) | +0.000 |
+| #555 horizon as-of split parity | **−0.482** |
+| #556 score→target decoding | +0.000 |
+| #557 target-availability skew (this sweep) | **−0.062** |
+| **Net measurement** | **−1.428** |
+| **Observed gap** (mean Target − mean Actual) | **+18.525** |
+| **Residual — genuine model optimism** | **+19.952** |
+
+The measurement candidates **roughly cancel and, on balance, slightly mask** the
+gap. So the residual genuine model optimism (**+19.95 pp**) is essentially the
+whole observed gap (**+18.53 pp**) — in fact a touch larger, because the
+dashboard's measurement choices net to a small masking effect. **There is no
+hidden measurement asymmetry left to find; the gap is genuine model optimism.**
+
+All figures are computed by the shipped dashboard kernels over the matured
+historical score set (274 score dates, 5 444 included stock-rows, as-of
+2026-06-26). Reproduce with:
+
+```bash
+deno task diagnose-residual-gap docs 2026-06-26
+```
+
+## Audited-area checklist
+
+Each area below was checked for an **apples-to-oranges, same-direction**
+asymmetry that would push Target over Actual **only in aggregate**.
+
+| # | Area | Verdict | Direction / magnitude |
+| --- | --- | --- | --- |
+| 1 | **Aggregation weighting** | ✅ Aligned | Both series are an **equal-weight mean** over included stocks. No bias. |
+| 2 | **Inclusion / exclusion gate** | ✅ Aligned | Both call the **same `isStockIncluded`** predicate; no tail is dropped asymmetrically by the gate. |
+| 3 | **Target-availability (null/NaN target)** | ⚠️ Real but immaterial | Missing-target rows counted in Actual, dropped from Target. **−0.062 pp** (masking), 131/5 444 rows. |
+| 4 | **Rounding / truncation** | ✅ Ruled out | Series values are raw floats; `toFixed`/`formatPercentage` affect **display only**, both sides identically. |
+| 5 | **NaN / null handling** | ✅ Ruled out (bar #3) | A date with no included stocks drops **both** series together; the only one-sided drop is the target case in #3. |
+| 6 | **Currency / FX timing** | ✅ Ruled out | Returns are **price-relative ratios** in each stock's own quote currency; no FX conversion enters the `%` path. |
+| 7 | **Divergent code paths** | ✅ Aligned | Dashboard, Trend view and the Rust backend all route Target/Actual through the **same `projection.js` kernels** (and `is_priceable`). |
+
+### 1–2. Aggregation weighting and the inclusion gate — aligned
+
+Both portfolio series are built by the same shared kernels in
+`docs/projection.js`:
+
+- **Actual %** — `calculateIncludedPortfolioPerformance(stocks)`: filters by
+  `isStockIncluded`, then returns the **mean** of the per-stock total returns
+  (`sum / includedReturns.length`).
+- **Target %** — `calculatePortfolioTargetPercentage(stocks)`: filters by the
+  **same** `isStockIncluded`, then returns the **mean** of the per-stock target
+  percentages (`totalTarget / validStocks`).
+
+Both are equal-weight (1/N over the included set), both apply the **identical**
+inclusion predicate, and the equal-weight policy is the issue-#429/#288 design.
+The `isStockIncluded` gate keys only on **price/split usability** (usable buy
+price, usable current price, reliable split) — it is **target-blind and
+actual-blind**, so it cannot drop losers or winners preferentially. The backend
+mirrors it with `is_priceable` (`src/utils.rs`). **No weighting or gate
+asymmetry.**
+
+### 3. Target-availability denominator skew — the one residual asymmetry
+
+The Target kernel has one extra drop the Actual kernel does not: it skips
+included stocks whose `adjustedTarget` is `null`/`NaN` (a score row with no
+parseable target). The Actual kernel keeps those same rows. So the two portfolio
+**means span slightly different subsets** — the only same-direction asymmetry the
+sweep surfaced.
+
+It is quantified by re-aggregating **both** series over the matched
+(target-present) subset and reading off the gap difference
+(`scripts/residual_gap_reconciliation.ts`):
+
+- Dropped-target rows: **131** of **5 444** included rows (2.4 %).
+- Observed gap **+18.525 pp**; matched-subset gap **+18.586 pp**.
+- Skew = observed − matched = **−0.062 pp**.
+
+The sign is **negative**: the dropped-target rows are, on average, marginal
+winners, so excluding them from Target lifts the matched gap slightly — i.e. the
+as-shipped skew **masks** (does not inflate) the gap, and by a negligible amount.
+It is far too small and the wrong direction to be a cause; left as-is.
+
+### 4. Rounding / truncation — ruled out
+
+The aggregation path is floating-point throughout (`sum / count`, `(t − b) / b`).
+The only rounding is in the **display** layer (`formatPercentage`, `toFixed`),
+applied **after** the series is computed and **identically** to both Target and
+Actual. No directional rounding enters the computed gap.
+
+### 5. NaN / null handling — ruled out (beyond #3)
+
+`buildMaturedTrendSeries` skips a date entirely when its Actual is `null` (no
+included stocks), which removes **both** series for that date together — no tail
+is lost on one side. Within a date, the only one-sided null drop is the
+target-availability case already quantified in #3. (Note: when included stocks
+exist but **none** has a target, `calculatePortfolioTargetPercentage` returns the
+20.0 % fallback; over the matured set every such date has at least one target, so
+the fallback never fires in aggregate.)
+
+### 6. Currency / FX timing — ruled out
+
+Every portfolio figure is a **ratio** — `(currentPrice − buyPrice + dividends) /
+buyPrice` and `(target − buyPrice) / buyPrice` — computed from prices in the
+stock's own quote currency, with the **same `buyPrice` denominator on both
+sides**. No per-stock FX conversion is applied inside the `%` path, so an FX rate
+(or its timing) cancels and cannot desynchronise Target from Actual.
+`docs/USDAUD.json` feeds currency **display** elsewhere, not the gap maths.
+
+### 7. Divergent code paths — aligned
+
+Target and Actual are never computed by drifting copies:
+
+- The **dashboard** totals (`docs/app.js`) delegate to
+  `GRQProjection.calculatePortfolioTargetPercentage` /
+  `calculateIncludedPortfolioPerformance`.
+- The **Trend view** (`docs/trend_series.js`) delegates to the **same** two
+  kernels.
+- The **Rust backend** (`src/utils.rs`) shares the `is_priceable` rule and the
+  equal-weight average.
+
+The single benign difference: the dashboard's live index uses
+`currentPriceFromLatest` while the matured Trend/reconciliation path uses the
+midpoint of the last in-window point — these resolve to the **same row** for a
+matured prediction, so they agree on the analysis here.
+
+## Reconciliation method and sign convention
+
+Each candidate's contribution is signed by its effect on the **apparent
+(dashboard) gap**: **positive** means the measurement choice **inflates** the
+apparent gap (correcting it would narrow the gap); **negative** means it
+**masks** the gap (correcting it would widen it). The #552–#556 magnitudes are
+the values each sub-issue's own diagnostic published over the same matured set;
+the #557 target-availability term is computed here. The residual genuine optimism
+is `observed gap − net measurement`.
+
+```mermaid
+flowchart LR
+    O["Observed gap +18.525 pp"] --> N["− net measurement (−1.428 pp)"]
+    subgraph M["#544 measurement candidates"]
+      A["#552 price-basis −2.242"]
+      B["#553 dividend +1.358"]
+      C["#554 denominator 0"]
+      D["#555 split parity −0.482"]
+      E["#556 decoding 0"]
+      F["#557 target-availability −0.062"]
+    end
+    M --> N
+    N --> R["Residual model optimism +19.952 pp"]
+```
+
+Because the candidates net to a **small masking** effect (−1.428 pp), the
+residual optimism (**+19.95 pp**) slightly **exceeds** the observed gap. In other
+words, the dashboard's measurement choices, taken together, make the model look
+**marginally better** than a strictly like-for-like, trained-basis comparison
+would — so none of the gap is an artefact that flatters the model. The full
++18.5 pp (≈ +20 pp like-for-like) is **genuine model optimism**.
+
+## New finding fed back to #544?
+
+No material new same-direction asymmetry was found. The only sweep finding —
+the target-availability skew — is **−0.062 pp** and **masking**, so it does not
+warrant its own quantification sub-issue. The catch-all is therefore closed with
+the reconciliation above rather than a new #544 child.
+
+## Reproducing
+
+```bash
+# Full reconciliation over the committed matured score set
+deno task diagnose-residual-gap docs 2026-06-26
+
+# Unit tests (real kernels + aggregation, synthetic data)
+deno test --allow-read --allow-write tests/residual_gap_reconciliation_test.ts
+```

--- a/docs/archive/pr-summaries/pr-summary-557.md
+++ b/docs/archive/pr-summaries/pr-summary-557.md
@@ -1,0 +1,107 @@
+## Summary
+
+Completes the milestone #544 breakdown with the **catch-all whole-application
+sweep** for any remaining same-direction Target/Actual asymmetry, plus a
+**residual-gap reconciliation** that nets the observed Target-over-Actual gap
+against every quantified #544 candidate (#552–#556) and this sweep's own finding.
+Closes #557.
+
+The sweep audits the aggregation layer the targeted sub-issues did not cover —
+aggregation weighting, the inclusion gate, rounding/null handling, FX, and
+divergent code paths — and confirms Target and Actual are aggregated by the
+**same equal-weight rule** over the **same `isStockIncluded` gate** through the
+**same shared `projection.js` kernels**. It surfaces exactly one residual
+aggregation-layer asymmetry — the **target-availability denominator skew**
+(priceable stocks with a missing target are counted in Actual but dropped from
+Target) — and shows it is **immaterial and masking, not inflating** (−0.062 pp
+over 131 of 5 444 included rows).
+
+Reconciliation over the committed matured set (274 dates, 5 444 rows,
+as-of 2026-06-26):
+
+| Contribution (+ inflates gap, − masks) | pp |
+| --- | --- |
+| #552 price-basis | −2.242 |
+| #553 dividend-basis | +1.358 |
+| #554 buy-price denominator | +0.000 |
+| #555 horizon split parity | −0.482 |
+| #556 score→target decoding | +0.000 |
+| #557 target-availability (this sweep) | −0.062 |
+| **Net measurement** | **−1.428** |
+| **Observed gap** | **+18.525** |
+| **Residual — genuine model optimism** | **+19.952** |
+
+The measurement candidates roughly cancel and on balance slightly *mask* the
+gap, so the residual genuine model optimism (+19.95 pp) is essentially the whole
+observed gap (+18.53 pp). **No hidden measurement asymmetry remains; the gap is
+genuine model optimism — no further #544 sub-issue is warranted.**
+
+Full audit (checklist with a verdict per area + reconciliation):
+`docs/archive/investigations/issue-557-whole-application-sweep.md`.
+
+### Deno regression avoided
+
+This is a Deno repo; the diagnostic ships as Deno-native TypeScript run via
+`deno task diagnose-residual-gap` (and `deno test`), with no Node tooling
+introduced.
+
+## Evidence
+
+Backend/CLI diagnostic — no web UI to screenshot. Verified by the new test
+suite and by running the diagnostic against the committed score data:
+
+```text
+$ deno task diagnose-residual-gap docs 2026-06-26
+Matured score dates:   274
+Included stock-rows:   5444
+Target-present rows:   5313
+Dropped-target rows:   131
+
+## Portfolio means (over matured dates)
+Mean Target %:         29.082 %
+Mean Actual %:         10.557 %
+Mean Actual % (matched):10.496 %
+Observed gap (T-A):    +18.525 pp
+Matched-subset gap:    +18.586 pp
+Target-availability:   -0.062 pp
+
+Net measurement:       -1.428 pp
+Observed gap:          +18.525 pp
+Residual (optimism):   +19.952 pp
+```
+
+```mermaid
+flowchart LR
+    O["Observed gap +18.525 pp"] --> N["− net measurement (−1.428 pp)"]
+    subgraph M["#544 measurement candidates"]
+      A["#552 price-basis −2.242"]
+      B["#553 dividend +1.358"]
+      C["#554 denominator 0"]
+      D["#555 split parity −0.482"]
+      E["#556 decoding 0"]
+      F["#557 target-availability −0.062"]
+    end
+    M --> N
+    N --> R["Residual model optimism +19.952 pp"]
+```
+
+## Test Plan
+
+New `tests/residual_gap_reconciliation_test.ts` (10 tests, all calling the real
+shipped kernels + aggregation with synthetic data — no source-text grepping):
+
+- `hasUsableTarget` includes only priceable rows with a usable target; drops
+  null/NaN targets and unpriceable rows.
+- `aggregateDate` counts included vs target-present rows and confirms the
+  as-shipped Actual spans more rows than the matched-set Actual (target-less
+  loser dilutes Actual but not Target).
+- `buildReconciliation` derives the target-availability skew as
+  `observedGap − matchedGap`, appends it as the #557 contribution, satisfies the
+  `residual + net == observed` identity, and zeroes cleanly on empty input.
+- `FAMILY_CONTRIBUTIONS` covers #552–#556 with the documented signs.
+- `computeResidualGapReconciliation` reconciles the committed score set
+  read-only (structural invariants) and honours the matured-only window.
+
+Quality gate: `./quality.sh` (cargo fmt/clippy/check/test + `deno fmt`/`lint`/
+`check`/`test`) run clean; the new task is wired as `deno task
+diagnose-residual-gap`.

--- a/scripts/diagnose_residual_gap.ts
+++ b/scripts/diagnose_residual_gap.ts
@@ -1,0 +1,58 @@
+// Diagnostic for issue #557 (milestone #544): whole-application sweep for any
+// remaining same-direction Target/Actual asymmetry, plus the residual-gap
+// reconciliation that nets the observed Target-over-Actual gap against the
+// quantified #544-family candidates (#552–#556) and this sweep's own finding.
+//
+// The sweep confirms that aggregation weighting and the inclusion gate are
+// SHARED between Target and Actual (both equal-weight over isStockIncluded),
+// and surfaces the one aggregation-layer asymmetry the targeted sub-issues did
+// not cover: the target-availability denominator skew (priceable rows with a
+// missing target count in Actual but not Target).
+//
+// It reuses the SHIPPED kernels — GRQProjection.calculatePortfolioTargetPercentage,
+// calculateIncludedPortfolioPerformance, isStockIncluded — plus the
+// GRQTrendPredictions CSV/TSV parsers, so the numbers are computed on exactly
+// the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_residual_gap.ts [docsPath] [asOf]
+// (default docsPath = "docs", asOf = now). Read-only; prints a Markdown report.
+
+import { computeResidualGapReconciliation } from "./residual_gap_reconciliation.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+
+const report = await computeResidualGapReconciliation(docsPath, asOf);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(`# Residual Target-over-Actual gap reconciliation — issue #557\n`);
+console.log(`As-of date:            ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Matured score dates:   ${report.maturedDates}`);
+console.log(`Included stock-rows:   ${report.includedRows}`);
+console.log(`Target-present rows:   ${report.targetRows}`);
+console.log(`Dropped-target rows:   ${report.droppedTargetRows}`);
+console.log("");
+console.log(`## Portfolio means (over matured dates)`);
+console.log(`Mean Target %:         ${report.meanTargetPct.toFixed(3)} %`);
+console.log(`Mean Actual %:         ${report.meanActualPct.toFixed(3)} %`);
+console.log(
+  `Mean Actual % (matched):${report.meanMatchedActualPct.toFixed(3)} %`,
+);
+console.log(`Observed gap (T-A):    ${pp(report.observedGapPp)}`);
+console.log(`Matched-subset gap:    ${pp(report.matchedGapPp)}`);
+console.log(`Target-availability:   ${pp(report.targetAvailabilityPp)}`);
+console.log("");
+console.log(`## Reconciliation against the #544 candidates`);
+console.log(
+  `(sign convention: + inflates the apparent gap, - masks it)\n`,
+);
+for (const c of report.contributions) {
+  console.log(`#${c.issue} ${c.key.padEnd(22)} ${pp(c.contributionPp)}`);
+}
+console.log("");
+console.log(`Net measurement:       ${pp(report.netMeasurementPp)}`);
+console.log(`Observed gap:          ${pp(report.observedGapPp)}`);
+console.log(`Residual (optimism):   ${pp(report.residualOptimismPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/scripts/residual_gap_reconciliation.ts
+++ b/scripts/residual_gap_reconciliation.ts
@@ -1,0 +1,331 @@
+// Core computation for the issue #557 whole-application sweep + residual-gap
+// reconciliation (catch-all sub-issue of milestone #544).
+//
+// Two jobs:
+//   1. Sweep the *aggregation* layer for any same-direction Target/Actual
+//      asymmetry the targeted #552–#556 sub-issues did not cover — specifically
+//      aggregation weighting, the inclusion gate, and null/NaN handling. The one
+//      genuine asymmetry the sweep finds is the TARGET-AVAILABILITY denominator
+//      skew: a priceable stock with a missing/NaN target is counted in the
+//      Actual mean (calculateIncludedPortfolioPerformance) but dropped from the
+//      Target mean (calculatePortfolioTargetPercentage), so the two portfolio
+//      means can be taken over different stock subsets. This module quantifies
+//      that skew by re-aggregating BOTH series over the matched (target-present)
+//      subset and reading off the gap difference.
+//   2. Reconcile the observed Target-over-Actual gap against the quantified
+//      #544-family candidates, leaving the residual that is genuine model
+//      optimism rather than measurement.
+//
+// Every per-stock figure is delegated to the SHIPPED kernels published on
+// globalThis by docs/projection.js and docs/trend_predictions.js, so the sweep
+// measures the dashboard's own aggregation rather than a re-implementation.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+// Sign convention for every reconciliation contribution: a POSITIVE value means
+// the measurement choice INFLATES the apparent (dashboard) Target-over-Actual
+// gap — correcting it would NARROW the gap. A NEGATIVE value means the choice
+// MASKS the gap — correcting it would WIDEN it. The residual genuine optimism is
+// the observed gap minus the net of these contributions.
+export interface GapContribution {
+  /** Short key, e.g. "price_basis". */
+  key: string;
+  /** Owning sub-issue number, e.g. 552. */
+  issue: number;
+  /** Effect on the apparent gap in percentage points (signed per convention). */
+  contributionPp: number;
+  /** One-line account of the candidate and its direction. */
+  note: string;
+}
+
+// The quantified #544-family candidates, as documented by their own diagnostics
+// (each computed on the same matured score set, as-of 2026-06-26). Encoded as
+// constants here so the reconciliation arithmetic is reproducible and testable;
+// the target-availability candidate (#557, this sweep) is computed at runtime
+// and appended by buildReconciliation.
+export const FAMILY_CONTRIBUTIONS: GapContribution[] = [
+  {
+    key: "price_basis",
+    issue: 552,
+    contributionPp: -2.242,
+    note:
+      "Dashboard reads Actual at the midpoint (high+low)/2; training uses the " +
+      "intraday low. mid >= low on every row lifts Actual and MASKS the gap " +
+      "(correcting to the trained low widens it by +2.242 pp).",
+  },
+  {
+    key: "dividend_basis",
+    issue: 553,
+    contributionPp: 1.358,
+    note:
+      "Training bakes a flat yearOfDividends/4 credit into the Target label; " +
+      "the dashboard credits only realised in-window dividends to Actual. The " +
+      "over-credit INFLATES the apparent gap (1%-trimmed mean +1.358 pp; raw " +
+      "mean +2.827 pp).",
+  },
+  {
+    key: "buy_price_denominator",
+    issue: 554,
+    contributionPp: 0.0,
+    note:
+      "Both Target and Actual divide by the SAME buyPrice, so the midpoint-vs-" +
+      "close denominator cannot desynchronise them; it only rescales the gap " +
+      "(mean buyPrice-vs-close offset +0.046 pp). Ruled out as an asymmetry.",
+  },
+  {
+    key: "horizon_split_parity",
+    issue: 555,
+    contributionPp: -0.482,
+    note:
+      "A reconcilable split between the horizon and end-of-series leaves the " +
+      "raw Actual on a different split basis than buyPrice; the forward split " +
+      "inflates Actual and MASKS the gap (correcting widens it by +0.482 pp).",
+  },
+  {
+    key: "score_target_decoding",
+    issue: 556,
+    contributionPp: 0.0,
+    note:
+      "reverseProfitRecommend round-trips cleanly (max |shift| 1.78e-15 pp) " +
+      "and the asymmetric floor never fires on the realised scores. Ruled out.",
+  },
+];
+
+/** Whether a stock has BOTH a usable Actual (included) AND a usable target. */
+// deno-lint-ignore no-explicit-any
+export function hasUsableTarget(stock: any): boolean {
+  if (
+    !P.isStockIncluded(stock.buyPrice, stock.currentPrice, stock.splitReliable)
+  ) {
+    return false;
+  }
+  const t = stock.adjustedTarget;
+  return t !== null && t !== undefined && !Number.isNaN(t);
+}
+
+/** One matured score date's portfolio figures, as-shipped and matched-set. */
+export interface DateAggregate {
+  date: string;
+  /** Equal-weight Target % over included + target-present stocks (as shipped). */
+  targetPct: number | null;
+  /** Equal-weight Actual % over ALL included stocks (as shipped). */
+  actualPct: number | null;
+  /** Equal-weight Actual % over only the target-present subset. */
+  matchedActualPct: number | null;
+  /** Included (priceable) stock-rows behind the Actual mean. */
+  includedRows: number;
+  /** Of those, rows that ALSO carry a usable target (behind the Target mean). */
+  targetRows: number;
+}
+
+// Build one matured score date's aggregate. Pure: the caller supplies the
+// already-parsed score rows and the market/dividend maps. Both series are taken
+// over the dashboard's own kernels so the as-shipped figures equal the live
+// dashboard's; the matched-set Actual re-runs the Actual kernel over only the
+// target-present subset so the target-availability skew can be read off.
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  dividendData: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  const stocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+
+  // `stocks` is the (untyped) kernel output, so `s` is implicitly any here —
+  // no explicit-any annotation needed.
+  let includedRows = 0;
+  for (const s of stocks) {
+    if (P.isStockIncluded(s.buyPrice, s.currentPrice, s.splitReliable)) {
+      includedRows++;
+    }
+  }
+  const matchedStocks = stocks.filter(hasUsableTarget);
+  const targetRows = matchedStocks.length;
+
+  return {
+    date,
+    // Target kernel already drops null-target rows, so as-shipped Target ==
+    // matched-set Target; the gap difference comes entirely from the Actual mean.
+    targetPct: P.calculatePortfolioTargetPercentage(stocks),
+    actualPct: P.calculateIncludedPortfolioPerformance(stocks),
+    matchedActualPct: P.calculateIncludedPortfolioPerformance(matchedStocks),
+    includedRows,
+    targetRows,
+  };
+}
+
+/** The full reconciliation result over the matured historical score set. */
+export interface ReconciliationReport {
+  maturedDates: number;
+  includedRows: number;
+  targetRows: number;
+  droppedTargetRows: number;
+  meanTargetPct: number;
+  meanActualPct: number;
+  meanMatchedActualPct: number;
+  /** Observed (as-shipped) gap = mean Target - mean Actual. */
+  observedGapPp: number;
+  /** Gap when both series are taken over the matched (target-present) subset. */
+  matchedGapPp: number;
+  /** Target-availability skew = observedGap - matchedGap (this sweep, #557). */
+  targetAvailabilityPp: number;
+  /** Every contribution, including the runtime target-availability one. */
+  contributions: GapContribution[];
+  /** Net of all contributions (signed per the convention above). */
+  netMeasurementPp: number;
+  /** observedGap - netMeasurement: the residual attributed to model optimism. */
+  residualOptimismPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Assemble the reconciliation from per-date aggregates and the family
+// contributions. Pure so it can be unit-tested with synthetic rows. The
+// target-availability contribution is computed from the aggregates and appended
+// to `family` before netting.
+export function buildReconciliation(
+  aggregates: DateAggregate[],
+  family: GapContribution[] = FAMILY_CONTRIBUTIONS,
+): ReconciliationReport {
+  // Dates with a full set of figures contribute to the portfolio means.
+  const withFigures = aggregates.filter((a) =>
+    a.targetPct !== null && a.actualPct !== null &&
+    a.matchedActualPct !== null
+  );
+  const meanTargetPct = mean(withFigures.map((a) => a.targetPct as number));
+  const meanActualPct = mean(withFigures.map((a) => a.actualPct as number));
+  const meanMatchedActualPct = mean(
+    withFigures.map((a) => a.matchedActualPct as number),
+  );
+
+  const observedGapPp = meanTargetPct - meanActualPct;
+  const matchedGapPp = meanTargetPct - meanMatchedActualPct;
+  const targetAvailabilityPp = observedGapPp - matchedGapPp;
+
+  const includedRows = aggregates.reduce((t, a) => t + a.includedRows, 0);
+  const targetRows = aggregates.reduce((t, a) => t + a.targetRows, 0);
+  const droppedTargetRows = includedRows - targetRows;
+
+  const contributions: GapContribution[] = [
+    ...family,
+    {
+      key: "target_availability",
+      issue: 557,
+      contributionPp: targetAvailabilityPp,
+      note:
+        `Priceable stocks with a missing/NaN target (${droppedTargetRows} of ` +
+        `${includedRows} included rows) are counted in Actual but dropped from ` +
+        `Target, so the two means span different subsets. Re-aggregating both ` +
+        `over the matched subset moves the gap by ${
+          targetAvailabilityPp.toFixed(3)
+        } pp.`,
+    },
+  ];
+
+  const netMeasurementPp = contributions.reduce(
+    (t, c) => t + c.contributionPp,
+    0,
+  );
+  const residualOptimismPp = observedGapPp - netMeasurementPp;
+
+  const verdict =
+    `VERDICT (whole-application sweep + reconciliation): aggregation weighting ` +
+    `and the inclusion gate are SHARED and equal-weight for both Target and ` +
+    `Actual; the only aggregation-layer asymmetry is the target-availability ` +
+    `skew (${targetAvailabilityPp.toFixed(3)} pp). Netting every quantified ` +
+    `#544 candidate leaves a residual of ${residualOptimismPp.toFixed(3)} pp ` +
+    `out of the observed ${observedGapPp.toFixed(3)} pp gap. The measurement ` +
+    `candidates roughly cancel (net ${
+      netMeasurementPp.toFixed(3)
+    } pp), so the ` +
+    `bulk of the gap is genuine model optimism, not measurement.`;
+
+  return {
+    maturedDates: aggregates.length,
+    includedRows,
+    targetRows,
+    droppedTargetRows,
+    meanTargetPct,
+    meanActualPct,
+    meanMatchedActualPct,
+    observedGapPp,
+    matchedGapPp,
+    targetAvailabilityPp,
+    contributions,
+    netMeasurementPp,
+    residualOptimismPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+// Load the matured score set from disk and compute the full reconciliation.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+export async function computeResidualGapReconciliation(
+  docsPath: string,
+  asOf: Date,
+): Promise<ReconciliationReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        TP.parseScoreTsv(tsvText),
+        TP.parseMarketCsv(csvText),
+        TP.parseDividendCsv(divText),
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReconciliation(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/tests/residual_gap_reconciliation_test.ts
+++ b/tests/residual_gap_reconciliation_test.ts
@@ -1,0 +1,250 @@
+// Tests for the issue #557 whole-application sweep + residual-gap reconciliation.
+//
+// These exercise the REAL shipped kernels (docs/projection.js,
+// docs/trend_predictions.js) and the real aggregation/reconciliation in
+// scripts/residual_gap_reconciliation.ts with synthetic data, asserting on
+// computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReconciliation,
+  computeResidualGapReconciliation,
+  type DateAggregate,
+  FAMILY_CONTRIBUTIONS,
+  type GapContribution,
+  hasUsableTarget,
+} from "../scripts/residual_gap_reconciliation.ts";
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+// --- hasUsableTarget ---------------------------------------------------------
+
+Deno.test("hasUsableTarget true only for included rows with a usable target", () => {
+  assert(
+    hasUsableTarget({
+      buyPrice: 100,
+      currentPrice: 120,
+      splitReliable: true,
+      adjustedTarget: 150,
+    }),
+  );
+  // Included but no target -> dropped from the Target mean.
+  assert(
+    !hasUsableTarget({
+      buyPrice: 100,
+      currentPrice: 120,
+      splitReliable: true,
+      adjustedTarget: null,
+    }),
+  );
+  assert(
+    !hasUsableTarget({
+      buyPrice: 100,
+      currentPrice: 120,
+      splitReliable: true,
+      adjustedTarget: NaN,
+    }),
+  );
+  // Not priceable -> excluded from both.
+  assert(
+    !hasUsableTarget({
+      buyPrice: 0,
+      currentPrice: 120,
+      splitReliable: true,
+      adjustedTarget: 150,
+    }),
+  );
+});
+
+// --- aggregateDate -----------------------------------------------------------
+
+// Build a one-day score set with a target-bearing winner (AAA) and a
+// target-less loser (BBB). No splits (coefficient 1.0), so prices are unadjusted.
+function syntheticDate() {
+  const scoreDate = midnight("2026-01-01");
+  // TSV: stock, score, target, exDiv, dividendPerShare, notes, ivB, ivA
+  const scoreRows = [
+    { stock: "AAA", score: 0.5, target: 150 }, // buy 100 -> target +50%
+    { stock: "BBB", score: 0.5, target: NaN }, // loser, missing target
+  ];
+  const marketData: Record<string, unknown[]> = {
+    AAA: [
+      { date: midnight("2026-01-02"), high: 110, low: 90, close: 100 }, // mid 100 buy
+      { date: midnight("2026-03-30"), high: 130, low: 110, close: 120 }, // mid 120 actual +20%
+    ],
+    BBB: [
+      { date: midnight("2026-01-02"), high: 110, low: 90, close: 100 }, // mid 100 buy
+      { date: midnight("2026-03-30"), high: 90, low: 70, close: 80 }, // mid 80 actual -20%
+    ],
+  };
+  return { scoreDate, scoreRows, marketData };
+}
+
+Deno.test("aggregateDate counts included vs target-present rows", () => {
+  const { scoreDate, scoreRows, marketData } = syntheticDate();
+  const agg = aggregateDate(
+    "2026-01-01",
+    // deno-lint-ignore no-explicit-any
+    scoreRows as any,
+    // deno-lint-ignore no-explicit-any
+    marketData as any,
+    {},
+    scoreDate,
+  );
+  assertEquals(agg.includedRows, 2); // AAA + BBB both priceable
+  assertEquals(agg.targetRows, 1); // only AAA carries a target
+});
+
+Deno.test("aggregateDate: as-shipped Actual spans more rows than matched Actual", () => {
+  const { scoreDate, scoreRows, marketData } = syntheticDate();
+  const agg = aggregateDate(
+    "2026-01-01",
+    // deno-lint-ignore no-explicit-any
+    scoreRows as any,
+    // deno-lint-ignore no-explicit-any
+    marketData as any,
+    {},
+    scoreDate,
+  );
+  // As-shipped Actual = mean(+20, -20) = 0; matched Actual (AAA only) = +20.
+  assertAlmostEquals(agg.actualPct as number, 0, 1e-9);
+  assertAlmostEquals(agg.matchedActualPct as number, 20, 1e-9);
+  // Target is over the target-present subset (AAA): +50%.
+  assertAlmostEquals(agg.targetPct as number, 50, 1e-9);
+});
+
+// --- buildReconciliation -----------------------------------------------------
+
+const ZERO_FAMILY: GapContribution[] = [];
+
+Deno.test("buildReconciliation: target-availability = observed - matched gap", () => {
+  const aggregates: DateAggregate[] = [{
+    date: "2026-01-01",
+    targetPct: 50,
+    actualPct: 0,
+    matchedActualPct: 20,
+    includedRows: 2,
+    targetRows: 1,
+  }];
+  const r = buildReconciliation(aggregates, ZERO_FAMILY);
+  assertAlmostEquals(r.observedGapPp, 50, 1e-9); // 50 - 0
+  assertAlmostEquals(r.matchedGapPp, 30, 1e-9); // 50 - 20
+  assertAlmostEquals(r.targetAvailabilityPp, 20, 1e-9); // 50 - 30
+  assertEquals(r.droppedTargetRows, 1);
+});
+
+Deno.test("buildReconciliation: residual + net == observed gap (round-trip)", () => {
+  const aggregates: DateAggregate[] = [{
+    date: "2026-01-01",
+    targetPct: 30,
+    actualPct: 10,
+    matchedActualPct: 10, // no target-availability skew
+    includedRows: 3,
+    targetRows: 3,
+  }];
+  const family: GapContribution[] = [
+    { key: "a", issue: 1, contributionPp: 2, note: "" },
+    { key: "b", issue: 2, contributionPp: -1, note: "" },
+  ];
+  const r = buildReconciliation(aggregates, family);
+  assertAlmostEquals(r.targetAvailabilityPp, 0, 1e-9);
+  // net = 2 + (-1) + 0 (target-availability) = 1
+  assertAlmostEquals(r.netMeasurementPp, 1, 1e-9);
+  // residual = observed(20) - net(1) = 19
+  assertAlmostEquals(r.residualOptimismPp, 19, 1e-9);
+  assertAlmostEquals(
+    r.residualOptimismPp + r.netMeasurementPp,
+    r.observedGapPp,
+    1e-9,
+  );
+});
+
+Deno.test("buildReconciliation appends a target_availability contribution (#557)", () => {
+  const aggregates: DateAggregate[] = [{
+    date: "2026-01-01",
+    targetPct: 50,
+    actualPct: 0,
+    matchedActualPct: 20,
+    includedRows: 2,
+    targetRows: 1,
+  }];
+  const r = buildReconciliation(aggregates, ZERO_FAMILY);
+  const ta = r.contributions.find((c) => c.key === "target_availability");
+  assert(ta !== undefined);
+  assertEquals(ta?.issue, 557);
+  assertAlmostEquals(ta?.contributionPp as number, 20, 1e-9);
+});
+
+Deno.test("buildReconciliation: empty aggregates yield zeros, not NaN", () => {
+  const r = buildReconciliation([], ZERO_FAMILY);
+  assertEquals(r.observedGapPp, 0);
+  assertEquals(r.matchedGapPp, 0);
+  assertEquals(r.targetAvailabilityPp, 0);
+  assertEquals(r.netMeasurementPp, 0);
+  assertEquals(r.residualOptimismPp, 0);
+  assertEquals(r.includedRows, 0);
+});
+
+Deno.test("FAMILY_CONTRIBUTIONS covers the quantified #544 sub-issues", () => {
+  const issues = FAMILY_CONTRIBUTIONS.map((c) => c.issue).sort();
+  assertEquals(issues, [552, 553, 554, 555, 556]);
+  // Sign convention: price-basis and split parity mask (negative); dividend
+  // inflates (positive); denominator and decoding are ruled out (zero).
+  const by = (k: string) =>
+    FAMILY_CONTRIBUTIONS.find((c) => c.key === k)?.contributionPp;
+  assert((by("price_basis") as number) < 0);
+  assert((by("dividend_basis") as number) > 0);
+  assertEquals(by("buy_price_denominator"), 0);
+  assert((by("horizon_split_parity") as number) < 0);
+  assertEquals(by("score_target_decoding"), 0);
+});
+
+// --- computeResidualGapReconciliation (real committed data, read-only) -------
+
+// Read-only against the committed docs tree (no --allow-write needed, matching
+// quality.sh's `deno test --allow-read`). Asserts structural invariants rather
+// than exact figures, which shift as the daily score history grows.
+
+Deno.test("computeResidualGapReconciliation reconciles the committed score set", async () => {
+  const report = await computeResidualGapReconciliation(
+    "docs",
+    midnight("2026-06-26"),
+  );
+  // There is a matured history with included rows behind the means.
+  assert(report.maturedDates > 0);
+  assert(report.includedRows > 0);
+  // Target is averaged over a subset of Actual's rows (target-availability).
+  assert(report.targetRows <= report.includedRows);
+  assertEquals(
+    report.droppedTargetRows,
+    report.includedRows - report.targetRows,
+  );
+  // The model is optimistic in aggregate: Target sits above Actual.
+  assert(report.observedGapPp > 0);
+  // The reconciliation identity always holds.
+  assertAlmostEquals(
+    report.residualOptimismPp + report.netMeasurementPp,
+    report.observedGapPp,
+    1e-9,
+  );
+  // The target-availability term is present and small (immaterial asymmetry).
+  const ta = report.contributions.find((c) => c.key === "target_availability");
+  assert(ta !== undefined);
+  assert(Math.abs(ta?.contributionPp as number) < 1);
+});
+
+Deno.test("computeResidualGapReconciliation honours the matured-only window", async () => {
+  // An as-of date before any score date matures yields an empty, zeroed report.
+  const early = await computeResidualGapReconciliation(
+    "docs",
+    midnight("2000-01-01"),
+  );
+  assertEquals(early.maturedDates, 0);
+  assertEquals(early.observedGapPp, 0);
+});


### PR DESCRIPTION
## Summary

Completes the milestone #544 breakdown with the **catch-all whole-application
sweep** for any remaining same-direction Target/Actual asymmetry, plus a
**residual-gap reconciliation** that nets the observed Target-over-Actual gap
against every quantified #544 candidate (#552–#556) and this sweep's own finding.
Closes #557.

The sweep audits the aggregation layer the targeted sub-issues did not cover —
aggregation weighting, the inclusion gate, rounding/null handling, FX, and
divergent code paths — and confirms Target and Actual are aggregated by the
**same equal-weight rule** over the **same `isStockIncluded` gate** through the
**same shared `projection.js` kernels**. It surfaces exactly one residual
aggregation-layer asymmetry — the **target-availability denominator skew**
(priceable stocks with a missing target are counted in Actual but dropped from
Target) — and shows it is **immaterial and masking, not inflating** (−0.062 pp
over 131 of 5 444 included rows).

Reconciliation over the committed matured set (274 dates, 5 444 rows,
as-of 2026-06-26):

| Contribution (+ inflates gap, − masks) | pp |
| --- | --- |
| #552 price-basis | −2.242 |
| #553 dividend-basis | +1.358 |
| #554 buy-price denominator | +0.000 |
| #555 horizon split parity | −0.482 |
| #556 score→target decoding | +0.000 |
| #557 target-availability (this sweep) | −0.062 |
| **Net measurement** | **−1.428** |
| **Observed gap** | **+18.525** |
| **Residual — genuine model optimism** | **+19.952** |

The measurement candidates roughly cancel and on balance slightly *mask* the
gap, so the residual genuine model optimism (+19.95 pp) is essentially the whole
observed gap (+18.53 pp). **No hidden measurement asymmetry remains; the gap is
genuine model optimism — no further #544 sub-issue is warranted.**

Full audit (checklist with a verdict per area + reconciliation):
`docs/archive/investigations/issue-557-whole-application-sweep.md`.

### Deno regression avoided

This is a Deno repo; the diagnostic ships as Deno-native TypeScript run via
`deno task diagnose-residual-gap` (and `deno test`), with no Node tooling
introduced.

## Evidence

Backend/CLI diagnostic — no web UI to screenshot. Verified by the new test
suite and by running the diagnostic against the committed score data:

```text
$ deno task diagnose-residual-gap docs 2026-06-26
Matured score dates:   274
Included stock-rows:   5444
Target-present rows:   5313
Dropped-target rows:   131

## Portfolio means (over matured dates)
Mean Target %:         29.082 %
Mean Actual %:         10.557 %
Mean Actual % (matched):10.496 %
Observed gap (T-A):    +18.525 pp
Matched-subset gap:    +18.586 pp
Target-availability:   -0.062 pp

Net measurement:       -1.428 pp
Observed gap:          +18.525 pp
Residual (optimism):   +19.952 pp
```

```mermaid
flowchart LR
    O["Observed gap +18.525 pp"] --> N["− net measurement (−1.428 pp)"]
    subgraph M["#544 measurement candidates"]
      A["#552 price-basis −2.242"]
      B["#553 dividend +1.358"]
      C["#554 denominator 0"]
      D["#555 split parity −0.482"]
      E["#556 decoding 0"]
      F["#557 target-availability −0.062"]
    end
    M --> N
    N --> R["Residual model optimism +19.952 pp"]
```

## Test Plan

New `tests/residual_gap_reconciliation_test.ts` (10 tests, all calling the real
shipped kernels + aggregation with synthetic data — no source-text grepping):

- `hasUsableTarget` includes only priceable rows with a usable target; drops
  null/NaN targets and unpriceable rows.
- `aggregateDate` counts included vs target-present rows and confirms the
  as-shipped Actual spans more rows than the matched-set Actual (target-less
  loser dilutes Actual but not Target).
- `buildReconciliation` derives the target-availability skew as
  `observedGap − matchedGap`, appends it as the #557 contribution, satisfies the
  `residual + net == observed` identity, and zeroes cleanly on empty input.
- `FAMILY_CONTRIBUTIONS` covers #552–#556 with the documented signs.
- `computeResidualGapReconciliation` reconciles the committed score set
  read-only (structural invariants) and honours the matured-only window.

Quality gate: `./quality.sh` (cargo fmt/clippy/check/test + `deno fmt`/`lint`/
`check`/`test`) run clean; the new task is wired as `deno task
diagnose-residual-gap`.



## Milestone
This PR is part of the **#544 Diagnose systematic Target-over-Actual gap in validation's measurement basis** milestone and targets the `milestone/544-diagnose-systematic-target-over-actual-gap-in` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqu8v0b0-4105d2`<!-- vibe-worker-issue-557 -->