### PR TITLE
Milestone: #544 Diagnose systematic Target-over-Actual gap in validation's measurement basis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "2.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.11"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",

--- a/README.md
+++ b/README.md
@@ -424,7 +424,9 @@ GRQ-validation/
 │   ├── fetch_market_indices.ts    # Server-side benchmark-index fetcher
 │   ├── refresh_market_indices.ts  # Non-blocking daily-scorer wrapper (#238)
 │   ├── price_basis_diagnostic.ts  # mid-vs-low basis bias computation (#552)
-│   └── diagnose_price_basis.ts    # CLI report for the basis diagnostic (#552)
+│   ├── diagnose_price_basis.ts    # CLI report for the basis diagnostic (#552)
+│   ├── dividend_basis_diagnostic.ts # flat-1/4-vs-windowed dividend bias (#553)
+│   └── diagnose_dividend_basis.ts # CLI report for the dividend diagnostic (#553)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/README.md
+++ b/README.md
@@ -430,7 +430,9 @@ GRQ-validation/
 │   ├── buy_price_denominator_diagnostic.ts # midpoint-vs-close denominator bias (#554)
 │   ├── diagnose_buy_price_denominator.ts # CLI report for the denominator diagnostic (#554)
 │   ├── horizon_split_parity_diagnostic.ts # horizon as-of split-basis parity (#555)
-│   └── diagnose_horizon_split_parity.ts # CLI report for the timing/split parity audit (#555)
+│   ├── diagnose_horizon_split_parity.ts # CLI report for the timing/split parity audit (#555)
+│   ├── score_target_decoding_diagnostic.ts # reverseProfitRecommend round-trip bias (#556)
+│   └── diagnose_score_target_decoding.ts # CLI report for the score→target decode audit (#556)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/README.md
+++ b/README.md
@@ -428,7 +428,9 @@ GRQ-validation/
 │   ├── dividend_basis_diagnostic.ts # flat-1/4-vs-windowed dividend bias (#553)
 │   ├── diagnose_dividend_basis.ts # CLI report for the dividend diagnostic (#553)
 │   ├── buy_price_denominator_diagnostic.ts # midpoint-vs-close denominator bias (#554)
-│   └── diagnose_buy_price_denominator.ts # CLI report for the denominator diagnostic (#554)
+│   ├── diagnose_buy_price_denominator.ts # CLI report for the denominator diagnostic (#554)
+│   ├── horizon_split_parity_diagnostic.ts # horizon as-of split-basis parity (#555)
+│   └── diagnose_horizon_split_parity.ts # CLI report for the timing/split parity audit (#555)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/README.md
+++ b/README.md
@@ -426,7 +426,9 @@ GRQ-validation/
 │   ├── price_basis_diagnostic.ts  # mid-vs-low basis bias computation (#552)
 │   ├── diagnose_price_basis.ts    # CLI report for the basis diagnostic (#552)
 │   ├── dividend_basis_diagnostic.ts # flat-1/4-vs-windowed dividend bias (#553)
-│   └── diagnose_dividend_basis.ts # CLI report for the dividend diagnostic (#553)
+│   ├── diagnose_dividend_basis.ts # CLI report for the dividend diagnostic (#553)
+│   ├── buy_price_denominator_diagnostic.ts # midpoint-vs-close denominator bias (#554)
+│   └── diagnose_buy_price_denominator.ts # CLI report for the denominator diagnostic (#554)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/README.md
+++ b/README.md
@@ -422,7 +422,9 @@ GRQ-validation/
 ├── scripts/                # Utility scripts
 │   ├── bump_version.ts            # CI app-version incrementer (#323)
 │   ├── fetch_market_indices.ts    # Server-side benchmark-index fetcher
-│   └── refresh_market_indices.ts  # Non-blocking daily-scorer wrapper (#238)
+│   ├── refresh_market_indices.ts  # Non-blocking daily-scorer wrapper (#238)
+│   ├── price_basis_diagnostic.ts  # mid-vs-low basis bias computation (#552)
+│   └── diagnose_price_basis.ts    # CLI report for the basis diagnostic (#552)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/README.md
+++ b/README.md
@@ -432,7 +432,9 @@ GRQ-validation/
 │   ├── horizon_split_parity_diagnostic.ts # horizon as-of split-basis parity (#555)
 │   ├── diagnose_horizon_split_parity.ts # CLI report for the timing/split parity audit (#555)
 │   ├── score_target_decoding_diagnostic.ts # reverseProfitRecommend round-trip bias (#556)
-│   └── diagnose_score_target_decoding.ts # CLI report for the score→target decode audit (#556)
+│   ├── diagnose_score_target_decoding.ts # CLI report for the score→target decode audit (#556)
+│   ├── residual_gap_reconciliation.ts # whole-app sweep + residual-gap reconciliation (#557)
+│   └── diagnose_residual_gap.ts      # CLI report for the catch-all sweep / reconciliation (#557)
 ├── .github/workflows/      # GitHub Actions workflows
 ├── run.sh                  # Build-and-run wrapper for the CLI
 ├── quality.sh              # Local quality gate (fmt, clippy, tests, deno)

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,8 @@
     "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts",
     "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts",
     "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts",
-    "diagnose-buy-price-denominator": "deno run --allow-read scripts/diagnose_buy_price_denominator.ts"
+    "diagnose-buy-price-denominator": "deno run --allow-read scripts/diagnose_buy_price_denominator.ts",
+    "diagnose-horizon-split-parity": "deno run --allow-read scripts/diagnose_horizon_split_parity.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,8 @@
     "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts",
     "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts",
     "diagnose-buy-price-denominator": "deno run --allow-read scripts/diagnose_buy_price_denominator.ts",
-    "diagnose-horizon-split-parity": "deno run --allow-read scripts/diagnose_horizon_split_parity.ts"
+    "diagnose-horizon-split-parity": "deno run --allow-read scripts/diagnose_horizon_split_parity.ts",
+    "diagnose-score-target-decoding": "deno run --allow-read scripts/diagnose_score_target_decoding.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,8 @@
     "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts",
     "diagnose-buy-price-denominator": "deno run --allow-read scripts/diagnose_buy_price_denominator.ts",
     "diagnose-horizon-split-parity": "deno run --allow-read scripts/diagnose_horizon_split_parity.ts",
-    "diagnose-score-target-decoding": "deno run --allow-read scripts/diagnose_score_target_decoding.ts"
+    "diagnose-score-target-decoding": "deno run --allow-read scripts/diagnose_score_target_decoding.ts",
+    "diagnose-residual-gap": "deno run --allow-read scripts/diagnose_residual_gap.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,8 @@
     "fetch-indices": "deno run --allow-net --allow-read --allow-write scripts/fetch_market_indices.ts",
     "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts",
     "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts",
-    "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts"
+    "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts",
+    "diagnose-buy-price-denominator": "deno run --allow-read scripts/diagnose_buy_price_denominator.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,8 @@
   "tasks": {
     "fetch-indices": "deno run --allow-net --allow-read --allow-write scripts/fetch_market_indices.ts",
     "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts",
-    "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts"
+    "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts",
+    "diagnose-dividend-basis": "deno run --allow-read scripts/diagnose_dividend_basis.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,8 @@
 {
   "tasks": {
     "fetch-indices": "deno run --allow-net --allow-read --allow-write scripts/fetch_market_indices.ts",
-    "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts"
+    "refresh-indices": "deno run --allow-net --allow-read --allow-write scripts/refresh_market_indices.ts",
+    "diagnose-price-basis": "deno run --allow-read scripts/diagnose_price_basis.ts"
   },
   "minimumDependencyAge": {
     "age": "P1D",

--- a/docs/archive/investigations/issue-552-price-basis-bias.md
+++ b/docs/archive/investigations/issue-552-price-basis-bias.md
@@ -1,0 +1,121 @@
+# Price-basis bias: training intraday-low vs dashboard midpoint
+
+_Diagnostic for Issue #552 (sub-issue of #544 — one candidate source of the
+systematic Target-over-Actual measurement gap). Measurement lives in
+`GRQ-validation`; the root price-basis decision lives upstream in `GRQ`._
+
+## TL;DR
+
+The GRQ model is trained on a return label measured at the **intraday low** of
+the trading day 90 days ahead, but the validation dashboard measures **Actual**
+at the **midpoint** `(high + low) / 2` of the horizon row. Because `mid >= low`
+on every row, the mid basis **lifts** the measured Actual.
+
+Over the matured historical score set (274 score dates, 5 444 included
+stock-rows, as-of 2026-06-26) the basis offset `(mid - low) / buyPrice` is:
+
+| Statistic | Value |
+| --- | --- |
+| Mean | **+2.235 pp** |
+| Median | +1.546 pp |
+| Min | +0.000 pp |
+| Max | +93.273 pp (thin, low-priced outlier) |
+| Std dev | 3.216 pp |
+
+**Sign and netting.** The offset is **non-negative on every row** (sign **+**).
+Measuring Actual at the higher mid makes Actual larger, which **narrows / masks**
+the Target-over-Actual gap — the *opposite* direction to the observed gap. So
+this candidate **offsets** the gap rather than causing it:
+
+| Quantity (mean over matured dates) | Value |
+| --- | --- |
+| Mean Target % | 28.916 % |
+| Mean Actual % (mid — current dashboard) | 10.447 % |
+| Mean Actual % (low — trained basis) | 8.204 % |
+| **Observed gap** (Target − Actual, mid) | **+18.470 pp** |
+| Gap on the trained low basis | +20.712 pp |
+| **Basis contribution** (low − mid gap) | **+2.242 pp** |
+
+Restating Actual onto the basis the model was trained on (intraday low) would
+**widen** the apparent gap by ~**2.24 pp**, from ~18.5 pp to ~20.7 pp. Genuine
+model optimism (and the remaining candidates in #544) must therefore explain a
+gap that is *larger* than the headline figure, not smaller.
+
+> The per-row equal-weight mean (+2.235 pp) and the per-date portfolio-level
+> contribution (+2.242 pp) agree to within rounding, confirming the offset is a
+> broad, structural feature rather than an artefact of a few dates.
+
+## Acceptance criteria
+
+1. **Numeric aggregate contribution (pp) with sign** — mean basis offset
+   **+2.235 pp** (per row) / **+2.242 pp** (portfolio-level); always `>= 0`.
+2. **Widens or narrows the observed gap** — the mid basis **narrows (masks)**
+   the gap; switching to the trained low basis **widens** it by ~2.24 pp.
+3. **Fix-vs-leave recommendation** — see below.
+
+## Recommendation: confirm the asymmetry, but **leave the dashboard basis as-is**
+for now (low-priority hygiene fix only)
+
+A real, structural asymmetry **is** confirmed (a consistent, same-direction
+~2.2 pp offset), so a fix is *justifiable* on like-for-like grounds. However:
+
+- Correcting it **does not close** the Target-over-Actual gap — it **widens**
+  it. This candidate is therefore **exonerated as a cause** of the reported
+  symptom; it was partially *hiding* the gap.
+- The mid basis is also the more defensible figure to **show a user** as the
+  "Actual" return: the midpoint is an unbiased intraday estimate, whereas the
+  intraday low systematically understates what a holder realised. Switching the
+  user-facing Actual to the low purely to match a training artefact would make
+  the dashboard's headline returns look worse than reality.
+
+**Therefore:** the milestone should keep chasing genuine model optimism and the
+other #544 candidates (dividend timing, buy-price denominator, score decoding)
+as the real drivers. If a fully like-for-like trend comparison is later wanted,
+the cleaner fix is to **restate the model Target onto the midpoint basis**
+(upstream in `GRQ`) — i.e. train/evaluate both series on one consistent basis —
+rather than degrade the dashboard's user-facing Actual to the intraday low. That
+is a separate, low-priority piece of measurement hygiene, not a gap-closing fix.
+
+## How this was measured (reproducible)
+
+Every per-stock figure is delegated to the **shipped** kernels so the diagnostic
+measures the dashboard's own basis, not a re-implementation:
+
+- `GRQProjection.getBuyPrice` — split-adjusted midpoint buy price.
+- `GRQProjection.priceAtNinetyDayHorizon` — Actual on the **mid** basis.
+- `GRQProjection.lowPriceAtNinetyDayHorizon` — Actual on the **low** basis
+  (added for this diagnostic; mirrors the mid helper's horizon selection so both
+  pick the same row).
+- `GRQProjection.priceBasisOffsetPercent` — `(mid - low) / buyPrice * 100`.
+- `GRQProjection.isStockIncluded` — restricts to the same included set the
+  dashboard aggregates over.
+
+```bash
+deno task diagnose-price-basis            # against docs/, as-of today
+# raw form (pin an as-of date for a reproducible report):
+deno run --allow-read scripts/diagnose_price_basis.ts docs 2026-06-26
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>split-adjusted mid]
+    B --> D[priceAtNinetyDayHorizon<br/>Actual = mid]
+    B --> E[lowPriceAtNinetyDayHorizon<br/>Actual = low]
+    D --> F[priceBasisOffsetPercent<br/>= mid - low / buyPrice]
+    E --> F
+    C --> F
+    F --> G[aggregate: mean/median/dist<br/>+ net vs observed gap]
+```
+
+## Code references
+
+- Training label (intraday low, 90 days ahead): `GRQ/src/LearnUtil.ts`
+  (`market.lowPrice(symbol, targetDate)`).
+- Dashboard Actual (midpoint): `GRQ-validation/docs/projection.js`
+  — `currentPriceFromLatest`, `priceAtNinetyDayHorizon`.
+- Matching low basis + offset helper: `GRQ-validation/docs/projection.js`
+  — `lowPriceAtNinetyDayHorizon`, `priceBasisOffsetPercent` (this issue).
+- Diagnostic: `scripts/diagnose_price_basis.ts`,
+  `scripts/price_basis_diagnostic.ts`;
+  tests `tests/price_basis_diagnostic_test.ts`.

--- a/docs/archive/investigations/issue-552-price-basis-bias.md
+++ b/docs/archive/investigations/issue-552-price-basis-bias.md
@@ -24,7 +24,7 @@ stock-rows, as-of 2026-06-26) the basis offset `(mid - low) / buyPrice` is:
 
 **Sign and netting.** The offset is **non-negative on every row** (sign **+**).
 Measuring Actual at the higher mid makes Actual larger, which **narrows / masks**
-the Target-over-Actual gap — the *opposite* direction to the observed gap. So
+the Target-over-Actual gap — the _opposite_ direction to the observed gap. So
 this candidate **offsets** the gap rather than causing it:
 
 | Quantity (mean over matured dates) | Value |
@@ -39,7 +39,7 @@ this candidate **offsets** the gap rather than causing it:
 Restating Actual onto the basis the model was trained on (intraday low) would
 **widen** the apparent gap by ~**2.24 pp**, from ~18.5 pp to ~20.7 pp. Genuine
 model optimism (and the remaining candidates in #544) must therefore explain a
-gap that is *larger* than the headline figure, not smaller.
+gap that is _larger_ than the headline figure, not smaller.
 
 > The per-row equal-weight mean (+2.235 pp) and the per-date portfolio-level
 > contribution (+2.242 pp) agree to within rounding, confirming the offset is a
@@ -57,11 +57,11 @@ gap that is *larger* than the headline figure, not smaller.
 for now (low-priority hygiene fix only)
 
 A real, structural asymmetry **is** confirmed (a consistent, same-direction
-~2.2 pp offset), so a fix is *justifiable* on like-for-like grounds. However:
+~2.2 pp offset), so a fix is _justifiable_ on like-for-like grounds. However:
 
 - Correcting it **does not close** the Target-over-Actual gap — it **widens**
   it. This candidate is therefore **exonerated as a cause** of the reported
-  symptom; it was partially *hiding* the gap.
+  symptom; it was partially _hiding_ the gap.
 - The mid basis is also the more defensible figure to **show a user** as the
   "Actual" return: the midpoint is an unbiased intraday estimate, whereas the
   intraday low systematically understates what a holder realised. Switching the

--- a/docs/archive/investigations/issue-553-dividend-basis-bias.md
+++ b/docs/archive/investigations/issue-553-dividend-basis-bias.md
@@ -42,7 +42,7 @@ realised in-window dividends. Because the model's Target embeds the flat credit
 while the dashboard's Actual credits only realised in-window dividends, this
 dividend basis **contributes to (widens)** the Target-over-Actual gap — the
 **same** direction as the observed gap, unlike the price-basis candidate (#552),
-which *narrowed* it.
+which _narrowed_ it.
 
 The headline raw mean (+2.83 pp) is **lumpy and tail-driven**: 86.4 % of rows
 sit within ±1 pp and the median is exactly 0 (non-payers and quarterly payers
@@ -76,7 +76,7 @@ estimate is therefore the **1%-trimmed mean ≈ +1.36 pp** (and the median 0).
 
 ## Recommendation: real, same-direction contributor — **fix the basis upstream in `GRQ`** (align training onto realised forward-window dividends)
 
-Unlike the price-basis candidate (#552, exonerated because it *hid* the gap),
+Unlike the price-basis candidate (#552, exonerated because it _hid_ the gap),
 the dividend basis is a **genuine, same-direction contributor** of roughly
 **+1.4 pp (robust) to +2.8 pp (raw)**. It is worth correcting, and the correct
 direction is to **align both sides on realised dividends**:

--- a/docs/archive/investigations/issue-553-dividend-basis-bias.md
+++ b/docs/archive/investigations/issue-553-dividend-basis-bias.md
@@ -1,0 +1,154 @@
+# Dividend-basis bias: flat training quarter vs windowed actual ex-dividends
+
+_Diagnostic for Issue #553 (sub-issue of #544 — one candidate source of the
+systematic Target-over-Actual measurement gap). The windowed credit lives in
+`GRQ-validation`; the flat training credit lives upstream in `GRQ`._
+
+## TL;DR
+
+GRQ training bakes a **flat** quarter of the trailing annual dividend,
+`core.yearOfDividends / 4`, into the total-return label for **every** stock —
+whether or not a dividend actually lands in the forward window
+(`GRQ/src/LearnUtil.ts:147-148`, built from `GRQ/src/CoreFeatures.ts`). The
+validation dashboard credits only the **actual ex-dividends inside the 90-day
+window** (`GRQ-validation/src/utils.rs` `calculate_dividends_for_period`,
+mirrored by the shipped JS kernels `filterDividendsWithin90Days` +
+`sumDividends`).
+
+Per matured row the diagnostic compares the two credits as a percentage of the
+buy price and aggregates the **mean difference and its sign**. Over the matured
+historical score set (274 score dates, 5 444 included stock-rows, as-of
+2026-06-26), `(flatCredit − windowedCredit) / buyPrice` is:
+
+| Statistic | Value |
+| --- | --- |
+| Mean (raw) | **+2.827 pp** |
+| Mean (1%-trimmed) | **+1.358 pp** |
+| Median | +0.000 pp |
+| Min | −116.652 pp (special distribution caught in-window, low-priced) |
+| Max | +277.778 pp (special distribution missed by the window, low-priced) |
+| Std dev | 20.174 pp |
+| Rows within ±1 pp | 86.4 % |
+
+| Dividend-return component (mean over included rows) | Value |
+| --- | --- |
+| Mean flat credit yield (`yearOfDividends / 4` / buy) | 3.656 % |
+| Mean realised in-window yield (dashboard Actual) | 0.829 % |
+| Included rows with **zero** in-window dividends | 45.2 % |
+
+**Sign and netting.** The mean difference is **positive (sign +)**: the flat
+training quarter is, on average, a **consistent over-credit** relative to the
+realised in-window dividends. Because the model's Target embeds the flat credit
+while the dashboard's Actual credits only realised in-window dividends, this
+dividend basis **contributes to (widens)** the Target-over-Actual gap — the
+**same** direction as the observed gap, unlike the price-basis candidate (#552),
+which *narrowed* it.
+
+The headline raw mean (+2.83 pp) is **lumpy and tail-driven**: 86.4 % of rows
+sit within ±1 pp and the median is exactly 0 (non-payers and quarterly payers
+roughly net out), but a handful of **special / liquidating distributions on
+low-priced stocks** (EQC, ELME, VISN) dominate both tails. The robust central
+estimate is therefore the **1%-trimmed mean ≈ +1.36 pp** (and the median 0).
+
+## Why the two sides diverge
+
+- **Cadence.** 45.2 % of included rows realise **no** dividend in their 90-day
+  window — semi-annual and annual payers contribute 0 to Actual in most windows
+  yet always receive the flat quarter in training. This is the dominant,
+  same-direction driver: their per-row difference is `+flatCredit/buy > 0`.
+- **Growth / cuts.** `yearOfDividends` is the trailing year, so it misses
+  forward dividend growth or cuts that the realised in-window figure captures.
+- **Specials.** One-off special and liquidating distributions are credited
+  realised-only on the validation side, but are diluted into (or excluded from)
+  the trailing-annual quarter on the training side. On low-priced stocks these
+  produce the extreme ± tails above and inflate the raw mean.
+
+## Acceptance criteria
+
+1. **Mean dividend-basis difference (pp) with sign** — **+2.827 pp** raw /
+   **+1.358 pp** (1%-trimmed), median 0; **sign +** (flat quarter is a
+   consistent over-credit).
+2. **Contributes to or offsets the gap** — it **contributes to (widens)** the
+   Target-over-Actual gap, because Target carries the larger flat credit while
+   Actual carries the smaller realised in-window credit. (Opposite to #552's
+   price basis, which masked the gap.)
+3. **Fix-vs-leave recommendation** — see below.
+
+## Recommendation: real, same-direction contributor — **fix the basis upstream in `GRQ`** (align training onto realised forward-window dividends)
+
+Unlike the price-basis candidate (#552, exonerated because it *hid* the gap),
+the dividend basis is a **genuine, same-direction contributor** of roughly
+**+1.4 pp (robust) to +2.8 pp (raw)**. It is worth correcting, and the correct
+direction is to **align both sides on realised dividends**:
+
+- The dashboard's realised in-window credit is the **defensible** "Actual": it
+  reflects the cash a holder actually received in the 90 days. Degrading it to a
+  fabricated flat quarter (to match training) would credit dividend income that
+  was never realised — strictly worse for a user-facing figure.
+- Therefore the clean fix lives **upstream in `GRQ`**: train/evaluate the label
+  on the dividends that actually fall in the forward 90-day window (the same
+  basis `calculate_dividends_for_period` uses), instead of a flat
+  `yearOfDividends / 4`. That removes the structural over-credit at source and
+  makes Target and Actual like-for-like on dividends.
+- The root-cause change is a **training-label** decision in `GRQ`, out of scope
+  for this `GRQ-validation` diagnostic issue (whose deliverable is the written
+  analysis + recommendation). It should be carried as a fix candidate under
+  milestone #544.
+
+**Net for the milestone:** keep this candidate as a **confirmed, modest,
+same-direction contributor** (~+1.4 to +2.8 pp) alongside genuine model optimism
+— but treat the raw +2.83 pp as an upper bound inflated by a few special-dividend
+outliers; the robust figure is ~+1.4 pp.
+
+## How this was measured (reproducible)
+
+Every per-stock figure is delegated to the **shipped** kernels so the windowed
+credit measured here is the dashboard's own credit, not a re-implementation:
+
+- `GRQTrendPredictions.resolvePredictionStocks` — split-aware `buyPrice`,
+  `currentPrice`, inclusion flag and the realised in-window `totalDividends`
+  (`sumDividends` ∘ `filterDividendsWithin90Days`) — the dashboard's Actual
+  dividend credit.
+- `GRQProjection.trailingAnnualDividends` — trailing-365-day dividend total as
+  of the score date; `/ 4` reproduces the model's flat training credit (added
+  for this diagnostic).
+- `GRQProjection.dividendBasisDifferencePercent` —
+  `(flatCredit − windowedCredit) / buyPrice * 100`.
+- `GRQProjection.isStockIncluded` — restricts to the same included set the
+  dashboard aggregates over.
+
+The flat credit is read from the full per-ticker dividend history in the
+sibling `../GRQ-dividends` tree (the same source `src/utils.rs` reads via
+`DIVIDEND_DATA_BASE_PATH`); the windowed credit is read from the committed
+per-score `*-dividends.csv` files.
+
+```bash
+deno task diagnose-dividend-basis              # docs/, today, ../GRQ-dividends
+# raw form (pin an as-of date + explicit history root for a reproducible report):
+deno run --allow-read scripts/diagnose_dividend_basis.ts docs 2026-06-26 ../GRQ-dividends
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv]
+    B --> C[resolvePredictionStocks<br/>buyPrice + realised in-window totalDividends]
+    A --> D[../GRQ-dividends<br/>full per-ticker history]
+    D --> E[trailingAnnualDividends / 4<br/>flat training credit]
+    C --> F[dividendBasisDifferencePercent<br/>= flat - windowed / buyPrice]
+    E --> F
+    F --> G[aggregate: mean / 1%-trimmed / median / dist<br/>+ sign vs observed gap]
+```
+
+## Code references
+
+- Flat training credit: `GRQ/src/LearnUtil.ts:147-148`
+  (`(targetPrice + core.yearOfDividends / 4) / core.monthsAgoPrice`),
+  `yearOfDividends` built in `GRQ/src/CoreFeatures.ts`.
+- Windowed actual credit: `GRQ-validation/src/utils.rs`
+  `calculate_dividends_for_period` (invoked at the 90-day window), mirrored by
+  `docs/projection.js` `filterDividendsWithin90Days` + `sumDividends`.
+- Trailing-annual basis + difference helper: `docs/projection.js`
+  `trailingAnnualDividends`, `dividendBasisDifferencePercent` (this issue).
+- Diagnostic: `scripts/diagnose_dividend_basis.ts`,
+  `scripts/dividend_basis_diagnostic.ts`;
+  tests `tests/dividend_basis_diagnostic_test.ts`.

--- a/docs/archive/investigations/issue-554-buy-price-denominator-bias.md
+++ b/docs/archive/investigations/issue-554-buy-price-denominator-bias.md
@@ -10,7 +10,7 @@ The GRQ model is trained on a 90-day return whose **denominator** is
 `monthsAgoPrice` — the **close** on the score date. The validation dashboard
 divides **both** Target and Actual by `buyPrice` — the **split-adjusted
 midpoint** `(high + low) / 2` of the first usable point. Because the dashboard
-applies the *same* `buyPrice` to Target and Actual, the denominator choice
+applies the _same_ `buyPrice` to Target and Actual, the denominator choice
 **cannot desynchronise** them: it only rescales the (Target − Actual) gap by
 `buyPrice / close`.
 
@@ -87,10 +87,10 @@ flowchart TD
   first usable point; **both** `calculateTargetPercentage` /
   `calculatePortfolioTargetPercentage` and `calculatePerformanceReturn` /
   `calculateIncludedPortfolioPerformance` divide by that **one** `buyPrice`.
-- **Mixed basis?** Only at the level of the model's *emitted absolute target
-  price*: the network learned that price relative to the close, but the
+- **Mixed basis?** Only at the level of the model's _emitted absolute target
+  price_: the network learned that price relative to the close, but the
   dashboard expresses the (target − buyPrice) spread over `buyPrice`. Since
-  Actual is expressed over the *same* `buyPrice`, the choice rescales both
+  Actual is expressed over the _same_ `buyPrice`, the choice rescales both
   identically — it never measures Target and Actual on different denominators.
 
 ## Aggregate contribution to the gap (part 3)
@@ -113,7 +113,7 @@ Target-over-Actual gap. The milestone (#544) should keep chasing genuine model
 optimism and the remaining candidates (price basis #552 — the dominant
 ~2.2 pp masking term; dividend basis #553; score decoding). If a fully
 like-for-like trend comparison is ever wanted, the cleaner fix is to align the
-*price basis* (#552) upstream in `GRQ`, not to swap the dashboard's shared
+_price basis_ (#552) upstream in `GRQ`, not to swap the dashboard's shared
 denominator for the training close.
 
 ## How this was measured (reproducible)

--- a/docs/archive/investigations/issue-554-buy-price-denominator-bias.md
+++ b/docs/archive/investigations/issue-554-buy-price-denominator-bias.md
@@ -1,0 +1,166 @@
+# Buy-price denominator bias: training close vs dashboard midpoint
+
+_Diagnostic for Issue #554 (sub-issue of #544 — one candidate source of the
+systematic Target-over-Actual measurement gap). Measurement lives in
+`GRQ-validation`; the root denominator decision lives upstream in `GRQ`._
+
+## TL;DR
+
+The GRQ model is trained on a 90-day return whose **denominator** is
+`monthsAgoPrice` — the **close** on the score date. The validation dashboard
+divides **both** Target and Actual by `buyPrice` — the **split-adjusted
+midpoint** `(high + low) / 2` of the first usable point. Because the dashboard
+applies the *same* `buyPrice` to Target and Actual, the denominator choice
+**cannot desynchronise** them: it only rescales the (Target − Actual) gap by
+`buyPrice / close`.
+
+Over the matured historical score set (274 score dates, 5 444 included
+stock-rows, as-of 2026-06-26) the denominator offset
+`(buyPrice − close) / buyPrice` is:
+
+| Statistic | Value |
+| --- | --- |
+| Mean | **+0.046 pp** |
+| Median | +0.000 pp |
+| Min | −11.868 pp |
+| Max | +9.886 pp |
+| Std dev | 1.418 pp |
+
+**Sign and netting.** Unlike the price-basis offset of #552 (which is `>= 0` on
+every row), the midpoint-vs-close offset is **roughly symmetric around zero**
+(median 0.000, mean **+0.046 pp**, sign **+** but tiny). The close sits inside
+`[low, high]`, so on any given day it may be above or below the midpoint; across
+5 444 rows the two nearly cancel, leaving a negligible upward bias in `buyPrice`.
+
+| Quantity (mean over matured dates) | Value |
+| --- | --- |
+| Mean Target % (mid — current dashboard) | 28.916 % |
+| Mean Actual % (mid — current dashboard) | 10.447 % |
+| Mean Target % (close — trained basis) | 29.019 % |
+| Mean Actual % (close — trained basis) | 10.502 % |
+| **Observed gap** (Target − Actual, mid) | **+18.470 pp** |
+| Gap on the trained close basis | +18.517 pp |
+| **Basis contribution** (close − mid gap) | **+0.048 pp** |
+
+Restating **both** series onto the trained close denominator moves the apparent
+gap by ~**0.05 pp**, from ~18.47 pp to ~18.52 pp — three orders of magnitude
+smaller than the gap itself.
+
+> The per-row equal-weight mean (+0.046 pp) and the per-date portfolio-level
+> contribution (+0.048 pp) agree to within rounding, confirming the offset is a
+> broad, structural near-zero rather than an artefact of a few dates.
+
+## Acceptance criteria
+
+1. **Numeric denominator offset (pp) with sign** — mean **+0.046 pp** (per row)
+   / **+0.048 pp** (portfolio-level); roughly symmetric (median 0.000 pp).
+2. **A clear yes/no on whether Target vs Actual are desynchronised by the
+   denominator choice** — **NO.** The dashboard divides **both**
+   `calculatePortfolioTargetPercentage` and
+   `calculateIncludedPortfolioPerformance` by the **same** per-stock
+   `buyPrice`, so the denominator is shared. It rescales any existing gap by
+   `buyPrice / close`; it does not split Target and Actual onto different bases.
+3. **Fix-vs-leave recommendation** — see below.
+
+## Tracing the denominators (part 2)
+
+```mermaid
+flowchart TD
+    subgraph GRQ[Training — GRQ]
+        A[closePrices0 = close on score date] --> B[monthsAgoPrice]
+        B --> C["percentage = targetPrice + div/4 / monthsAgoPrice - 1"]
+    end
+    subgraph DASH[Dashboard — GRQ-validation]
+        D["getBuyPrice = split-adjusted high+low/2"] --> E[buyPrice]
+        E --> F[Target % = adjustedTarget - buyPrice / buyPrice]
+        E --> G[Actual % = currentPrice + div - buyPrice / buyPrice]
+    end
+    C -. emits absolute target price .-> F
+```
+
+- **Training denominator:** `GRQ/src/CoreFeatures.ts` sets
+  `monthsAgoPrice = closePrices[0]` (the close on the score date);
+  `GRQ/src/LearnUtil.ts:147-148` divides the labelled return by it, and
+  `:218` persists it with the train item.
+- **Dashboard denominator:** `GRQ-validation/docs/projection.js`
+  `getBuyPrice` (lines ~522-546) resolves the split-adjusted midpoint of the
+  first usable point; **both** `calculateTargetPercentage` /
+  `calculatePortfolioTargetPercentage` and `calculatePerformanceReturn` /
+  `calculateIncludedPortfolioPerformance` divide by that **one** `buyPrice`.
+- **Mixed basis?** Only at the level of the model's *emitted absolute target
+  price*: the network learned that price relative to the close, but the
+  dashboard expresses the (target − buyPrice) spread over `buyPrice`. Since
+  Actual is expressed over the *same* `buyPrice`, the choice rescales both
+  identically — it never measures Target and Actual on different denominators.
+
+## Aggregate contribution to the gap (part 3)
+
+**+0.048 pp** (portfolio-level), i.e. essentially nil. The denominator is a
+second-order rescale of an ~18.5 pp gap, not a driver of it.
+
+## Recommendation: **leave the dashboard denominator as-is** — exonerated
+
+- The denominator offset is **near-zero and symmetric** (mean +0.046 pp), so it
+  contributes a negligible **+0.048 pp** to the gap.
+- Target and Actual **already share** the denominator, so there is no
+  desynchronisation to fix — the property the issue asked us to confirm holds.
+- The midpoint `buyPrice` is also the more defensible figure to show a user as
+  the cost basis (an unbiased intraday estimate), and it is already split-aware,
+  which the raw training close is not.
+
+**Therefore:** this candidate is **exonerated as a cause** of the
+Target-over-Actual gap. The milestone (#544) should keep chasing genuine model
+optimism and the remaining candidates (price basis #552 — the dominant
+~2.2 pp masking term; dividend basis #553; score decoding). If a fully
+like-for-like trend comparison is ever wanted, the cleaner fix is to align the
+*price basis* (#552) upstream in `GRQ`, not to swap the dashboard's shared
+denominator for the training close.
+
+## How this was measured (reproducible)
+
+Every per-stock figure is delegated to the **shipped** kernels so the diagnostic
+measures the dashboard's own denominator, not a re-implementation:
+
+- `GRQProjection.getBuyPrice` — split-adjusted midpoint buy price (dashboard).
+- `GRQProjection.buyPriceCloseBasis` — split-adjusted close of the **same**
+  first point (the trained `monthsAgoPrice` basis; added for this diagnostic).
+- `GRQProjection.denominatorBasisOffsetPercent` —
+  `(buyPrice − close) / buyPrice * 100`.
+- `GRQProjection.calculatePortfolioTargetPercentage` /
+  `calculateIncludedPortfolioPerformance` — Target % and Actual % on each
+  denominator over the same included set.
+
+```bash
+deno task diagnose-buy-price-denominator   # against docs/, as-of today
+# raw form (pin an as-of date for a reproducible report):
+deno run --allow-read scripts/diagnose_buy_price_denominator.ts docs 2026-06-26
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>split-adjusted mid]
+    B --> D[buyPriceCloseBasis<br/>split-adjusted close]
+    C --> E[denominatorBasisOffsetPercent<br/>= buyPrice - close / buyPrice]
+    D --> E
+    C --> F[Target%/Actual% on mid basis]
+    D --> G[Target%/Actual% on close basis]
+    E --> H[aggregate: mean/median/dist<br/>+ gap rescale]
+    F --> H
+    G --> H
+```
+
+## Code references
+
+- Training denominator (close on score date): `GRQ/src/CoreFeatures.ts`
+  (`monthsAgoPrice = closePrices[0]`), `GRQ/src/LearnUtil.ts:147-148` (divides
+  by it), `:218` (persists it).
+- Dashboard denominator (shared midpoint): `GRQ-validation/docs/projection.js`
+  — `getBuyPrice`; consumed by `calculateTargetPercentage` /
+  `calculatePortfolioTargetPercentage` and `calculatePerformanceReturn` /
+  `calculateIncludedPortfolioPerformance`.
+- Matching close basis + offset helper: `GRQ-validation/docs/projection.js`
+  — `buyPriceCloseBasis`, `denominatorBasisOffsetPercent` (this issue).
+- Diagnostic: `scripts/diagnose_buy_price_denominator.ts`,
+  `scripts/buy_price_denominator_diagnostic.ts`;
+  tests `tests/buy_price_denominator_diagnostic_test.ts`.

--- a/docs/archive/investigations/issue-555-market-data-timing-corporate-action-parity.md
+++ b/docs/archive/investigations/issue-555-market-data-timing-corporate-action-parity.md
@@ -1,0 +1,203 @@
+# Market-data timing & corporate-action parity: training vs dashboard
+
+_Parity audit for Issue #555 (sub-issue of #544 — one candidate source of the
+systematic Target-over-Actual measurement gap). User-raised candidate. The
+training timing/adjustment lives upstream in `GRQ`; the dashboard
+timing/adjustment lives in `GRQ-validation`._
+
+## TL;DR
+
+Of the four timing/corporate-action decisions the issue asked us to confirm,
+**three are aligned** between training and the dashboard and **one is
+divergent**:
+
+1. **Horizon-date selection — aligned.** Training takes the trading day on or
+   before `asOf + 90*DAY`; the dashboard takes the last market-data point on or
+   before `scoreDate + 90 days`. On the stock's own daily series these resolve
+   to the **same row**.
+2. **OHLC field — divergent, but already owned upstream.** Training reads the
+   intraday **low** at the horizon and the **close** at the score date; the
+   dashboard reads the **midpoint** `(high + low) / 2` at both. These are the
+   #552 (horizon field, ~+2.2 pp masking) and #554 (buy-price field, ~+0.05 pp)
+   findings — not re-quantified here.
+3. **Split/merge adjustment convention — aligned.** Both sides work on
+   split-adjusted prices and restate a historical price into current
+   (end-of-series) terms by dividing out the cumulative split factor for splits
+   **after** that date.
+4. **As-of split basis of the Actual horizon price — DIVERGENT (this audit's
+   finding).** The dashboard restates the **buy price** and the **model target**
+   into current terms, but reads the **Actual horizon price RAW**. When a
+   reconcilable split falls **between the 90-day horizon and the end of the data
+   series**, the Actual sits on a different split basis than the buy price it is
+   divided by.
+
+Measured over the matured historical score set (274 score dates, 5 444 included
+stock-rows, as-of 2026-06-26): **123 rows** carry a reconcilable post-horizon
+split. Restating their Actual onto the buy price's current basis moves the
+portfolio gap by **+0.482 pp** (a forward split inflates Actual, _masking_ the
+gap), while the per-row distortion is large and two-sided:
+
+| Statistic (per-row offset `(rawHorizon − currentBasis) / buyPrice`) | Value |
+| --- | --- |
+| Mean | **+0.565 pp** |
+| Median | +0.000 pp |
+| Min | −316.116 pp |
+| Max | +1395.893 pp |
+| Std dev | 51.437 pp |
+
+| Quantity (mean over 274 matured dates) | Value |
+| --- | --- |
+| Mean Target % | 28.916 % |
+| Mean Actual % (raw horizon — current dashboard) | 10.447 % |
+| Mean Actual % (split-consistent horizon) | 9.965 % |
+| **Observed gap** (Target − Actual, raw) | **+18.470 pp** |
+| Gap on the split-consistent basis | +18.952 pp |
+| **As-of-basis contribution** (consistent − raw gap) | **+0.482 pp** |
+
+> The mean raw Actual (10.447 %) reproduces the #554 audit's dashboard Actual
+> figure exactly, confirming this diagnostic measures the **shipped** Actual,
+> not a re-implementation.
+
+## Parity table
+
+Training (`GRQ`) vs dashboard (`GRQ-validation`), each row marked **aligned** or
+**divergent**:
+
+| # | Decision | Training (GRQ) | Dashboard (GRQ-validation) | Status | Direction if divergent |
+| --- | --- | --- | --- | --- | --- |
+| 1 | **Horizon-date selection** | `lowPrice` at `rewindToTradingDay(asOf + 90*DAY)` — trading day on/before exactly 90 days out (`GRQ/src/LearnUtil.ts:138-140`, `GRQ/src/Market.ts:241`) | last point with `date <= scoreDate + 90 days` (`priceAtNinetyDayHorizon` / `currentPriceWithinWindow`) | **Aligned** | — (same row on the stock's own daily series) |
+| 2 | **OHLC field — horizon** | intraday **low** (`market.lowPrice`) | **midpoint** `(high + low) / 2` | **Divergent** | mid ≥ low ⇒ Actual lifted ⇒ **masks** the gap; ~+2.2 pp — **owned by #552** |
+| 3 | **OHLC field — buy/score point** | **close** (`monthsAgoPrice = closePrices[0]`, `GRQ/src/CoreFeatures.ts`) | **midpoint** `(high + low) / 2` (`getBuyPrice`) | **Divergent** | symmetric ~+0.05 pp — **owned by #554** |
+| 4 | **Split/merge adjustment convention** | adjusted series; cumulative factor from each date to the data end (`GRQ/src/History.ts` accumulates `adj /= split` backwards) | on-the-fly restate-to-current via `computeSplitAdjustment` / `adjustHistoricalPriceToCurrent`, reconciliation-gated (`docs/projection.js:433-520`) | **Aligned** | — (same convention; reconciliation only _excludes_ a stock, it does not skew an included one) |
+| 5 | **As-of split basis of the Actual horizon price** | both `monthsAgoPrice` (score close) and `targetPrice` (horizon low) carry the data-end `adj`; the post-horizon factor **cancels** in `targetPrice / monthsAgoPrice` | **buy price** & **target** restated to current terms, but the **Actual horizon price read RAW** (`getStockReturnBreakdown` app.js:4458, `currentPriceWithinWindow`) | **Divergent** | forward post-horizon split inflates Actual ⇒ **masks** (+0.482 pp portfolio); reverse split widens; ±extreme per-row (−316 → +1396 pp on 123/5 444 rows) |
+
+## Why row 5 diverges (the mechanics)
+
+Let `S_in` be the cumulative split factor for splits **between** the score date
+and the horizon, and `S_after` for splits **between** the horizon and the end of
+the data series.
+
+- **Training** restates both the score close and the horizon low onto the
+  data-end basis. The return ratio `targetPrice / monthsAgoPrice` reduces to
+  `raw_low_horizon · S_in / raw_close_score` — the post-horizon factor `S_after`
+  appears in both numerator and denominator and **cancels**. Economically
+  correct: a split after the horizon does not change wealth.
+- **Dashboard** computes `buyPrice = raw_mid_score / (S_in · S_after)` (restated
+  to current terms by `getBuyPrice`) but `currentPrice = raw_mid_horizon`
+  (**unadjusted**, already post-`S_in` because the split actually happened by the
+  horizon). The Actual ratio becomes `raw_mid_horizon · S_in · S_after /
+  raw_mid_score` — an **extra factor of `S_after`**. A 2:1 forward split after
+  the horizon roughly **doubles** the displayed Actual for that stock; a reverse
+  split deflates it.
+
+**Target % is unaffected.** `calculateTargetPercentage` divides both
+`adjustedTarget` and `buyPrice` by the same `S_in · S_after`, so the split
+cancels: `(adjustedTarget − buyPrice) / buyPrice` is invariant to the
+post-horizon split. The divergence therefore shifts **only** the Actual side.
+
+```mermaid
+flowchart TD
+    subgraph GRQ[Training — GRQ]
+        A["monthsAgoPrice = close@score · adj_dataEnd"] --> R["ratio = targetPrice / monthsAgoPrice<br/>S_after cancels ✓"]
+        B["targetPrice = low@horizon · adj_dataEnd"] --> R
+    end
+    subgraph DASH[Dashboard — GRQ-validation]
+        C["buyPrice = mid@score / (S_in·S_after)<br/>restated to current"] --> P["Actual = (currentPrice − buyPrice)/buyPrice<br/>extra factor S_after ✗"]
+        D["currentPrice = mid@horizon RAW<br/>post-S_in only"] --> P
+        E["adjustedTarget = target / (S_in·S_after)"] --> T["Target % invariant — S_after cancels ✓"]
+        C --> T
+    end
+```
+
+## Fix recommendations & ruled-out notes
+
+- **Row 1 — Horizon-date selection: ruled out.** The dashboard's "last point on
+  or before `scoreDate + 90 days`" and training's `rewindToTradingDay(asOf +
+  90*DAY)` pick the same trading day on the stock's own daily series. The only
+  residual is training's `lowPrice` scan-back not crossing a **year boundary**
+  (a rare exclusion, not a directional skew). **No change recommended.**
+- **Row 2 / Row 3 — OHLC field: ruled out here; tracked in #552 / #554.** The
+  field mismatch is real but already enumerated and quantified by the sibling
+  audits. **No new action in this issue.**
+- **Row 4 — Split/merge convention: ruled out.** Both sides use the same
+  restate-to-current convention; the dashboard's reconciliation gate only drops
+  a stock it cannot trust (`reliable === false`), it never skews an included
+  row's adjustment relative to training. **No change recommended.**
+- **Row 5 — As-of split basis of the Actual horizon price: FIX RECOMMENDED.**
+  Read the Actual horizon price on the **same** current basis as the buy price,
+  i.e. divide the raw horizon midpoint by `postHorizonSplitFactor` (the new
+  `GRQProjection.horizonPriceCurrentBasis` helper). This removes the spurious
+  `S_after` factor, brings Actual onto the buy price's basis, and matches
+  training's cancellation. The portfolio-level effect is modest (**+0.482 pp**,
+  a _masking_ term that means genuine model optimism must exceed the raw gap by
+  this much), but the **per-row** distortion is large (up to +1 396 pp), so the
+  fix is primarily a **correctness** improvement for individual stocks that split
+  after their horizon. This is a behaviour change to the displayed Actual and
+  should land as its own focused PR (with UI evidence), not inside this audit.
+
+## Aggregate contribution to the gap
+
+**+0.482 pp** (portfolio-level), a _masking_ term: forward post-horizon splits
+dominate, so the shipped raw Actual is slightly **inflated**, and restating onto
+the split-consistent basis would **widen** the observed Target-over-Actual gap
+from 18.470 pp to 18.952 pp. Like #552 and #554, this candidate _offsets_
+rather than causes the gap — but unlike them it also flags a genuine per-row
+correctness bug worth fixing on its own merits.
+
+## How this was measured (reproducible)
+
+Every per-stock figure is delegated to the **shipped** kernels so the diagnostic
+measures the dashboard's own basis, not a re-implementation:
+
+- `GRQProjection.getBuyPrice` — split-adjusted midpoint buy price (current basis).
+- `GRQProjection.priceAtNinetyDayHorizon` — raw midpoint Actual (shipped basis).
+- `GRQProjection.horizonPointDate` — the date of the row the Actual is read from.
+- `GRQProjection.postHorizonSplitFactor` — `S_after` (reliable splits after the
+  horizon), added for this diagnostic.
+- `GRQProjection.horizonPriceCurrentBasis` — the horizon midpoint restated onto
+  the buy price's current basis.
+- `GRQProjection.horizonAsOfBasisOffsetPercent` —
+  `(rawHorizon − currentBasis) / buyPrice * 100`.
+- `GRQProjection.calculatePortfolioTargetPercentage` /
+  `calculateIncludedPortfolioPerformance` — Target % and Actual % on each basis
+  over the same included set.
+
+```bash
+deno task diagnose-horizon-split-parity            # against docs/, as-of today
+# raw form (pin an as-of date for a reproducible report):
+deno run --allow-read scripts/diagnose_horizon_split_parity.ts docs 2026-06-26
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>current basis]
+    B --> D[priceAtNinetyDayHorizon<br/>raw mid]
+    B --> E[horizonPriceCurrentBasis<br/>raw mid / S_after]
+    C --> F[horizonAsOfBasisOffsetPercent]
+    D --> F
+    E --> F
+    C --> G[Target%/Actual% raw basis]
+    C --> H[Target%/Actual% consistent basis]
+    F --> I[aggregate: mean/median/dist<br/>+ gap rescale + affected-row count]
+    G --> I
+    H --> I
+```
+
+## Code references
+
+- Training horizon & adjustment: `GRQ/src/LearnUtil.ts:138-148`
+  (`rewindToTradingDay`, `lowPrice`, `restrictHistoryTo`), `GRQ/src/Market.ts:194`
+  (`lowPrice`), `:241` (`rewindToTradingDay`), `GRQ/src/CoreFeatures.ts`
+  (`monthsAgoPrice = closePrices[0]`), `GRQ/src/History.ts` (split-adjusted load).
+- Dashboard horizon & adjustment: `GRQ-validation/docs/projection.js` —
+  `priceAtNinetyDayHorizon`, `getBuyPrice`, `computeSplitAdjustment`,
+  `adjustHistoricalPriceToCurrent`; `docs/app.js:4443-4490`
+  (`getStockReturnBreakdown`, raw horizon price); `docs/trend_predictions.js`
+  (`currentPriceWithinWindow`, `resolvePredictionStocks`).
+- New parity helpers: `GRQ-validation/docs/projection.js` — `horizonPointDate`,
+  `postHorizonSplitFactor`, `horizonPriceCurrentBasis`,
+  `horizonAsOfBasisOffsetPercent` (this issue).
+- Diagnostic: `scripts/diagnose_horizon_split_parity.ts`,
+  `scripts/horizon_split_parity_diagnostic.ts`;
+  tests `tests/horizon_split_parity_diagnostic_test.ts`.

--- a/docs/archive/investigations/issue-556-score-target-decoding-bias.md
+++ b/docs/archive/investigations/issue-556-score-target-decoding-bias.md
@@ -1,0 +1,146 @@
+# Score→target decoding (`reverseProfitRecommend`): does decoding add bias?
+
+_Diagnostic for Issue #556 (sub-issue of #544 — one candidate source of the
+systematic Target-over-Actual measurement gap). User-raised candidate. The
+score→target decode lives upstream in `GRQ`
+(`GRQ/src/LearnUtilTypes.ts`, called at `GRQ/src/portfolio/ScoreApp.ts:473`);
+this repo holds only the already-decoded Target in each score TSV._
+
+## TL;DR
+
+**Decoding is ruled out as a source of the Target-over-Actual gap.** Over the
+realised score distribution the round-trip
+`profitRecommend ∘ reverseProfitRecommend` shifts the Target by **0 pp**
+(machine epsilon — max |shift| `1.78e-15` pp across all 7 108 stock-rows). The
+asymmetric clamps the issue flagged cannot bias the realised data:
+
+- The **+50% cap** (`score >= 1`) fires for a large share of rows but
+  round-trips **cleanly** — it is consistent with its own forward mapping.
+- The **`0`/-100% floor** (`score <= -1`) **never fires**: there is not a single
+  negative score in the history, so the asymmetry that worried the issue is
+  **dormant**.
+
+The only residual candidate is **encode-side quantisation** (a saturated
+`score == 1` is a fixed +50% point estimate of an unknown true intent ≥ the
+saturation threshold). That is information lost in `GRQ` at _encode_ time and is
+**not** a `reverseProfitRecommend` round-trip asymmetry — the dashboard decode
+cannot recover or distort it. It is flagged below for `GRQ` but is out of scope
+for this decode audit.
+
+## The mapping under test
+
+Forward (training encode) and reverse (dashboard decode):
+
+```text
+encode:  profitRecommend(pct)  = tanh((pct - 1.5) / 3)            pct → score
+decode:  pct = 3 * atanh(score) + 1.5                             score → pct
+         target = price * (1 + pct / 100)
+clamps:  score >=  1 → +MAX_REVERSE_PERCENT (+50%)
+         score <= -1 → target 0            (pct = -100%)
+         interior pct capped to ±MAX_REVERSE_PERCENT (±50%)
+```
+
+`tanh` and `atanh` are exact inverses, so in the interior the decode reproduces
+the encoded percentage exactly. The decode identity is anchored against the real
+data: a `score == 1` row (NYSE:DD, Target 68.39) decodes to `1.5 × 45.59 =
+68.39`, and an interior row (`score 0.70043`, buy 75.66) decodes to
+`75.66 × (1 + 4.105/100) = 78.77` — both reproduce the stored Target.
+
+```mermaid
+flowchart LR
+    P["true return % (GRQ, unobserved)"] -->|"encode: tanh((pct-1.5)/3)"| S["score ∈ [-1, 1]"]
+    S -->|"decode: 3·atanh + 1.5, clamp"| D["decoded % → Target"]
+    D -->|"re-encode"| S2["score'"]
+    S2 -->|"re-decode"| D2["decoded %'"]
+    D2 -. "round-trip shift = 0 pp" .- D
+```
+
+## What the round-trip measures
+
+The diagnostic feeds each realised score through
+`reverseProfitRecommend → profitRecommend → reverseProfitRecommend` and reports
+`pct₂ − pct₁` (a price-independent percentage-point shift in the implied
+Target). A non-zero mean would mean the decode is _not_ a faithful inverse of
+the training encode. It also takes a census of which clamp region each score
+lands in, isolating the clamp contribution.
+
+## Results (as-of 2026-06-26)
+
+| Quantity | Matured only | All dates |
+| --- | --- | --- |
+| Score dates | 274 | 354 |
+| Score rows | 5 508 | 7 108 |
+| **Round-trip shift — mean** | **+0.000000 pp** | **+0.000000 pp** |
+| Round-trip shift — max \|shift\| | `1.78e-15` pp | `1.78e-15` pp |
+| Round-trip shift — std dev | 0.000000 pp | 0.000000 pp |
+
+Clamp-region census (matured set; share of 5 508 rows):
+
+| Region | Count | Share | Round-trips? |
+| --- | --- | --- | --- |
+| `interior` (clean inverse) | 2 976 | 54.03 % | yes (exact) |
+| `cap_high` (`score >= 1` → +50%) | 2 532 | 45.97 % | yes (exact) |
+| `floor_low` (`score <= -1` → target 0) | 0 | 0.00 % | n/a — never fires |
+| `interior_cap_high` (interior pct > +50%) | 0 | 0.00 % | n/a — never fires |
+| `interior_cap_low` (interior pct < −50%) | 0 | 0.00 % | n/a — never fires |
+
+Across **all** 354 dates the census is `interior` 4 400 (61.90 %), `cap_high`
+2 708 (38.10 %), and every other region 0. The realised scores span
+`[0.174, 1.0]` — strictly positive — so the negative floor and both interior
+caps are unreachable in practice.
+
+## Acceptance criteria
+
+1. **Quantified round-trip bias (pp, with sign).** **0 pp** (max |shift|
+   `1.78e-15` pp — floating-point noise) over the realised score distribution.
+   Sign is immaterial at that magnitude.
+2. **Clamp + `min(volumeRecommend, …)` isolation.** The **+50% cap** fires for
+   45.97 % of matured rows (38.10 % of all rows) and round-trips cleanly; the
+   **`0`/-100% floor** fires for **0 %** (no negative scores exist); the interior
+   ±50% caps fire for **0 %**. The asymmetry the issue described is real in the
+   code but **dormant** in the data. The `min(volumeRecommend, priceRecommend,
+   1)` interaction lives entirely upstream in `GRQ` training — it shapes which
+   `pct` was encoded, not how the dashboard decodes a given score — and so
+   contributes nothing measurable on the decode side. Its only footprint here is
+   that 38–46 % of scores **saturate** to exactly 1, which is the encode-side
+   point we hand to `GRQ` below.
+3. **Whether decoding contributes to the gap → no.** Decoding does **not**
+   contribute to the Target-over-Actual gap: it is an exact inverse on every
+   realised score, and the asymmetric clamp that could have biased it never
+   engages.
+4. **Fix recommendation → explicit "ruled out".** No dashboard fix is warranted.
+   `reverseProfitRecommend` is decoding faithfully. **Ruled out.**
+
+## Residual (encode-side) candidate — for `GRQ`, not this decode
+
+A `score == 1` is a _saturated_ encode: `tanh` reaches 1.0 (in float) for any
+true return above roughly +28 %, so 38–46 % of names that "wanted ≥ ~28 %" all
+collapse to the same score and the dashboard decodes every one of them to a
+fixed **+50 %**. If the true intent of those saturated names averages **below**
++50 %, the decoded Target over-states them — a _plausibly upward_ contribution to
+Target-over-Actual. Crucially this is **information lost at encode time inside
+`GRQ`**, not a `reverseProfitRecommend` asymmetry: the dashboard receives only
+the saturated score and cannot recover the lost magnitude. Resolving it needs
+the _training-side_ distribution of true `pct` for saturated names, which lives
+in `GRQ` and is outside this repo's data.
+
+**Recommendation:** keep the dashboard decode as-is (ruled out), and raise a
+`GRQ` issue to check whether saturating the score at +50 % on decode is the right
+point estimate for the ~38–46 % of names that hit `score == 1` — i.e. whether
+the encode should reserve headroom above +50 % or the decode should use a
+distribution-aware estimate rather than the cap. Cross-referenced from this
+sub-issue of #544.
+
+## Reproduce
+
+```bash
+deno task diagnose-score-target-decoding            # matured set, as-of today
+deno run --allow-read \
+  scripts/diagnose_score_target_decoding.ts docs 2026-06-26 all   # all dates
+```
+
+The computation reuses the **shipped** score parser
+(`docs/trend_predictions.js → GRQTrendPredictions.parseScoreTsv`), so the scores
+it reads are exactly the column the dashboard reads. The `profitRecommend` /
+`reverseProfitRecommend` functions are ported faithfully from
+`GRQ/src/LearnUtilTypes.ts` (the source of truth lives upstream in `GRQ`).

--- a/docs/archive/investigations/issue-557-whole-application-sweep.md
+++ b/docs/archive/investigations/issue-557-whole-application-sweep.md
@@ -1,0 +1,193 @@
+# Whole-application sweep + residual-gap reconciliation
+
+_Catch-all audit for Issue #557 (sub-issue of milestone #544 — the systematic
+Target-over-Actual measurement gap). User-raised: "anywhere in this
+application". This is the final sub-issue: after the targeted candidates
+(#552–#556) were quantified, it sweeps the rest of the validation pipeline for
+any other same-direction asymmetry and reconciles the residual gap._
+
+## TL;DR
+
+The aggregation layer is **symmetric**: Target and Actual are aggregated by the
+**same equal-weight rule** over the **same `isStockIncluded` gate**, through the
+**same shared kernels**. The sweep found exactly one residual aggregation-layer
+asymmetry — the **target-availability denominator skew** (priceable stocks with
+a missing target are counted in Actual but dropped from Target) — and it is
+**immaterial and masking, not inflating** (−0.062 pp over 131 of 5 444 included
+rows).
+
+Reconciling the observed gap against every quantified #544 candidate:
+
+| Candidate (sign: + inflates the apparent gap, − masks it) | pp |
+| --- | --- |
+| #552 price-basis (mid vs low horizon) | **−2.242** |
+| #553 dividend-basis (flat quarter vs windowed) | **+1.358** |
+| #554 buy-price denominator (mid vs close) | +0.000 |
+| #555 horizon as-of split parity | **−0.482** |
+| #556 score→target decoding | +0.000 |
+| #557 target-availability skew (this sweep) | **−0.062** |
+| **Net measurement** | **−1.428** |
+| **Observed gap** (mean Target − mean Actual) | **+18.525** |
+| **Residual — genuine model optimism** | **+19.952** |
+
+The measurement candidates **roughly cancel and, on balance, slightly mask** the
+gap. So the residual genuine model optimism (**+19.95 pp**) is essentially the
+whole observed gap (**+18.53 pp**) — in fact a touch larger, because the
+dashboard's measurement choices net to a small masking effect. **There is no
+hidden measurement asymmetry left to find; the gap is genuine model optimism.**
+
+All figures are computed by the shipped dashboard kernels over the matured
+historical score set (274 score dates, 5 444 included stock-rows, as-of
+2026-06-26). Reproduce with:
+
+```bash
+deno task diagnose-residual-gap docs 2026-06-26
+```
+
+## Audited-area checklist
+
+Each area below was checked for an **apples-to-oranges, same-direction**
+asymmetry that would push Target over Actual **only in aggregate**.
+
+| # | Area | Verdict | Direction / magnitude |
+| --- | --- | --- | --- |
+| 1 | **Aggregation weighting** | ✅ Aligned | Both series are an **equal-weight mean** over included stocks. No bias. |
+| 2 | **Inclusion / exclusion gate** | ✅ Aligned | Both call the **same `isStockIncluded`** predicate; no tail is dropped asymmetrically by the gate. |
+| 3 | **Target-availability (null/NaN target)** | ⚠️ Real but immaterial | Missing-target rows counted in Actual, dropped from Target. **−0.062 pp** (masking), 131/5 444 rows. |
+| 4 | **Rounding / truncation** | ✅ Ruled out | Series values are raw floats; `toFixed`/`formatPercentage` affect **display only**, both sides identically. |
+| 5 | **NaN / null handling** | ✅ Ruled out (bar #3) | A date with no included stocks drops **both** series together; the only one-sided drop is the target case in #3. |
+| 6 | **Currency / FX timing** | ✅ Ruled out | Returns are **price-relative ratios** in each stock's own quote currency; no FX conversion enters the `%` path. |
+| 7 | **Divergent code paths** | ✅ Aligned | Dashboard, Trend view and the Rust backend all route Target/Actual through the **same `projection.js` kernels** (and `is_priceable`). |
+
+### 1–2. Aggregation weighting and the inclusion gate — aligned
+
+Both portfolio series are built by the same shared kernels in
+`docs/projection.js`:
+
+- **Actual %** — `calculateIncludedPortfolioPerformance(stocks)`: filters by
+  `isStockIncluded`, then returns the **mean** of the per-stock total returns
+  (`sum / includedReturns.length`).
+- **Target %** — `calculatePortfolioTargetPercentage(stocks)`: filters by the
+  **same** `isStockIncluded`, then returns the **mean** of the per-stock target
+  percentages (`totalTarget / validStocks`).
+
+Both are equal-weight (1/N over the included set), both apply the **identical**
+inclusion predicate, and the equal-weight policy is the issue-#429/#288 design.
+The `isStockIncluded` gate keys only on **price/split usability** (usable buy
+price, usable current price, reliable split) — it is **target-blind and
+actual-blind**, so it cannot drop losers or winners preferentially. The backend
+mirrors it with `is_priceable` (`src/utils.rs`). **No weighting or gate
+asymmetry.**
+
+### 3. Target-availability denominator skew — the one residual asymmetry
+
+The Target kernel has one extra drop the Actual kernel does not: it skips
+included stocks whose `adjustedTarget` is `null`/`NaN` (a score row with no
+parseable target). The Actual kernel keeps those same rows. So the two portfolio
+**means span slightly different subsets** — the only same-direction asymmetry the
+sweep surfaced.
+
+It is quantified by re-aggregating **both** series over the matched
+(target-present) subset and reading off the gap difference
+(`scripts/residual_gap_reconciliation.ts`):
+
+- Dropped-target rows: **131** of **5 444** included rows (2.4 %).
+- Observed gap **+18.525 pp**; matched-subset gap **+18.586 pp**.
+- Skew = observed − matched = **−0.062 pp**.
+
+The sign is **negative**: the dropped-target rows are, on average, marginal
+winners, so excluding them from Target lifts the matched gap slightly — i.e. the
+as-shipped skew **masks** (does not inflate) the gap, and by a negligible amount.
+It is far too small and the wrong direction to be a cause; left as-is.
+
+### 4. Rounding / truncation — ruled out
+
+The aggregation path is floating-point throughout (`sum / count`, `(t − b) / b`).
+The only rounding is in the **display** layer (`formatPercentage`, `toFixed`),
+applied **after** the series is computed and **identically** to both Target and
+Actual. No directional rounding enters the computed gap.
+
+### 5. NaN / null handling — ruled out (beyond #3)
+
+`buildMaturedTrendSeries` skips a date entirely when its Actual is `null` (no
+included stocks), which removes **both** series for that date together — no tail
+is lost on one side. Within a date, the only one-sided null drop is the
+target-availability case already quantified in #3. (Note: when included stocks
+exist but **none** has a target, `calculatePortfolioTargetPercentage` returns the
+20.0 % fallback; over the matured set every such date has at least one target, so
+the fallback never fires in aggregate.)
+
+### 6. Currency / FX timing — ruled out
+
+Every portfolio figure is a **ratio** — `(currentPrice − buyPrice + dividends) /
+buyPrice` and `(target − buyPrice) / buyPrice` — computed from prices in the
+stock's own quote currency, with the **same `buyPrice` denominator on both
+sides**. No per-stock FX conversion is applied inside the `%` path, so an FX rate
+(or its timing) cancels and cannot desynchronise Target from Actual.
+`docs/USDAUD.json` feeds currency **display** elsewhere, not the gap maths.
+
+### 7. Divergent code paths — aligned
+
+Target and Actual are never computed by drifting copies:
+
+- The **dashboard** totals (`docs/app.js`) delegate to
+  `GRQProjection.calculatePortfolioTargetPercentage` /
+  `calculateIncludedPortfolioPerformance`.
+- The **Trend view** (`docs/trend_series.js`) delegates to the **same** two
+  kernels.
+- The **Rust backend** (`src/utils.rs`) shares the `is_priceable` rule and the
+  equal-weight average.
+
+The single benign difference: the dashboard's live index uses
+`currentPriceFromLatest` while the matured Trend/reconciliation path uses the
+midpoint of the last in-window point — these resolve to the **same row** for a
+matured prediction, so they agree on the analysis here.
+
+## Reconciliation method and sign convention
+
+Each candidate's contribution is signed by its effect on the **apparent
+(dashboard) gap**: **positive** means the measurement choice **inflates** the
+apparent gap (correcting it would narrow the gap); **negative** means it
+**masks** the gap (correcting it would widen it). The #552–#556 magnitudes are
+the values each sub-issue's own diagnostic published over the same matured set;
+the #557 target-availability term is computed here. The residual genuine optimism
+is `observed gap − net measurement`.
+
+```mermaid
+flowchart LR
+    O["Observed gap +18.525 pp"] --> N["− net measurement (−1.428 pp)"]
+    subgraph M["#544 measurement candidates"]
+      A["#552 price-basis −2.242"]
+      B["#553 dividend +1.358"]
+      C["#554 denominator 0"]
+      D["#555 split parity −0.482"]
+      E["#556 decoding 0"]
+      F["#557 target-availability −0.062"]
+    end
+    M --> N
+    N --> R["Residual model optimism +19.952 pp"]
+```
+
+Because the candidates net to a **small masking** effect (−1.428 pp), the
+residual optimism (**+19.95 pp**) slightly **exceeds** the observed gap. In other
+words, the dashboard's measurement choices, taken together, make the model look
+**marginally better** than a strictly like-for-like, trained-basis comparison
+would — so none of the gap is an artefact that flatters the model. The full
++18.5 pp (≈ +20 pp like-for-like) is **genuine model optimism**.
+
+## New finding fed back to #544?
+
+No material new same-direction asymmetry was found. The only sweep finding —
+the target-availability skew — is **−0.062 pp** and **masking**, so it does not
+warrant its own quantification sub-issue. The catch-all is therefore closed with
+the reconciliation above rather than a new #544 child.
+
+## Reproducing
+
+```bash
+# Full reconciliation over the committed matured score set
+deno task diagnose-residual-gap docs 2026-06-26
+
+# Unit tests (real kernels + aggregation, synthetic data)
+deno test --allow-read --allow-write tests/residual_gap_reconciliation_test.ts
+```

--- a/docs/archive/pr-summaries/pr-summary-552.md
+++ b/docs/archive/pr-summaries/pr-summary-552.md
@@ -1,8 +1,9 @@
 ## Summary
 
 Quantifies the Target/Actual measurement bias that comes purely from the **price
-basis** mismatch between training and the dashboard (one candidate source in the
-#544 milestone breakdown). The GRQ model is trained on the **intraday low** of
+basis** mismatch between training and the dashboard (one candidate source in
+the #544 milestone breakdown). The GRQ model is trained on the **intraday low**
+of
 the trading day 90 days ahead, while the dashboard measures **Actual** at the
 **midpoint** `(high + low) / 2`. Because `mid >= low` on every row this is a
 structural, same-direction offset.

--- a/docs/archive/pr-summaries/pr-summary-552.md
+++ b/docs/archive/pr-summaries/pr-summary-552.md
@@ -1,0 +1,84 @@
+## Summary
+
+Quantifies the Target/Actual measurement bias that comes purely from the **price
+basis** mismatch between training and the dashboard (one candidate source in the
+#544 milestone breakdown). The GRQ model is trained on the **intraday low** of
+the trading day 90 days ahead, while the dashboard measures **Actual** at the
+**midpoint** `(high + low) / 2`. Because `mid >= low` on every row this is a
+structural, same-direction offset.
+
+The deliverable is a **written diagnostic** plus a reproducible analysis, both
+computed with the dashboard's own shipped kernels. Over the matured historical
+score set (274 score dates, 5 444 included stock-rows, as-of 2026-06-26):
+
+- Mean per-row basis offset `(mid - low) / buyPrice` = **+2.235 pp** (median
+  +1.546 pp, std dev 3.216 pp); **non-negative on every row** (sign **+**).
+- The mid basis **narrows / masks** the gap rather than causing it: the observed
+  Target-over-Actual gap is **+18.470 pp** on the mid basis and **+20.712 pp** on
+  the trained low basis — restating Actual onto the trained basis **widens** the
+  gap by **+2.242 pp**.
+- **Recommendation:** the asymmetry is real but this candidate is **exonerated as
+  a cause** — correcting it widens, not closes, the gap. Leave the dashboard's
+  user-facing Actual on the (unbiased) midpoint; if a fully like-for-like
+  comparison is later wanted, restate the *Target* onto the midpoint basis
+  upstream in `GRQ`. Genuine model optimism and the other #544 candidates remain
+  the drivers to chase.
+
+Full write-up: `docs/archive/investigations/issue-552-price-basis-bias.md`.
+
+Closes #552.
+
+### Deno regression avoided
+
+This is a Deno repo; the diagnostic ships as Deno-native TypeScript run via
+`deno task diagnose-price-basis` (and `deno test`), with no Node tooling
+introduced.
+
+## Evidence
+
+Backend/CLI diagnostic — no web UI to screenshot. Verified by the new test
+suite and by running the diagnostic against the committed score data:
+
+```text
+$ deno task diagnose-price-basis docs 2026-06-26
+Matured score dates:   274
+Included stock-rows:   5444
+## Per-row basis offset (mid - low) / buyPrice
+Mean:                  +2.235 pp
+Median:                +1.546 pp
+Min:                   +0.000 pp
+Max:                   +93.273 pp
+Std dev:               3.216 pp
+Observed gap (T-A,mid):+18.470 pp
+Gap on low basis:      +20.712 pp
+Basis contribution:    +2.242 pp
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>split-adjusted mid]
+    B --> D[priceAtNinetyDayHorizon<br/>Actual = mid]
+    B --> E[lowPriceAtNinetyDayHorizon<br/>Actual = low]
+    C --> F[priceBasisOffsetPercent<br/>= mid - low / buyPrice]
+    D --> F
+    E --> F
+    F --> G[aggregate + net vs observed gap]
+```
+
+## Test Plan
+
+New tests in `tests/price_basis_diagnostic_test.ts` (all exercise real shipped
+kernels / aggregation with synthetic data — no source-text grepping):
+
+- `lowPriceAtNinetyDayHorizon` returns the in-window low, picks the **same row**
+  as `priceAtNinetyDayHorizon`, and guards empty/null data.
+- `priceBasisOffsetPercent` computes `(mid - low) / buyPrice * 100`, is always
+  `>= 0` when `mid >= low`, and guards bad inputs.
+- `summariseOffsets` mean/median/min/max/stdDev plus the empty case.
+- `aggregateDate` measures the per-row offset over included stocks and confirms
+  the mid-vs-low Actual difference equals the offset.
+- `buildReport` confirms the basis contribution **widens** the gap and the
+  verdict states the masking sign.
+
+Existing suite unchanged: `deno test --allow-read tests/*.ts` → 1010 passed.

--- a/docs/archive/pr-summaries/pr-summary-553.md
+++ b/docs/archive/pr-summaries/pr-summary-553.md
@@ -1,0 +1,98 @@
+## Summary
+
+Adds a written diagnostic and reproducible analysis quantifying the
+Target-over-Actual bias that comes purely from the **dividend basis** mismatch
+between training and the dashboard (milestone #544 candidate). GRQ training bakes
+a **flat** quarter of the trailing annual dividend, `core.yearOfDividends / 4`,
+into the total-return label for **every** stock
+(`GRQ/src/LearnUtil.ts:147-148`), whereas the validation side credits only the
+**actual ex-dividends inside the 90-day window**
+(`GRQ-validation/src/utils.rs` `calculate_dividends_for_period`, mirrored by the
+shipped JS kernels `filterDividendsWithin90Days` + `sumDividends`).
+
+Over the matured score set (274 score dates, 5 444 included stock-rows, as-of
+2026-06-26) the per-row difference `(flatCredit − windowedCredit) / buyPrice` is
+**+2.827 pp raw / +1.358 pp (1%-trimmed)**, median 0, **sign +**. The flat
+training quarter is a **consistent over-credit** relative to realised in-window
+dividends, so — because Target embeds the flat credit while Actual credits only
+realised dividends — this dividend basis **contributes to (widens)** the
+Target-over-Actual gap (the *opposite* of the price-basis candidate #552, which
+masked it). The raw mean is lumpy: 86.4 % of rows fall within ±1 pp and a few
+special/liquidating distributions on low-priced stocks (EQC, ELME, VISN)
+dominate the tails, so the robust contribution is ~+1.4 pp. The main
+same-direction driver is that **45.2 % of included rows realise zero in-window
+dividends yet still receive the flat quarter in training**.
+
+**Recommendation:** a genuine, modest, same-direction contributor worth fixing
+by **aligning both sides on realised in-window dividends** — the clean fix is
+upstream in `GRQ` (train/evaluate the label on the forward-window dividends
+rather than a flat `yearOfDividends / 4`), since degrading the dashboard's
+realised "Actual" to a fabricated flat quarter would credit dividends never
+received. The root-cause training-label change is out of scope for this
+`GRQ-validation` diagnostic and is carried as a fix candidate under #544.
+
+Closes #553.
+
+## Evidence
+
+Backend/CLI diagnostic — no web UI to screenshot. Verified by the new unit tests
+(below) and by running the reproducible report:
+
+```text
+$ deno run --allow-read scripts/diagnose_dividend_basis.ts docs 2026-06-26 ../GRQ-dividends
+Matured score dates:     274
+Included stock-rows:     5444
+Mean (raw):              +2.827 pp
+Mean (1%-trimmed):       +1.358 pp
+Median:                  +0.000 pp
+Within +/-1 pp:          86.4 %
+Mean flat credit yield:  3.656 %
+Mean windowed yield:     0.829 %
+Rows with 0 in-window:   45.2 %
+Gap contribution:        +2.827 pp
+```
+
+The full written diagnostic (mechanism, tables, mermaid flow, recommendation,
+acceptance criteria) lives in
+`docs/archive/investigations/issue-553-dividend-basis-bias.md`.
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates only] --> B[parse tsv/csv]
+    B --> C[resolvePredictionStocks<br/>buyPrice + realised in-window totalDividends]
+    A --> D[../GRQ-dividends<br/>full per-ticker history]
+    D --> E[trailingAnnualDividends / 4<br/>flat training credit]
+    C --> F[dividendBasisDifferencePercent<br/>= flat - windowed / buyPrice]
+    E --> F
+    F --> G[aggregate: mean / 1%-trimmed / median / dist<br/>+ sign vs observed gap]
+```
+
+## Test Plan
+
+- `tests/dividend_basis_diagnostic_test.ts` (new, 14 tests) exercises the real
+  shipped kernels and the real aggregation with synthetic data:
+  - `trailingAnnualDividends` trailing-year sum, boundary semantics
+    (`> scoreDate-365 && <= scoreDate`), and empty/invalid guards.
+  - `dividendBasisDifferencePercent` arithmetic, the offsetting (negative)
+    direction, and bad-input guards.
+  - `stripSymbol` exchange-prefix/dot normalisation matching
+    `extract_symbol_from_ticker`.
+  - `summariseDiffs` and `trimmedMean` statistics, including outlier robustness.
+  - `aggregateDate` for a semi-annual payer (flat > windowed, zero in-window)
+    and a quarterly payer (flat ≈ windowed, nets to ~0).
+  - `buildReport` contributing (+) and offsetting (−) verdicts and the
+    `within1ppSharePct` / `windowedZeroSharePct` aggregates.
+- All run read-only under `deno test --allow-read`; pure functions assert on
+  computed results, not source text.
+
+## Files
+
+- `docs/projection.js` — new shipped kernels `trailingAnnualDividends` and
+  `dividendBasisDifferencePercent` (published on `GRQProjection`).
+- `scripts/dividend_basis_diagnostic.ts` — pure aggregation + disk loader.
+- `scripts/diagnose_dividend_basis.ts` — CLI report (`deno task
+  diagnose-dividend-basis`).
+- `tests/dividend_basis_diagnostic_test.ts` — kernel + aggregation tests.
+- `docs/archive/investigations/issue-553-dividend-basis-bias.md` — written
+  diagnostic.
+- `deno.json`, `README.md` — task entry and script-tree documentation.

--- a/docs/archive/pr-summaries/pr-summary-554.md
+++ b/docs/archive/pr-summaries/pr-summary-554.md
@@ -1,0 +1,102 @@
+## Summary
+
+Diagnostic for issue #554 (sub-issue of milestone #544): quantify the
+Target/Actual bias that comes purely from the **buy-price denominator**
+mismatch — training divides the 90-day return by `monthsAgoPrice` (the **close**
+on the score date), while the dashboard divides **both** Target and Actual by
+`buyPrice` (the split-adjusted **midpoint** of the first usable point).
+
+The headline finding: because the dashboard applies the **same** `buyPrice` to
+Target and Actual, the denominator choice **cannot desynchronise** them — it
+only rescales the existing gap by `buyPrice / close`. Over the matured
+historical score set the denominator offset is **near-zero and symmetric**
+(mean **+0.046 pp**, median 0.000 pp), contributing a negligible **+0.048 pp**
+to the ~18.5 pp gap. This candidate is **exonerated** as a cause of the gap;
+recommendation is to **leave** the dashboard denominator as-is.
+
+Closes #554.
+
+### Acceptance criteria
+
+- **Numeric denominator offset (pp) with sign** — mean **+0.046 pp** per row /
+  **+0.048 pp** portfolio-level; roughly symmetric (median 0.000 pp, min
+  −11.868 pp, max +9.886 pp, σ 1.418 pp) over 274 matured dates, 5 444 rows
+  (as-of 2026-06-26).
+- **Yes/no — are Target vs Actual desynchronised by the denominator choice?**
+  **NO.** `calculatePortfolioTargetPercentage` and
+  `calculateIncludedPortfolioPerformance` both divide by the **same** per-stock
+  `buyPrice`; the only mixed-basis level is the model's emitted absolute target
+  price (trained against the close), but since Actual uses the same `buyPrice`
+  the choice rescales both identically.
+- **Fix-vs-leave recommendation** — **leave**: the offset is negligible and the
+  denominator is already shared; the midpoint buy price is also the more
+  defensible, split-aware cost basis. The dominant masking term is the price
+  basis (#552), not the denominator.
+
+## Evidence
+
+Backend/CLI diagnostic — no web UI change, so no screenshot. Reproduce with:
+
+```bash
+deno task diagnose-buy-price-denominator            # against docs/, as-of today
+deno run --allow-read scripts/diagnose_buy_price_denominator.ts docs 2026-06-26
+```
+
+Output (as-of 2026-06-26):
+
+```
+## Per-row denominator offset (buyPrice - close) / buyPrice
+Mean:                  +0.046 pp
+Median:                +0.000 pp
+Min:                   -11.868 pp
+Max:                   +9.886 pp
+Std dev:               1.418 pp
+
+Observed gap (mid):    +18.470 pp
+Gap on close basis:    +18.517 pp
+Basis contribution:    +0.048 pp
+```
+
+Full write-up: `docs/archive/investigations/issue-554-buy-price-denominator-bias.md`.
+
+```mermaid
+flowchart TD
+    subgraph GRQ[Training — GRQ]
+        A[closePrices0 = close on score date] --> B[monthsAgoPrice]
+        B --> C["return / monthsAgoPrice - 1"]
+    end
+    subgraph DASH[Dashboard — GRQ-validation]
+        D["getBuyPrice = split-adjusted high+low/2"] --> E[buyPrice]
+        E --> F[Target % over buyPrice]
+        E --> G[Actual % over buyPrice]
+    end
+    C -. emits absolute target price .-> F
+```
+
+## Test Plan
+
+Added `tests/buy_price_denominator_diagnostic_test.ts` (11 tests), exercising
+the real shipped kernels and aggregation with synthetic data:
+
+- `buyPriceCloseBasis` — returns the split-adjusted close of the first usable
+  point; picks the **same** row as `getBuyPrice`; null on no data.
+- `denominatorBasisOffsetPercent` — `(buyPrice − close) / buyPrice * 100`,
+  including the negative-offset (close above midpoint) case and input guards.
+- `summariseOffsets` — mean/median/min/max/stdDev and empty input.
+- `aggregateDate` — per-row offset; and that a smaller denominator inflates
+  **both** Target and Actual together (the no-desync property).
+- `buildReport` — gap rescale, basis contribution, and verdict wording
+  (states "does NOT desynchronise"; renders a negative mean sign).
+
+All 1035 Deno tests pass; `deno fmt`, `deno lint` and `deno check` clean.
+
+## Files
+
+- `docs/projection.js` — new shipped kernels `buyPriceCloseBasis`,
+  `denominatorBasisOffsetPercent` (exported on `GRQProjection`).
+- `scripts/buy_price_denominator_diagnostic.ts` — pure aggregation + disk loader.
+- `scripts/diagnose_buy_price_denominator.ts` — CLI report runner.
+- `tests/buy_price_denominator_diagnostic_test.ts` — tests.
+- `deno.json` — `diagnose-buy-price-denominator` task.
+- `README.md` — scripts listing.
+- `docs/archive/investigations/issue-554-buy-price-denominator-bias.md` — write-up.

--- a/docs/archive/pr-summaries/pr-summary-555.md
+++ b/docs/archive/pr-summaries/pr-summary-555.md
@@ -1,0 +1,87 @@
+## Summary
+
+Audited **market-data timing & corporate-action parity** between GRQ training
+and the GRQ-validation dashboard, as requested by the milestone #544 breakdown.
+The audit enumerates each timing/adjustment decision on both sides, marks it
+**aligned** or **divergent**, and — for the one divergent row — quantifies its
+aggregate contribution to the Target-over-Actual gap using the dashboard's own
+shipped kernels. Closes #555.
+
+**Finding.** Three of four decisions are aligned; one is divergent:
+
+| # | Decision | Status |
+| --- | --- | --- |
+| 1 | Horizon-date selection (trading day on/before `+90d` vs last point `<= +90d`) | **Aligned** — same row on the stock's daily series |
+| 2 | OHLC field at the horizon (low vs midpoint) | **Divergent** — owned by #552 (~+2.2 pp) |
+| 3 | OHLC field at the buy point (close vs midpoint) | **Divergent** — owned by #554 (~+0.05 pp) |
+| 4 | Split/merge adjustment convention (restate-to-current, reconciliation-gated) | **Aligned** |
+| 5 | **As-of split basis of the Actual horizon price** | **DIVERGENT (this audit)** |
+
+Row 5: the dashboard restates the **buy price** and the **model target** into
+current (end-of-series) split terms but reads the **Actual horizon price RAW**.
+When a reconcilable split falls between the 90-day horizon and the data-series
+end, the Actual carries a spurious post-horizon split factor `S_after` that
+training (and the economically-correct return) cancels. Target % is unaffected
+(both `adjustedTarget` and `buyPrice` divide by the same factor).
+
+**Measured (as-of 2026-06-26, 274 matured dates, 5 444 included rows):** 123
+rows carry a reconcilable post-horizon split; restating their Actual onto the
+buy price's basis moves the portfolio gap by **+0.482 pp** (a *masking* term —
+forward splits dominate), with large two-sided per-row distortion (−316 →
++1 396 pp). Like #552/#554 the candidate *offsets* rather than causes the gap,
+but it also flags a genuine per-row correctness bug. **Recommendation:** read
+the horizon price through the new `horizonPriceCurrentBasis` so Actual shares
+the buy price's basis — landed as its own focused PR with UI evidence (this PR
+is the audit + measurement only, matching the sibling diagnostics).
+
+## Evidence
+
+CLI/analysis change — no UI was modified, so no screenshot. Verified by the new
+unit tests and the reproducible diagnostic run below (delegating to the shipped
+`GRQProjection` kernels, so it measures the dashboard's own basis):
+
+```
+$ deno run --allow-read scripts/diagnose_horizon_split_parity.ts docs 2026-06-26
+Matured score dates:      274
+Included stock-rows:      5444
+Post-horizon split rows:  123
+Mean Target %:            28.916 %
+Mean Actual % (raw):      10.447 %   # reproduces the #554 dashboard Actual exactly
+Mean Actual % (current):  9.965 %
+Observed gap (T-A,raw):   +18.470 pp
+Gap on current basis:     +18.952 pp
+Basis contribution:       +0.482 pp
+```
+
+```mermaid
+flowchart LR
+    A[scores/index.json<br/>matured dates] --> B[parse tsv/csv/dividends]
+    B --> C[getBuyPrice<br/>current basis]
+    B --> D[priceAtNinetyDayHorizon<br/>raw mid]
+    B --> E[horizonPriceCurrentBasis<br/>raw mid / S_after]
+    C --> F[horizonAsOfBasisOffsetPercent]
+    D --> F
+    E --> F
+    F --> G[aggregate: dist + gap rescale<br/>+ affected-row count]
+```
+
+Full written parity audit (table, mechanics, fix/ruled-out notes):
+`docs/archive/investigations/issue-555-market-data-timing-corporate-action-parity.md`.
+
+## Test Plan
+
+- `tests/horizon_split_parity_diagnostic_test.ts` (18 cases) — exercises the new
+  shipped kernels and the real aggregation with synthetic market data:
+  - `horizonPointDate` row selection (happy / empty / all-after-horizon).
+  - `postHorizonSplitFactor` — no split (1.0), reconcilable forward split (2.0),
+    reverse split (0.5), and a split **on/before** the horizon ignored.
+  - `horizonPriceCurrentBasis` — raw mid ÷ factor; coincides with the raw mid
+    when no split follows; null on no usable point.
+  - `horizonAsOfBasisOffsetPercent` — formula, forward (+) / reverse (−) sign,
+    and input guards (zero/negative buy price, NaN).
+  - `aggregateDate` — a post-horizon split desynchronises Actual but not Target;
+    the two Actual bases coincide with no split.
+  - `buildReport` — forward-split contribution widens the consistent-basis gap;
+    zero affected rows ⇒ DORMANT verdict / 0 pp; `summariseOffsets` stats.
+- Full suite green: `deno test --allow-read tests/*.ts` → **1053 passed**.
+- New `deno task diagnose-horizon-split-parity` registered in `deno.json`.

--- a/docs/archive/pr-summaries/pr-summary-556.md
+++ b/docs/archive/pr-summaries/pr-summary-556.md
@@ -1,0 +1,85 @@
+## Summary
+
+Adds a diagnostic that confirms the score→target decode
+(`reverseProfitRecommend`) introduces **no systematic bias** into the
+dashboard's Target, as asked by Issue #556 (sub-issue of milestone #544).
+Closes #556.
+
+The AI emits a score in `[-1, 1]`; the GRQ dashboard derives Target via
+`reverseProfitRecommend(price, score)` (upstream in `GRQ`). The forward training
+encode is `profitRecommend(pct) = tanh((pct - 1.5) / 3)` and the reverse is
+`pct = 3·atanh(score) + 1.5` with clamps (`score >= 1` → +50%, `score <= -1` →
+target 0, interior pct capped to ±50%). The issue asked whether the **asymmetric
+clamps** (`0` floor vs +50% cap) bias Target over the realised score
+distribution.
+
+**Finding — ruled out.** Over the realised scores the round-trip
+`profitRecommend ∘ reverseProfitRecommend` shifts Target by **0 pp** (machine
+epsilon: max |shift| `1.78e-15` pp across all 7 108 stock-rows). `tanh`/`atanh`
+are exact inverses, and the asymmetry is **dormant**: the +50% cap fires (45.97 %
+of matured rows) but round-trips cleanly, while the `0`/-100% floor **never
+fires** (zero negative scores exist in the entire history). The decode is faithful
+— no dashboard fix is warranted.
+
+The one residual candidate is **encode-side quantisation** (a saturated
+`score == 1` is a fixed +50% point estimate of an unknown true intent ≥ the
+saturation threshold). That information is lost inside `GRQ` at encode time and
+is **not** a `reverseProfitRecommend` round-trip asymmetry, so it is flagged for
+a `GRQ` follow-up rather than fixed here. **Cross-repo:** this is a `GRQ` root
+cause; the diagnostic is filed here per the issue and the residual encode-side
+candidate is recommended for a `GRQ` issue.
+
+## Evidence
+
+Backend/CLI diagnostic — no web interface to screenshot. The diagnostic runs on
+the committed score history (read-only):
+
+```text
+$ deno task diagnose-score-target-decoding   # matured, as-of 2026-06-26
+Score dates:           274
+Score rows:            5508
+
+## Round-trip Target shift (profitRecommend ∘ reverseProfitRecommend)
+Mean:                  +0.000000 pp
+Max:                   +0.000000 pp   (true max |shift| 1.78e-15 pp)
+
+## Clamp-region census (realised scores)
+interior               2976  54.03 %
+cap_high               2532  45.97 %
+floor_low                 0   0.00 %   ← asymmetric floor never fires
+interior_cap_high         0   0.00 %
+interior_cap_low          0   0.00 %
+
+VERDICT (decode round-trip RULED OUT): … decoding adds NO systematic Target shift …
+```
+
+```mermaid
+flowchart LR
+    P["true return % (GRQ, unobserved)"] -->|"encode: tanh((pct-1.5)/3)"| S["score ∈ [-1, 1]"]
+    S -->|"decode: 3·atanh + 1.5, clamp"| D["decoded % → Target"]
+    D -->|"re-encode"| S2["score'"]
+    S2 -->|"re-decode"| D2["decoded %'"]
+    D2 -. "round-trip shift = 0 pp" .- D
+```
+
+Full write-up:
+`docs/archive/investigations/issue-556-score-target-decoding-bias.md`.
+
+## Test Plan
+
+Added `tests/score_target_decoding_diagnostic_test.ts` (12 tests, all calling the
+real ported functions and aggregation):
+
+- `profitRecommend` matches `tanh((pct-1.5)/3)`; `reverseProfitPct` is the clean
+  interior inverse; the +50% cap (`cap_high`), `0`/-100% floor (`floor_low`) and
+  interior caps are each asserted.
+- `reverseProfitTarget` reproduces stored Targets anchored to real rows
+  (`score == 1` → `1.5 × price`; interior row → stored Target) and the 0 floor.
+- `roundTripShiftPp` is ~0 for interior scores and at the saturated `+1` clamp.
+- `buildReport` rules out decode bias on a realistic positive-only mixture,
+  census fractions sum to 1, and empty input yields a zeroed report.
+- `computeDecodingDiagnostic` reads scores from a synthetic docs tree and honours
+  matured-only vs all-dates selection.
+
+Quality gate: `./quality.sh` (cargo fmt/clippy/test + `deno fmt`/`lint`/`check`/
+`test`) run clean.

--- a/docs/archive/pr-summaries/pr-summary-557.md
+++ b/docs/archive/pr-summaries/pr-summary-557.md
@@ -1,0 +1,107 @@
+## Summary
+
+Completes the milestone #544 breakdown with the **catch-all whole-application
+sweep** for any remaining same-direction Target/Actual asymmetry, plus a
+**residual-gap reconciliation** that nets the observed Target-over-Actual gap
+against every quantified #544 candidate (#552–#556) and this sweep's own finding.
+Closes #557.
+
+The sweep audits the aggregation layer the targeted sub-issues did not cover —
+aggregation weighting, the inclusion gate, rounding/null handling, FX, and
+divergent code paths — and confirms Target and Actual are aggregated by the
+**same equal-weight rule** over the **same `isStockIncluded` gate** through the
+**same shared `projection.js` kernels**. It surfaces exactly one residual
+aggregation-layer asymmetry — the **target-availability denominator skew**
+(priceable stocks with a missing target are counted in Actual but dropped from
+Target) — and shows it is **immaterial and masking, not inflating** (−0.062 pp
+over 131 of 5 444 included rows).
+
+Reconciliation over the committed matured set (274 dates, 5 444 rows,
+as-of 2026-06-26):
+
+| Contribution (+ inflates gap, − masks) | pp |
+| --- | --- |
+| #552 price-basis | −2.242 |
+| #553 dividend-basis | +1.358 |
+| #554 buy-price denominator | +0.000 |
+| #555 horizon split parity | −0.482 |
+| #556 score→target decoding | +0.000 |
+| #557 target-availability (this sweep) | −0.062 |
+| **Net measurement** | **−1.428** |
+| **Observed gap** | **+18.525** |
+| **Residual — genuine model optimism** | **+19.952** |
+
+The measurement candidates roughly cancel and on balance slightly *mask* the
+gap, so the residual genuine model optimism (+19.95 pp) is essentially the whole
+observed gap (+18.53 pp). **No hidden measurement asymmetry remains; the gap is
+genuine model optimism — no further #544 sub-issue is warranted.**
+
+Full audit (checklist with a verdict per area + reconciliation):
+`docs/archive/investigations/issue-557-whole-application-sweep.md`.
+
+### Deno regression avoided
+
+This is a Deno repo; the diagnostic ships as Deno-native TypeScript run via
+`deno task diagnose-residual-gap` (and `deno test`), with no Node tooling
+introduced.
+
+## Evidence
+
+Backend/CLI diagnostic — no web UI to screenshot. Verified by the new test
+suite and by running the diagnostic against the committed score data:
+
+```text
+$ deno task diagnose-residual-gap docs 2026-06-26
+Matured score dates:   274
+Included stock-rows:   5444
+Target-present rows:   5313
+Dropped-target rows:   131
+
+## Portfolio means (over matured dates)
+Mean Target %:         29.082 %
+Mean Actual %:         10.557 %
+Mean Actual % (matched):10.496 %
+Observed gap (T-A):    +18.525 pp
+Matched-subset gap:    +18.586 pp
+Target-availability:   -0.062 pp
+
+Net measurement:       -1.428 pp
+Observed gap:          +18.525 pp
+Residual (optimism):   +19.952 pp
+```
+
+```mermaid
+flowchart LR
+    O["Observed gap +18.525 pp"] --> N["− net measurement (−1.428 pp)"]
+    subgraph M["#544 measurement candidates"]
+      A["#552 price-basis −2.242"]
+      B["#553 dividend +1.358"]
+      C["#554 denominator 0"]
+      D["#555 split parity −0.482"]
+      E["#556 decoding 0"]
+      F["#557 target-availability −0.062"]
+    end
+    M --> N
+    N --> R["Residual model optimism +19.952 pp"]
+```
+
+## Test Plan
+
+New `tests/residual_gap_reconciliation_test.ts` (10 tests, all calling the real
+shipped kernels + aggregation with synthetic data — no source-text grepping):
+
+- `hasUsableTarget` includes only priceable rows with a usable target; drops
+  null/NaN targets and unpriceable rows.
+- `aggregateDate` counts included vs target-present rows and confirms the
+  as-shipped Actual spans more rows than the matched-set Actual (target-less
+  loser dilutes Actual but not Target).
+- `buildReconciliation` derives the target-availability skew as
+  `observedGap − matchedGap`, appends it as the #557 contribution, satisfies the
+  `residual + net == observed` identity, and zeroes cleanly on empty input.
+- `FAMILY_CONTRIBUTIONS` covers #552–#556 with the documented signs.
+- `computeResidualGapReconciliation` reconciles the committed score set
+  read-only (structural invariants) and honours the matured-only window.
+
+Quality gate: `./quality.sh` (cargo fmt/clippy/check/test + `deno fmt`/`lint`/
+`check`/`test`) run clean; the new task is wired as `deno task
+diagnose-residual-gap`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.7">
+    <meta name="app-version" content="1.1.8">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -517,6 +517,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.7"></script>
+    <script src="sw-register.js?v=1.1.8"></script>
   </body>
 </html>

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -622,6 +622,51 @@ function priceBasisOffsetPercent(buyPrice, midPrice, lowPrice) {
     return ((midPrice - lowPrice) / buyPrice) * 100;
 }
 
+// Trailing-365-day dividend total as of the score date — the quantity the GRQ
+// model turns into a FLAT training credit of `yearOfDividends / 4`
+// (GRQ/src/CoreFeatures.ts builds `yearOfDividends`; GRQ/src/LearnUtil.ts bakes
+// `yearOfDividends / 4` into the total-return label for EVERY stock). Sums the
+// cash amount of every dividend whose ex-dividend date falls in the year ending
+// at the score date (`scoreDate - 365 days < exDivDate <= scoreDate`). Mirrors
+// the shape `filterDividendsWithin90Days`/`sumDividends` consume so the
+// diagnostic measures the same dividend records the dashboard does. Pure given
+// its inputs; returns 0 for a missing/empty list (issue #553).
+function trailingAnnualDividends(dividends, scoreDate) {
+    if (!Array.isArray(dividends) || !(scoreDate instanceof Date)) {
+        return 0;
+    }
+    const yearStart = new Date(
+        scoreDate.getTime() - (365 * 24 * 60 * 60 * 1000),
+    );
+    return dividends
+        .filter((d) => d && d.exDivDate > yearStart && d.exDivDate <= scoreDate)
+        .reduce((sum, d) => sum + (d.amount || 0), 0);
+}
+
+// Dividend-basis difference between the model's FLAT training credit
+// (`yearOfDividends / 4`) and the dashboard's realised in-window dividends,
+// expressed as a percentage of the buy price (issue #553):
+// `(flatCredit - windowedCredit) / buyPrice * 100`. A POSITIVE value means the
+// flat training credit EXCEEDS the realised in-window dividends, so the model's
+// dividend-inflated Target sits above an Actual that credits only the dividends
+// that actually fell inside the 90-day window — i.e. it CONTRIBUTES to (widens)
+// the Target-over-Actual gap. A negative value means the realised in-window
+// dividends exceed the flat quarter, which NARROWS (masks) the gap. Returns null
+// when any input is missing or the buy price is not a positive number.
+function dividendBasisDifferencePercent(flatCredit, windowedCredit, buyPrice) {
+    if (
+        buyPrice === null || buyPrice === undefined || Number.isNaN(buyPrice) ||
+        buyPrice <= 0 ||
+        flatCredit === null || flatCredit === undefined ||
+        Number.isNaN(flatCredit) ||
+        windowedCredit === null || windowedCredit === undefined ||
+        Number.isNaN(windowedCredit)
+    ) {
+        return null;
+    }
+    return ((flatCredit - windowedCredit) / buyPrice) * 100;
+}
+
 // Target return as a percentage of the buy price. Returns null when either input
 // is missing, matching the dashboard's guard before reporting a target figure.
 function calculateTargetPercentage(buyPrice, adjustedTarget) {
@@ -1095,6 +1140,8 @@ globalThis.GRQProjection = {
     priceAtNinetyDayHorizon,
     lowPriceAtNinetyDayHorizon,
     priceBasisOffsetPercent,
+    trailingAnnualDividends,
+    dividendBasisDifferencePercent,
     calculateTargetPercentage,
     calculatePortfolioTargetPercentage,
     getFairValueRange,

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -622,6 +622,66 @@ function priceBasisOffsetPercent(buyPrice, midPrice, lowPrice) {
     return ((midPrice - lowPrice) / buyPrice) * 100;
 }
 
+// Buy-price denominator on the model's TRAINED basis: the split-adjusted
+// CLOSE of the first usable market-data point on or within five days after the
+// score date (issue #554). The GRQ training label divides the 90-day return by
+// `core.monthsAgoPrice`, which is `closePrices[0]` — the close on the score date
+// (GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts). The dashboard instead
+// divides by `getBuyPrice`, the split-adjusted MIDPOINT `(high + low) / 2` of
+// the same first point. This helper mirrors `getBuyPrice`'s point selection and
+// split adjustment EXACTLY — only the close replaces the midpoint — so a
+// like-for-like denominator comparison isolates the midpoint-vs-close basis (the
+// shared split factor cancels in the ratio). Returns `{ price, dateUsed,
+// reliable }`, or null when no market data falls in that window.
+function buyPriceCloseBasis(marketData, scoreDate) {
+    if (!marketData) return null;
+
+    const { reliable } = computeSplitAdjustment(marketData, scoreDate);
+
+    for (let offset = 0; offset <= 5; offset++) {
+        const candidateDate = new Date(scoreDate.getTime());
+        candidateDate.setDate(candidateDate.getDate() + offset);
+        const candidateData = marketData.find((point) => {
+            const pointDate = new Date(
+                point.date.getFullYear(),
+                point.date.getMonth(),
+                point.date.getDate(),
+            );
+            return pointDate.getTime() === candidateDate.getTime();
+        });
+        if (candidateData) {
+            const adjustedPrice = adjustHistoricalPriceToCurrent(
+                candidateData.close,
+                marketData,
+                scoreDate,
+            );
+            return { price: adjustedPrice, dateUsed: candidateDate, reliable };
+        }
+    }
+    return null;
+}
+
+// Denominator-basis offset between the dashboard's midpoint buy price and the
+// model's trained close basis, as a percentage of the dashboard buy price
+// (issue #554): `(buyPrice - buyPriceClose) / buyPrice * 100`. This is how much
+// LARGER (sign +) or smaller (sign -) the dashboard denominator is than the
+// close the model was trained to divide by. Because the dashboard applies the
+// SAME `buyPrice` to BOTH Target and Actual, this offset does not desynchronise
+// them — it rescales any existing Target-over-Actual gap by `buyPrice /
+// buyPriceClose`. Returns null when any input is missing or a price is not a
+// positive number.
+function denominatorBasisOffsetPercent(buyPrice, buyPriceClose) {
+    if (
+        buyPrice === null || buyPrice === undefined || Number.isNaN(buyPrice) ||
+        buyPrice <= 0 ||
+        buyPriceClose === null || buyPriceClose === undefined ||
+        Number.isNaN(buyPriceClose) || buyPriceClose <= 0
+    ) {
+        return null;
+    }
+    return ((buyPrice - buyPriceClose) / buyPrice) * 100;
+}
+
 // Trailing-365-day dividend total as of the score date — the quantity the GRQ
 // model turns into a FLAT training credit of `yearOfDividends / 4`
 // (GRQ/src/CoreFeatures.ts builds `yearOfDividends`; GRQ/src/LearnUtil.ts bakes
@@ -1140,6 +1200,8 @@ globalThis.GRQProjection = {
     priceAtNinetyDayHorizon,
     lowPriceAtNinetyDayHorizon,
     priceBasisOffsetPercent,
+    buyPriceCloseBasis,
+    denominatorBasisOffsetPercent,
     trailingAnnualDividends,
     dividendBasisDifferencePercent,
     calculateTargetPercentage,

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -682,6 +682,79 @@ function denominatorBasisOffsetPercent(buyPrice, buyPriceClose) {
     return ((buyPrice - buyPriceClose) / buyPrice) * 100;
 }
 
+// The DATE of the last market-data point on or before the 90-day horizon — the
+// row priceAtNinetyDayHorizon / currentPriceWithinWindow read the Actual price
+// from (issue #555). Exposed so the as-of split basis of that row can be judged
+// against the buy price (which getBuyPrice has already restated to current
+// terms). Returns null when no point falls on or before the horizon.
+function horizonPointDate(marketData, scoreDate) {
+    if (!marketData || marketData.length === 0) return null;
+    const ninetyDayDate = new Date(
+        scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+    );
+    let last = null;
+    for (const point of marketData) {
+        if (point && point.date instanceof Date && point.date <= ninetyDayDate) {
+            last = point;
+        }
+    }
+    return last ? last.date : null;
+}
+
+// Cumulative RELIABLE split factor for splits strictly AFTER the 90-day horizon
+// up to the end of the series (issue #555): `getSplitAdjustment` evaluated at the
+// horizon point's own date. 1.0 means there is no reconcilable post-horizon
+// split, so the raw horizon price the shipped Actual reads already sits on the
+// current (end-of-series) basis its buy price uses. A FORWARD split gives a
+// factor > 1; a REVERSE split gives a factor < 1. Returns 1.0 when there is no
+// horizon point (no adjustment to make). Mirrors the `reliable`-gated factor, so
+// an unreconcilable series yields 1.0 rather than a silently wrong factor.
+function postHorizonSplitFactor(marketData, scoreDate) {
+    const date = horizonPointDate(marketData, scoreDate);
+    if (date === null) return 1.0;
+    return getSplitAdjustment(marketData, date);
+}
+
+// Midpoint at the 90-day horizon restated onto the CURRENT (end-of-series) split
+// basis — the SAME as-of basis getBuyPrice uses for the buy price (issue #555).
+// The shipped Actual (getStockReturnBreakdown / currentPriceWithinWindow) reads
+// this row's midpoint RAW while dividing by a buy price that getBuyPrice has
+// already restated to current terms; when a split falls between the horizon and
+// the series end the two sit on different split bases. Dividing the raw midpoint
+// by `postHorizonSplitFactor` puts the horizon price on the buy price's basis so
+// a like-for-like, same-basis Actual can be measured. Returns null when no point
+// falls on or before the horizon.
+function horizonPriceCurrentBasis(marketData, scoreDate) {
+    const rawMid = priceAtNinetyDayHorizon(marketData, scoreDate);
+    if (rawMid === null) return null;
+    return rawMid / postHorizonSplitFactor(marketData, scoreDate);
+}
+
+// As-of-basis offset the shipped Actual carries by reading the horizon midpoint
+// RAW instead of on the current basis its buy price uses (issue #555), as a
+// percentage of the buy price: `(rawHorizonMid - currentBasisHorizonMid) /
+// buyPrice * 100`. Sign: a FORWARD post-horizon split makes the raw price LARGER
+// than the current-basis price, INFLATING the measured Actual -> NARROWS (masks)
+// the Target-over-Actual gap; a REVERSE split deflates Actual -> WIDENS it. 0
+// when there is no post-horizon split (the two prices coincide). Because Target%
+// divides both adjustedTarget and buyPrice by the same factor, the post-horizon
+// split cancels there — so this offset shifts ONLY the Actual side. Returns null
+// when any input is missing or the buy price is not positive.
+function horizonAsOfBasisOffsetPercent(buyPrice, rawHorizonMid, currentBasisHorizonMid) {
+    if (
+        buyPrice === null || buyPrice === undefined || Number.isNaN(buyPrice) ||
+        buyPrice <= 0 ||
+        rawHorizonMid === null || rawHorizonMid === undefined ||
+        Number.isNaN(rawHorizonMid) ||
+        currentBasisHorizonMid === null ||
+        currentBasisHorizonMid === undefined ||
+        Number.isNaN(currentBasisHorizonMid)
+    ) {
+        return null;
+    }
+    return ((rawHorizonMid - currentBasisHorizonMid) / buyPrice) * 100;
+}
+
 // Trailing-365-day dividend total as of the score date — the quantity the GRQ
 // model turns into a FLAT training credit of `yearOfDividends / 4`
 // (GRQ/src/CoreFeatures.ts builds `yearOfDividends`; GRQ/src/LearnUtil.ts bakes
@@ -1202,6 +1275,10 @@ globalThis.GRQProjection = {
     priceBasisOffsetPercent,
     buyPriceCloseBasis,
     denominatorBasisOffsetPercent,
+    horizonPointDate,
+    postHorizonSplitFactor,
+    horizonPriceCurrentBasis,
+    horizonAsOfBasisOffsetPercent,
     trailingAnnualDividends,
     dividendBasisDifferencePercent,
     calculateTargetPercentage,

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -582,6 +582,46 @@ function priceAtNinetyDayHorizon(marketData, scoreDate) {
     return (lastData.high + lastData.low) / 2;
 }
 
+// Intraday LOW of the last market-data point on or before the 90-day horizon —
+// the price basis the GRQ model is TRAINED on (GRQ/src/LearnUtil.ts uses
+// `market.lowPrice(symbol, targetDate)` for the 90-day return label). The
+// dashboard measures Actual at the midpoint (priceAtNinetyDayHorizon); this
+// helper exposes the matching low so a like-for-like, same-basis comparison can
+// be made (issue #552). Mirrors priceAtNinetyDayHorizon's horizon selection
+// exactly so the two pick the SAME row. Returns null when there is no usable
+// data on or before the horizon.
+function lowPriceAtNinetyDayHorizon(marketData, scoreDate) {
+    if (!marketData || marketData.length === 0) return null;
+    const ninetyDayDate = new Date(
+        scoreDate.getTime() + (90 * 24 * 60 * 60 * 1000),
+    );
+    const within90Days = marketData.filter((point) =>
+        point.date <= ninetyDayDate
+    );
+    if (within90Days.length === 0) return null;
+    return within90Days[within90Days.length - 1].low;
+}
+
+// Price-basis offset between the dashboard's midpoint Actual and the model's
+// trained intraday-low basis, expressed as a percentage of the buy price
+// (issue #552): `(mid - low) / buyPrice * 100`. This is the amount the measured
+// Actual % is LIFTED by reading the horizon at the midpoint rather than the low
+// the model was trained to hit. Because `mid >= low` on every row the offset is
+// always >= 0, so it NARROWS (masks) any Target-over-Actual gap rather than
+// causing it. Returns null when any input is missing or the buy price is not a
+// positive number.
+function priceBasisOffsetPercent(buyPrice, midPrice, lowPrice) {
+    if (
+        buyPrice === null || buyPrice === undefined || Number.isNaN(buyPrice) ||
+        buyPrice <= 0 ||
+        midPrice === null || midPrice === undefined || Number.isNaN(midPrice) ||
+        lowPrice === null || lowPrice === undefined || Number.isNaN(lowPrice)
+    ) {
+        return null;
+    }
+    return ((midPrice - lowPrice) / buyPrice) * 100;
+}
+
 // Target return as a percentage of the buy price. Returns null when either input
 // is missing, matching the dashboard's guard before reporting a target figure.
 function calculateTargetPercentage(buyPrice, adjustedTarget) {
@@ -1053,6 +1093,8 @@ globalThis.GRQProjection = {
     getBuyPrice,
     currentPriceFromLatest,
     priceAtNinetyDayHorizon,
+    lowPriceAtNinetyDayHorizon,
+    priceBasisOffsetPercent,
     calculateTargetPercentage,
     calculatePortfolioTargetPercentage,
     getFairValueRange,

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.7")
+    navigator.serviceWorker.register("./sw.js?v=1.1.8")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.7";
+const APP_VERSION = "1.1.8";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.7">
+    <meta name="app-version" content="1.1.8">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -207,6 +207,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.7"></script>
+    <script src="sw-register.js?v=1.1.8"></script>
   </body>
 </html>

--- a/scripts/buy_price_denominator_diagnostic.ts
+++ b/scripts/buy_price_denominator_diagnostic.ts
@@ -1,0 +1,270 @@
+// Core computation for the issue #554 buy-price denominator diagnostic.
+//
+// Splits the pure aggregation (testable with synthetic rows, no disk) from the
+// file IO. Every per-stock figure is delegated to the SHIPPED kernels published
+// on globalThis by docs/projection.js and docs/trend_predictions.js, so the
+// diagnostic measures the dashboard's own denominator rather than a
+// re-implementation.
+//
+// The question: training divides the 90-day return by `monthsAgoPrice` (the
+// CLOSE on the score date — GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts),
+// while the dashboard divides BOTH Target and Actual by `buyPrice` (the
+// split-adjusted MIDPOINT of the first usable point). This module quantifies the
+// denominator offset and the gap it contributes when Target and Actual are
+// restated onto the trained close basis.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Summary statistics for a list of per-row denominator offsets (pp). */
+export interface OffsetSummary {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  stdDev: number;
+}
+
+/** Pure stats over a list of numbers. Empty input yields all-zero summary. */
+export function summariseOffsets(values: number[]): OffsetSummary {
+  const finite = values.filter((v) =>
+    typeof v === "number" && !Number.isNaN(v)
+  );
+  if (finite.length === 0) {
+    return { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 };
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  const sum = finite.reduce((t, v) => t + v, 0);
+  const mean = sum / finite.length;
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+  const variance = finite.reduce((t, v) => t + (v - mean) ** 2, 0) /
+    finite.length;
+  return {
+    count: finite.length,
+    mean,
+    median,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+/** One matured score date's portfolio figures on both buy-price bases. */
+export interface DateAggregate {
+  date: string;
+  // Dashboard basis (denominator = midpoint buyPrice).
+  targetMidPct: number | null;
+  actualMidPct: number | null;
+  // Trained basis (denominator = split-adjusted close).
+  targetClosePct: number | null;
+  actualClosePct: number | null;
+  rowOffsetsPp: number[];
+}
+
+// Build the dashboard (midpoint-denominator) and trained (close-denominator)
+// per-stock inputs for one score date and compute the portfolio Target % and
+// Actual % on each basis, plus the per-row `(buyPrice - buyPriceClose) /
+// buyPrice` denominator offsets over the INCLUDED stocks. Pure: the caller
+// supplies already-parsed score rows and the market-data map.
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  dividendData: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  const midStocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+
+  const rowOffsetsPp: number[] = [];
+  // deno-lint-ignore no-explicit-any
+  const closeStocks = midStocks.map((stock: any, i: number) => {
+    const points = marketData[scoreRows[i].stock];
+    const closeObj = P.buyPriceCloseBasis(points, scoreDate);
+    const buyPriceClose = closeObj ? closeObj.price : null;
+    const offset = P.denominatorBasisOffsetPercent(
+      stock.buyPrice,
+      buyPriceClose,
+    );
+    const included = P.isStockIncluded(
+      stock.buyPrice,
+      stock.currentPrice,
+      stock.splitReliable,
+    );
+    if (included && offset !== null) {
+      rowOffsetsPp.push(offset);
+    }
+    // Same stock, both Target and Actual measured on the trained close
+    // denominator instead of the midpoint buy price. Only the denominator
+    // changes; numerators (adjustedTarget, currentPrice, dividends) are shared.
+    return { ...stock, buyPrice: buyPriceClose };
+  });
+
+  return {
+    date,
+    targetMidPct: P.calculatePortfolioTargetPercentage(midStocks),
+    actualMidPct: P.calculateIncludedPortfolioPerformance(midStocks),
+    targetClosePct: P.calculatePortfolioTargetPercentage(closeStocks),
+    actualClosePct: P.calculateIncludedPortfolioPerformance(closeStocks),
+    rowOffsetsPp,
+  };
+}
+
+/** The full diagnostic result over the matured historical score set. */
+export interface DenominatorReport {
+  maturedDates: number;
+  rowCount: number;
+  meanOffsetPp: number;
+  medianOffsetPp: number;
+  minOffsetPp: number;
+  maxOffsetPp: number;
+  stdDevPp: number;
+  meanTargetMidPct: number;
+  meanActualMidPct: number;
+  meanTargetClosePct: number;
+  meanActualClosePct: number;
+  observedGapPp: number;
+  gapOnCloseBasisPp: number;
+  basisContributionPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Assemble the report from per-date aggregates. Pure so it can be unit-tested
+// with synthetic DateAggregate rows.
+export function buildReport(aggregates: DateAggregate[]): DenominatorReport {
+  const allOffsets = aggregates.flatMap((a) => a.rowOffsetsPp);
+  const stats = summariseOffsets(allOffsets);
+
+  const withFigures = aggregates.filter((a) =>
+    a.targetMidPct !== null && a.actualMidPct !== null &&
+    a.targetClosePct !== null && a.actualClosePct !== null
+  );
+  const meanTargetMidPct = mean(
+    withFigures.map((a) => a.targetMidPct as number),
+  );
+  const meanActualMidPct = mean(
+    withFigures.map((a) => a.actualMidPct as number),
+  );
+  const meanTargetClosePct = mean(
+    withFigures.map((a) => a.targetClosePct as number),
+  );
+  const meanActualClosePct = mean(
+    withFigures.map((a) => a.actualClosePct as number),
+  );
+  // Both bases divide Target and Actual by the SAME denominator, so each basis
+  // is internally self-consistent; the gap on each is Target - Actual.
+  const observedGapPp = meanTargetMidPct - meanActualMidPct;
+  const gapOnCloseBasisPp = meanTargetClosePct - meanActualClosePct;
+  const basisContributionPp = gapOnCloseBasisPp - observedGapPp;
+
+  const sign = stats.mean >= 0 ? "+" : "-";
+  const widthWord = basisContributionPp >= 0 ? "WIDEN" : "NARROW";
+  const verdict =
+    `VERDICT: the dashboard divides BOTH Target and Actual by the same ` +
+    `midpoint buyPrice, so the denominator choice does NOT desynchronise ` +
+    `Target vs Actual — it rescales any existing gap by buyPrice/close. The ` +
+    `midpoint buyPrice runs a mean ${sign}${
+      Math.abs(stats.mean).toFixed(3)
+    } pp versus the trained close denominator. Restating BOTH series onto the ` +
+    `trained close basis would ${widthWord} the observed gap by ${
+      Math.abs(basisContributionPp).toFixed(3)
+    } pp (from ${observedGapPp.toFixed(3)} to ${
+      gapOnCloseBasisPp.toFixed(3)
+    } pp). The denominator is therefore a second-order rescale, not a cause of ` +
+    `the Target-over-Actual gap.`;
+
+  return {
+    maturedDates: aggregates.length,
+    rowCount: stats.count,
+    meanOffsetPp: stats.mean,
+    medianOffsetPp: stats.median,
+    minOffsetPp: stats.min,
+    maxOffsetPp: stats.max,
+    stdDevPp: stats.stdDev,
+    meanTargetMidPct,
+    meanActualMidPct,
+    meanTargetClosePct,
+    meanActualClosePct,
+    observedGapPp,
+    gapOnCloseBasisPp,
+    basisContributionPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+// Load the matured score set from disk and compute the full diagnostic.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+export async function computeDenominatorDiagnostic(
+  docsPath: string,
+  asOf: Date,
+): Promise<DenominatorReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    const scoreRows = TP.parseScoreTsv(tsvText);
+    const marketData = TP.parseMarketCsv(csvText);
+    const dividendData = TP.parseDividendCsv(divText);
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        scoreRows,
+        marketData,
+        dividendData,
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReport(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/scripts/diagnose_buy_price_denominator.ts
+++ b/scripts/diagnose_buy_price_denominator.ts
@@ -1,0 +1,61 @@
+// Diagnostic for issue #554 (milestone #544): quantify the Target/Actual bias
+// that comes purely from the buy-price DENOMINATOR mismatch between training and
+// the dashboard.
+//
+//   - The GRQ model is trained on a 90-day return divided by `monthsAgoPrice`,
+//     which is the CLOSE on the score date (GRQ/src/CoreFeatures.ts builds
+//     `monthsAgoPrice = closePrices[0]`; GRQ/src/LearnUtil.ts divides by it).
+//   - The dashboard divides BOTH Target and Actual by `buyPrice`, the
+//     split-adjusted MIDPOINT (high + low) / 2 of the first usable point
+//     (docs/projection.js -> getBuyPrice).
+//
+// Because the dashboard uses the SAME buyPrice for Target and Actual, the
+// denominator choice cannot desynchronise them — it only rescales any existing
+// gap by buyPrice/close. This script quantifies that offset and the gap it
+// contributes when both series are restated onto the trained close basis.
+//
+// It reuses the SHIPPED kernels — GRQProjection.getBuyPrice,
+// buyPriceCloseBasis, denominatorBasisOffsetPercent, isStockIncluded,
+// calculatePortfolioTargetPercentage and calculateIncludedPortfolioPerformance,
+// plus the GRQTrendPredictions CSV/TSV parsers — so the numbers it reports are
+// computed on exactly the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_buy_price_denominator.ts [docsPath] [asOf]
+// (default docsPath = "docs"). Read-only; prints a Markdown-friendly report.
+
+import { computeDenominatorDiagnostic } from "./buy_price_denominator_diagnostic.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+// "Today" governs which score dates have a complete 90-day window. Default to
+// the real clock; allow an override (second arg, YYYY-MM-DD) for reproducible
+// reports pinned to a specific as-of date.
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+
+const report = await computeDenominatorDiagnostic(docsPath, asOf);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(
+  `# Buy-price denominator (midpoint vs close) diagnostic — issue #554\n`,
+);
+console.log(`As-of date:            ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Matured score dates:   ${report.maturedDates}`);
+console.log(`Included stock-rows:   ${report.rowCount}`);
+console.log("");
+console.log(`## Per-row denominator offset (buyPrice - close) / buyPrice`);
+console.log(`Mean:                  ${pp(report.meanOffsetPp)}`);
+console.log(`Median:                ${pp(report.medianOffsetPp)}`);
+console.log(`Min:                   ${pp(report.minOffsetPp)}`);
+console.log(`Max:                   ${pp(report.maxOffsetPp)}`);
+console.log(`Std dev:               ${report.stdDevPp.toFixed(3)} pp`);
+console.log("");
+console.log(`## Per-date portfolio aggregates (mean over matured dates)`);
+console.log(`Mean Target % (mid):   ${report.meanTargetMidPct.toFixed(3)} %`);
+console.log(`Mean Actual % (mid):   ${report.meanActualMidPct.toFixed(3)} %`);
+console.log(`Mean Target % (close): ${report.meanTargetClosePct.toFixed(3)} %`);
+console.log(`Mean Actual % (close): ${report.meanActualClosePct.toFixed(3)} %`);
+console.log(`Observed gap (mid):    ${pp(report.observedGapPp)}`);
+console.log(`Gap on close basis:    ${pp(report.gapOnCloseBasisPp)}`);
+console.log(`Basis contribution:    ${pp(report.basisContributionPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/scripts/diagnose_dividend_basis.ts
+++ b/scripts/diagnose_dividend_basis.ts
@@ -1,0 +1,76 @@
+// Diagnostic for issue #553 (milestone #544): quantify the Target/Actual bias
+// that comes purely from the DIVIDEND basis mismatch between training and the
+// dashboard.
+//
+//   - The GRQ model bakes a FLAT quarter of the trailing annual dividend,
+//     `core.yearOfDividends / 4`, into the total-return training label for EVERY
+//     stock (GRQ/src/LearnUtil.ts:147-148, GRQ/src/CoreFeatures.ts).
+//   - The dashboard/validation side credits only the ACTUAL ex-dividends inside
+//     the 90-day window (GRQ-validation/src/utils.rs
+//     `calculate_dividends_for_period`, mirrored by the shipped JS kernels
+//     `filterDividendsWithin90Days` + `sumDividends`).
+//
+// Per matured row this script compares the two credits and aggregates the mean
+// difference (in pp of buy price) and its SIGN, so we know whether the flat
+// quarter is a consistent over- or under-credit relative to realised dividends,
+// and whether it contributes to (or offsets) the Target-over-Actual gap.
+//
+// It reuses the SHIPPED kernels — GRQProjection.trailingAnnualDividends,
+// dividendBasisDifferencePercent, isStockIncluded, and the
+// GRQTrendPredictions resolver/parsers — so the windowed credit it reports is
+// computed on exactly the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_dividend_basis.ts \
+//        [docsPath] [asOf YYYY-MM-DD] [dividendsRoot]
+// (defaults: docsPath="docs", asOf=today, dividendsRoot="../GRQ-dividends").
+// Read-only; prints a Markdown-friendly report.
+
+import { computeDividendBasisDiagnostic } from "./dividend_basis_diagnostic.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+// "Today" governs which score dates have a complete 90-day window. Default to
+// the real clock; allow an override (second arg, YYYY-MM-DD) for reproducible
+// reports pinned to a specific as-of date.
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+const dividendsRoot = Deno.args[2] ?? "../GRQ-dividends";
+
+const report = await computeDividendBasisDiagnostic(
+  docsPath,
+  asOf,
+  dividendsRoot,
+);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(
+  `# Dividend-basis (flat 1/4 vs windowed) diagnostic — issue #553\n`,
+);
+console.log(`As-of date:              ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Dividend history root:   ${dividendsRoot}`);
+console.log(`Matured score dates:     ${report.maturedDates}`);
+console.log(`Included stock-rows:     ${report.rowCount}`);
+console.log("");
+console.log(
+  `## Per-row basis difference (flatCredit - windowedCredit) / buyPrice`,
+);
+console.log(`Mean (raw):              ${pp(report.meanDiffPp)}`);
+console.log(`Mean (1%-trimmed):       ${pp(report.trimmedMeanDiffPp)}`);
+console.log(`Median:                  ${pp(report.medianDiffPp)}`);
+console.log(`Min:                     ${pp(report.minDiffPp)}`);
+console.log(`Max:                     ${pp(report.maxDiffPp)}`);
+console.log(`Std dev:                 ${report.stdDevPp.toFixed(3)} pp`);
+console.log(
+  `Within +/-1 pp:          ${report.within1ppSharePct.toFixed(1)} %`,
+);
+console.log("");
+console.log(`## Dividend-return components (mean over included rows)`);
+console.log(`Mean flat credit yield:  ${report.meanFlatYieldPct.toFixed(3)} %`);
+console.log(
+  `Mean windowed yield:     ${report.meanWindowedYieldPct.toFixed(3)} %`,
+);
+console.log(
+  `Rows with 0 in-window:   ${report.windowedZeroSharePct.toFixed(1)} %`,
+);
+console.log(`Gap contribution:        ${pp(report.contributionPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/scripts/diagnose_horizon_split_parity.ts
+++ b/scripts/diagnose_horizon_split_parity.ts
@@ -1,0 +1,68 @@
+// Diagnostic for issue #555 (milestone #544): audit the market-data TIMING and
+// CORPORATE-ACTION parity between GRQ training and the GRQ-validation dashboard,
+// and quantify the one divergence that is measurable on the dashboard's data —
+// the as-of split basis of the Actual horizon price.
+//
+//   - Horizon ROW selection: training takes lowPrice at
+//     rewindToTradingDay(asOf + 90*DAY); the dashboard takes the last point on
+//     or before scoreDate + 90 days. On the stock's own daily series these
+//     resolve to the SAME row, so the horizon DATE is aligned.
+//   - Split-adjusted series: both sides work on split-adjusted prices. The
+//     dashboard restates the buy price AND the model's target into CURRENT
+//     (end-of-series) terms, but reads the Actual horizon price RAW. When a
+//     reconcilable split falls between the horizon and the series end, the
+//     Actual sits on a different split basis than the buy price it is divided
+//     by — a forward split inflates Actual (masking the gap), a reverse split
+//     deflates it (widening the gap). Target % is invariant (it divides both
+//     adjustedTarget and buyPrice by the same factor).
+//
+// This script measures that as-of-basis offset over the matured historical
+// score set, reusing the SHIPPED kernels — GRQProjection.horizonPriceCurrentBasis,
+// postHorizonSplitFactor, horizonAsOfBasisOffsetPercent, getBuyPrice,
+// calculatePortfolioTargetPercentage, calculateIncludedPortfolioPerformance and
+// isStockIncluded, plus the GRQTrendPredictions CSV/TSV parsers — so the numbers
+// it reports are computed on exactly the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_horizon_split_parity.ts [docsPath] [asOf]
+// (default docsPath = "docs", asOf = today). Read-only; prints a Markdown report.
+
+import { computeHorizonSplitParityDiagnostic } from "./horizon_split_parity_diagnostic.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+// "Today" governs which score dates have a complete 90-day window. Default to
+// the real clock; allow an override (second arg, YYYY-MM-DD) for reproducible
+// reports pinned to a specific as-of date.
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+
+const report = await computeHorizonSplitParityDiagnostic(docsPath, asOf);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(`# Horizon split-basis parity diagnostic — issue #555\n`);
+console.log(`As-of date:               ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Matured score dates:      ${report.maturedDates}`);
+console.log(`Included stock-rows:      ${report.rowCount}`);
+console.log(`Post-horizon split rows:  ${report.splitAffectedRows}`);
+console.log("");
+console.log(
+  `## Per-row as-of-basis offset (rawHorizon - currentBasis) / buyPrice`,
+);
+console.log(`Mean:                     ${pp(report.meanOffsetPp)}`);
+console.log(`Median:                   ${pp(report.medianOffsetPp)}`);
+console.log(`Min:                      ${pp(report.minOffsetPp)}`);
+console.log(`Max:                      ${pp(report.maxOffsetPp)}`);
+console.log(`Std dev:                  ${report.stdDevPp.toFixed(3)} pp`);
+console.log("");
+console.log(`## Per-date portfolio aggregates (mean over matured dates)`);
+console.log(`Mean Target %:            ${report.meanTargetPct.toFixed(3)} %`);
+console.log(
+  `Mean Actual % (raw):      ${report.meanActualRawPct.toFixed(3)} %`,
+);
+console.log(
+  `Mean Actual % (current):  ${report.meanActualCurrentBasisPct.toFixed(3)} %`,
+);
+console.log(`Observed gap (T-A,raw):   ${pp(report.observedGapPp)}`);
+console.log(`Gap on current basis:     ${pp(report.gapOnCurrentBasisPp)}`);
+console.log(`Basis contribution:       ${pp(report.basisContributionPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/scripts/diagnose_price_basis.ts
+++ b/scripts/diagnose_price_basis.ts
@@ -1,0 +1,55 @@
+// Diagnostic for issue #552 (milestone #544): quantify the Target/Actual bias
+// that comes purely from the price BASIS mismatch between training and the
+// dashboard.
+//
+//   - The GRQ model is trained on the intraday LOW of the trading day 90 days
+//     ahead (GRQ/src/LearnUtil.ts -> market.lowPrice(symbol, targetDate)).
+//   - The dashboard measures Actual at the MIDPOINT (high + low) / 2 of the last
+//     point on or before the 90-day horizon (docs/projection.js).
+//
+// Because mid >= low on every row, reading Actual at the mid LIFTS the measured
+// Actual %, which NARROWS (masks) any Target-over-Actual gap. This script
+// quantifies that offset over the matured historical score set so we know how
+// much of the residual gap genuine model optimism still has to explain.
+//
+// It reuses the SHIPPED kernels — GRQProjection.getBuyPrice,
+// priceAtNinetyDayHorizon, lowPriceAtNinetyDayHorizon, priceBasisOffsetPercent
+// and isStockIncluded, plus the GRQTrendPredictions CSV/TSV parsers — so the
+// numbers it reports are computed on exactly the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_price_basis.ts [docsPath]
+// (default docsPath = "docs"). Read-only; prints a Markdown-friendly report.
+
+import { computePriceBasisDiagnostic } from "./price_basis_diagnostic.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+// "Today" governs which score dates have a complete 90-day window. Default to
+// the real clock; allow an override (second arg, YYYY-MM-DD) for reproducible
+// reports pinned to a specific as-of date.
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+
+const report = await computePriceBasisDiagnostic(docsPath, asOf);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(`# Price-basis (mid vs low) diagnostic — issue #552\n`);
+console.log(`As-of date:            ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Matured score dates:   ${report.maturedDates}`);
+console.log(`Included stock-rows:   ${report.rowCount}`);
+console.log("");
+console.log(`## Per-row basis offset (mid - low) / buyPrice`);
+console.log(`Mean:                  ${pp(report.meanOffsetPp)}`);
+console.log(`Median:                ${pp(report.medianOffsetPp)}`);
+console.log(`Min:                   ${pp(report.minOffsetPp)}`);
+console.log(`Max:                   ${pp(report.maxOffsetPp)}`);
+console.log(`Std dev:               ${report.stdDevPp.toFixed(3)} pp`);
+console.log("");
+console.log(`## Per-date portfolio aggregates (mean over matured dates)`);
+console.log(`Mean Target %:         ${report.meanTargetPct.toFixed(3)} %`);
+console.log(`Mean Actual % (mid):   ${report.meanActualMidPct.toFixed(3)} %`);
+console.log(`Mean Actual % (low):   ${report.meanActualLowPct.toFixed(3)} %`);
+console.log(`Observed gap (T-A,mid):${pp(report.observedGapPp)}`);
+console.log(`Gap on low basis:      ${pp(report.gapOnLowBasisPp)}`);
+console.log(`Basis contribution:    ${pp(report.basisContributionPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/scripts/diagnose_residual_gap.ts
+++ b/scripts/diagnose_residual_gap.ts
@@ -1,0 +1,58 @@
+// Diagnostic for issue #557 (milestone #544): whole-application sweep for any
+// remaining same-direction Target/Actual asymmetry, plus the residual-gap
+// reconciliation that nets the observed Target-over-Actual gap against the
+// quantified #544-family candidates (#552–#556) and this sweep's own finding.
+//
+// The sweep confirms that aggregation weighting and the inclusion gate are
+// SHARED between Target and Actual (both equal-weight over isStockIncluded),
+// and surfaces the one aggregation-layer asymmetry the targeted sub-issues did
+// not cover: the target-availability denominator skew (priceable rows with a
+// missing target count in Actual but not Target).
+//
+// It reuses the SHIPPED kernels — GRQProjection.calculatePortfolioTargetPercentage,
+// calculateIncludedPortfolioPerformance, isStockIncluded — plus the
+// GRQTrendPredictions CSV/TSV parsers, so the numbers are computed on exactly
+// the same basis the dashboard uses.
+//
+// Run: deno run --allow-read scripts/diagnose_residual_gap.ts [docsPath] [asOf]
+// (default docsPath = "docs", asOf = now). Read-only; prints a Markdown report.
+
+import { computeResidualGapReconciliation } from "./residual_gap_reconciliation.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+
+const report = await computeResidualGapReconciliation(docsPath, asOf);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(3)} pp`;
+
+console.log(`# Residual Target-over-Actual gap reconciliation — issue #557\n`);
+console.log(`As-of date:            ${asOf.toISOString().slice(0, 10)}`);
+console.log(`Matured score dates:   ${report.maturedDates}`);
+console.log(`Included stock-rows:   ${report.includedRows}`);
+console.log(`Target-present rows:   ${report.targetRows}`);
+console.log(`Dropped-target rows:   ${report.droppedTargetRows}`);
+console.log("");
+console.log(`## Portfolio means (over matured dates)`);
+console.log(`Mean Target %:         ${report.meanTargetPct.toFixed(3)} %`);
+console.log(`Mean Actual %:         ${report.meanActualPct.toFixed(3)} %`);
+console.log(
+  `Mean Actual % (matched):${report.meanMatchedActualPct.toFixed(3)} %`,
+);
+console.log(`Observed gap (T-A):    ${pp(report.observedGapPp)}`);
+console.log(`Matched-subset gap:    ${pp(report.matchedGapPp)}`);
+console.log(`Target-availability:   ${pp(report.targetAvailabilityPp)}`);
+console.log("");
+console.log(`## Reconciliation against the #544 candidates`);
+console.log(
+  `(sign convention: + inflates the apparent gap, - masks it)\n`,
+);
+for (const c of report.contributions) {
+  console.log(`#${c.issue} ${c.key.padEnd(22)} ${pp(c.contributionPp)}`);
+}
+console.log("");
+console.log(`Net measurement:       ${pp(report.netMeasurementPp)}`);
+console.log(`Observed gap:          ${pp(report.observedGapPp)}`);
+console.log(`Residual (optimism):   ${pp(report.residualOptimismPp)}`);
+console.log("");
+console.log(report.verdict);

--- a/scripts/diagnose_score_target_decoding.ts
+++ b/scripts/diagnose_score_target_decoding.ts
@@ -1,0 +1,76 @@
+// Diagnostic for issue #556 (milestone #544): confirm whether the score→target
+// decoding `reverseProfitRecommend` adds a systematic bias to the dashboard's
+// Target.
+//
+//   - The AI emits a score in [-1, 1]; the GRQ dashboard derives Target via
+//     reverseProfitRecommend(price, score) (GRQ/src/portfolio/ScoreApp.ts:473,
+//     defined in GRQ/src/LearnUtilTypes.ts:19-39).
+//   - Forward (training) encode:  profitRecommend(pct) = tanh((pct - 1.5) / 3).
+//   - Reverse (dashboard) decode: pct = 3*atanh(score) + 1.5, then
+//     target = price * (1 + pct/100), with clamps score>=1 → +50%,
+//     score<=-1 → target 0, interior pct capped to ±50%.
+//
+// In the interior tanh/atanh are exact inverses, so the round-trip is the
+// identity; the clamps are asymmetric (a 0/-100% floor vs a +50% cap). This
+// script feeds the REALISED score distribution through
+// profitRecommend ∘ reverseProfitRecommend, measures the round-trip Target shift
+// (pp, with sign), and takes a census of how often scores land in each clamped
+// region — isolating the clamp contribution.
+//
+// Run: deno run --allow-read scripts/diagnose_score_target_decoding.ts \
+//        [docsPath] [asOf] [all]
+//   docsPath default "docs"; asOf default today (YYYY-MM-DD to pin);
+//   pass "all" as the third arg to include not-yet-matured score dates.
+// Read-only; prints a Markdown-friendly report.
+
+import { computeDecodingDiagnostic } from "./score_target_decoding_diagnostic.ts";
+
+const docsPath = Deno.args[0] ?? "docs";
+const asOf = Deno.args[1] ? new Date(Deno.args[1]) : new Date();
+const maturedOnly = (Deno.args[2] ?? "") !== "all";
+
+const report = await computeDecodingDiagnostic(docsPath, asOf, maturedOnly);
+
+const pp = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(6)} pp`;
+const pct = (n: number) => `${n.toFixed(3)} %`;
+
+console.log(
+  `# Score→target decoding (reverseProfitRecommend) diagnostic — issue #556\n`,
+);
+console.log(`As-of date:            ${asOf.toISOString().slice(0, 10)}`);
+console.log(
+  `Score set:             ${maturedOnly ? "matured only" : "all dates"}`,
+);
+console.log(`Score dates:           ${report.scoreDates}`);
+console.log(`Score rows:            ${report.scoreRows}`);
+console.log("");
+console.log(
+  `## Round-trip Target shift (profitRecommend ∘ reverseProfitRecommend)`,
+);
+console.log(`Mean:                  ${pp(report.shift.mean)}`);
+console.log(`Median:                ${pp(report.shift.median)}`);
+console.log(`Min:                   ${pp(report.shift.min)}`);
+console.log(`Max:                   ${pp(report.shift.max)}`);
+console.log(`Std dev:               ${report.shift.stdDev.toFixed(6)} pp`);
+console.log("");
+console.log(`## Clamp-region census (realised scores)`);
+for (const c of report.census) {
+  console.log(
+    `${c.region.padEnd(20)} ${String(c.count).padStart(6)}  ` +
+      `${(c.fraction * 100).toFixed(2)} %`,
+  );
+}
+console.log("");
+console.log(`Mean decoded return:   ${pct(report.meanDecodedPct)}`);
+console.log(
+  `Saturated rows (==1):  ${report.saturatedRows} (${
+    (report.fractionCapHigh * 100).toFixed(2)
+  } %)`,
+);
+console.log(
+  `Floor rows (<=-1):     ${
+    Math.round(report.fractionFloorLow * report.scoreRows)
+  } (${(report.fractionFloorLow * 100).toFixed(2)} %)`,
+);
+console.log("");
+console.log(report.verdict);

--- a/scripts/dividend_basis_diagnostic.ts
+++ b/scripts/dividend_basis_diagnostic.ts
@@ -1,0 +1,388 @@
+// Core computation for the issue #553 dividend-basis diagnostic.
+//
+// Quantifies the Target/Actual bias that comes from the DIVIDEND basis mismatch
+// between training and the dashboard:
+//
+//   - Training (GRQ/src/LearnUtil.ts:147-148) bakes a FLAT quarter of the
+//     trailing annual dividend, `core.yearOfDividends / 4`, into the
+//     total-return label for EVERY stock, whether or not a dividend actually
+//     falls in the forward window.
+//   - The dashboard/validation side credits only the ACTUAL ex-dividends that
+//     fall inside the 90-day window
+//     (GRQ-validation/src/utils.rs `calculate_dividends_for_period`, mirrored on
+//     the JS side by `filterDividendsWithin90Days` + `sumDividends`).
+//
+// Splits the pure aggregation (testable with synthetic rows, no disk) from the
+// file IO. Every per-stock figure is delegated to the SHIPPED kernels published
+// on globalThis by docs/projection.js and docs/trend_predictions.js, so the
+// windowed credit measured here is exactly the dashboard's own credit rather
+// than a re-implementation.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Summary statistics for a list of per-row differences (percentage points). */
+export interface DiffSummary {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  stdDev: number;
+}
+
+/** Pure stats over a list of numbers. Empty input yields all-zero summary. */
+export function summariseDiffs(values: number[]): DiffSummary {
+  const finite = values.filter((v) =>
+    typeof v === "number" && !Number.isNaN(v)
+  );
+  if (finite.length === 0) {
+    return { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 };
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  const sum = finite.reduce((t, v) => t + v, 0);
+  const mean = sum / finite.length;
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+  const variance = finite.reduce((t, v) => t + (v - mean) ** 2, 0) /
+    finite.length;
+  return {
+    count: finite.length,
+    mean,
+    median,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+// Strip an exchange prefix and normalise dots to hyphens, mirroring the Rust
+// `extract_symbol_from_ticker` so a score ticker ("NYSE:SEM", "HEI.A") maps to
+// the per-ticker dividend-history filename ("SEM", "HEI-A").
+export function stripSymbol(ticker: string): string {
+  const idx = ticker.lastIndexOf(":");
+  const sym = idx >= 0 ? ticker.slice(idx + 1) : ticker;
+  return sym.replace(/\./g, "-");
+}
+
+/** One matured score date's per-row dividend-basis differences. */
+export interface DateAggregate {
+  date: string;
+  /** Per included row: (flatCredit - windowedCredit) / buyPrice * 100. */
+  rowDiffsPp: number[];
+  /** Per included row: flat training credit as a % of buy price. */
+  flatYieldsPct: number[];
+  /** Per included row: realised in-window credit as a % of buy price. */
+  windowedYieldsPct: number[];
+  /** Included rows where the realised in-window dividend was exactly 0. */
+  windowedZeroCount: number;
+  /** Total included rows contributing to the figures above. */
+  includedCount: number;
+}
+
+// Build the per-row dividend-basis differences for one score date. Pure: the
+// caller supplies already-parsed score rows, the market-data map, the COMMITTED
+// in-window dividend map (the dashboard's Actual source), and the FULL trailing
+// dividend history keyed by stripped symbol (the training-credit source).
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  windowedDividends: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  fullHistory: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  // Shipped resolver: gives buyPrice, currentPrice, splitReliable and the
+  // realised in-window `totalDividends` — exactly the dashboard's Actual credit.
+  const stocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    windowedDividends,
+    scoreDate,
+  );
+
+  const rowDiffsPp: number[] = [];
+  const flatYieldsPct: number[] = [];
+  const windowedYieldsPct: number[] = [];
+  let windowedZeroCount = 0;
+  let includedCount = 0;
+
+  // deno-lint-ignore no-explicit-any
+  stocks.forEach((stock: any, i: number) => {
+    if (
+      !P.isStockIncluded(
+        stock.buyPrice,
+        stock.currentPrice,
+        stock.splitReliable,
+      )
+    ) {
+      return;
+    }
+    includedCount += 1;
+
+    const history = fullHistory[stripSymbol(scoreRows[i].stock)] || [];
+    const flatCredit = P.trailingAnnualDividends(history, scoreDate) / 4;
+    const windowedCredit = stock.totalDividends || 0;
+
+    const diff = P.dividendBasisDifferencePercent(
+      flatCredit,
+      windowedCredit,
+      stock.buyPrice,
+    );
+    if (diff === null) {
+      return;
+    }
+    rowDiffsPp.push(diff);
+    flatYieldsPct.push((flatCredit / stock.buyPrice) * 100);
+    windowedYieldsPct.push((windowedCredit / stock.buyPrice) * 100);
+    if (windowedCredit === 0) {
+      windowedZeroCount += 1;
+    }
+  });
+
+  return {
+    date,
+    rowDiffsPp,
+    flatYieldsPct,
+    windowedYieldsPct,
+    windowedZeroCount,
+    includedCount,
+  };
+}
+
+/** The full diagnostic result over the matured historical score set. */
+export interface DividendBasisReport {
+  maturedDates: number;
+  rowCount: number;
+  meanDiffPp: number;
+  medianDiffPp: number;
+  minDiffPp: number;
+  maxDiffPp: number;
+  stdDevPp: number;
+  /** Mean after dropping the most extreme `trimFraction` of each tail. */
+  trimmedMeanDiffPp: number;
+  /** Share of included rows whose difference sits within +/-1 pp. */
+  within1ppSharePct: number;
+  meanFlatYieldPct: number;
+  meanWindowedYieldPct: number;
+  windowedZeroSharePct: number;
+  /** Equal-weight per-row mean difference == portfolio-level gap contribution. */
+  contributionPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Mean after dropping the most extreme `trimFraction` of values at EACH tail.
+// The raw per-row mean is dominated by a handful of special/liquidating
+// distributions on low-priced stocks (e.g. EQC, ELME, VISN), so a trimmed mean
+// reports the robust central tendency alongside the lumpy raw figure.
+export function trimmedMean(values: number[], trimFraction: number): number {
+  const finite = values
+    .filter((v) => typeof v === "number" && !Number.isNaN(v))
+    .sort((a, b) => a - b);
+  if (finite.length === 0) return 0;
+  const k = Math.floor(finite.length * trimFraction);
+  const kept = finite.slice(k, finite.length - k);
+  return mean(kept.length > 0 ? kept : finite);
+}
+
+// Assemble the report from per-date aggregates. Pure so it can be unit-tested
+// with synthetic DateAggregate rows.
+export function buildReport(aggregates: DateAggregate[]): DividendBasisReport {
+  const allDiffs = aggregates.flatMap((a) => a.rowDiffsPp);
+  const stats = summariseDiffs(allDiffs);
+
+  const meanFlatYieldPct = mean(aggregates.flatMap((a) => a.flatYieldsPct));
+  const meanWindowedYieldPct = mean(
+    aggregates.flatMap((a) => a.windowedYieldsPct),
+  );
+  const totalIncluded = aggregates.reduce((t, a) => t + a.includedCount, 0);
+  const totalWindowedZero = aggregates.reduce(
+    (t, a) => t + a.windowedZeroCount,
+    0,
+  );
+  const windowedZeroSharePct = totalIncluded === 0
+    ? 0
+    : (totalWindowedZero / totalIncluded) * 100;
+
+  const trimmedMeanDiffPp = trimmedMean(allDiffs, 0.01);
+  const within1ppSharePct = stats.count === 0
+    ? 0
+    : (allDiffs.filter((d) => Math.abs(d) <= 1).length / stats.count) * 100;
+
+  // Under equal weighting the mean per-row (flat - windowed)/buy difference IS
+  // the amount the dividend basis moves the Target-over-Actual gap: Target
+  // carries the flat credit, Actual carries the windowed credit.
+  const contributionPp = stats.mean;
+  const direction = contributionPp >= 0
+    ? "CONTRIBUTES to (widens)"
+    : "OFFSETS (narrows)";
+
+  const verdict =
+    `VERDICT: the flat training credit (yearOfDividends / 4) exceeds the ` +
+    `realised in-window dividends by a mean ${stats.mean.toFixed(3)} pp of ` +
+    `buy price (median ${stats.median.toFixed(3)} pp; 1%-trimmed mean ` +
+    `${trimmedMeanDiffPp.toFixed(3)} pp). Because Target embeds the flat ` +
+    `credit while Actual credits only realised in-window dividends, this ` +
+    `dividend basis ${direction} the Target-over-Actual gap by ` +
+    `${Math.abs(contributionPp).toFixed(3)} pp. ` +
+    `${windowedZeroSharePct.toFixed(1)}% of included rows realised ZERO ` +
+    `in-window dividends yet still receive the flat quarter in training (the ` +
+    `same-direction driver), but the raw mean is lumpy: ` +
+    `${within1ppSharePct.toFixed(1)}% of rows fall within +/-1 pp and the ` +
+    `mean is dominated by a few special/liquidating distributions on ` +
+    `low-priced stocks, so the robust contribution is the smaller trimmed mean.`;
+
+  return {
+    maturedDates: aggregates.length,
+    rowCount: stats.count,
+    meanDiffPp: stats.mean,
+    medianDiffPp: stats.median,
+    minDiffPp: stats.min,
+    maxDiffPp: stats.max,
+    stdDevPp: stats.stdDev,
+    trimmedMeanDiffPp,
+    within1ppSharePct,
+    meanFlatYieldPct,
+    meanWindowedYieldPct,
+    windowedZeroSharePct,
+    contributionPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+interface DividendHistoryRecord {
+  ex_dividend_date?: string;
+  amount?: string | number;
+}
+
+// Load one ticker's FULL dividend history from the GRQ-dividends tree
+// (../GRQ-dividends/data/<L>/<SYM>.json) into the { exDivDate, amount } shape the
+// kernels consume. Returns [] when the file is absent or unparseable so a ticker
+// with no published history simply contributes a 0 flat credit.
+async function loadDividendHistory(
+  dividendsRoot: string,
+  strippedSymbol: string,
+): Promise<{ exDivDate: Date; amount: number }[]> {
+  if (!strippedSymbol) return [];
+  const letter = strippedSymbol.charAt(0).toUpperCase();
+  const path = `${dividendsRoot}/data/${letter}/${strippedSymbol}.json`;
+  let text: string;
+  try {
+    text = await Deno.readTextFile(path);
+  } catch {
+    return [];
+  }
+  let parsed: { data?: DividendHistoryRecord[] };
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  const records = Array.isArray(parsed.data) ? parsed.data : [];
+  const out: { exDivDate: Date; amount: number }[] = [];
+  for (const r of records) {
+    if (!r || typeof r.ex_dividend_date !== "string") continue;
+    const amount = typeof r.amount === "number"
+      ? r.amount
+      : parseFloat(String(r.amount));
+    if (Number.isNaN(amount)) continue;
+    out.push({
+      exDivDate: P.setDateToMidnight(new Date(r.ex_dividend_date)),
+      amount,
+    });
+  }
+  return out;
+}
+
+// Load the matured score set from disk and compute the full diagnostic.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+// `dividendsRoot` points at the GRQ-dividends history tree (default
+// "../GRQ-dividends", matching src/utils.rs DIVIDEND_DATA_BASE_PATH).
+export async function computeDividendBasisDiagnostic(
+  docsPath: string,
+  asOf: Date,
+  dividendsRoot = "../GRQ-dividends",
+): Promise<DividendBasisReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const historyCache = new Map<string, { exDivDate: Date; amount: number }[]>();
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    const scoreRows = TP.parseScoreTsv(tsvText);
+    const marketData = TP.parseMarketCsv(csvText);
+    const windowedDividends = TP.parseDividendCsv(divText);
+
+    // Full trailing history per ticker on this date (cached across dates).
+    // deno-lint-ignore no-explicit-any
+    const fullHistory: Record<string, any[]> = {};
+    for (const row of scoreRows) {
+      const sym = stripSymbol(row.stock);
+      if (!historyCache.has(sym)) {
+        historyCache.set(sym, await loadDividendHistory(dividendsRoot, sym));
+      }
+      fullHistory[sym] = historyCache.get(sym) as {
+        exDivDate: Date;
+        amount: number;
+      }[];
+    }
+
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        scoreRows,
+        marketData,
+        windowedDividends,
+        fullHistory,
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReport(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/scripts/horizon_split_parity_diagnostic.ts
+++ b/scripts/horizon_split_parity_diagnostic.ts
@@ -1,0 +1,280 @@
+// Core computation for the issue #555 market-data timing & corporate-action
+// parity diagnostic (milestone #544).
+//
+// The training label and the dashboard agree on the 90-day horizon ROW (both
+// take the last point on or before scoreDate + 90 days) and on a split-adjusted
+// series. They diverge on ONE as-of basis: the dashboard restates the buy price
+// and the model's target into CURRENT (end-of-series) split terms, but reads the
+// Actual horizon price RAW. When a reconcilable split falls between the horizon
+// and the series end, the Actual sits on a different split basis than the buy
+// price it is divided by — a forward split inflates Actual (masking the
+// Target-over-Actual gap), a reverse split deflates it (widening the gap).
+//
+// This module quantifies that as-of-basis offset over the matured historical
+// score set. Every per-stock figure is delegated to the SHIPPED kernels
+// published on globalThis by docs/projection.js and docs/trend_predictions.js,
+// so the diagnostic measures the dashboard's own basis, not a re-implementation.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Summary statistics for a list of per-row basis offsets (percentage points). */
+export interface OffsetSummary {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  stdDev: number;
+}
+
+/** Pure stats over a list of numbers. Empty input yields an all-zero summary. */
+export function summariseOffsets(values: number[]): OffsetSummary {
+  const finite = values.filter((v) =>
+    typeof v === "number" && !Number.isNaN(v)
+  );
+  if (finite.length === 0) {
+    return { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 };
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  const sum = finite.reduce((t, v) => t + v, 0);
+  const mean = sum / finite.length;
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+  const variance = finite.reduce((t, v) => t + (v - mean) ** 2, 0) /
+    finite.length;
+  return {
+    count: finite.length,
+    mean,
+    median,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+/** One matured score date's portfolio figures on both Actual bases. */
+export interface DateAggregate {
+  date: string;
+  targetPct: number | null;
+  actualRawPct: number | null;
+  actualCurrentBasisPct: number | null;
+  rowOffsetsPp: number[];
+  /** Included rows whose horizon price carries a reconcilable post-horizon split. */
+  splitAffectedRows: number;
+  /** Included rows considered (denominator for the affected-row share). */
+  includedRows: number;
+}
+
+// Build the per-stock inputs for one score date and compute the portfolio
+// Target %, Actual % on the shipped RAW horizon basis and Actual % on the
+// current (split-consistent) horizon basis, plus the per-row as-of-basis offsets
+// over the INCLUDED stocks. Pure: the caller supplies already-parsed score rows
+// and the market-data map.
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  dividendData: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  const rawStocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+
+  const rowOffsetsPp: number[] = [];
+  let splitAffectedRows = 0;
+  let includedRows = 0;
+  // deno-lint-ignore no-explicit-any
+  const currentBasisStocks = rawStocks.map((stock: any, i: number) => {
+    const points = marketData[scoreRows[i].stock];
+    const currentBasisMid = P.horizonPriceCurrentBasis(points, scoreDate);
+    const offset = P.horizonAsOfBasisOffsetPercent(
+      stock.buyPrice,
+      stock.currentPrice,
+      currentBasisMid,
+    );
+    const included = P.isStockIncluded(
+      stock.buyPrice,
+      stock.currentPrice,
+      stock.splitReliable,
+    );
+    if (included) {
+      includedRows++;
+      if (offset !== null) {
+        rowOffsetsPp.push(offset);
+        if (Math.abs(offset) > 0) splitAffectedRows++;
+      }
+    }
+    // Same stock, Actual measured on the buy price's current split basis.
+    return { ...stock, currentPrice: currentBasisMid };
+  });
+
+  return {
+    date,
+    targetPct: P.calculatePortfolioTargetPercentage(rawStocks),
+    actualRawPct: P.calculateIncludedPortfolioPerformance(rawStocks),
+    actualCurrentBasisPct: P.calculateIncludedPortfolioPerformance(
+      currentBasisStocks,
+    ),
+    rowOffsetsPp,
+    splitAffectedRows,
+    includedRows,
+  };
+}
+
+/** The full diagnostic result over the matured historical score set. */
+export interface HorizonSplitParityReport {
+  maturedDates: number;
+  rowCount: number;
+  splitAffectedRows: number;
+  meanOffsetPp: number;
+  medianOffsetPp: number;
+  minOffsetPp: number;
+  maxOffsetPp: number;
+  stdDevPp: number;
+  meanTargetPct: number;
+  meanActualRawPct: number;
+  meanActualCurrentBasisPct: number;
+  observedGapPp: number;
+  gapOnCurrentBasisPp: number;
+  basisContributionPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Assemble the report from per-date aggregates. Pure so it can be unit-tested
+// with synthetic DateAggregate rows.
+export function buildReport(
+  aggregates: DateAggregate[],
+): HorizonSplitParityReport {
+  const allOffsets = aggregates.flatMap((a) => a.rowOffsetsPp);
+  const stats = summariseOffsets(allOffsets);
+  const splitAffectedRows = aggregates.reduce(
+    (t, a) => t + a.splitAffectedRows,
+    0,
+  );
+
+  const withFigures = aggregates.filter((a) =>
+    a.targetPct !== null && a.actualRawPct !== null &&
+    a.actualCurrentBasisPct !== null
+  );
+  const meanTargetPct = mean(withFigures.map((a) => a.targetPct as number));
+  const meanActualRawPct = mean(
+    withFigures.map((a) => a.actualRawPct as number),
+  );
+  const meanActualCurrentBasisPct = mean(
+    withFigures.map((a) => a.actualCurrentBasisPct as number),
+  );
+  const observedGapPp = meanTargetPct - meanActualRawPct;
+  const gapOnCurrentBasisPp = meanTargetPct - meanActualCurrentBasisPct;
+  const basisContributionPp = gapOnCurrentBasisPp - observedGapPp;
+
+  const direction = splitAffectedRows === 0
+    ? "NO matured row carries a reconcilable post-horizon split, so the " +
+      "as-of-basis divergence is DORMANT on the current data — it contributes " +
+      "0 pp in practice"
+    : `${splitAffectedRows} matured row(s) carry a reconcilable post-horizon ` +
+      `split; restating their Actual onto the buy price's current split basis ` +
+      `moves the observed gap by ${basisContributionPp.toFixed(3)} pp`;
+
+  const verdict =
+    `VERDICT: the horizon row and the split-adjusted series are ALIGNED ` +
+    `between training and the dashboard; the only divergence is the as-of ` +
+    `split basis of the Actual horizon price (read RAW) versus the buy price ` +
+    `(restated to current terms). ${direction}. A forward post-horizon split ` +
+    `inflates Actual (MASKING the gap); a reverse split deflates it (WIDENING ` +
+    `the gap). The fix is to read the horizon price through ` +
+    `horizonPriceCurrentBasis so Actual shares the buy price's basis.`;
+
+  return {
+    maturedDates: aggregates.length,
+    rowCount: stats.count,
+    splitAffectedRows,
+    meanOffsetPp: stats.mean,
+    medianOffsetPp: stats.median,
+    minOffsetPp: stats.min,
+    maxOffsetPp: stats.max,
+    stdDevPp: stats.stdDev,
+    meanTargetPct,
+    meanActualRawPct,
+    meanActualCurrentBasisPct,
+    observedGapPp,
+    gapOnCurrentBasisPp,
+    basisContributionPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+// Load the matured score set from disk and compute the full diagnostic.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+export async function computeHorizonSplitParityDiagnostic(
+  docsPath: string,
+  asOf: Date,
+): Promise<HorizonSplitParityReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    const scoreRows = TP.parseScoreTsv(tsvText);
+    const marketData = TP.parseMarketCsv(csvText);
+    const dividendData = TP.parseDividendCsv(divText);
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        scoreRows,
+        marketData,
+        dividendData,
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReport(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/scripts/price_basis_diagnostic.ts
+++ b/scripts/price_basis_diagnostic.ts
@@ -1,0 +1,240 @@
+// Core computation for the issue #552 price-basis diagnostic.
+//
+// Splits the pure aggregation (testable with synthetic rows, no disk) from the
+// file IO. Every per-stock figure is delegated to the SHIPPED kernels published
+// on globalThis by docs/projection.js and docs/trend_predictions.js, so the
+// diagnostic measures the dashboard's own basis rather than a re-implementation.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** Summary statistics for a list of per-row basis offsets (percentage points). */
+export interface OffsetSummary {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  stdDev: number;
+}
+
+/** Pure stats over a list of numbers. Empty input yields all-zero summary. */
+export function summariseOffsets(values: number[]): OffsetSummary {
+  const finite = values.filter((v) =>
+    typeof v === "number" && !Number.isNaN(v)
+  );
+  if (finite.length === 0) {
+    return { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 };
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  const sum = finite.reduce((t, v) => t + v, 0);
+  const mean = sum / finite.length;
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+  const variance = finite.reduce((t, v) => t + (v - mean) ** 2, 0) /
+    finite.length;
+  return {
+    count: finite.length,
+    mean,
+    median,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+/** One matured score date's portfolio figures on both price bases. */
+export interface DateAggregate {
+  date: string;
+  targetPct: number | null;
+  actualMidPct: number | null;
+  actualLowPct: number | null;
+  rowOffsetsPp: number[];
+}
+
+// Build the mid-basis and low-basis per-stock inputs for one score date and
+// compute the portfolio Target %, Actual % (mid) and Actual % (low), plus the
+// per-row (mid - low) / buyPrice offsets over the INCLUDED stocks. Pure: the
+// caller supplies already-parsed score rows and the market-data map.
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  dividendData: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  const midStocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+
+  const rowOffsetsPp: number[] = [];
+  // deno-lint-ignore no-explicit-any
+  const lowStocks = midStocks.map((stock: any, i: number) => {
+    const points = marketData[scoreRows[i].stock];
+    const low = P.lowPriceAtNinetyDayHorizon(points, scoreDate);
+    const offset = P.priceBasisOffsetPercent(
+      stock.buyPrice,
+      stock.currentPrice,
+      low,
+    );
+    const included = P.isStockIncluded(
+      stock.buyPrice,
+      stock.currentPrice,
+      stock.splitReliable,
+    );
+    if (included && offset !== null) {
+      rowOffsetsPp.push(offset);
+    }
+    // Same stock, Actual measured at the trained low basis instead of mid.
+    return { ...stock, currentPrice: low };
+  });
+
+  return {
+    date,
+    targetPct: P.calculatePortfolioTargetPercentage(midStocks),
+    actualMidPct: P.calculateIncludedPortfolioPerformance(midStocks),
+    actualLowPct: P.calculateIncludedPortfolioPerformance(lowStocks),
+    rowOffsetsPp,
+  };
+}
+
+/** The full diagnostic result over the matured historical score set. */
+export interface PriceBasisReport {
+  maturedDates: number;
+  rowCount: number;
+  meanOffsetPp: number;
+  medianOffsetPp: number;
+  minOffsetPp: number;
+  maxOffsetPp: number;
+  stdDevPp: number;
+  meanTargetPct: number;
+  meanActualMidPct: number;
+  meanActualLowPct: number;
+  observedGapPp: number;
+  gapOnLowBasisPp: number;
+  basisContributionPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Assemble the report from per-date aggregates. Pure so it can be unit-tested
+// with synthetic DateAggregate rows.
+export function buildReport(aggregates: DateAggregate[]): PriceBasisReport {
+  const allOffsets = aggregates.flatMap((a) => a.rowOffsetsPp);
+  const stats = summariseOffsets(allOffsets);
+
+  const withFigures = aggregates.filter((a) =>
+    a.targetPct !== null && a.actualMidPct !== null &&
+    a.actualLowPct !== null
+  );
+  const meanTargetPct = mean(withFigures.map((a) => a.targetPct as number));
+  const meanActualMidPct = mean(
+    withFigures.map((a) => a.actualMidPct as number),
+  );
+  const meanActualLowPct = mean(
+    withFigures.map((a) => a.actualLowPct as number),
+  );
+  const observedGapPp = meanTargetPct - meanActualMidPct;
+  const gapOnLowBasisPp = meanTargetPct - meanActualLowPct;
+  const basisContributionPp = gapOnLowBasisPp - observedGapPp;
+
+  const verdict =
+    `VERDICT: the midpoint basis lifts Actual by a mean ${
+      stats.mean.toFixed(3)
+    } pp versus the trained intraday-low basis. The offset is >= 0 on every ` +
+    `row, so it NARROWS (masks) the Target-over-Actual gap; restating Actual ` +
+    `onto the trained low basis would WIDEN the observed gap by ` +
+    `${basisContributionPp.toFixed(3)} pp. This candidate therefore offsets, ` +
+    `rather than causes, the gap — genuine model optimism must exceed the ` +
+    `raw observed gap by this amount.`;
+
+  return {
+    maturedDates: aggregates.length,
+    rowCount: stats.count,
+    meanOffsetPp: stats.mean,
+    medianOffsetPp: stats.median,
+    minOffsetPp: stats.min,
+    maxOffsetPp: stats.max,
+    stdDevPp: stats.stdDev,
+    meanTargetPct,
+    meanActualMidPct,
+    meanActualLowPct,
+    observedGapPp,
+    gapOnLowBasisPp,
+    basisContributionPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+// Load the matured score set from disk and compute the full diagnostic.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+export async function computePriceBasisDiagnostic(
+  docsPath: string,
+  asOf: Date,
+): Promise<PriceBasisReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    const scoreRows = TP.parseScoreTsv(tsvText);
+    const marketData = TP.parseMarketCsv(csvText);
+    const dividendData = TP.parseDividendCsv(divText);
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        scoreRows,
+        marketData,
+        dividendData,
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReport(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/scripts/residual_gap_reconciliation.ts
+++ b/scripts/residual_gap_reconciliation.ts
@@ -1,0 +1,331 @@
+// Core computation for the issue #557 whole-application sweep + residual-gap
+// reconciliation (catch-all sub-issue of milestone #544).
+//
+// Two jobs:
+//   1. Sweep the *aggregation* layer for any same-direction Target/Actual
+//      asymmetry the targeted #552–#556 sub-issues did not cover — specifically
+//      aggregation weighting, the inclusion gate, and null/NaN handling. The one
+//      genuine asymmetry the sweep finds is the TARGET-AVAILABILITY denominator
+//      skew: a priceable stock with a missing/NaN target is counted in the
+//      Actual mean (calculateIncludedPortfolioPerformance) but dropped from the
+//      Target mean (calculatePortfolioTargetPercentage), so the two portfolio
+//      means can be taken over different stock subsets. This module quantifies
+//      that skew by re-aggregating BOTH series over the matched (target-present)
+//      subset and reading off the gap difference.
+//   2. Reconcile the observed Target-over-Actual gap against the quantified
+//      #544-family candidates, leaving the residual that is genuine model
+//      optimism rather than measurement.
+//
+// Every per-stock figure is delegated to the SHIPPED kernels published on
+// globalThis by docs/projection.js and docs/trend_predictions.js, so the sweep
+// measures the dashboard's own aggregation rather than a re-implementation.
+
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+// Sign convention for every reconciliation contribution: a POSITIVE value means
+// the measurement choice INFLATES the apparent (dashboard) Target-over-Actual
+// gap — correcting it would NARROW the gap. A NEGATIVE value means the choice
+// MASKS the gap — correcting it would WIDEN it. The residual genuine optimism is
+// the observed gap minus the net of these contributions.
+export interface GapContribution {
+  /** Short key, e.g. "price_basis". */
+  key: string;
+  /** Owning sub-issue number, e.g. 552. */
+  issue: number;
+  /** Effect on the apparent gap in percentage points (signed per convention). */
+  contributionPp: number;
+  /** One-line account of the candidate and its direction. */
+  note: string;
+}
+
+// The quantified #544-family candidates, as documented by their own diagnostics
+// (each computed on the same matured score set, as-of 2026-06-26). Encoded as
+// constants here so the reconciliation arithmetic is reproducible and testable;
+// the target-availability candidate (#557, this sweep) is computed at runtime
+// and appended by buildReconciliation.
+export const FAMILY_CONTRIBUTIONS: GapContribution[] = [
+  {
+    key: "price_basis",
+    issue: 552,
+    contributionPp: -2.242,
+    note:
+      "Dashboard reads Actual at the midpoint (high+low)/2; training uses the " +
+      "intraday low. mid >= low on every row lifts Actual and MASKS the gap " +
+      "(correcting to the trained low widens it by +2.242 pp).",
+  },
+  {
+    key: "dividend_basis",
+    issue: 553,
+    contributionPp: 1.358,
+    note:
+      "Training bakes a flat yearOfDividends/4 credit into the Target label; " +
+      "the dashboard credits only realised in-window dividends to Actual. The " +
+      "over-credit INFLATES the apparent gap (1%-trimmed mean +1.358 pp; raw " +
+      "mean +2.827 pp).",
+  },
+  {
+    key: "buy_price_denominator",
+    issue: 554,
+    contributionPp: 0.0,
+    note:
+      "Both Target and Actual divide by the SAME buyPrice, so the midpoint-vs-" +
+      "close denominator cannot desynchronise them; it only rescales the gap " +
+      "(mean buyPrice-vs-close offset +0.046 pp). Ruled out as an asymmetry.",
+  },
+  {
+    key: "horizon_split_parity",
+    issue: 555,
+    contributionPp: -0.482,
+    note:
+      "A reconcilable split between the horizon and end-of-series leaves the " +
+      "raw Actual on a different split basis than buyPrice; the forward split " +
+      "inflates Actual and MASKS the gap (correcting widens it by +0.482 pp).",
+  },
+  {
+    key: "score_target_decoding",
+    issue: 556,
+    contributionPp: 0.0,
+    note:
+      "reverseProfitRecommend round-trips cleanly (max |shift| 1.78e-15 pp) " +
+      "and the asymmetric floor never fires on the realised scores. Ruled out.",
+  },
+];
+
+/** Whether a stock has BOTH a usable Actual (included) AND a usable target. */
+// deno-lint-ignore no-explicit-any
+export function hasUsableTarget(stock: any): boolean {
+  if (
+    !P.isStockIncluded(stock.buyPrice, stock.currentPrice, stock.splitReliable)
+  ) {
+    return false;
+  }
+  const t = stock.adjustedTarget;
+  return t !== null && t !== undefined && !Number.isNaN(t);
+}
+
+/** One matured score date's portfolio figures, as-shipped and matched-set. */
+export interface DateAggregate {
+  date: string;
+  /** Equal-weight Target % over included + target-present stocks (as shipped). */
+  targetPct: number | null;
+  /** Equal-weight Actual % over ALL included stocks (as shipped). */
+  actualPct: number | null;
+  /** Equal-weight Actual % over only the target-present subset. */
+  matchedActualPct: number | null;
+  /** Included (priceable) stock-rows behind the Actual mean. */
+  includedRows: number;
+  /** Of those, rows that ALSO carry a usable target (behind the Target mean). */
+  targetRows: number;
+}
+
+// Build one matured score date's aggregate. Pure: the caller supplies the
+// already-parsed score rows and the market/dividend maps. Both series are taken
+// over the dashboard's own kernels so the as-shipped figures equal the live
+// dashboard's; the matched-set Actual re-runs the Actual kernel over only the
+// target-present subset so the target-availability skew can be read off.
+export function aggregateDate(
+  date: string,
+  // deno-lint-ignore no-explicit-any
+  scoreRows: any[],
+  // deno-lint-ignore no-explicit-any
+  marketData: Record<string, any[]>,
+  // deno-lint-ignore no-explicit-any
+  dividendData: Record<string, any[]>,
+  scoreDate: Date,
+): DateAggregate {
+  const stocks = TP.resolvePredictionStocks(
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+
+  // `stocks` is the (untyped) kernel output, so `s` is implicitly any here —
+  // no explicit-any annotation needed.
+  let includedRows = 0;
+  for (const s of stocks) {
+    if (P.isStockIncluded(s.buyPrice, s.currentPrice, s.splitReliable)) {
+      includedRows++;
+    }
+  }
+  const matchedStocks = stocks.filter(hasUsableTarget);
+  const targetRows = matchedStocks.length;
+
+  return {
+    date,
+    // Target kernel already drops null-target rows, so as-shipped Target ==
+    // matched-set Target; the gap difference comes entirely from the Actual mean.
+    targetPct: P.calculatePortfolioTargetPercentage(stocks),
+    actualPct: P.calculateIncludedPortfolioPerformance(stocks),
+    matchedActualPct: P.calculateIncludedPortfolioPerformance(matchedStocks),
+    includedRows,
+    targetRows,
+  };
+}
+
+/** The full reconciliation result over the matured historical score set. */
+export interface ReconciliationReport {
+  maturedDates: number;
+  includedRows: number;
+  targetRows: number;
+  droppedTargetRows: number;
+  meanTargetPct: number;
+  meanActualPct: number;
+  meanMatchedActualPct: number;
+  /** Observed (as-shipped) gap = mean Target - mean Actual. */
+  observedGapPp: number;
+  /** Gap when both series are taken over the matched (target-present) subset. */
+  matchedGapPp: number;
+  /** Target-availability skew = observedGap - matchedGap (this sweep, #557). */
+  targetAvailabilityPp: number;
+  /** Every contribution, including the runtime target-availability one. */
+  contributions: GapContribution[];
+  /** Net of all contributions (signed per the convention above). */
+  netMeasurementPp: number;
+  /** observedGap - netMeasurement: the residual attributed to model optimism. */
+  residualOptimismPp: number;
+  verdict: string;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((t, v) => t + v, 0) / values.length;
+}
+
+// Assemble the reconciliation from per-date aggregates and the family
+// contributions. Pure so it can be unit-tested with synthetic rows. The
+// target-availability contribution is computed from the aggregates and appended
+// to `family` before netting.
+export function buildReconciliation(
+  aggregates: DateAggregate[],
+  family: GapContribution[] = FAMILY_CONTRIBUTIONS,
+): ReconciliationReport {
+  // Dates with a full set of figures contribute to the portfolio means.
+  const withFigures = aggregates.filter((a) =>
+    a.targetPct !== null && a.actualPct !== null &&
+    a.matchedActualPct !== null
+  );
+  const meanTargetPct = mean(withFigures.map((a) => a.targetPct as number));
+  const meanActualPct = mean(withFigures.map((a) => a.actualPct as number));
+  const meanMatchedActualPct = mean(
+    withFigures.map((a) => a.matchedActualPct as number),
+  );
+
+  const observedGapPp = meanTargetPct - meanActualPct;
+  const matchedGapPp = meanTargetPct - meanMatchedActualPct;
+  const targetAvailabilityPp = observedGapPp - matchedGapPp;
+
+  const includedRows = aggregates.reduce((t, a) => t + a.includedRows, 0);
+  const targetRows = aggregates.reduce((t, a) => t + a.targetRows, 0);
+  const droppedTargetRows = includedRows - targetRows;
+
+  const contributions: GapContribution[] = [
+    ...family,
+    {
+      key: "target_availability",
+      issue: 557,
+      contributionPp: targetAvailabilityPp,
+      note:
+        `Priceable stocks with a missing/NaN target (${droppedTargetRows} of ` +
+        `${includedRows} included rows) are counted in Actual but dropped from ` +
+        `Target, so the two means span different subsets. Re-aggregating both ` +
+        `over the matched subset moves the gap by ${
+          targetAvailabilityPp.toFixed(3)
+        } pp.`,
+    },
+  ];
+
+  const netMeasurementPp = contributions.reduce(
+    (t, c) => t + c.contributionPp,
+    0,
+  );
+  const residualOptimismPp = observedGapPp - netMeasurementPp;
+
+  const verdict =
+    `VERDICT (whole-application sweep + reconciliation): aggregation weighting ` +
+    `and the inclusion gate are SHARED and equal-weight for both Target and ` +
+    `Actual; the only aggregation-layer asymmetry is the target-availability ` +
+    `skew (${targetAvailabilityPp.toFixed(3)} pp). Netting every quantified ` +
+    `#544 candidate leaves a residual of ${residualOptimismPp.toFixed(3)} pp ` +
+    `out of the observed ${observedGapPp.toFixed(3)} pp gap. The measurement ` +
+    `candidates roughly cancel (net ${
+      netMeasurementPp.toFixed(3)
+    } pp), so the ` +
+    `bulk of the gap is genuine model optimism, not measurement.`;
+
+  return {
+    maturedDates: aggregates.length,
+    includedRows,
+    targetRows,
+    droppedTargetRows,
+    meanTargetPct,
+    meanActualPct,
+    meanMatchedActualPct,
+    observedGapPp,
+    matchedGapPp,
+    targetAvailabilityPp,
+    contributions,
+    netMeasurementPp,
+    residualOptimismPp,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+// Load the matured score set from disk and compute the full reconciliation.
+// A score date is "matured" once its full 90-day window has elapsed by `asOf`.
+export async function computeResidualGapReconciliation(
+  docsPath: string,
+  asOf: Date,
+): Promise<ReconciliationReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const aggregates: DateAggregate[] = [];
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const csvText = await readOptional(`${base}.csv`);
+    const divText = await readOptional(`${base}-dividends.csv`);
+
+    aggregates.push(
+      aggregateDate(
+        entry.date,
+        TP.parseScoreTsv(tsvText),
+        TP.parseMarketCsv(csvText),
+        TP.parseDividendCsv(divText),
+        scoreDate,
+      ),
+    );
+  }
+
+  return buildReconciliation(aggregates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/scripts/score_target_decoding_diagnostic.ts
+++ b/scripts/score_target_decoding_diagnostic.ts
@@ -1,0 +1,307 @@
+// Core computation for the issue #556 score→target decoding diagnostic
+// (milestone #544 — one candidate source of the systematic Target-over-Actual
+// measurement gap).
+//
+// The question: the AI emits a score in [-1, 1]; the GRQ dashboard derives the
+// Target from it via `reverseProfitRecommend(price, score)`
+// (GRQ/src/LearnUtilTypes.ts:19-39, called at GRQ/src/portfolio/ScoreApp.ts:473).
+// The FORWARD mapping used in training is
+//   profitRecommend(pct) = tanh((pct - 1.5) / 3)            (encode: pct → score)
+// and the REVERSE is
+//   pct = 3 * atanh(score) + 1.5, then target = price * (1 + pct / 100)
+// with three clamps:
+//   - score >=  1 → +MAX_REVERSE_PERCENT (+50%)
+//   - score <= -1 → target 0 (i.e. pct = -100%)
+//   - interior pct capped to ±MAX_REVERSE_PERCENT (±50%)
+//
+// In the interior `tanh`/`atanh` are exact inverses, so the round-trip
+// `profitRecommend ∘ reverseProfitRecommend` is the identity. The *clamps* are
+// asymmetric (a `0`/-100% floor versus a +50% cap), so the concern is whether,
+// over the REALISED score distribution, decoding introduces a consistent
+// same-direction (plausibly upward) Target shift.
+//
+// This module ports the two GRQ functions faithfully (they live upstream in
+// `GRQ`, not in this repo) and measures the round-trip Target shift purely in
+// score↔return-percent space — the per-row pp shift is price-independent, so no
+// market data is needed. It also takes a census of how often the realised
+// scores land in each clamped region.
+//
+// The score parsing is delegated to the SHIPPED dashboard kernel
+// (docs/trend_predictions.js → GRQTrendPredictions.parseScoreTsv), so the
+// diagnostic reads exactly the score column the dashboard reads.
+
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const TP = (globalThis as any).GRQTrendPredictions;
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** The +50% cap / -50% interior cap magnitude from GRQ's LearnUtilTypes. */
+export const MAX_REVERSE_PERCENT = 50;
+
+/**
+ * Forward training encode: a candidate return percentage → score in (-1, 1).
+ * Mirrors GRQ `profitRecommend` (GRQ/src/LearnUtilTypes.ts:12-15).
+ */
+export function profitRecommend(pct: number): number {
+  return Math.tanh((pct - 1.5) / 3);
+}
+
+/** Which clamp region a score lands in when decoded. */
+export type DecodeRegion =
+  | "interior" // clean tanh/atanh inverse, no clamp engaged
+  | "cap_high" // score >= 1 → +MAX_REVERSE_PERCENT
+  | "floor_low" // score <= -1 → target 0 (pct = -100%)
+  | "interior_cap_high" // interior atanh pct exceeded +MAX_REVERSE_PERCENT
+  | "interior_cap_low"; // interior atanh pct fell below -MAX_REVERSE_PERCENT
+
+/** The decoded return percentage plus the region that produced it. */
+export interface DecodeResult {
+  pct: number;
+  region: DecodeRegion;
+}
+
+/**
+ * Reverse decode: score → return percentage, with GRQ's three clamps.
+ * Mirrors the percentage half of GRQ `reverseProfitRecommend`
+ * (GRQ/src/LearnUtilTypes.ts:19-39). The `target = price * (1 + pct/100)` step
+ * is split out into {@link reverseProfitTarget} so the round-trip can be
+ * measured in price-independent return-percent space.
+ */
+export function reverseProfitPct(score: number): DecodeResult {
+  if (score >= 1) {
+    return { pct: MAX_REVERSE_PERCENT, region: "cap_high" };
+  }
+  if (score <= -1) {
+    // Decodes to target 0 → a -100% return, deeper than the -50% interior cap.
+    return { pct: -100, region: "floor_low" };
+  }
+  const raw = 3 * Math.atanh(score) + 1.5;
+  if (raw > MAX_REVERSE_PERCENT) {
+    return { pct: MAX_REVERSE_PERCENT, region: "interior_cap_high" };
+  }
+  if (raw < -MAX_REVERSE_PERCENT) {
+    return { pct: -MAX_REVERSE_PERCENT, region: "interior_cap_low" };
+  }
+  return { pct: raw, region: "interior" };
+}
+
+/**
+ * Reverse decode to a price target, mirroring GRQ `reverseProfitRecommend`
+ * end-to-end. `score <= -1` yields a 0 target; otherwise
+ * `price * (1 + pct / 100)`.
+ */
+export function reverseProfitTarget(price: number, score: number): number {
+  if (score <= -1) return 0;
+  const { pct } = reverseProfitPct(score);
+  return price * (1 + pct / 100);
+}
+
+/**
+ * The round-trip return-percent shift for a single score:
+ * decode → re-encode → re-decode, returning `pct2 - pct1` (the same-units pp
+ * shift in the implied Target return). Zero to floating-point precision wherever
+ * the decode is a clean inverse of `profitRecommend`.
+ */
+export function roundTripShiftPp(score: number): number {
+  const pct1 = reverseProfitPct(score).pct;
+  const reEncoded = profitRecommend(pct1);
+  const pct2 = reverseProfitPct(reEncoded).pct;
+  return pct2 - pct1;
+}
+
+/** Summary statistics for a list of values. Empty input → all-zero. */
+export interface Summary {
+  count: number;
+  mean: number;
+  median: number;
+  min: number;
+  max: number;
+  stdDev: number;
+}
+
+/** Pure stats over a list of numbers. Empty input yields an all-zero summary. */
+export function summarise(values: number[]): Summary {
+  const finite = values.filter((v) =>
+    typeof v === "number" && !Number.isNaN(v)
+  );
+  if (finite.length === 0) {
+    return { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 };
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  const sum = finite.reduce((t, v) => t + v, 0);
+  const mean = sum / finite.length;
+  const mid = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+  const variance = finite.reduce((t, v) => t + (v - mean) ** 2, 0) /
+    finite.length;
+  return {
+    count: finite.length,
+    mean,
+    median,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    stdDev: Math.sqrt(variance),
+  };
+}
+
+/** A per-region row count plus its share of the total. */
+export interface RegionCensus {
+  region: DecodeRegion;
+  count: number;
+  fraction: number;
+}
+
+/** The full diagnostic result over the score set. */
+export interface DecodingReport {
+  scoreDates: number;
+  scoreRows: number;
+  // Round-trip shift over the realised scores (pp of return).
+  shift: Summary;
+  // Clamp-region census over the realised scores.
+  census: RegionCensus[];
+  // Convenience headline numbers.
+  fractionCapHigh: number;
+  fractionFloorLow: number;
+  // The mean DECODED return percentage (the average Target return the decode
+  // assigns), and what the SATURATED (score == 1) rows alone decode to.
+  meanDecodedPct: number;
+  saturatedRows: number;
+  verdict: string;
+}
+
+const REGION_ORDER: DecodeRegion[] = [
+  "interior",
+  "cap_high",
+  "floor_low",
+  "interior_cap_high",
+  "interior_cap_low",
+];
+
+function censusOf(regions: DecodeRegion[]): RegionCensus[] {
+  const total = regions.length;
+  return REGION_ORDER.map((region) => {
+    const count = regions.filter((r) => r === region).length;
+    return { region, count, fraction: total === 0 ? 0 : count / total };
+  });
+}
+
+/**
+ * Assemble the report from a flat list of realised scores spread over a number
+ * of score dates. Pure, so it can be unit-tested with synthetic scores.
+ */
+export function buildReport(
+  scores: number[],
+  scoreDates: number,
+): DecodingReport {
+  const decoded = scores.map((s) => reverseProfitPct(s));
+  const regions = decoded.map((d) => d.region);
+  const shift = summarise(scores.map(roundTripShiftPp));
+  const census = censusOf(regions);
+
+  const capHigh = census.find((c) => c.region === "cap_high");
+  const floorLow = census.find((c) => c.region === "floor_low");
+  const fractionCapHigh = capHigh ? capHigh.fraction : 0;
+  const fractionFloorLow = floorLow ? floorLow.fraction : 0;
+  const saturatedRows = capHigh ? capHigh.count : 0;
+
+  const decodedPcts = decoded.map((d) => d.pct);
+  const meanDecodedPct = decodedPcts.length === 0
+    ? 0
+    : decodedPcts.reduce((t, v) => t + v, 0) / decodedPcts.length;
+
+  const shiftSign = shift.mean >= 0 ? "+" : "-";
+  const negligible = Math.abs(shift.mean) < 1e-6 && shift.stdDev < 1e-6;
+  const verdict = negligible
+    ? `VERDICT (decode round-trip RULED OUT): over ${scores.length} realised ` +
+      `scores the round-trip profitRecommend∘reverseProfitRecommend shift is ` +
+      `${shiftSign}${Math.abs(shift.mean).toFixed(6)} pp (max |shift| ` +
+      `${
+        Math.max(Math.abs(shift.min), Math.abs(shift.max)).toFixed(6)
+      } pp) — ` +
+      `tanh/atanh are exact inverses, so decoding adds NO systematic Target ` +
+      `shift. The asymmetric clamps cannot bias the realised data either: the ` +
+      `+50% cap fires for ${(fractionCapHigh * 100).toFixed(1)}% of rows but ` +
+      `round-trips cleanly, and the 0/-100% floor fires for ` +
+      `${(fractionFloorLow * 100).toFixed(1)}% (no negative scores exist). ` +
+      `The one residual, NON-decode candidate is encode-side quantisation: a ` +
+      `saturated score (==1) is a fixed +50% point estimate of an unknown true ` +
+      `intent ≥ the saturation threshold — flag for GRQ, not fixable in the ` +
+      `dashboard decode.`
+    : `VERDICT: round-trip shift mean ${shiftSign}${
+      Math.abs(shift.mean).toFixed(6)
+    } pp is non-negligible — investigate the clamp interaction further.`;
+
+  return {
+    scoreDates,
+    scoreRows: scores.length,
+    shift,
+    census,
+    fractionCapHigh,
+    fractionFloorLow,
+    meanDecodedPct,
+    saturatedRows,
+    verdict,
+  };
+}
+
+interface ScoreIndexEntry {
+  file: string;
+  date: string;
+}
+
+/**
+ * Load every score file's realised scores from disk and compute the diagnostic.
+ * `maturedOnly` (default true) restricts to score dates whose full 90-day
+ * window has elapsed by `asOf` — matching how the trend/gap is measured — but
+ * the decode round-trip is a property of the score alone, so the conclusion is
+ * stable either way.
+ */
+export async function computeDecodingDiagnostic(
+  docsPath: string,
+  asOf: Date,
+  maturedOnly = true,
+): Promise<DecodingReport> {
+  const indexText = await Deno.readTextFile(`${docsPath}/scores/index.json`);
+  const index = JSON.parse(indexText) as { scores: ScoreIndexEntry[] };
+
+  const scores: number[] = [];
+  let scoreDates = 0;
+  for (const entry of index.scores) {
+    const scoreDate = TP.parseScoreDateString(entry.date);
+    if (
+      maturedOnly && asOf.getTime() < scoreDate.getTime() + NINETY_DAYS_MS
+    ) {
+      continue; // window not yet complete — not matured
+    }
+    const base = `${docsPath}/scores/${entry.file.replace(/\.tsv$/, "")}`;
+    const tsvText = await readOptional(`${base}.tsv`);
+    if (!tsvText.trim()) {
+      continue; // index references a date with no generated score file
+    }
+    const rows = TP.parseScoreTsv(tsvText);
+    let any = false;
+    // deno-lint-ignore no-explicit-any
+    for (const row of rows as any[]) {
+      if (typeof row.score === "number" && !Number.isNaN(row.score)) {
+        scores.push(row.score);
+        any = true;
+      }
+    }
+    if (any) scoreDates++;
+  }
+
+  return buildReport(scores, scoreDates);
+}
+
+async function readOptional(path: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return "";
+    throw err;
+  }
+}

--- a/tests/buy_price_denominator_diagnostic_test.ts
+++ b/tests/buy_price_denominator_diagnostic_test.ts
@@ -1,0 +1,234 @@
+// Tests for the issue #554 buy-price denominator (midpoint vs close) diagnostic.
+//
+// These exercise the REAL shipped kernels (docs/projection.js) and the real
+// aggregation in scripts/buy_price_denominator_diagnostic.ts with synthetic
+// market data, asserting on computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReport,
+  type DateAggregate,
+  summariseOffsets,
+} from "../scripts/buy_price_denominator_diagnostic.ts";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+Deno.test("buyPriceCloseBasis returns the split-adjusted close of the first usable point", () => {
+  const scoreDate = midnight("2026-01-01");
+  const market = [
+    {
+      date: midnight("2026-01-02"),
+      high: 12,
+      low: 8,
+      open: 9,
+      close: 11,
+      splitCoefficient: 1,
+    },
+  ];
+  const obj = P.buyPriceCloseBasis(market, scoreDate);
+  // No split -> adjusted close == raw close 11.
+  assertEquals(obj.price, 11);
+  assertEquals(obj.reliable, true);
+});
+
+Deno.test("buyPriceCloseBasis picks the SAME first point as getBuyPrice (close vs midpoint)", () => {
+  const scoreDate = midnight("2026-01-01");
+  const market = [
+    {
+      date: midnight("2026-01-03"), // 2 days forward — both must use this row
+      high: 20,
+      low: 10,
+      open: 12,
+      close: 18,
+      splitCoefficient: 1,
+    },
+  ];
+  const close = P.buyPriceCloseBasis(market, scoreDate);
+  const buy = P.getBuyPrice(market, scoreDate);
+  assertEquals(close.price, 18); // close
+  assertEquals(buy.price, (20 + 10) / 2); // midpoint = 15
+  assertEquals(close.dateUsed.getTime(), buy.dateUsed.getTime());
+});
+
+Deno.test("buyPriceCloseBasis returns null with no usable data", () => {
+  assertEquals(P.buyPriceCloseBasis([], midnight("2026-01-01")), null);
+  assertEquals(P.buyPriceCloseBasis(null, midnight("2026-01-01")), null);
+});
+
+Deno.test("denominatorBasisOffsetPercent computes (buyPrice - close) / buyPrice * 100", () => {
+  // buyPrice 100, close 95 -> +5 pp (midpoint above close)
+  assertAlmostEquals(P.denominatorBasisOffsetPercent(100, 95), 5);
+  // close above midpoint -> negative offset
+  assertAlmostEquals(P.denominatorBasisOffsetPercent(100, 105), -5);
+  // equal -> zero
+  assertEquals(P.denominatorBasisOffsetPercent(100, 100), 0);
+});
+
+Deno.test("denominatorBasisOffsetPercent guards bad inputs", () => {
+  assertEquals(P.denominatorBasisOffsetPercent(0, 9), null);
+  assertEquals(P.denominatorBasisOffsetPercent(-5, 9), null);
+  assertEquals(P.denominatorBasisOffsetPercent(100, 0), null);
+  assertEquals(P.denominatorBasisOffsetPercent(100, NaN), null);
+  assertEquals(P.denominatorBasisOffsetPercent(null, 9), null);
+});
+
+Deno.test("summariseOffsets computes mean/median/min/max/stdDev", () => {
+  const s = summariseOffsets([1, 2, 3, 4]);
+  assertEquals(s.count, 4);
+  assertAlmostEquals(s.mean, 2.5);
+  assertAlmostEquals(s.median, 2.5);
+  assertEquals(s.min, 1);
+  assertEquals(s.max, 4);
+  assertAlmostEquals(s.stdDev, Math.sqrt(1.25));
+});
+
+Deno.test("summariseOffsets handles empty input", () => {
+  const s = summariseOffsets([]);
+  assertEquals(s, { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 });
+});
+
+Deno.test("aggregateDate measures the per-row midpoint-vs-close denominator offset", () => {
+  const scoreDate = midnight("2026-01-01");
+  const scoreRows = [{
+    stock: "X",
+    target: 130,
+    score: 0.5,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    X: [
+      {
+        date: midnight("2026-01-02"),
+        high: 110, // midpoint = 100
+        low: 90,
+        open: 95,
+        close: 95, // trained close basis
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 120,
+        low: 100, // midpoint = 110 -> Actual numerator
+        open: 110,
+        close: 115,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, scoreDate);
+  // buyPrice = mid of first day = 100; close = 95.
+  // offset = (100 - 95) / 100 * 100 = 5 pp.
+  assertEquals(agg.rowOffsetsPp.length, 1);
+  assertAlmostEquals(agg.rowOffsetsPp[0], 5, 1e-9);
+  // Actual numerator = horizon mid 110. On mid basis: (110-100)/100 = +10%.
+  // On close basis: (110-95)/95 = +15.789%.
+  assert(agg.actualMidPct !== null && agg.actualClosePct !== null);
+  assertAlmostEquals(agg.actualMidPct as number, 10, 1e-9);
+  assertAlmostEquals(
+    agg.actualClosePct as number,
+    ((110 - 95) / 95) * 100,
+    1e-9,
+  );
+  // Target adjustedTarget = 130. mid: (130-100)/100 = 30%; close: (130-95)/95.
+  assertAlmostEquals(agg.targetMidPct as number, 30, 1e-9);
+  assertAlmostEquals(
+    agg.targetClosePct as number,
+    ((130 - 95) / 95) * 100,
+    1e-9,
+  );
+});
+
+Deno.test("aggregateDate: a smaller denominator inflates BOTH Target and Actual together", () => {
+  // When close < buyPrice, dividing by the smaller close lifts both the Target
+  // and the Actual percentages — confirming the denominator does NOT
+  // desynchronise the two (it rescales both).
+  const scoreDate = midnight("2026-01-01");
+  const scoreRows = [{
+    stock: "Y",
+    target: 150,
+    score: 0.5,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    Y: [
+      {
+        date: midnight("2026-01-02"),
+        high: 110,
+        low: 90, // mid = 100
+        open: 95,
+        close: 80, // close well below midpoint
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 130,
+        low: 110, // mid = 120
+        open: 120,
+        close: 125,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, scoreDate);
+  assert((agg.targetClosePct as number) > (agg.targetMidPct as number));
+  assert((agg.actualClosePct as number) > (agg.actualMidPct as number));
+});
+
+Deno.test("buildReport: rescales the gap and verdict states no desync", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetMidPct: 25,
+      actualMidPct: 10,
+      targetClosePct: 27,
+      actualClosePct: 11,
+      rowOffsetsPp: [3, 5],
+    },
+    {
+      date: "2026-02-01",
+      targetMidPct: 15,
+      actualMidPct: 8,
+      targetClosePct: 16,
+      actualClosePct: 8.5,
+      rowOffsetsPp: [1, 3],
+    },
+  ];
+  const r = buildReport(aggregates);
+  assertEquals(r.maturedDates, 2);
+  assertEquals(r.rowCount, 4);
+  assertAlmostEquals(r.meanOffsetPp, 3); // (3+5+1+3)/4
+  // mean Target(mid) 20, Actual(mid) 9 -> observed gap 11.
+  assertAlmostEquals(r.observedGapPp, 11);
+  // mean Target(close) 21.5, Actual(close) 9.75 -> gap 11.75.
+  assertAlmostEquals(r.gapOnCloseBasisPp, 11.75);
+  assertAlmostEquals(r.basisContributionPp, 0.75); // 11.75 - 11
+  assert(
+    r.verdict.includes("does NOT desynchronise"),
+    "verdict states Target/Actual share the denominator",
+  );
+});
+
+Deno.test("buildReport: negative mean offset reported with sign", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetMidPct: 20,
+      actualMidPct: 10,
+      targetClosePct: 18,
+      actualClosePct: 9,
+      rowOffsetsPp: [-2, -4],
+    },
+  ];
+  const r = buildReport(aggregates);
+  assert(r.meanOffsetPp < 0);
+  assert(r.verdict.includes("-"), "negative mean sign rendered");
+});

--- a/tests/dividend_basis_diagnostic_test.ts
+++ b/tests/dividend_basis_diagnostic_test.ts
@@ -1,0 +1,279 @@
+// Tests for the issue #553 dividend-basis (flat 1/4 vs windowed) diagnostic.
+//
+// These exercise the REAL shipped kernels (docs/projection.js) and the real
+// aggregation in scripts/dividend_basis_diagnostic.ts with synthetic data,
+// asserting on computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReport,
+  type DateAggregate,
+  stripSymbol,
+  summariseDiffs,
+  trimmedMean,
+} from "../scripts/dividend_basis_diagnostic.ts";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+Deno.test("trailingAnnualDividends sums the year ending at the score date", () => {
+  const scoreDate = midnight("2026-01-01");
+  const divs = [
+    { exDivDate: midnight("2025-02-15"), amount: 0.25 }, // in trailing year
+    { exDivDate: midnight("2025-05-15"), amount: 0.25 }, // in trailing year
+    { exDivDate: midnight("2025-08-15"), amount: 0.25 }, // in trailing year
+    { exDivDate: midnight("2025-11-15"), amount: 0.25 }, // in trailing year
+    { exDivDate: midnight("2026-02-15"), amount: 0.30 }, // after score date
+    { exDivDate: midnight("2024-06-15"), amount: 0.20 }, // before the year
+  ];
+  assertAlmostEquals(P.trailingAnnualDividends(divs, scoreDate), 1.0, 1e-9);
+});
+
+Deno.test("trailingAnnualDividends boundaries: includes score date, excludes -365", () => {
+  const scoreDate = midnight("2026-01-01");
+  // exactly 365 days before score date -> excluded (strictly greater than).
+  const onYearStart = { exDivDate: midnight("2025-01-01"), amount: 1 };
+  // on the score date -> included.
+  const onScoreDate = { exDivDate: midnight("2026-01-01"), amount: 2 };
+  assertAlmostEquals(
+    P.trailingAnnualDividends([onYearStart, onScoreDate], scoreDate),
+    2,
+    1e-9,
+  );
+});
+
+Deno.test("trailingAnnualDividends returns 0 for empty/invalid input", () => {
+  assertEquals(P.trailingAnnualDividends([], midnight("2026-01-01")), 0);
+  assertEquals(P.trailingAnnualDividends(null, midnight("2026-01-01")), 0);
+  assertEquals(P.trailingAnnualDividends([{ amount: 1 }], "nope"), 0);
+});
+
+Deno.test("dividendBasisDifferencePercent computes (flat - windowed)/buy*100", () => {
+  // buy 100, flat 0.50, windowed 0.25 -> (0.25)/100*100 = 0.25 pp.
+  assertAlmostEquals(P.dividendBasisDifferencePercent(0.5, 0.25, 100), 0.25);
+  // flat == windowed -> zero difference.
+  assertEquals(P.dividendBasisDifferencePercent(0.4, 0.4, 100), 0);
+  // windowed exceeds flat -> negative (the offsetting direction).
+  assertAlmostEquals(P.dividendBasisDifferencePercent(0.2, 0.6, 100), -0.4);
+});
+
+Deno.test("dividendBasisDifferencePercent guards bad inputs", () => {
+  assertEquals(P.dividendBasisDifferencePercent(0.5, 0.25, 0), null);
+  assertEquals(P.dividendBasisDifferencePercent(0.5, 0.25, -5), null);
+  assertEquals(P.dividendBasisDifferencePercent(null, 0.25, 100), null);
+  assertEquals(P.dividendBasisDifferencePercent(0.5, NaN, 100), null);
+});
+
+Deno.test("stripSymbol drops the exchange prefix and normalises dots", () => {
+  assertEquals(stripSymbol("NYSE:SEM"), "SEM");
+  assertEquals(stripSymbol("NASDAQ:IBKR"), "IBKR");
+  assertEquals(stripSymbol("HEI.A"), "HEI-A");
+  assertEquals(stripSymbol("PLAIN"), "PLAIN");
+});
+
+Deno.test("summariseDiffs computes mean/median/min/max/stdDev", () => {
+  const s = summariseDiffs([1, 2, 3, 4]);
+  assertEquals(s.count, 4);
+  assertAlmostEquals(s.mean, 2.5);
+  assertAlmostEquals(s.median, 2.5);
+  assertEquals(s.min, 1);
+  assertEquals(s.max, 4);
+  assertAlmostEquals(s.stdDev, Math.sqrt(1.25));
+});
+
+Deno.test("summariseDiffs handles empty input", () => {
+  const s = summariseDiffs([]);
+  assertEquals(s, { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 });
+});
+
+Deno.test("trimmedMean drops the extreme tails so a single outlier cannot dominate", () => {
+  // Without trimming the +100 outlier dominates; trimming 10% each side at this
+  // size drops exactly the min and max, leaving a robust central mean of 0.
+  const values = [-100, 0, 0, 0, 0, 0, 0, 0, 0, 100];
+  assertAlmostEquals(trimmedMean(values, 0.0), 0); // 10 values, mean 0 anyway
+  assertAlmostEquals(trimmedMean(values, 0.1), 0); // drops -100 and +100
+  // A right-skewed set: raw mean is pulled up, trimmed mean is lower.
+  const skew = [0, 0, 0, 0, 0, 0, 0, 0, 0, 50];
+  assert(trimmedMean(skew, 0.0) > trimmedMean(skew, 0.1));
+});
+
+Deno.test("trimmedMean handles empty input", () => {
+  assertEquals(trimmedMean([], 0.01), 0);
+});
+
+Deno.test("aggregateDate measures flat-vs-windowed difference for a semi-annual payer", () => {
+  const scoreDate = midnight("2026-01-01");
+  // One stock, buy ~100. Pays semi-annually: trailing year has two 0.50
+  // dividends (annual 1.00 -> flat quarter 0.25). The forward 90-day window
+  // catches NONE of its dividends (next pays in 2026-06), so windowed = 0.
+  const scoreRows = [{
+    stock: "NYSE:X",
+    target: 130,
+    score: 1,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    "NYSE:X": [
+      {
+        date: midnight("2026-01-02"),
+        high: 101,
+        low: 99,
+        open: 100,
+        close: 100,
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 120,
+        low: 100,
+        open: 110,
+        close: 115,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  // Committed in-window dividend CSV: empty for X over this window.
+  const windowedDividends = {};
+  // Full trailing history keyed by STRIPPED symbol.
+  const fullHistory = {
+    X: [
+      { exDivDate: midnight("2025-06-15"), amount: 0.5 },
+      { exDivDate: midnight("2025-12-15"), amount: 0.5 },
+    ],
+  };
+  const agg = aggregateDate(
+    "2026-01-01",
+    scoreRows,
+    marketData,
+    windowedDividends,
+    fullHistory,
+    scoreDate,
+  );
+  // buyPrice = mid of 2026-01-02 = 100. flat = 1.00/4 = 0.25, windowed = 0.
+  // diff = (0.25 - 0)/100 * 100 = 0.25 pp.
+  assertEquals(agg.includedCount, 1);
+  assertEquals(agg.rowDiffsPp.length, 1);
+  assertAlmostEquals(agg.rowDiffsPp[0], 0.25, 1e-9);
+  assertEquals(agg.windowedZeroCount, 1);
+  assertAlmostEquals(agg.flatYieldsPct[0], 0.25, 1e-9);
+  assertAlmostEquals(agg.windowedYieldsPct[0], 0, 1e-9);
+});
+
+Deno.test("aggregateDate: a quarterly payer with one in-window dividend nets near zero", () => {
+  const scoreDate = midnight("2026-01-01");
+  const scoreRows = [{
+    stock: "NYSE:Q",
+    target: 130,
+    score: 1,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    "NYSE:Q": [
+      {
+        date: midnight("2026-01-02"),
+        high: 101,
+        low: 99,
+        open: 100,
+        close: 100,
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 110,
+        low: 100,
+        open: 105,
+        close: 108,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  // One realised in-window dividend of 0.25 (ex-div 2026-02-15 <= horizon).
+  const windowedDividends = {
+    "NYSE:Q": [{ exDivDate: midnight("2026-02-15"), amount: 0.25 }],
+  };
+  // Trailing year: four 0.25 quarterly dividends -> flat quarter 0.25.
+  const fullHistory = {
+    Q: [
+      { exDivDate: midnight("2025-02-15"), amount: 0.25 },
+      { exDivDate: midnight("2025-05-15"), amount: 0.25 },
+      { exDivDate: midnight("2025-08-15"), amount: 0.25 },
+      { exDivDate: midnight("2025-11-15"), amount: 0.25 },
+    ],
+  };
+  const agg = aggregateDate(
+    "2026-01-01",
+    scoreRows,
+    marketData,
+    windowedDividends,
+    fullHistory,
+    scoreDate,
+  );
+  // flat 0.25, windowed 0.25 -> diff 0.
+  assertEquals(agg.rowDiffsPp.length, 1);
+  assertAlmostEquals(agg.rowDiffsPp[0], 0, 1e-9);
+  assertEquals(agg.windowedZeroCount, 0);
+});
+
+Deno.test("buildReport: positive mean difference contributes to (widens) the gap", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      rowDiffsPp: [0.25, 0.10],
+      flatYieldsPct: [0.25, 0.10],
+      windowedYieldsPct: [0, 0],
+      windowedZeroCount: 2,
+      includedCount: 2,
+    },
+    {
+      date: "2026-02-01",
+      rowDiffsPp: [0.05, -0.05],
+      flatYieldsPct: [0.30, 0.20],
+      windowedYieldsPct: [0.25, 0.25],
+      windowedZeroCount: 0,
+      includedCount: 2,
+    },
+  ];
+  const r = buildReport(aggregates);
+  assertEquals(r.maturedDates, 2);
+  assertEquals(r.rowCount, 4);
+  assertAlmostEquals(r.meanDiffPp, (0.25 + 0.10 + 0.05 - 0.05) / 4); // 0.0875
+  // Equal-weight per-row mean is the portfolio-level contribution.
+  assertAlmostEquals(r.contributionPp, r.meanDiffPp);
+  assert(r.contributionPp > 0, "flat > windowed should WIDEN the gap");
+  // 2 of 4 rows realised zero in-window dividends.
+  assertAlmostEquals(r.windowedZeroSharePct, 50);
+  // All four rows are within +/-1 pp here.
+  assertAlmostEquals(r.within1ppSharePct, 100);
+  assert(Number.isFinite(r.trimmedMeanDiffPp), "trimmed mean is reported");
+  assert(
+    r.verdict.includes("CONTRIBUTES") && r.verdict.includes("flat training"),
+    "verdict states the contributing direction",
+  );
+});
+
+Deno.test("buildReport: realised dividends exceeding the flat quarter OFFSET the gap", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      rowDiffsPp: [-0.40, -0.20],
+      flatYieldsPct: [0.20, 0.10],
+      windowedYieldsPct: [0.60, 0.30],
+      windowedZeroCount: 0,
+      includedCount: 2,
+    },
+  ];
+  const r = buildReport(aggregates);
+  assert(r.contributionPp < 0);
+  assert(
+    r.verdict.includes("OFFSETS"),
+    "verdict states the offsetting direction",
+  );
+});

--- a/tests/horizon_split_parity_diagnostic_test.ts
+++ b/tests/horizon_split_parity_diagnostic_test.ts
@@ -1,0 +1,223 @@
+// Tests for the issue #555 market-data timing & corporate-action parity
+// diagnostic.
+//
+// These exercise the REAL shipped kernels (docs/projection.js,
+// docs/trend_predictions.js) and the real aggregation in
+// scripts/horizon_split_parity_diagnostic.ts with synthetic market data,
+// asserting on computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReport,
+  type DateAggregate,
+  summariseOffsets,
+} from "../scripts/horizon_split_parity_diagnostic.ts";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+// A flat OHLC point with an optional split coefficient (mid = price).
+function pt(date: string, price: number, splitCoefficient = 1.0) {
+  return {
+    date: midnight(date),
+    high: price,
+    low: price,
+    open: price,
+    close: price,
+    splitCoefficient,
+  };
+}
+
+// Score 2026-01-01 -> horizon 2026-04-01. A clean 2:1 forward split on 05-15
+// (after the horizon): mid halves 120 -> 60, so the price-ratio cross-check
+// reconciles (120 / 60 == 2).
+function marketWithPostHorizonSplit() {
+  return [
+    pt("2026-01-02", 100), // buy point
+    pt("2026-03-30", 120), // horizon point (last <= 2026-04-01)
+    pt("2026-05-15", 60, 2.0), // post-horizon 2:1 forward split
+  ];
+}
+
+const SCORE = midnight("2026-01-01");
+
+Deno.test("horizonPointDate returns the DATE of the last point on/before the horizon", () => {
+  const date = P.horizonPointDate(marketWithPostHorizonSplit(), SCORE);
+  assertEquals(date.getTime(), midnight("2026-03-30").getTime());
+});
+
+Deno.test("horizonPointDate returns null when no point falls on/before the horizon", () => {
+  assertEquals(P.horizonPointDate([], SCORE), null);
+  assertEquals(P.horizonPointDate(null, SCORE), null);
+  // Only points AFTER the horizon -> null.
+  assertEquals(P.horizonPointDate([pt("2026-09-01", 10)], SCORE), null);
+});
+
+Deno.test("postHorizonSplitFactor is 1.0 when there is no post-horizon split", () => {
+  const market = [pt("2026-01-02", 100), pt("2026-03-30", 120)];
+  assertEquals(P.postHorizonSplitFactor(market, SCORE), 1.0);
+});
+
+Deno.test("postHorizonSplitFactor captures a reconcilable forward split after the horizon", () => {
+  assertAlmostEquals(
+    P.postHorizonSplitFactor(marketWithPostHorizonSplit(), SCORE),
+    2.0,
+  );
+});
+
+Deno.test("postHorizonSplitFactor ignores a split ON/BEFORE the horizon (already in the raw price)", () => {
+  // Split lands on the horizon row itself -> not strictly after it.
+  const market = [pt("2026-01-02", 100), pt("2026-03-30", 60, 2.0)];
+  assertEquals(P.postHorizonSplitFactor(market, SCORE), 1.0);
+});
+
+Deno.test("postHorizonSplitFactor handles a reverse split (factor < 1)", () => {
+  // 1:2 reverse split on 05-15: mid doubles 120 -> 240, ratio 120/240 = 0.5.
+  const market = [
+    pt("2026-01-02", 100),
+    pt("2026-03-30", 120),
+    pt("2026-05-15", 240, 0.5),
+  ];
+  assertAlmostEquals(P.postHorizonSplitFactor(market, SCORE), 0.5);
+});
+
+Deno.test("horizonPriceCurrentBasis = raw horizon mid / post-horizon split factor", () => {
+  // raw mid 120, factor 2.0 -> 60 (the buy-price's current basis).
+  assertAlmostEquals(
+    P.horizonPriceCurrentBasis(marketWithPostHorizonSplit(), SCORE),
+    60,
+  );
+});
+
+Deno.test("horizonPriceCurrentBasis equals the raw horizon mid when no split follows", () => {
+  const market = [pt("2026-01-02", 100), pt("2026-03-30", 120)];
+  assertEquals(
+    P.horizonPriceCurrentBasis(market, SCORE),
+    P.priceAtNinetyDayHorizon(market, SCORE),
+  );
+});
+
+Deno.test("horizonPriceCurrentBasis returns null with no usable horizon point", () => {
+  assertEquals(P.horizonPriceCurrentBasis([], SCORE), null);
+});
+
+Deno.test("horizonAsOfBasisOffsetPercent computes (raw - currentBasis) / buyPrice * 100", () => {
+  // buyPrice 50, raw 120, currentBasis 60 -> (120-60)/50*100 = 120 pp.
+  assertAlmostEquals(P.horizonAsOfBasisOffsetPercent(50, 120, 60), 120);
+  // No post-horizon split: raw == currentBasis -> zero offset.
+  assertEquals(P.horizonAsOfBasisOffsetPercent(50, 120, 120), 0);
+});
+
+Deno.test("horizonAsOfBasisOffsetPercent is positive for forward, negative for reverse splits", () => {
+  // Forward: currentBasis < raw -> positive (Actual inflated, masks the gap).
+  assert(P.horizonAsOfBasisOffsetPercent(50, 120, 60) > 0);
+  // Reverse: currentBasis > raw -> negative (Actual deflated, widens the gap).
+  assert(P.horizonAsOfBasisOffsetPercent(100, 120, 240) < 0);
+});
+
+Deno.test("horizonAsOfBasisOffsetPercent guards bad inputs", () => {
+  assertEquals(P.horizonAsOfBasisOffsetPercent(0, 120, 60), null);
+  assertEquals(P.horizonAsOfBasisOffsetPercent(-5, 120, 60), null);
+  assertEquals(P.horizonAsOfBasisOffsetPercent(50, null, 60), null);
+  assertEquals(P.horizonAsOfBasisOffsetPercent(50, 120, NaN), null);
+});
+
+Deno.test("aggregateDate: a post-horizon split desynchronises Actual but not Target", () => {
+  const scoreRows = [{ stock: "AAA", target: 130 }];
+  const marketData = { AAA: marketWithPostHorizonSplit() };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, SCORE);
+
+  // One included row carrying a reconcilable post-horizon split.
+  assertEquals(agg.includedRows, 1);
+  assertEquals(agg.splitAffectedRows, 1);
+  assertEquals(agg.rowOffsetsPp.length, 1);
+  // buyPrice = 100/2 = 50; raw horizon 120; currentBasis 60 -> 120 pp.
+  assertAlmostEquals(agg.rowOffsetsPp[0], 120);
+
+  // The shipped (raw) Actual sits far above the split-consistent Actual.
+  assert(
+    (agg.actualRawPct as number) > (agg.actualCurrentBasisPct as number),
+  );
+  // Target % is invariant to the post-horizon split (same factor cancels).
+  assert(agg.targetPct !== null);
+});
+
+Deno.test("aggregateDate: no post-horizon split -> the two Actual bases coincide", () => {
+  const scoreRows = [{ stock: "AAA", target: 130 }];
+  const marketData = {
+    AAA: [pt("2026-01-02", 100), pt("2026-03-30", 120)],
+  };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, SCORE);
+  assertEquals(agg.splitAffectedRows, 0);
+  assertAlmostEquals(agg.rowOffsetsPp[0], 0);
+  assertAlmostEquals(
+    agg.actualRawPct as number,
+    agg.actualCurrentBasisPct as number,
+  );
+});
+
+Deno.test("buildReport: forward-split contribution WIDENS the gap on the consistent basis", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetPct: 30,
+      actualRawPct: 25, // inflated by the post-horizon forward split
+      actualCurrentBasisPct: 10, // split-consistent
+      rowOffsetsPp: [15],
+      splitAffectedRows: 1,
+      includedRows: 1,
+    },
+  ];
+  const report = buildReport(aggregates);
+  assertEquals(report.splitAffectedRows, 1);
+  assertAlmostEquals(report.observedGapPp, 5); // 30 - 25
+  assertAlmostEquals(report.gapOnCurrentBasisPp, 20); // 30 - 10
+  assertAlmostEquals(report.basisContributionPp, 15); // masking term
+  assert(report.verdict.includes("ALIGNED"));
+});
+
+Deno.test("buildReport: zero affected rows -> DORMANT verdict and 0 pp contribution", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetPct: 30,
+      actualRawPct: 12,
+      actualCurrentBasisPct: 12,
+      rowOffsetsPp: [0, 0],
+      splitAffectedRows: 0,
+      includedRows: 2,
+    },
+  ];
+  const report = buildReport(aggregates);
+  assertEquals(report.splitAffectedRows, 0);
+  assertAlmostEquals(report.basisContributionPp, 0);
+  assert(report.verdict.includes("DORMANT"));
+});
+
+Deno.test("summariseOffsets over a known list", () => {
+  const s = summariseOffsets([0, 10, 20]);
+  assertEquals(s.count, 3);
+  assertAlmostEquals(s.mean, 10);
+  assertAlmostEquals(s.median, 10);
+  assertEquals(s.min, 0);
+  assertEquals(s.max, 20);
+});
+
+Deno.test("summariseOffsets on empty input is all-zero", () => {
+  assertEquals(summariseOffsets([]), {
+    count: 0,
+    mean: 0,
+    median: 0,
+    min: 0,
+    max: 0,
+    stdDev: 0,
+  });
+});

--- a/tests/price_basis_diagnostic_test.ts
+++ b/tests/price_basis_diagnostic_test.ts
@@ -1,0 +1,181 @@
+// Tests for the issue #552 price-basis (mid vs low) diagnostic.
+//
+// These exercise the REAL shipped kernels (docs/projection.js) and the real
+// aggregation in scripts/price_basis_diagnostic.ts with synthetic market data,
+// asserting on computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReport,
+  type DateAggregate,
+  summariseOffsets,
+} from "../scripts/price_basis_diagnostic.ts";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+Deno.test("lowPriceAtNinetyDayHorizon returns the low of the last in-window point", () => {
+  const scoreDate = midnight("2026-01-01");
+  const market = [
+    { date: midnight("2026-01-02"), high: 10, low: 9 },
+    { date: midnight("2026-03-30"), high: 12, low: 11 }, // within 90 days
+    { date: midnight("2026-05-30"), high: 20, low: 19 }, // beyond horizon
+  ];
+  assertEquals(P.lowPriceAtNinetyDayHorizon(market, scoreDate), 11);
+});
+
+Deno.test("lowPriceAtNinetyDayHorizon picks the SAME row as priceAtNinetyDayHorizon", () => {
+  const scoreDate = midnight("2026-01-01");
+  const market = [
+    { date: midnight("2026-02-01"), high: 12, low: 8 },
+    { date: midnight("2026-03-15"), high: 16, low: 10 },
+  ];
+  const low = P.lowPriceAtNinetyDayHorizon(market, scoreDate);
+  const mid = P.priceAtNinetyDayHorizon(market, scoreDate);
+  assertEquals(low, 10);
+  assertEquals(mid, (16 + 10) / 2);
+});
+
+Deno.test("lowPriceAtNinetyDayHorizon returns null with no usable data", () => {
+  assertEquals(P.lowPriceAtNinetyDayHorizon([], midnight("2026-01-01")), null);
+  assertEquals(
+    P.lowPriceAtNinetyDayHorizon(null, midnight("2026-01-01")),
+    null,
+  );
+});
+
+Deno.test("priceBasisOffsetPercent computes (mid - low) / buyPrice * 100", () => {
+  // buyPrice 100, mid 110, low 105 -> 5%
+  assertAlmostEquals(P.priceBasisOffsetPercent(100, 110, 105), 5);
+  // mid == low -> zero offset (the only-in-aggregate, same-direction case)
+  assertEquals(P.priceBasisOffsetPercent(100, 110, 110), 0);
+});
+
+Deno.test("priceBasisOffsetPercent is always >= 0 when mid >= low", () => {
+  for (
+    const [buy, mid, low] of [[50, 60, 55], [10, 10.1, 9.9], [200, 200, 200]]
+  ) {
+    const offset = P.priceBasisOffsetPercent(buy, mid, low);
+    assert(offset !== null && offset >= 0, `offset ${offset} should be >= 0`);
+  }
+});
+
+Deno.test("priceBasisOffsetPercent guards bad inputs", () => {
+  assertEquals(P.priceBasisOffsetPercent(0, 10, 9), null);
+  assertEquals(P.priceBasisOffsetPercent(-5, 10, 9), null);
+  assertEquals(P.priceBasisOffsetPercent(100, null, 9), null);
+  assertEquals(P.priceBasisOffsetPercent(100, 10, NaN), null);
+});
+
+Deno.test("summariseOffsets computes mean/median/min/max/stdDev", () => {
+  const s = summariseOffsets([1, 2, 3, 4]);
+  assertEquals(s.count, 4);
+  assertAlmostEquals(s.mean, 2.5);
+  assertAlmostEquals(s.median, 2.5);
+  assertEquals(s.min, 1);
+  assertEquals(s.max, 4);
+  assertAlmostEquals(s.stdDev, Math.sqrt(1.25));
+});
+
+Deno.test("summariseOffsets handles empty input", () => {
+  const s = summariseOffsets([]);
+  assertEquals(s, { count: 0, mean: 0, median: 0, min: 0, max: 0, stdDev: 0 });
+});
+
+Deno.test("aggregateDate measures the per-row mid-vs-low offset over included stocks", () => {
+  const scoreDate = midnight("2026-01-01");
+  // One stock: buy near 100 (mid of first day), horizon mid 110, low 100.
+  const scoreRows = [{
+    stock: "X",
+    target: 130,
+    score: 0.5,
+    dividendPerShare: 0,
+  }];
+  const marketData = {
+    X: [
+      {
+        date: midnight("2026-01-02"),
+        high: 101,
+        low: 99,
+        open: 100,
+        close: 100,
+        splitCoefficient: 1,
+      },
+      {
+        date: midnight("2026-03-30"),
+        high: 120,
+        low: 100,
+        open: 110,
+        close: 115,
+        splitCoefficient: 1,
+      },
+    ],
+  };
+  const agg = aggregateDate("2026-01-01", scoreRows, marketData, {}, scoreDate);
+  // buyPrice = mid of 2026-01-02 = 100; horizon mid = 110, low = 100.
+  // offset = (110 - 100) / 100 * 100 = 10 pp.
+  assertEquals(agg.rowOffsetsPp.length, 1);
+  assertAlmostEquals(agg.rowOffsetsPp[0], 10, 1e-9);
+  // Actual(mid) uses 110 -> +10%; Actual(low) uses 100 -> 0%. Difference 10 pp.
+  assert(agg.actualMidPct !== null && agg.actualLowPct !== null);
+  assertAlmostEquals(
+    (agg.actualMidPct as number) - (agg.actualLowPct as number),
+    10,
+    1e-9,
+  );
+});
+
+Deno.test("buildReport: basis contribution widens the gap and verdict states the sign", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetPct: 25,
+      actualMidPct: 10,
+      actualLowPct: 6,
+      rowOffsetsPp: [3, 5],
+    },
+    {
+      date: "2026-02-01",
+      targetPct: 15,
+      actualMidPct: 8,
+      actualLowPct: 6,
+      rowOffsetsPp: [1, 3],
+    },
+  ];
+  const r = buildReport(aggregates);
+  assertEquals(r.maturedDates, 2);
+  assertEquals(r.rowCount, 4);
+  assertAlmostEquals(r.meanOffsetPp, 3); // (3+5+1+3)/4
+  // mean Target 20, mean Actual(mid) 9 -> observed gap 11; Actual(low) 6 -> 14.
+  assertAlmostEquals(r.observedGapPp, 11);
+  assertAlmostEquals(r.gapOnLowBasisPp, 14);
+  assertAlmostEquals(r.basisContributionPp, 3); // 14 - 11
+  assert(r.basisContributionPp > 0, "low basis should WIDEN the gap");
+  assert(
+    r.verdict.includes("NARROWS") && r.verdict.includes("WIDEN"),
+    "verdict states the masking sign",
+  );
+});
+
+Deno.test("buildReport: all offsets non-negative implies a non-negative mean", () => {
+  const aggregates: DateAggregate[] = [
+    {
+      date: "2026-01-01",
+      targetPct: 20,
+      actualMidPct: 10,
+      actualLowPct: 8,
+      rowOffsetsPp: [0, 2, 4],
+    },
+  ];
+  const r = buildReport(aggregates);
+  assert(r.meanOffsetPp >= 0);
+  assert(r.basisContributionPp >= 0);
+});

--- a/tests/residual_gap_reconciliation_test.ts
+++ b/tests/residual_gap_reconciliation_test.ts
@@ -1,0 +1,250 @@
+// Tests for the issue #557 whole-application sweep + residual-gap reconciliation.
+//
+// These exercise the REAL shipped kernels (docs/projection.js,
+// docs/trend_predictions.js) and the real aggregation/reconciliation in
+// scripts/residual_gap_reconciliation.ts with synthetic data, asserting on
+// computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+import {
+  aggregateDate,
+  buildReconciliation,
+  computeResidualGapReconciliation,
+  type DateAggregate,
+  FAMILY_CONTRIBUTIONS,
+  type GapContribution,
+  hasUsableTarget,
+} from "../scripts/residual_gap_reconciliation.ts";
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+// --- hasUsableTarget ---------------------------------------------------------
+
+Deno.test("hasUsableTarget true only for included rows with a usable target", () => {
+  assert(
+    hasUsableTarget({
+      buyPrice: 100,
+      currentPrice: 120,
+      splitReliable: true,
+      adjustedTarget: 150,
+    }),
+  );
+  // Included but no target -> dropped from the Target mean.
+  assert(
+    !hasUsableTarget({
+      buyPrice: 100,
+      currentPrice: 120,
+      splitReliable: true,
+      adjustedTarget: null,
+    }),
+  );
+  assert(
+    !hasUsableTarget({
+      buyPrice: 100,
+      currentPrice: 120,
+      splitReliable: true,
+      adjustedTarget: NaN,
+    }),
+  );
+  // Not priceable -> excluded from both.
+  assert(
+    !hasUsableTarget({
+      buyPrice: 0,
+      currentPrice: 120,
+      splitReliable: true,
+      adjustedTarget: 150,
+    }),
+  );
+});
+
+// --- aggregateDate -----------------------------------------------------------
+
+// Build a one-day score set with a target-bearing winner (AAA) and a
+// target-less loser (BBB). No splits (coefficient 1.0), so prices are unadjusted.
+function syntheticDate() {
+  const scoreDate = midnight("2026-01-01");
+  // TSV: stock, score, target, exDiv, dividendPerShare, notes, ivB, ivA
+  const scoreRows = [
+    { stock: "AAA", score: 0.5, target: 150 }, // buy 100 -> target +50%
+    { stock: "BBB", score: 0.5, target: NaN }, // loser, missing target
+  ];
+  const marketData: Record<string, unknown[]> = {
+    AAA: [
+      { date: midnight("2026-01-02"), high: 110, low: 90, close: 100 }, // mid 100 buy
+      { date: midnight("2026-03-30"), high: 130, low: 110, close: 120 }, // mid 120 actual +20%
+    ],
+    BBB: [
+      { date: midnight("2026-01-02"), high: 110, low: 90, close: 100 }, // mid 100 buy
+      { date: midnight("2026-03-30"), high: 90, low: 70, close: 80 }, // mid 80 actual -20%
+    ],
+  };
+  return { scoreDate, scoreRows, marketData };
+}
+
+Deno.test("aggregateDate counts included vs target-present rows", () => {
+  const { scoreDate, scoreRows, marketData } = syntheticDate();
+  const agg = aggregateDate(
+    "2026-01-01",
+    // deno-lint-ignore no-explicit-any
+    scoreRows as any,
+    // deno-lint-ignore no-explicit-any
+    marketData as any,
+    {},
+    scoreDate,
+  );
+  assertEquals(agg.includedRows, 2); // AAA + BBB both priceable
+  assertEquals(agg.targetRows, 1); // only AAA carries a target
+});
+
+Deno.test("aggregateDate: as-shipped Actual spans more rows than matched Actual", () => {
+  const { scoreDate, scoreRows, marketData } = syntheticDate();
+  const agg = aggregateDate(
+    "2026-01-01",
+    // deno-lint-ignore no-explicit-any
+    scoreRows as any,
+    // deno-lint-ignore no-explicit-any
+    marketData as any,
+    {},
+    scoreDate,
+  );
+  // As-shipped Actual = mean(+20, -20) = 0; matched Actual (AAA only) = +20.
+  assertAlmostEquals(agg.actualPct as number, 0, 1e-9);
+  assertAlmostEquals(agg.matchedActualPct as number, 20, 1e-9);
+  // Target is over the target-present subset (AAA): +50%.
+  assertAlmostEquals(agg.targetPct as number, 50, 1e-9);
+});
+
+// --- buildReconciliation -----------------------------------------------------
+
+const ZERO_FAMILY: GapContribution[] = [];
+
+Deno.test("buildReconciliation: target-availability = observed - matched gap", () => {
+  const aggregates: DateAggregate[] = [{
+    date: "2026-01-01",
+    targetPct: 50,
+    actualPct: 0,
+    matchedActualPct: 20,
+    includedRows: 2,
+    targetRows: 1,
+  }];
+  const r = buildReconciliation(aggregates, ZERO_FAMILY);
+  assertAlmostEquals(r.observedGapPp, 50, 1e-9); // 50 - 0
+  assertAlmostEquals(r.matchedGapPp, 30, 1e-9); // 50 - 20
+  assertAlmostEquals(r.targetAvailabilityPp, 20, 1e-9); // 50 - 30
+  assertEquals(r.droppedTargetRows, 1);
+});
+
+Deno.test("buildReconciliation: residual + net == observed gap (round-trip)", () => {
+  const aggregates: DateAggregate[] = [{
+    date: "2026-01-01",
+    targetPct: 30,
+    actualPct: 10,
+    matchedActualPct: 10, // no target-availability skew
+    includedRows: 3,
+    targetRows: 3,
+  }];
+  const family: GapContribution[] = [
+    { key: "a", issue: 1, contributionPp: 2, note: "" },
+    { key: "b", issue: 2, contributionPp: -1, note: "" },
+  ];
+  const r = buildReconciliation(aggregates, family);
+  assertAlmostEquals(r.targetAvailabilityPp, 0, 1e-9);
+  // net = 2 + (-1) + 0 (target-availability) = 1
+  assertAlmostEquals(r.netMeasurementPp, 1, 1e-9);
+  // residual = observed(20) - net(1) = 19
+  assertAlmostEquals(r.residualOptimismPp, 19, 1e-9);
+  assertAlmostEquals(
+    r.residualOptimismPp + r.netMeasurementPp,
+    r.observedGapPp,
+    1e-9,
+  );
+});
+
+Deno.test("buildReconciliation appends a target_availability contribution (#557)", () => {
+  const aggregates: DateAggregate[] = [{
+    date: "2026-01-01",
+    targetPct: 50,
+    actualPct: 0,
+    matchedActualPct: 20,
+    includedRows: 2,
+    targetRows: 1,
+  }];
+  const r = buildReconciliation(aggregates, ZERO_FAMILY);
+  const ta = r.contributions.find((c) => c.key === "target_availability");
+  assert(ta !== undefined);
+  assertEquals(ta?.issue, 557);
+  assertAlmostEquals(ta?.contributionPp as number, 20, 1e-9);
+});
+
+Deno.test("buildReconciliation: empty aggregates yield zeros, not NaN", () => {
+  const r = buildReconciliation([], ZERO_FAMILY);
+  assertEquals(r.observedGapPp, 0);
+  assertEquals(r.matchedGapPp, 0);
+  assertEquals(r.targetAvailabilityPp, 0);
+  assertEquals(r.netMeasurementPp, 0);
+  assertEquals(r.residualOptimismPp, 0);
+  assertEquals(r.includedRows, 0);
+});
+
+Deno.test("FAMILY_CONTRIBUTIONS covers the quantified #544 sub-issues", () => {
+  const issues = FAMILY_CONTRIBUTIONS.map((c) => c.issue).sort();
+  assertEquals(issues, [552, 553, 554, 555, 556]);
+  // Sign convention: price-basis and split parity mask (negative); dividend
+  // inflates (positive); denominator and decoding are ruled out (zero).
+  const by = (k: string) =>
+    FAMILY_CONTRIBUTIONS.find((c) => c.key === k)?.contributionPp;
+  assert((by("price_basis") as number) < 0);
+  assert((by("dividend_basis") as number) > 0);
+  assertEquals(by("buy_price_denominator"), 0);
+  assert((by("horizon_split_parity") as number) < 0);
+  assertEquals(by("score_target_decoding"), 0);
+});
+
+// --- computeResidualGapReconciliation (real committed data, read-only) -------
+
+// Read-only against the committed docs tree (no --allow-write needed, matching
+// quality.sh's `deno test --allow-read`). Asserts structural invariants rather
+// than exact figures, which shift as the daily score history grows.
+
+Deno.test("computeResidualGapReconciliation reconciles the committed score set", async () => {
+  const report = await computeResidualGapReconciliation(
+    "docs",
+    midnight("2026-06-26"),
+  );
+  // There is a matured history with included rows behind the means.
+  assert(report.maturedDates > 0);
+  assert(report.includedRows > 0);
+  // Target is averaged over a subset of Actual's rows (target-availability).
+  assert(report.targetRows <= report.includedRows);
+  assertEquals(
+    report.droppedTargetRows,
+    report.includedRows - report.targetRows,
+  );
+  // The model is optimistic in aggregate: Target sits above Actual.
+  assert(report.observedGapPp > 0);
+  // The reconciliation identity always holds.
+  assertAlmostEquals(
+    report.residualOptimismPp + report.netMeasurementPp,
+    report.observedGapPp,
+    1e-9,
+  );
+  // The target-availability term is present and small (immaterial asymmetry).
+  const ta = report.contributions.find((c) => c.key === "target_availability");
+  assert(ta !== undefined);
+  assert(Math.abs(ta?.contributionPp as number) < 1);
+});
+
+Deno.test("computeResidualGapReconciliation honours the matured-only window", async () => {
+  // An as-of date before any score date matures yields an empty, zeroed report.
+  const early = await computeResidualGapReconciliation(
+    "docs",
+    midnight("2000-01-01"),
+  );
+  assertEquals(early.maturedDates, 0);
+  assertEquals(early.observedGapPp, 0);
+});

--- a/tests/score_target_decoding_diagnostic_test.ts
+++ b/tests/score_target_decoding_diagnostic_test.ts
@@ -1,0 +1,168 @@
+// Tests for the issue #556 score→target decoding (reverseProfitRecommend)
+// diagnostic. These exercise the ported GRQ functions and the pure aggregation
+// in scripts/score_target_decoding_diagnostic.ts with synthetic scores,
+// asserting on computed results — not source text.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import {
+  buildReport,
+  computeDecodingDiagnostic,
+  MAX_REVERSE_PERCENT,
+  profitRecommend,
+  reverseProfitPct,
+  reverseProfitTarget,
+  roundTripShiftPp,
+  summarise,
+} from "../scripts/score_target_decoding_diagnostic.ts";
+
+Deno.test("profitRecommend matches tanh((pct - 1.5) / 3)", () => {
+  assertAlmostEquals(profitRecommend(1.5), 0, 1e-12); // centre maps to 0
+  assertAlmostEquals(profitRecommend(4.5), Math.tanh(1), 1e-12);
+  assert(profitRecommend(50) > 0.999999); // saturates near +1
+});
+
+Deno.test("reverseProfitPct is the clean inverse of profitRecommend in the interior", () => {
+  for (const pct of [-10, -2, 0, 1.5, 4.10463, 12.5, 30]) {
+    const score = profitRecommend(pct);
+    const back = reverseProfitPct(score);
+    assertEquals(back.region, "interior");
+    // atanh amplifies float error near saturation; 1e-6 still confirms the
+    // inverse holds to well under a thousandth of a percentage point.
+    assertAlmostEquals(back.pct, pct, 1e-6);
+  }
+});
+
+Deno.test("reverseProfitPct clamps score >= 1 to +MAX_REVERSE_PERCENT (cap_high)", () => {
+  const r = reverseProfitPct(1);
+  assertEquals(r.pct, MAX_REVERSE_PERCENT);
+  assertEquals(r.region, "cap_high");
+  // Strictly above 1 clamps identically.
+  assertEquals(reverseProfitPct(1.5).region, "cap_high");
+});
+
+Deno.test("reverseProfitPct clamps score <= -1 to -100% (floor_low, asymmetric)", () => {
+  const r = reverseProfitPct(-1);
+  assertEquals(r.pct, -100); // deeper than the -50% interior cap → asymmetric
+  assertEquals(r.region, "floor_low");
+});
+
+Deno.test("reverseProfitTarget mirrors price * (1 + pct/100) and the 0 floor", () => {
+  // score == 1 → +50% → target = 1.5 * price (anchored to the real data:
+  // NYSE:DD score 1, target 68.39, buy ~45.59 = 68.39 / 1.5).
+  assertAlmostEquals(reverseProfitTarget(45.5933, 1), 68.39, 1e-3);
+  // interior score reproduces the stored target (anchored row: s=0.70043,
+  // price 75.66 → target ~78.77).
+  assertAlmostEquals(
+    reverseProfitTarget(75.66, 0.7004302144050806),
+    78.77,
+    1e-2,
+  );
+  // score <= -1 → target 0.
+  assertEquals(reverseProfitTarget(100, -1), 0);
+});
+
+Deno.test("roundTripShiftPp is ~0 for interior scores (exact inverse)", () => {
+  for (const pct of [-20, -5, 0, 3.5, 15, 28]) {
+    const score = profitRecommend(pct);
+    assertAlmostEquals(roundTripShiftPp(score), 0, 1e-6);
+  }
+});
+
+Deno.test("roundTripShiftPp is ~0 even at the saturated +1 clamp", () => {
+  // score 1 → +50% → re-encode tanh(16.166) ≈ 1 → re-decode +50% → shift 0.
+  assertAlmostEquals(roundTripShiftPp(1), 0, 1e-6);
+});
+
+Deno.test("summarise computes mean/median/min/max/stdDev and handles empty", () => {
+  const s = summarise([1, 2, 3, 4]);
+  assertEquals(s.count, 4);
+  assertAlmostEquals(s.mean, 2.5);
+  assertAlmostEquals(s.median, 2.5);
+  assertEquals(s.min, 1);
+  assertEquals(s.max, 4);
+  assertAlmostEquals(s.stdDev, Math.sqrt(1.25));
+  assertEquals(summarise([]), {
+    count: 0,
+    mean: 0,
+    median: 0,
+    min: 0,
+    max: 0,
+    stdDev: 0,
+  });
+});
+
+Deno.test("buildReport: realistic positive-only distribution rules out decode bias", () => {
+  // Mixture mirroring the realised data: many saturated (==1) plus interior
+  // positives, no negatives.
+  const scores = [
+    1,
+    1,
+    1,
+    profitRecommend(4),
+    profitRecommend(10),
+    profitRecommend(25),
+    profitRecommend(2),
+  ];
+  const r = buildReport(scores, 3);
+  assertEquals(r.scoreRows, 7);
+  assertEquals(r.scoreDates, 3);
+  // Round-trip shift is negligible across the whole distribution.
+  assertAlmostEquals(r.shift.mean, 0, 1e-6);
+  assert(Math.abs(r.shift.min) < 1e-6 && Math.abs(r.shift.max) < 1e-6);
+  // Census: 3 saturated cap_high, 4 interior, no floor_low.
+  assertEquals(r.saturatedRows, 3);
+  assertAlmostEquals(r.fractionCapHigh, 3 / 7, 1e-9);
+  assertEquals(r.fractionFloorLow, 0);
+  assert(r.verdict.includes("RULED OUT"));
+});
+
+Deno.test("buildReport: census fractions sum to 1 and cover every region", () => {
+  const scores = [1, -1, profitRecommend(5), profitRecommend(20)];
+  const r = buildReport(scores, 1);
+  const total = r.census.reduce((t, c) => t + c.fraction, 0);
+  assertAlmostEquals(total, 1, 1e-9);
+  const counts = r.census.reduce((t, c) => t + c.count, 0);
+  assertEquals(counts, 4);
+  assertEquals(r.fractionFloorLow, 0.25); // the single -1
+});
+
+Deno.test("buildReport: empty input yields a zeroed report", () => {
+  const r = buildReport([], 0);
+  assertEquals(r.scoreRows, 0);
+  assertEquals(r.shift.count, 0);
+  assertEquals(r.meanDecodedPct, 0);
+});
+
+Deno.test("computeDecodingDiagnostic over the real score history holds the round-trip invariants", async () => {
+  // Read-only against the committed docs/ tree (matches the suite's
+  // --allow-read permission model). Asserts the stable invariants the verdict
+  // rests on rather than brittle exact counts, so it survives data refreshes.
+  const all = await computeDecodingDiagnostic(
+    "docs",
+    new Date("2026-06-26"),
+    false,
+  );
+  assert(all.scoreRows > 0, "history has scores");
+  assert(all.scoreDates > 0, "history has dates");
+  // Round-trip shift is machine epsilon — decoding is a faithful inverse.
+  assert(Math.abs(all.shift.mean) < 1e-9, "mean round-trip shift ~ 0");
+  assert(
+    Math.max(Math.abs(all.shift.min), Math.abs(all.shift.max)) < 1e-9,
+    "max round-trip shift ~ 0",
+  );
+  // The asymmetric 0/-100% floor never fires in the realised data.
+  assertEquals(all.fractionFloorLow, 0);
+  // Census fractions are a partition of the rows.
+  const total = all.census.reduce((t, c) => t + c.fraction, 0);
+  assertAlmostEquals(total, 1, 1e-9);
+  assert(all.verdict.includes("RULED OUT"));
+
+  // Maturing the set never grows it.
+  const matured = await computeDecodingDiagnostic(
+    "docs",
+    new Date("2026-06-26"),
+    true,
+  );
+  assert(matured.scoreRows <= all.scoreRows);
+  assert(matured.scoreDates <= all.scoreDates);
+});


### PR DESCRIPTION
## Milestone: #544 Diagnose systematic Target-over-Actual gap in validation's measurement basis

This PR merges the completed milestone branch into main.
Closes #573

### Issues addressed
- #557: Whole-application sweep for any remaining same-direction Target/Actual asymmetry
- #556: Confirm score-to-target decoding (reverseProfitRecommend) adds no systematic bias
- #555: Audit market-data timing & corporate-action parity between training and validation
- #554: Quantify Target/Actual bias from buy-price denominator: training monthsAgoPrice vs dashboard buyPrice midpoint
- #553: Quantify Target/Actual bias from dividend basis: flat yearOfDividends/4 vs windowed actual ex-dividends
- #552: Quantify Target/Actual bias from price basis: training intraday-low vs dashboard midpoint

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to main.