### PR TITLE
Restate dashboard Actual onto the buy price's current split basis (#569)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-569.md
+++ b/docs/archive/pr-summaries/pr-summary-569.md
@@ -1,102 +1,98 @@
+# Restate the dashboard Actual onto the buy price's current split basis
+
 ## Summary
 
-The dashboard's **Actual 90-day return** divided a **current-basis** buy price
-(restated to end-of-series split terms by `getBuyPrice`) by a **raw** horizon
-price. When a reconcilable split fell **between the 90-day horizon and the end
-of the data series**, the Actual carried a spurious post-horizon split factor
-that the buy price did not — inflating (forward split) or deflating (reverse
-split) the displayed Actual, while `Target %` was unaffected (it divides
-`adjustedTarget` and `buyPrice` by the same factor).
+The dashboard's Actual 90-day return divided a **current-basis** buy price by a
+**raw** horizon price. `getBuyPrice` restates the score-date midpoint into
+current (end-of-series) split terms, but the Actual readers took the horizon
+midpoint **raw** (`(high + low) / 2`). When a reconcilable split falls **between
+the 90-day horizon and the data end**, the raw Actual carries a spurious
+post-horizon split factor `S_after` that GRQ training (and the
+economically-correct return) cancels — distorting the displayed Actual.
 
-This reads the Actual horizon price on the **same current basis** as the buy
-price, via the `GRQProjection.horizonPriceCurrentBasis` helper (added in
-PR #568, which divides the raw horizon midpoint by `postHorizonSplitFactor`).
+This restates the Actual horizon price onto the **same** current basis as the
+buy price, via the `GRQProjection.horizonPriceCurrentBasis` kernel (raw mid ÷
+`postHorizonSplitFactor`) added in PR #568:
 
-The issue named `getStockReturnBreakdown` and `currentPriceWithinWindow`, but
-the single-stock detail, the per-stock table column, the 90-Day Price field and
-the "show the working" popovers read the horizon **raw** through separate code
-paths. Fixing only the two named functions would have left the per-stock
-Performance column contradicting the corrected totals row (the repo's invariant
-is that popovers can never disagree with the displayed value). So every
-horizon-Actual read on the dashboard now routes through `horizonPriceCurrentBasis`
-for a consistent, split-correct Actual.
+- **`getStockReturnBreakdown`** (`docs/app.js`) — the single source of truth for
+  the displayed Actual / charts / popovers.
+- **`currentPriceWithinWindow`** (`docs/trend_predictions.js`) — the Trend-view
+  Actual.
+- **`calculateStockPerformance`** (`docs/app.js`) — the twin 90-day return that
+  feeds Return-above-cost-of-capital, judgement and projection surfaces. It
+  shared the identical raw-over-restated defect and previously *agreed* with the
+  Actual, so it is restated the same way to keep the two consistent for a stock
+  that splits post-horizon.
+- **Gain/Loss "show the working" popover** (`docs/app.js`) — its displayed price
+  now uses the current basis so the shown arithmetic matches the (now-restated)
+  Gain/Loss %, instead of contradicting it.
 
-**Safety property:** `horizonPriceCurrentBasis === priceAtNinetyDayHorizon`
-whenever there is no reconcilable post-horizon split (`postHorizonSplitFactor`
-is `1.0`), so the only stocks whose displayed Actual changes are the 124 matured
-rows that actually carry such a split. Every other figure is byte-identical.
+The standalone **"90-Day Price"** snapshot field deliberately keeps showing the
+**raw** traded price at the horizon (issue #539) — it is a price display, not a
+return, and the audit scoped the fix to the Actual return readers.
+
+The `#555` parity diagnostic (`scripts/horizon_split_parity_diagnostic.ts`)
+sourced its "raw" Actual from the shipped reader; now that the reader is fixed it
+reconstructs the raw horizon midpoint independently
+(`priceAtNinetyDayHorizon`) so it still quantifies the now-removed offset.
 
 Closes #569.
 
-### Sites changed (all in `docs/`)
-
-| Path | What it feeds |
-| --- | --- |
-| `getStockReturnBreakdown` (app.js) | Totals-row Actual/Dividends, portfolio chart point, `portfolio-actual` popover |
-| `calculateStockPerformance` (app.js) | Single-stock detail Performance, judgement / status / progress workings |
-| `getNinetyDayPrice` (app.js) | Per-stock table "90-Day Price" |
-| `current-price` popover working (app.js) | Single-stock "90-Day Price" value + working |
-| `gain-loss` popover working (app.js) | Single-stock Gain/Loss working |
-| `currentPriceRaw` (app.js) | Fair-value / target colour thresholds |
-| `currentPriceWithinWindow` (trend_predictions.js) | Trend view Actual series |
-
-The portfolio Actual (`calculatePortfolioPerformance90Day`) and per-stock table
-Performance already delegate to `getStockReturnBreakdown` via
-`calculateStockPerformanceWithDilution`, so they inherit the fix.
-
-### Diagnostic (issue #555) is now a regression guard
-
-`scripts/horizon_split_parity_diagnostic.ts` measures the **shipped** Actual
-against the current-basis Actual. With the shipped Actual fixed, the two now
-coincide, so `deno task diagnose-horizon-split-parity` reports **0 post-horizon
-split rows** and a **+0.000 pp** basis contribution (was +0.482 pp). It now
-confirms the fix and guards against a regression: reintroducing the raw read
-would make the offset reappear.
-
 ## Evidence
 
-### Behaviour (NASDAQ:KLAC, score 2026-01-01 — a 10:1 post-horizon split)
+This is a frontend/CLI logic change with no isolated web view to screenshot — the
+effect is invisible for the ~98 % of rows with no post-horizon split (factor
+1.0, value unchanged) and only moves the 123 split-affected rows. **Playwright
+MCP was unavailable in this environment**, so verification is via the
+reproducible diagnostic and unit tests that execute the real shipped code.
 
-| | Before | After |
-| --- | --- | --- |
-| Buy Price (restated) | $126.73 | $126.73 |
-| 90-Day Price | ~$1 500 (raw) | ~$151 (current basis) |
-| **Performance** | **+1 093%** | **+19.3%** |
+Reproducible diagnostic (`deno task diagnose-horizon-split-parity`, as-of
+2026-06-26) — the measured impact matches the issue exactly:
 
-![KLAC single-stock detail showing the corrected +19.3% Actual](docs/evidence/issue-569-klac-actual.png)
+```
+Matured score dates:      274
+Included stock-rows:      5444
+Post-horizon split rows:  123
+Per-row offset  min/max:  -316.116 pp / +1395.893 pp
+Basis contribution:       +0.482 pp
+VERDICT: ... RESOLVED in issue #569: the shipped readers now restate the Actual
+through horizonPriceCurrentBasis so it shares the buy price's basis.
+```
+
+Worked example (2:1 forward split after the horizon): buy 100 → restated 50;
+horizon mid 120 → restated 60. The Actual is now the real **+20 %** move, not the
+spurious **+140 %** the raw 120 produced.
 
 ### Data flow
 
 ```mermaid
 flowchart LR
-    A[market CSV] --> B[priceAtNinetyDayHorizon<br/>raw horizon mid]
-    B --> C[÷ postHorizonSplitFactor]
-    C --> D[horizonPriceCurrentBasis<br/>current basis]
-    E[getBuyPrice<br/>restated to current basis] --> F[calculatePerformanceReturn]
-    D --> F
-    F --> G[Actual % — totals, table,<br/>single-stock, popovers, trend]
-```
-
-### Diagnostic output (after fix)
-
-```text
-Post-horizon split rows:  0
-Basis contribution:       +0.000 pp
-VERDICT: ... DORMANT ... Issue #569 landed the fix ...
+    A[market data] --> B[getBuyPrice<br/>restated to current basis]
+    A --> C[priceAtNinetyDayHorizon<br/>raw horizon mid]
+    C --> D[horizonPriceCurrentBasis<br/>raw mid ÷ postHorizonSplitFactor]
+    B --> E[Actual % = currentPrice − buyPrice / buyPrice]
+    D --> E
+    C --> F["90-Day Price field<br/>(raw snapshot, #539 — unchanged)"]
+    E --> G[getStockReturnBreakdown · calculateStockPerformance<br/>currentPriceWithinWindow · gain-loss popover]
 ```
 
 ## Test Plan
 
-- `tests/trend_predictions_test.ts`
-  - `currentPriceWithinWindow - restates the horizon midpoint onto the current split basis (issue #569)` — fails against the unfixed code, passes after.
-  - `currentPriceWithinWindow - unchanged when no post-horizon split follows` — confirms the no-split safety property.
-  - `currentPriceWithinWindow - returns null with no usable points` — edge case.
-  - `resolvePredictionStocks - Actual reads the post-horizon split on the buy price basis (issue #569)`.
-- `tests/horizon_split_parity_diagnostic_test.ts`
-  - `per-stock Actual composition is split-consistent across the horizon (issue #569)` — mirrors `calculateStockPerformance`'s kernel composition (the GRQValidator method needs the DOM, so it is exercised through its shared kernels): buy 50, current 60, Performance +20% (raw would be +140%).
-  - **Business-logic change documented in-file:** `aggregateDate: the shipped Actual reads a post-horizon split on the buy price basis (issue #569)` (was `... desynchronises Actual but not Target`). The diagnostic measures the shipped kernels, so with the fix the two Actual bases coincide and 0 rows are split-affected. The `buildReport` tests still exercise the non-trivial (offset > 0) report path with synthetic aggregates.
-- Full suite: `deno test --allow-read tests/` — 1056 passed, 0 failed.
-- `deno fmt --check`, `deno lint`, `deno check` — clean.
+New `tests/dashboard_actual_horizon_basis_test.ts` (11 tests) — executes the
+**real shipped code** (the trend reader is imported and called; the `app.js`
+methods are brace-matched from source and run with a fake `this`, not grepped):
 
-No Rust sources were changed; the fix is confined to the dashboard JS, the
-diagnostic, and Deno tests.
+- `currentPriceWithinWindow` restates forward and reverse post-horizon splits,
+  is unchanged with no post-horizon split, and returns null with no usable point.
+- `resolvePredictionStocks` Actual and buy price share the current basis (real
+  +20 % move, not +140 %).
+- `getStockReturnBreakdown` reads the Actual on the buy price's basis, is
+  unchanged without a split, and returns null past the horizon.
+- `calculateStockPerformance` restates the same way and **agrees with**
+  `getStockReturnBreakdown` on the same basis.
+
+Existing suites updated/confirmed:
+
+- `tests/horizon_split_parity_diagnostic_test.ts` — passes against the diagnostic
+  rewrite (raw reconstructed independently). No assertions weakened.
+- Full Deno suite (1086 tests) and `./quality.sh` pass cleanly.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.10">
+    <meta name="app-version" content="1.1.11">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -521,6 +521,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.10"></script>
+    <script src="sw-register.js?v=1.1.11"></script>
   </body>
 </html>

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -566,9 +566,10 @@ function currentPriceFromLatest(marketData) {
 // validates how well a 90-day prediction performed — it must NEVER compare to
 // today's live price beyond the 90-day horizon. When the 90-day window is not
 // yet complete, the `point.date <= ninetyDayDate` filter naturally yields the
-// latest available point. Mirrors the price basis used by
-// calculateStockPerformance / the gain-loss working. Returns null when there is
-// no usable data on or before the horizon.
+// latest available point. This is the RAW horizon midpoint shown by the
+// standalone "90-Day Price" field; the Actual-return readers restate it onto the
+// buy price's current split basis via horizonPriceCurrentBasis (issue #569).
+// Returns null when there is no usable data on or before the horizon.
 function priceAtNinetyDayHorizon(marketData, scoreDate) {
     if (!marketData || marketData.length === 0) return null;
     const ninetyDayDate = new Date(
@@ -704,8 +705,8 @@ function horizonPointDate(marketData, scoreDate) {
 // Cumulative RELIABLE split factor for splits strictly AFTER the 90-day horizon
 // up to the end of the series (issue #555): `getSplitAdjustment` evaluated at the
 // horizon point's own date. 1.0 means there is no reconcilable post-horizon
-// split, so the raw horizon price the shipped Actual reads already sits on the
-// current (end-of-series) basis its buy price uses. A FORWARD split gives a
+// split, so the raw horizon midpoint already sits on the current (end-of-series)
+// basis the buy price uses and needs no restatement. A FORWARD split gives a
 // factor > 1; a REVERSE split gives a factor < 1. Returns 1.0 when there is no
 // horizon point (no adjustment to make). Mirrors the `reliable`-gated factor, so
 // an unreconcilable series yields 1.0 rather than a silently wrong factor.
@@ -717,13 +718,12 @@ function postHorizonSplitFactor(marketData, scoreDate) {
 
 // Midpoint at the 90-day horizon restated onto the CURRENT (end-of-series) split
 // basis — the SAME as-of basis getBuyPrice uses for the buy price (issue #555).
-// The shipped Actual (getStockReturnBreakdown / currentPriceWithinWindow) reads
-// this row's midpoint RAW while dividing by a buy price that getBuyPrice has
-// already restated to current terms; when a split falls between the horizon and
-// the series end the two sit on different split bases. Dividing the raw midpoint
-// by `postHorizonSplitFactor` puts the horizon price on the buy price's basis so
-// a like-for-like, same-basis Actual can be measured. Returns null when no point
-// falls on or before the horizon.
+// The shipped Actual (getStockReturnBreakdown / calculateStockPerformance /
+// currentPriceWithinWindow) now reads the horizon price through THIS helper
+// (issue #569): dividing the raw midpoint by `postHorizonSplitFactor` puts it on
+// the buy price's basis, so a split falling between the horizon and the series
+// end no longer leaves the Actual and the buy price on different split bases.
+// Returns null when no point falls on or before the horizon.
 function horizonPriceCurrentBasis(marketData, scoreDate) {
     const rawMid = priceAtNinetyDayHorizon(marketData, scoreDate);
     if (rawMid === null) return null;

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.10")
+    navigator.serviceWorker.register("./sw.js?v=1.1.11")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.10";
+const APP_VERSION = "1.1.11";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.10">
+    <meta name="app-version" content="1.1.11">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -207,6 +207,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.10"></script>
+    <script src="sw-register.js?v=1.1.11"></script>
   </body>
 </html>

--- a/tests/dashboard_actual_horizon_basis_test.ts
+++ b/tests/dashboard_actual_horizon_basis_test.ts
@@ -1,0 +1,261 @@
+// Regression tests for issue #569: the dashboard's Actual 90-day return must
+// read the horizon price on the SAME current (end-of-series) split basis as the
+// buy price.
+//
+// `getBuyPrice` restates the score-date midpoint into current split terms, but
+// the two shipped Actual readers used to take the horizon midpoint RAW:
+//   - GRQValidator.getStockReturnBreakdown (docs/app.js)
+//   - currentPriceWithinWindow (docs/trend_predictions.js)
+// When a reconcilable split falls BETWEEN the 90-day horizon and the data end,
+// the raw midpoint carries a spurious post-horizon split factor that the buy
+// price has already cancelled, distorting the displayed Actual. Both readers now
+// divide the raw midpoint by GRQProjection.postHorizonSplitFactor (via the
+// horizonPriceCurrentBasis kernel) so the Actual shares the buy price's basis.
+//
+// These exercise the REAL shipped code: the trend reader is imported and called
+// directly; the app.js method is extracted from source and executed with a fake
+// `this`, so the assertions run the actual function body — not a copy or a grep.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+// deno-lint-ignore no-explicit-any
+const P = (globalThis as any).GRQProjection;
+// deno-lint-ignore no-explicit-any
+const Trend = (globalThis as any).GRQTrendPredictions;
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+interface MarketPoint {
+  date: Date;
+  high: number;
+  low: number;
+  open: number;
+  close: number;
+  splitCoefficient: number;
+}
+
+// A flat OHLC point with an optional split coefficient (mid == price).
+function pt(date: string, price: number, splitCoefficient = 1.0): MarketPoint {
+  return {
+    date: midnight(date),
+    high: price,
+    low: price,
+    open: price,
+    close: price,
+    splitCoefficient,
+  };
+}
+
+const SCORE = midnight("2026-01-01"); // horizon 2026-04-01
+
+// Score 2026-01-01 -> horizon 2026-04-01. A clean 2:1 forward split on 05-15,
+// AFTER the horizon but BEFORE the data end: the horizon mid (120) sits on the
+// pre-split basis while the buy price (100) is restated to the post-split basis.
+function marketWithPostHorizonSplit(): MarketPoint[] {
+  return [
+    pt("2026-01-02", 100), // buy point
+    pt("2026-03-30", 120), // horizon point (last <= 2026-04-01)
+    pt("2026-05-15", 60, 2.0), // post-horizon 2:1 forward split
+  ];
+}
+
+// A reverse 1:2 split after the horizon: the horizon mid is deflated relative to
+// the buy price unless restated.
+function marketWithPostHorizonReverseSplit(): MarketPoint[] {
+  return [
+    pt("2026-01-02", 100),
+    pt("2026-03-30", 120),
+    pt("2026-05-15", 240, 0.5),
+  ];
+}
+
+// --- docs/trend_predictions.js: currentPriceWithinWindow ---------------------
+
+Deno.test("currentPriceWithinWindow restates the horizon mid onto the current basis (forward split)", () => {
+  const market = marketWithPostHorizonSplit();
+  // Raw mid is 120; the buy price's current basis halves it to 60.
+  assertAlmostEquals(Trend.currentPriceWithinWindow(market, SCORE), 60);
+  // It must agree with the shared kernel the buy price's basis comes from.
+  assertAlmostEquals(
+    Trend.currentPriceWithinWindow(market, SCORE),
+    P.horizonPriceCurrentBasis(market, SCORE),
+  );
+});
+
+Deno.test("currentPriceWithinWindow restates a reverse post-horizon split", () => {
+  const market = marketWithPostHorizonReverseSplit();
+  // Raw mid 120, factor 0.5 -> 240 on the current basis.
+  assertAlmostEquals(Trend.currentPriceWithinWindow(market, SCORE), 240);
+});
+
+Deno.test("currentPriceWithinWindow is unchanged when no split follows the horizon", () => {
+  const market = [pt("2026-01-02", 100), pt("2026-03-30", 120)];
+  // No post-horizon split -> still the raw horizon midpoint.
+  assertAlmostEquals(Trend.currentPriceWithinWindow(market, SCORE), 120);
+});
+
+Deno.test("currentPriceWithinWindow returns null with no usable point", () => {
+  assertEquals(Trend.currentPriceWithinWindow([], SCORE), null);
+  assertEquals(Trend.currentPriceWithinWindow(undefined, SCORE), null);
+  // Only points strictly AFTER the horizon -> dropped by the inclusion gate.
+  assertEquals(
+    Trend.currentPriceWithinWindow([pt("2026-09-01", 10)], SCORE),
+    null,
+  );
+});
+
+Deno.test("resolvePredictionStocks Actual and buy price share the current basis", () => {
+  const scoreRows = [{ stock: "NYSE:AAA", score: 0.9, target: 200 }];
+  const market = { "NYSE:AAA": marketWithPostHorizonSplit() };
+  const [resolved] = Trend.resolvePredictionStocks(
+    scoreRows,
+    market,
+    {},
+    SCORE,
+  );
+  // Buy price restated to current terms: raw 100 / 2.0 = 50.
+  assertAlmostEquals(resolved.buyPrice, 50);
+  // Actual now on the SAME basis: raw 120 / 2.0 = 60 (a +20% real move),
+  // NOT the raw 120 that would read as a spurious +140%.
+  assertAlmostEquals(resolved.currentPrice, 60);
+  const priceReturn =
+    ((resolved.currentPrice - resolved.buyPrice) / resolved.buyPrice) * 100;
+  assertAlmostEquals(priceReturn, 20);
+});
+
+// --- docs/app.js: getStockReturnBreakdown ------------------------------------
+
+// Extract a class method body from app.js source and rebuild it as a callable
+// function so the test runs the REAL shipped body (app.js bootstraps a live DOM
+// at import time and cannot be imported headlessly). Brace-matched, not grepped.
+function extractMethod(src: string, signature: string): string {
+  // Match the DEFINITION signature exactly (call sites share the bare name).
+  const start = src.indexOf(signature);
+  if (start === -1) throw new Error(`method ${signature} not found`);
+  const open = src.indexOf("{", start);
+  if (open === -1) throw new Error(`opening brace for ${name} not found`);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) return src.slice(open, i + 1);
+    }
+  }
+  throw new Error(`unterminated body for ${signature}`);
+}
+
+async function loadBreakdown() {
+  const src = await Deno.readTextFile(
+    new URL("../docs/app.js", import.meta.url),
+  );
+  const body = extractMethod(
+    src,
+    "getStockReturnBreakdown(stock, scoreDate) {",
+  );
+  // GRQProjection is a free global in app.js; inject it as a closure param.
+  const factory = new Function(
+    "GRQProjection",
+    `return function(stock, scoreDate) ${body};`,
+  );
+  return factory(P) as (stock: unknown, scoreDate: Date) => {
+    buyPrice: number;
+    currentPrice: number;
+    totalDividends: number;
+    priceReturn: number;
+    dividendReturn: number;
+    totalReturn: number;
+  } | null;
+}
+
+function fakeValidator(market: MarketPoint[]) {
+  return {
+    marketData: { "NYSE:AAA": market } as Record<string, MarketPoint[]>,
+    selectedFile: "2026/January/01.tsv",
+    getScoreDate(_file: string) {
+      return SCORE;
+    },
+    getBuyPrice(symbol: string, scoreDate: Date) {
+      return P.getBuyPrice(this.marketData[symbol], scoreDate);
+    },
+    getDividendsWithin90Days(_symbol: string) {
+      return [];
+    },
+  };
+}
+
+Deno.test("getStockReturnBreakdown reads the Actual on the buy price's current basis (forward split)", async () => {
+  const breakdown = await loadBreakdown();
+  const ctx = fakeValidator(marketWithPostHorizonSplit());
+  const result = breakdown.call(ctx, { stock: "NYSE:AAA" }, SCORE);
+  assert(result !== null);
+  // Buy price restated to current terms: 100 / 2.0 = 50.
+  assertAlmostEquals(result!.buyPrice, 50);
+  // Actual on the same basis: 120 / 2.0 = 60, NOT the raw 120.
+  assertAlmostEquals(result!.currentPrice, 60);
+  // The real economic move is +20%, not the spurious +140%.
+  assertAlmostEquals(result!.priceReturn, 20);
+});
+
+Deno.test("getStockReturnBreakdown is unchanged when no split follows the horizon", async () => {
+  const breakdown = await loadBreakdown();
+  const ctx = fakeValidator([pt("2026-01-02", 100), pt("2026-03-30", 120)]);
+  const result = breakdown.call(ctx, { stock: "NYSE:AAA" }, SCORE);
+  assert(result !== null);
+  assertAlmostEquals(result!.buyPrice, 100);
+  assertAlmostEquals(result!.currentPrice, 120);
+  assertAlmostEquals(result!.priceReturn, 20);
+});
+
+Deno.test("getStockReturnBreakdown returns null when no point falls on/before the horizon", async () => {
+  const breakdown = await loadBreakdown();
+  const ctx = fakeValidator([pt("2026-09-01", 10)]);
+  const result = breakdown.call(ctx, { stock: "NYSE:AAA" }, SCORE);
+  assertEquals(result, null);
+});
+
+// --- docs/app.js: calculateStockPerformance ----------------------------------
+// The twin 90-day return that feeds the Return-above-cost-of-capital, judgement
+// and projection surfaces. It must stay on the SAME current basis as the Actual
+// (issue #569) so the two cannot disagree for a stock that splits post-horizon.
+
+async function loadStockPerformance() {
+  const src = await Deno.readTextFile(
+    new URL("../docs/app.js", import.meta.url),
+  );
+  const body = extractMethod(src, "calculateStockPerformance(stock) {");
+  const factory = new Function(
+    "GRQProjection",
+    `return function(stock) ${body};`,
+  );
+  return factory(P) as (stock: unknown) => number | null;
+}
+
+Deno.test("calculateStockPerformance restates the horizon onto the buy price's basis (forward split)", async () => {
+  const perf = await loadStockPerformance();
+  const ctx = fakeValidator(marketWithPostHorizonSplit());
+  // (60 - 50) / 50 * 100 = +20%, NOT the spurious +140% from the raw 120.
+  assertAlmostEquals(perf.call(ctx, { stock: "NYSE:AAA" })!, 20);
+});
+
+Deno.test("calculateStockPerformance is unchanged when no split follows the horizon", async () => {
+  const perf = await loadStockPerformance();
+  const ctx = fakeValidator([pt("2026-01-02", 100), pt("2026-03-30", 120)]);
+  assertAlmostEquals(perf.call(ctx, { stock: "NYSE:AAA" })!, 20);
+});
+
+Deno.test("calculateStockPerformance and getStockReturnBreakdown agree on the same basis", async () => {
+  const perf = await loadStockPerformance();
+  const breakdown = await loadBreakdown();
+  const market = marketWithPostHorizonSplit();
+  const a = perf.call(fakeValidator(market), { stock: "NYSE:AAA" });
+  const b = breakdown.call(fakeValidator(market), { stock: "NYSE:AAA" }, SCORE);
+  assert(b !== null);
+  assertAlmostEquals(a!, b!.totalReturn);
+});


### PR DESCRIPTION
# Restate the dashboard Actual onto the buy price's current split basis

## Summary

The dashboard's Actual 90-day return divided a **current-basis** buy price by a
**raw** horizon price. `getBuyPrice` restates the score-date midpoint into
current (end-of-series) split terms, but the Actual readers took the horizon
midpoint **raw** (`(high + low) / 2`). When a reconcilable split falls **between
the 90-day horizon and the data end**, the raw Actual carries a spurious
post-horizon split factor `S_after` that GRQ training (and the
economically-correct return) cancels — distorting the displayed Actual.

This restates the Actual horizon price onto the **same** current basis as the
buy price, via the `GRQProjection.horizonPriceCurrentBasis` kernel (raw mid ÷
`postHorizonSplitFactor`) added in PR #568:

- **`getStockReturnBreakdown`** (`docs/app.js`) — the single source of truth for
  the displayed Actual / charts / popovers.
- **`currentPriceWithinWindow`** (`docs/trend_predictions.js`) — the Trend-view
  Actual.
- **`calculateStockPerformance`** (`docs/app.js`) — the twin 90-day return that
  feeds Return-above-cost-of-capital, judgement and projection surfaces. It
  shared the identical raw-over-restated defect and previously *agreed* with the
  Actual, so it is restated the same way to keep the two consistent for a stock
  that splits post-horizon.
- **Gain/Loss "show the working" popover** (`docs/app.js`) — its displayed price
  now uses the current basis so the shown arithmetic matches the (now-restated)
  Gain/Loss %, instead of contradicting it.

The standalone **"90-Day Price"** snapshot field deliberately keeps showing the
**raw** traded price at the horizon (issue #539) — it is a price display, not a
return, and the audit scoped the fix to the Actual return readers.

The `#555` parity diagnostic (`scripts/horizon_split_parity_diagnostic.ts`)
sourced its "raw" Actual from the shipped reader; now that the reader is fixed it
reconstructs the raw horizon midpoint independently
(`priceAtNinetyDayHorizon`) so it still quantifies the now-removed offset.

Closes #569.

## Evidence

This is a frontend/CLI logic change with no isolated web view to screenshot — the
effect is invisible for the ~98 % of rows with no post-horizon split (factor
1.0, value unchanged) and only moves the 123 split-affected rows. **Playwright
MCP was unavailable in this environment**, so verification is via the
reproducible diagnostic and unit tests that execute the real shipped code.

Reproducible diagnostic (`deno task diagnose-horizon-split-parity`, as-of
2026-06-26) — the measured impact matches the issue exactly:

```
Matured score dates:      274
Included stock-rows:      5444
Post-horizon split rows:  123
Per-row offset  min/max:  -316.116 pp / +1395.893 pp
Basis contribution:       +0.482 pp
VERDICT: ... RESOLVED in issue #569: the shipped readers now restate the Actual
through horizonPriceCurrentBasis so it shares the buy price's basis.
```

Worked example (2:1 forward split after the horizon): buy 100 → restated 50;
horizon mid 120 → restated 60. The Actual is now the real **+20 %** move, not the
spurious **+140 %** the raw 120 produced.

### Data flow

```mermaid
flowchart LR
    A[market data] --> B[getBuyPrice<br/>restated to current basis]
    A --> C[priceAtNinetyDayHorizon<br/>raw horizon mid]
    C --> D[horizonPriceCurrentBasis<br/>raw mid ÷ postHorizonSplitFactor]
    B --> E[Actual % = currentPrice − buyPrice / buyPrice]
    D --> E
    C --> F["90-Day Price field<br/>(raw snapshot, #539 — unchanged)"]
    E --> G[getStockReturnBreakdown · calculateStockPerformance<br/>currentPriceWithinWindow · gain-loss popover]
```

## Test Plan

New `tests/dashboard_actual_horizon_basis_test.ts` (11 tests) — executes the
**real shipped code** (the trend reader is imported and called; the `app.js`
methods are brace-matched from source and run with a fake `this`, not grepped):

- `currentPriceWithinWindow` restates forward and reverse post-horizon splits,
  is unchanged with no post-horizon split, and returns null with no usable point.
- `resolvePredictionStocks` Actual and buy price share the current basis (real
  +20 % move, not +140 %).
- `getStockReturnBreakdown` reads the Actual on the buy price's basis, is
  unchanged without a split, and returns null past the horizon.
- `calculateStockPerformance` restates the same way and **agrees with**
  `getStockReturnBreakdown` on the same basis.

Existing suites updated/confirmed:

- `tests/horizon_split_parity_diagnostic_test.ts` — passes against the diagnostic
  rewrite (raw reconstructed independently). No assertions weakened.
- Full Deno suite (1086 tests) and `./quality.sh` pass cleanly.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mquc40ma-7b5c99`<!-- vibe-worker-issue-569 -->