### PR TITLE
[#577] Flag and exclude low-volume stocks from the dashboard portfolio and aggregations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Pages.
   excludes the stock through the single `is_priceable` gate, dropping it from
   the average, the included count and into `excluded_tickers`. The thresholds
   mirror the frontend so backend and dashboard agree.
+- **Low-Volume Exclusion** — illiquid names are flagged and dropped from the
+  dashboard portfolio and from every aggregate (equal-weight) figure, so a name
+  too thin to trade neither helps nor hurts the "Actual"/Target lines. The
+  decision reuses GRQ training's `volumeRecommend` definition as a single source
+  of truth (`docs/volume_recommend.js`, issue #576): over a trailing 10-weekday
+  window, average daily **dollar** volume (`volume × low price`) below the
+  `BUDGET_DOLLARS = 10000` trade budget flags the stock. Flagged rows carry a
+  visible **Low volume** badge (issue #577) rather than vanishing silently. When
+  volume is unknown — older pre-volume-column CSVs — the name is **not** flagged
+  (insufficient data ⇒ not flagged), so historical dates are never
+  mass-excluded.
 - **Dividend Tracking** — calculate dividend income and total returns.
 - **Web Dashboard** — interactive charts and tables for performance analysis,
   served as a static site from `docs/`. On mobile, a pop-out control expands the

--- a/docs/app.js
+++ b/docs/app.js
@@ -610,9 +610,19 @@ class GRQValidator {
                 const open = parseFloat(values[4]);
                 const close = parseFloat(values[5]);
                 const splitCoefficient = parseFloat(values[6]);
+                // Trailing volume column (issue #575): present only in
+                // 8-column CSVs. Blank / non-numeric / absent -> null so the
+                // low-volume helper (#576) treats it as "unknown" rather than
+                // zero and never mass-excludes pre-volume-column history.
+                const volumeRaw = values[7];
+                const volumeNum =
+                    volumeRaw !== undefined && volumeRaw.trim() !== ""
+                        ? parseFloat(volumeRaw)
+                        : NaN;
+                const volume = Number.isFinite(volumeNum) ? volumeNum : null;
 
                 if (index < 3) { // Debug first 3 lines
-                    console.log(`Parsed values: date=${date}, ticker=${ticker}, high=${high}, low=${low}, open=${open}, close=${close}, split=${splitCoefficient}`);
+                    console.log(`Parsed values: date=${date}, ticker=${ticker}, high=${high}, low=${low}, open=${open}, close=${close}, split=${splitCoefficient}, volume=${volume}`);
                 }
 
                 if (!this.marketData[ticker]) {
@@ -629,6 +639,7 @@ class GRQValidator {
                     open,
                     close,
                     splitCoefficient,
+                    volume,
                 });
             });
             
@@ -3194,8 +3205,15 @@ class GRQValidator {
                 // Aggregate view
                 // Escape untrusted TSV-derived ticker before interpolation (issue #63).
                 const safeStock = escapeHtml(stock.stock);
+                // Visible low-volume badge (issue #577): flagged names are
+                // excluded from the portfolio and every aggregate, so surface
+                // the reason rather than dropping them silently.
+                const lowVolume = this.isStockLowVolume(stock.stock, scoreDate);
+                const lowVolumeBadge = lowVolume
+                    ? ` <span class="badge bg-warning text-dark low-volume-badge" title="Low volume — excluded from the portfolio and all aggregate figures (issue #577)">Low volume</span>`
+                    : "";
                 row.innerHTML = `
-            <td class="clickable-stock" data-stock="${safeStock}">${safeStock}</td>
+            <td class="clickable-stock" data-stock="${safeStock}">${safeStock}${lowVolumeBadge}</td>
             <td>
                 <span class="clickable-value ${buyPrice === null ? 'price-error' : ''}" data-bs-toggle="popover" data-bs-trigger="click" data-bs-content="" data-bs-title="Buy Price - ${safeStock}"
                     data-field="buy-price" data-stock="${safeStock}"
@@ -3237,6 +3255,11 @@ class GRQValidator {
                 // calculations.
                 if (!this.isStockPriceable(stock.stock, scoreDate)) {
                     row.classList.add("excluded-stock");
+                }
+                // Tag low-volume exclusions (issue #577) distinctly so the
+                // badge and any low-volume styling can target them.
+                if (lowVolume) {
+                    row.classList.add("low-volume-stock");
                 }
                 // Add highlighting for selected stock in aggregate view
                 if (this.selectedStock === stock.stock) {
@@ -3763,16 +3786,35 @@ class GRQValidator {
     // helpers all agree on the rule. Excluded stocks (delisted, merged for
     // cash, renamed) are dropped entirely, re-weighting the portfolio equally
     // over the remaining included stocks.
+    // Whether a stock is flagged low-volume as of the score date (issue #577),
+    // using the shared single-source-of-truth helper (#576) over a trailing
+    // 10-weekday { volume, lowPrice } window drawn from the already-loaded
+    // historical series. Unknown volume (e.g. pre-volume-column CSVs) ⇒ NOT
+    // flagged, so historical dates are never mass-excluded.
+    isStockLowVolume(stockSymbol, scoreDate) {
+        const series = this.marketData ? this.marketData[stockSymbol] : null;
+        if (!series) {
+            return false;
+        }
+        const window = GRQVolume.buildTrailingVolumeWindow(series, scoreDate);
+        return GRQVolume.isLowVolume(window);
+    }
+
     isStockPriceable(stockSymbol, scoreDate) {
         const buyPriceObj = this.getBuyPrice(stockSymbol, scoreDate);
         const buyPrice = buyPriceObj ? buyPriceObj.price : null;
         const currentPrice = GRQProjection.currentPriceFromLatest(
             this.marketData[stockSymbol],
         );
+        // Low-volume names are excluded from the portfolio and from EVERY
+        // aggregate (issue #577): this single gate feeds the chart Actual /
+        // "Actual (After 90 Days)" line, the totals row and the dividend
+        // figures, so an illiquid name neither helps nor hurts any of them.
         return GRQProjection.isStockIncluded(
             buyPrice,
             currentPrice,
             buyPriceObj ? buyPriceObj.reliable !== false : true,
+            this.isStockLowVolume(stockSymbol, scoreDate),
         );
     }
 

--- a/docs/archive/pr-summaries/pr-summary-577.md
+++ b/docs/archive/pr-summaries/pr-summary-577.md
@@ -1,0 +1,113 @@
+# [#577] Flag and exclude low-volume stocks from the dashboard portfolio and aggregations
+
+## Summary
+
+Low-volume (illiquid) names are now **flagged** and **excluded** from the
+dashboard portfolio and from **every** aggregate (equal-weight) figure —
+notably the "Actual (After 90 Days)" line — so a name too thin to trade neither
+helps nor hurts the Actual/Target lines. Flagged names stay **visible** via a
+"Low volume" badge and a legend, rather than vanishing silently. **Closes #577.**
+
+The liquidity decision reuses GRQ training's `volumeRecommend` definition as a
+single source of truth (the #576 helper, added here since it was an unmet
+dependency): over a trailing 10-weekday window, the average daily **dollar**
+volume (`volume × low price`) below the `BUDGET_DOLLARS = 10000` trade budget
+flags the stock. Per #576's units caveat, the dashboard CSVs store prices in
+**dollars**, so dollar volume is computed directly (no `/100`).
+
+When volume is **unknown** (older pre-volume-column CSVs — currently every
+committed CSV, since #575 only added the column), the name is **not** flagged
+("insufficient data ⇒ not flagged"), so historical dates are never
+mass-excluded. The effect today is therefore a no-op on live data; the wiring
+activates automatically once 8-column CSVs carry volume.
+
+### What changed
+
+- **`docs/volume_recommend.js` (new)** — the #576 single-source-of-truth helper:
+  `BUDGET_DOLLARS`, `volumeRecommend(window)`, `isLowVolume(window)` and
+  `buildTrailingVolumeWindow(series, asOfDate)`. Pure, published on
+  `globalThis.GRQVolume`, loaded as a classic `<script>` and imported by tests.
+- **`docs/projection.js`** — `isStockIncluded` gains a 4th `lowVolume` parameter
+  (defaults `false`); the three equal-weight aggregators
+  (`calculateIncludedPortfolioPerformance`, `…DividendYield`,
+  `calculatePortfolioTargetPercentage`) honour `stock.lowVolume`.
+- **`docs/app.js`** — parses the trailing volume column, adds
+  `isStockLowVolume(symbol, scoreDate)` over a trailing 10-weekday window, and
+  routes it through the **single** `isStockPriceable` gate that feeds the chart
+  Actual / "Actual (After 90 Days)" line, the totals row and the dividend
+  figures. Renders a **Low volume** badge and tags the row `low-volume-stock`.
+- **`docs/trend_predictions.js` / `docs/trend_series.js`** — the Trend view
+  parses volume, resolves a `lowVolume` flag, and excludes flagged names from
+  its Actual/Target/count aggregates.
+- **`docs/index.html` / `docs/trend.html`** — load `volume_recommend.js` before
+  consumers; index adds the legend. **`docs/styles.css`** styles the badge.
+  **`docs/sw.js`** precaches the new asset.
+- **`scripts/*.ts` + affected tests** — import the new helper so the diagnostic
+  sweeps that call `resolvePredictionStocks` keep working.
+
+### Data flow
+
+```mermaid
+flowchart LR
+    CSV[market CSV<br/>trailing volume col #575] --> W[buildTrailingVolumeWindow<br/>last 10 weekdays]
+    W --> VR[volumeRecommend / isLowVolume<br/>BUDGET_DOLLARS = 10000 #576]
+    VR -->|lowVolume| GATE[isStockIncluded / isStockPriceable]
+    GATE -->|excluded| AGG[Actual / Target / dividend<br/>equal-weight aggregates]
+    GATE -->|flagged| UI[Low volume badge + legend]
+```
+
+## Evidence
+
+This is a dashboard (UI + data-pipeline) change. **Playwright MCP was not
+available in this environment**, so no live screenshot was captured. The
+behaviour is instead pinned by behavioural Deno tests against the real shipped
+kernels, and the UI surfaces are verified to be present in the committed markup:
+
+- Badge rendered in `docs/app.js` (`low-volume-badge`), styled in
+  `docs/styles.css`, legend in `docs/index.html`.
+- Because no committed CSV yet carries volume, no badge renders on live data
+  today (the documented "insufficient data ⇒ not flagged" rule); the
+  synthetic-fixture tests below exercise the flagged path end-to-end.
+
+### Test results
+
+- `deno test --allow-read tests/*.ts` → **1136 passed, 0 failed**.
+- `deno fmt` / `deno lint` / `deno check` → clean.
+- `cargo check` / `cargo clippy` → clean (no Rust changed).
+
+> **Pre-existing, unrelated failure:** `quality.sh`'s `cargo test` step fails on
+> `utils::tests::test_read_market_data`, which reads the external
+> `../GRQ-shareprices2026Q2` repo and needs a "SEM" symbol file that is absent
+> in this environment. The failure reproduces identically with the parent
+> commit's unmodified `src/utils.rs` — this change touches **no** Rust — so it is
+> environmental and out of scope for #577.
+
+## Test Plan
+
+New tests:
+
+- `tests/volume_recommend_test.ts` — the #576 helper: below-budget → `-1`;
+  liquid → ~1; borderline → capped 0.5; unknown volume → `null` (not flagged);
+  present-but-tiny vs unknown; non-numeric/zero cells skipped; trailing-window
+  builder.
+- `tests/low_volume_exclusion_test.ts` — `isStockIncluded` drops a low-volume
+  name and defaults `lowVolume` to false; low-volume names excluded from the
+  Actual, Target and dividend aggregates; **a known-illiquid synthetic fixture
+  is flagged and removed while the liquid name is unaffected**; a
+  pre-volume-column CSV flags nothing (no mass-exclusion).
+- `tests/js_syntax_test.ts` — `docs/volume_recommend.js` parses cleanly.
+
+Updated imports so existing suites/scripts load the new helper:
+`tests/trend_predictions_test.ts`, `tests/dashboard_actual_horizon_basis_test.ts`,
+and six `scripts/*_diagnostic*.ts` / `scripts/residual_gap_reconciliation.ts`.
+
+## Acceptance criteria
+
+- ✅ Low-volume names excluded from portfolio membership and from aggregate
+  (equal-weight) computations (single `isStockIncluded` / `isStockPriceable`
+  gate).
+- ✅ Visible indicator (Low volume badge + legend).
+- ✅ A known-illiquid synthetic fixture is removed from the aggregate; liquid
+  names unaffected (`tests/low_volume_exclusion_test.ts`).
+- ✅ Unknown volume ⇒ not flagged — no accidental mass-exclusion of historical
+  dates.

--- a/docs/index.html
+++ b/docs/index.html
@@ -373,6 +373,19 @@
                         <tbody id="stockTableBody"></tbody>
                       </table>
                     </div>
+                    <!-- Low-volume legend (issue #577): explain the badge so
+                         excluded illiquid names are visible, not silently
+                         dropped from the portfolio and aggregate figures. -->
+                    <div class="data-source-note text-muted mt-2 px-3 pb-2">
+                      <small>
+                        <span
+                          class="badge bg-warning text-dark low-volume-badge"
+                        >Low volume</span>
+                        &mdash; average daily dollar volume is below the
+                        $10,000 trade budget, so the stock is excluded from the
+                        portfolio and from every aggregate (equal-weight) figure.
+                      </small>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -460,6 +473,10 @@
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
     <script src="projection.js"></script>
+
+    <!-- Shared low-volume/liquidity helper (issue #576) — must load before
+         app.js, which excludes flagged names from the portfolio (issue #577) -->
+    <script src="volume_recommend.js"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
     <script src="chart_window_settings.js"></script>

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -194,14 +194,26 @@ function returnAboveCostOfCapital(performance, costOfCapital, daysElapsed) {
 }
 
 // Single source of truth for the "is this stock included?" rule (issue #288,
-// extended #293). Mirrors the Rust backend's `is_priceable` predicate
+// extended #293, #577). Mirrors the Rust backend's `is_priceable` predicate
 // (src/utils.rs). A stock counts towards portfolio performance ONLY when it has
 // BOTH a usable buy price AND a usable current price, AND its split series is
 // reliable. If either price is missing/non-positive, or `splitReliable` is
 // explicitly false, the stock is excluded entirely.
-function isStockIncluded(buyPrice, currentPrice, splitReliable = true) {
+//
+// Low-volume exclusion (issue #577): a name flagged low-volume (`lowVolume`
+// true, computed via the shared GRQVolume.volumeRecommend helper #576) is
+// dropped from portfolio membership and from EVERY aggregate average, so it
+// neither helps nor hurts the Actual/Target lines. `lowVolume` defaults to
+// false so an unknown/insufficient-volume name is never accidentally excluded.
+function isStockIncluded(
+    buyPrice,
+    currentPrice,
+    splitReliable = true,
+    lowVolume = false,
+) {
     const usable = (price) => typeof price === "number" && price > 0;
-    return usable(buyPrice) && usable(currentPrice) && splitReliable !== false;
+    return usable(buyPrice) && usable(currentPrice) &&
+        splitReliable !== false && lowVolume !== true;
 }
 
 // Equal-weight portfolio performance over ONLY the included stocks (issue #288).
@@ -221,7 +233,10 @@ function calculateIncludedPortfolioPerformance(stocks) {
         const buyPrice = stock && stock.buyPrice;
         const currentPrice = stock && stock.currentPrice;
         const splitReliable = stock && stock.splitReliable;
-        if (!isStockIncluded(buyPrice, currentPrice, splitReliable)) {
+        const lowVolume = stock && stock.lowVolume;
+        if (
+            !isStockIncluded(buyPrice, currentPrice, splitReliable, lowVolume)
+        ) {
             continue;
         }
         const totalReturn = calculatePerformanceReturn(
@@ -267,7 +282,10 @@ function calculateIncludedPortfolioDividendYield(stocks) {
         const buyPrice = stock && stock.buyPrice;
         const currentPrice = stock && stock.currentPrice;
         const splitReliable = stock && stock.splitReliable;
-        if (!isStockIncluded(buyPrice, currentPrice, splitReliable)) {
+        const lowVolume = stock && stock.lowVolume;
+        if (
+            !isStockIncluded(buyPrice, currentPrice, splitReliable, lowVolume)
+        ) {
             continue;
         }
         const yieldPercent = dividendReturnPercent(
@@ -828,7 +846,10 @@ function calculatePortfolioTargetPercentage(stocks) {
         const buyPrice = stock && stock.buyPrice;
         const currentPrice = stock && stock.currentPrice;
         const splitReliable = stock && stock.splitReliable;
-        if (!isStockIncluded(buyPrice, currentPrice, splitReliable)) {
+        const lowVolume = stock && stock.lowVolume;
+        if (
+            !isStockIncluded(buyPrice, currentPrice, splitReliable, lowVolume)
+        ) {
             continue;
         }
         const adjustedTarget = stock.adjustedTarget;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -333,6 +333,17 @@ body.chart-popout-open {
   text-decoration: underline line-through;
 }
 
+/* Low-volume badge (issue #577): a flagged name is excluded from the portfolio
+ * and every aggregate, so it carries a visible "Low volume" badge. Keep the
+ * badge legible (no inherited row strikethrough) so the reason for exclusion
+ * stays readable even on a struck-through excluded row. */
+.low-volume-badge {
+  text-decoration: none;
+  white-space: nowrap;
+  font-size: 0.7em;
+  vertical-align: middle;
+}
+
 /* Clickable stock names */
 .clickable-stock {
   cursor: pointer;

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -21,6 +21,8 @@ const STATIC_ASSETS = [
   "./index.html",
   "./app.js",
   "./projection.js",
+  // Shared low-volume/liquidity helper (issue #576/#577).
+  "./volume_recommend.js",
   "./chart_window_settings.js",
   "./color_key.js",
   "./series_label_colour.js",

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -169,6 +169,10 @@
     <!-- Shared projection/scoring maths — must load before the engines below -->
     <script src="projection.js"></script>
 
+    <!-- Shared low-volume/liquidity helper (issue #576) — before
+         trend_predictions.js, which flags low-volume names (issue #577) -->
+    <script src="volume_recommend.js"></script>
+
     <!-- Shared number-formatting helpers (issue #276) -->
     <script src="format.js"></script>
 

--- a/docs/trend_predictions.js
+++ b/docs/trend_predictions.js
@@ -99,6 +99,13 @@ function parseMarketCsv(text) {
         if (!marketData[ticker]) {
             marketData[ticker] = [];
         }
+        // Trailing volume column (issue #575): present only in 8-column CSVs.
+        // Blank / non-numeric / absent -> null so the low-volume helper (#576)
+        // treats it as "unknown" rather than zero.
+        const volumeRaw = values[7];
+        const volume = volumeRaw !== undefined && volumeRaw.trim() !== ""
+            ? parseFloat(volumeRaw)
+            : NaN;
         marketData[ticker].push({
             date: GRQProjection.setDateToMidnight(new Date(values[0])),
             high: parseFloat(values[2]),
@@ -106,6 +113,7 @@ function parseMarketCsv(text) {
             open: parseFloat(values[4]),
             close: parseFloat(values[5]),
             splitCoefficient: parseFloat(values[6]),
+            volume: Number.isFinite(volume) ? volume : null,
         });
     }
     for (const ticker of Object.keys(marketData)) {
@@ -207,7 +215,21 @@ function resolvePredictionStocks(scoreRows, marketData, dividendData, scoreDate)
                 scoreDate,
             )
             : null;
-        return { buyPrice, currentPrice, totalDividends, adjustedTarget, splitReliable };
+        // Low-volume flag (issue #577) over a trailing 10-weekday window ending
+        // at the score date, via the shared single-source-of-truth helper
+        // (#576). Unknown volume ⇒ not flagged, so pre-volume-column history is
+        // never mass-excluded from the trend aggregates.
+        const lowVolume = GRQVolume.isLowVolume(
+            GRQVolume.buildTrailingVolumeWindow(points, scoreDate),
+        );
+        return {
+            buyPrice,
+            currentPrice,
+            totalDividends,
+            adjustedTarget,
+            splitReliable,
+            lowVolume,
+        };
     });
 }
 

--- a/docs/trend_series.js
+++ b/docs/trend_series.js
@@ -73,7 +73,15 @@ function includedStockCount(stocks) {
         const buyPrice = stock && stock.buyPrice;
         const currentPrice = stock && stock.currentPrice;
         const splitReliable = stock && stock.splitReliable;
-        if (GRQProjection.isStockIncluded(buyPrice, currentPrice, splitReliable)) {
+        const lowVolume = stock && stock.lowVolume;
+        if (
+            GRQProjection.isStockIncluded(
+                buyPrice,
+                currentPrice,
+                splitReliable,
+                lowVolume,
+            )
+        ) {
             count++;
         }
     }

--- a/docs/volume_recommend.js
+++ b/docs/volume_recommend.js
@@ -1,0 +1,143 @@
+// Shared low-volume / liquidity helper — the SINGLE source of truth for the
+// dashboard's "is this name too illiquid to trade?" decision (issue #576,
+// consumed by the exclusion sub-issue #577 and the valuation sub-issue #578).
+//
+// Ported from GRQ training's `volumeRecommend` (GRQ/src/CoreFeatures.ts) so the
+// dashboard and the trainer agree on ONE definition — do not invent a new
+// threshold. The only constant is `BUDGET_DOLLARS = 10000`
+// (GRQ/src/LearnUtilTypes.ts).
+//
+// UNITS CAVEAT (critical correctness note): GRQ stores prices in CENTS and so
+// divides dollar volume by 100 before comparing to BUDGET_DOLLARS. The
+// dashboard CSVs store prices in DOLLARS (e.g. a close of 40.89), so here we
+// compute dollar volume directly as `volume * lowPrice` (NO `/100`) and compare
+// to BUDGET_DOLLARS = 10000 dollars. We reuse the DEFINITION, not the literal
+// `/100`.
+//
+// Mirrors docs/projection.js and docs/format.js: loaded as a classic <script>
+// in docs/index.html (no module syntax) and imported by the Deno tests, so the
+// browser dashboard and the tests exercise the exact same code. The helpers are
+// published on `globalThis.GRQVolume`.
+
+// The single liquidity threshold, in DOLLARS (GRQ/src/LearnUtilTypes.ts:69).
+const BUDGET_DOLLARS = 10000;
+
+// GRQ's "last 10 weekdays" lookback. Daily market-data rows are already
+// weekdays (markets trade Mon–Fri), so the trailing 10 trading rows on or
+// before the as-of date are the "last 10 weekdays".
+const WEEKDAY_WINDOW = 10;
+
+// Coerce a value to a finite, strictly-positive number, or null otherwise.
+// Accepts numbers and numeric strings; rejects NaN/Infinity, <= 0, null,
+// undefined and non-numeric strings. Keeps the maths defensive against the
+// mixed data the dashboard interpolates (blank/`not-a-number` volume cells).
+function toFinitePositive(value) {
+    const n = typeof value === "number" ? value : Number(value);
+    return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+// Average daily DOLLAR volume (mean of `volume * lowPrice`) over the window,
+// or null when NO day in the window carries usable {volume, lowPrice}. The
+// null result is the documented "insufficient data ⇒ not flagged" rule: older
+// pre-volume-column CSVs lack volume, and those historical dates must not be
+// mass-excluded. Days with missing/zero volume or price are skipped; a single
+// present-but-tiny day still yields a (small) average so it can be flagged.
+function averageDollarVolume(window) {
+    if (!Array.isArray(window) || window.length === 0) {
+        return null;
+    }
+    let sum = 0;
+    let days = 0;
+    for (const day of window) {
+        if (!day) {
+            continue;
+        }
+        const volume = toFinitePositive(day.volume);
+        const lowPrice = toFinitePositive(day.lowPrice);
+        if (volume === null || lowPrice === null) {
+            continue;
+        }
+        sum += volume * lowPrice;
+        days += 1;
+    }
+    return days === 0 ? null : sum / days;
+}
+
+// volumeRecommend(window): the ported GRQ definition over a trailing window of
+// { volume, lowPrice } points. Returns:
+//   - null  when volume is unknown across the WHOLE window (insufficient data,
+//           NOT flagged — pre-volume-column CSVs land here);
+//   - -1    when average dollar volume is below BUDGET_DOLLARS (never
+//           recommend / flag as low-volume);
+//   - else  min(marketPercentOfTrade, cap) in (0, 1], where
+//           marketPercentOfTrade = 1 - BUDGET_DOLLARS / averagePV and the cap is
+//           0.5 while marketPercentOfTrade < 0.99, otherwise 1.
+function volumeRecommend(window) {
+    const averagePV = averageDollarVolume(window);
+    if (averagePV === null) {
+        return null;
+    }
+    if (averagePV < BUDGET_DOLLARS) {
+        return -1;
+    }
+    const marketPercentOfTrade = 1 - BUDGET_DOLLARS / averagePV;
+    return marketPercentOfTrade < 0.99
+        ? Math.min(marketPercentOfTrade, 0.5)
+        : Math.min(marketPercentOfTrade, 1);
+}
+
+// Convenience: a name is low-volume when volumeRecommend is a real NEGATIVE
+// number. Unknown volume (null) is explicitly NOT low-volume (insufficient
+// data ⇒ not flagged), so callers never mass-exclude historical dates.
+function isLowVolume(window) {
+    const recommend = volumeRecommend(window);
+    return typeof recommend === "number" && recommend < 0;
+}
+
+// Build a trailing WEEKDAY_WINDOW window of { volume, lowPrice } from a daily
+// market-data series, ready for volumeRecommend/isLowVolume. `series` is the
+// dashboard's per-ticker array of points; each point exposes a `date` (Date or
+// parseable value), a low price (`lowPrice` or `low`) and `volume`. Points
+// dated AFTER `asOfDate` are ignored, and the most recent `weekdays` of the
+// remainder are returned oldest-first. Pure: no DOM, no class state.
+function buildTrailingVolumeWindow(series, asOfDate, weekdays = WEEKDAY_WINDOW) {
+    if (!Array.isArray(series)) {
+        return [];
+    }
+    const cutoff = asOfDate instanceof Date
+        ? asOfDate.getTime()
+        : new Date(asOfDate).getTime();
+    const usable = [];
+    for (const point of series) {
+        if (!point) {
+            continue;
+        }
+        const time = point.date instanceof Date
+            ? point.date.getTime()
+            : new Date(point.date).getTime();
+        if (!Number.isFinite(time)) {
+            continue;
+        }
+        if (Number.isFinite(cutoff) && time > cutoff) {
+            continue;
+        }
+        const lowPrice = point.lowPrice !== undefined
+            ? point.lowPrice
+            : point.low;
+        usable.push({ time, lowPrice, volume: point.volume });
+    }
+    usable.sort((a, b) => a.time - b.time);
+    return usable
+        .slice(-weekdays)
+        .map((point) => ({ volume: point.volume, lowPrice: point.lowPrice }));
+}
+
+globalThis.GRQVolume = {
+    BUDGET_DOLLARS,
+    WEEKDAY_WINDOW,
+    toFinitePositive,
+    averageDollarVolume,
+    volumeRecommend,
+    isLowVolume,
+    buildTrailingVolumeWindow,
+};

--- a/scripts/buy_price_denominator_diagnostic.ts
+++ b/scripts/buy_price_denominator_diagnostic.ts
@@ -14,6 +14,7 @@
 // restated onto the trained close basis.
 
 import "../docs/projection.js";
+import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
 // deno-lint-ignore no-explicit-any

--- a/scripts/dividend_basis_diagnostic.ts
+++ b/scripts/dividend_basis_diagnostic.ts
@@ -19,6 +19,7 @@
 // than a re-implementation.
 
 import "../docs/projection.js";
+import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
 // deno-lint-ignore no-explicit-any

--- a/scripts/horizon_split_parity_diagnostic.ts
+++ b/scripts/horizon_split_parity_diagnostic.ts
@@ -22,6 +22,7 @@
 // offset is DORMANT; were the raw read reintroduced, the offset would reappear.
 
 import "../docs/projection.js";
+import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
 // deno-lint-ignore no-explicit-any

--- a/scripts/price_basis_diagnostic.ts
+++ b/scripts/price_basis_diagnostic.ts
@@ -6,6 +6,7 @@
 // diagnostic measures the dashboard's own basis rather than a re-implementation.
 
 import "../docs/projection.js";
+import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
 // deno-lint-ignore no-explicit-any

--- a/scripts/residual_gap_reconciliation.ts
+++ b/scripts/residual_gap_reconciliation.ts
@@ -21,6 +21,7 @@
 // measures the dashboard's own aggregation rather than a re-implementation.
 
 import "../docs/projection.js";
+import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
 // deno-lint-ignore no-explicit-any

--- a/scripts/score_target_decoding_diagnostic.ts
+++ b/scripts/score_target_decoding_diagnostic.ts
@@ -30,6 +30,7 @@
 // (docs/trend_predictions.js → GRQTrendPredictions.parseScoreTsv), so the
 // diagnostic reads exactly the score column the dashboard reads.
 
+import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
 // deno-lint-ignore no-explicit-any

--- a/tests/dashboard_actual_horizon_basis_test.ts
+++ b/tests/dashboard_actual_horizon_basis_test.ts
@@ -18,6 +18,7 @@
 
 import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
 import "../docs/projection.js";
+import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
 // deno-lint-ignore no-explicit-any

--- a/tests/js_syntax_test.ts
+++ b/tests/js_syntax_test.ts
@@ -43,6 +43,14 @@ Deno.test("checkJsSyntax - production docs/app.js parses cleanly", async () => {
   assertEquals(result.valid, true, result.error);
 });
 
+Deno.test("checkJsSyntax - production docs/volume_recommend.js parses cleanly", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../docs/volume_recommend.js", import.meta.url),
+  );
+  const result = checkJsSyntax(source);
+  assertEquals(result.valid, true, result.error);
+});
+
 Deno.test("checkJsSyntax - production docs/theme.js parses cleanly", async () => {
   const source = await Deno.readTextFile(
     new URL("../docs/theme.js", import.meta.url),

--- a/tests/low_volume_exclusion_test.ts
+++ b/tests/low_volume_exclusion_test.ts
@@ -1,0 +1,240 @@
+// Low-volume exclusion tests (issue #577).
+//
+// A name flagged low-volume by the shared GRQVolume.volumeRecommend helper
+// (#576) must be excluded from portfolio membership AND from every aggregate
+// (equal-weight) average, so it neither helps nor hurts the "Actual"/Target
+// lines. Liquid names are unaffected, and when volume is unknown
+// (pre-volume-column CSVs) NO name is flagged.
+//
+// These exercise the REAL shipped kernels: the inclusion predicate and the
+// aggregate kernels in docs/projection.js, plus the Trend-view resolver in
+// docs/trend_predictions.js that wires the volume window into a `lowVolume`
+// flag. The dashboard glue (app.js) routes through the same predicate via
+// isStockPriceable, so these assertions pin the shared behaviour.
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/volume_recommend.js";
+import "../docs/trend_series.js";
+import "../docs/trend_predictions.js";
+
+interface ResolvedStock {
+  buyPrice: number | null;
+  currentPrice: number | null;
+  totalDividends: number;
+  adjustedTarget: number | null;
+  splitReliable?: boolean;
+  lowVolume?: boolean;
+}
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    isStockIncluded: (
+      buyPrice: number | null | undefined,
+      currentPrice: number | null | undefined,
+      splitReliable?: boolean,
+      lowVolume?: boolean,
+    ) => boolean;
+    calculateIncludedPortfolioPerformance: (
+      stocks: ResolvedStock[],
+    ) => number | null;
+    calculatePortfolioTargetPercentage: (stocks: ResolvedStock[]) => number;
+    calculateIncludedPortfolioDividendYield: (
+      stocks: ResolvedStock[],
+    ) => number | null;
+  };
+  GRQTrendPredictions: {
+    parseScoreTsv: (text: string) => Array<{ stock: string; target: number }>;
+    parseMarketCsv: (text: string) => Record<string, unknown[]>;
+    parseDividendCsv: (text: string) => Record<string, unknown[]>;
+    resolvePredictionStocks: (
+      scoreRows: Array<{ stock: string; target: number }>,
+      marketData: Record<string, unknown[]>,
+      dividendData: Record<string, unknown[]>,
+      scoreDate: Date,
+    ) => ResolvedStock[];
+  };
+};
+
+const GRQProjection = g.GRQProjection;
+const GRQTrendPredictions = g.GRQTrendPredictions;
+
+Deno.test("isStockIncluded drops a low-volume name (lowVolume=true)", () => {
+  // Fully priceable, split-reliable — only the low-volume flag excludes it.
+  assertEquals(GRQProjection.isStockIncluded(10, 12, true, false), true);
+  assertEquals(GRQProjection.isStockIncluded(10, 12, true, true), false);
+});
+
+Deno.test("isStockIncluded defaults lowVolume to false (unknown ⇒ included)", () => {
+  // Back-compat: callers that pass no lowVolume argument keep the old
+  // behaviour, so an unknown-volume name is never accidentally excluded.
+  assertEquals(GRQProjection.isStockIncluded(10, 12, true), true);
+});
+
+Deno.test("low-volume name is excluded from the equal-weight Actual aggregate", () => {
+  // Two liquid names at +10% and +30% (mean +20%) plus one illiquid name at
+  // +200% that would massively skew the equal-weight Actual if counted.
+  const stocks: ResolvedStock[] = [
+    {
+      buyPrice: 100,
+      currentPrice: 110,
+      totalDividends: 0,
+      adjustedTarget: 120,
+    },
+    {
+      buyPrice: 100,
+      currentPrice: 130,
+      totalDividends: 0,
+      adjustedTarget: 120,
+    },
+    {
+      buyPrice: 100,
+      currentPrice: 300,
+      totalDividends: 0,
+      adjustedTarget: 120,
+      lowVolume: true,
+    },
+  ];
+  const actual = GRQProjection.calculateIncludedPortfolioPerformance(stocks);
+  // Excluding the illiquid name leaves (10 + 30) / 2 = 20%, NOT (10+30+200)/3.
+  assertAlmostEquals(actual as number, 20, 1e-9);
+});
+
+Deno.test("low-volume name is excluded from the Target and dividend aggregates", () => {
+  const stocks: ResolvedStock[] = [
+    {
+      buyPrice: 100,
+      currentPrice: 110,
+      totalDividends: 5,
+      adjustedTarget: 120,
+    },
+    {
+      buyPrice: 100,
+      currentPrice: 130,
+      totalDividends: 50,
+      adjustedTarget: 300,
+      lowVolume: true,
+    },
+  ];
+  // Only the liquid name counts: target % = (120-100)/100 = 20%.
+  assertAlmostEquals(
+    GRQProjection.calculatePortfolioTargetPercentage(stocks),
+    20,
+    1e-9,
+  );
+  // Dividend yield = 5/100 = 5% (the illiquid 50% name is dropped).
+  assertAlmostEquals(
+    GRQProjection.calculateIncludedPortfolioDividendYield(stocks) as number,
+    5,
+    1e-9,
+  );
+});
+
+// --- End-to-end through the Trend-view resolver, using an 8-column CSV that
+// carries the volume column. A known-illiquid synthetic fixture must be flagged
+// and removed; the liquid fixture must be unaffected. ---
+
+const SCORE_DATE = new Date(2025, 0, 17); // 2025-01-17, a date present below
+
+function dailyRows(
+  ticker: string,
+  price: number,
+  volume: number | "",
+): string {
+  // 12 daily rows of flat data ending ON the score date (so getBuyPrice
+  // resolves), 8-column shape
+  // (date,ticker,high,low,open,close,split_coefficient,volume).
+  const rows: string[] = [];
+  for (let day = 6; day <= 17; day++) {
+    const d = `2025-01-${String(day).padStart(2, "0")}`;
+    rows.push(
+      `${d},${ticker},${price + 1},${price},${price},${price},1.0,${volume}`,
+    );
+  }
+  // A point inside the 90-day window so currentPrice resolves.
+  rows.push(
+    `2025-04-10,${ticker},${
+      price + 1
+    },${price},${price},${price},1.0,${volume}`,
+  );
+  return rows.join("\n");
+}
+
+Deno.test("illiquid synthetic fixture is flagged and removed; liquid name unaffected", () => {
+  const header = "date,ticker,high,low,open,close,split_coefficient,volume";
+  // LIQUID: $50 * 1,000,000 shares = $50,000,000/day >> $10,000 budget.
+  // ILLIQUID: $4 * 500 shares = $2,000/day << budget.
+  const csv = [
+    header,
+    dailyRows("NYSE:LIQUID", 50, 1_000_000),
+    dailyRows("NYSE:ILLIQ", 4, 500),
+  ].join("\n");
+
+  const scoreTsv = "stock\ttarget\nNYSE:LIQUID\t60\nNYSE:ILLIQ\t8";
+  const market = GRQTrendPredictions.parseMarketCsv(csv);
+  const rows = GRQTrendPredictions.parseScoreTsv(scoreTsv);
+  const stocks = GRQTrendPredictions.resolvePredictionStocks(
+    rows,
+    market,
+    {},
+    SCORE_DATE,
+  );
+
+  const liquid = stocks.find((_s, i) => rows[i].stock === "NYSE:LIQUID");
+  const illiquid = stocks.find((_s, i) => rows[i].stock === "NYSE:ILLIQ");
+
+  // The illiquid fixture is flagged; the liquid one is not.
+  assertEquals(illiquid?.lowVolume, true);
+  assertEquals(liquid?.lowVolume, false);
+
+  // The illiquid fixture is dropped from the inclusion predicate...
+  assert(
+    !GRQProjection.isStockIncluded(
+      illiquid?.buyPrice,
+      illiquid?.currentPrice,
+      illiquid?.splitReliable,
+      illiquid?.lowVolume,
+    ),
+  );
+  // ...while the liquid fixture remains included.
+  assert(
+    GRQProjection.isStockIncluded(
+      liquid?.buyPrice,
+      liquid?.currentPrice,
+      liquid?.splitReliable,
+      liquid?.lowVolume,
+    ),
+  );
+
+  // And the equal-weight Actual is computed over the liquid name ONLY.
+  const actual = GRQProjection.calculateIncludedPortfolioPerformance(stocks);
+  assertAlmostEquals(actual as number, 0, 1e-9); // LIQUID buy==current ⇒ 0%
+});
+
+Deno.test("pre-volume-column CSV (no volume) flags nothing — no mass-exclusion", () => {
+  // 7-column legacy shape: volume cells are empty across the whole window.
+  const header = "date,ticker,high,low,open,close,split_coefficient,volume";
+  const csv = [
+    header,
+    dailyRows("NYSE:ILLIQ", 4, ""), // empty volume cells
+  ].join("\n");
+  const scoreTsv = "stock\ttarget\nNYSE:ILLIQ\t8";
+  const market = GRQTrendPredictions.parseMarketCsv(csv);
+  const rows = GRQTrendPredictions.parseScoreTsv(scoreTsv);
+  const stocks = GRQTrendPredictions.resolvePredictionStocks(
+    rows,
+    market,
+    {},
+    SCORE_DATE,
+  );
+  // Unknown volume ⇒ NOT flagged (insufficient data), so the name is still
+  // included on its price merits — historical dates are not mass-excluded.
+  assertEquals(stocks[0].lowVolume, false);
+  assert(
+    GRQProjection.isStockIncluded(
+      stocks[0].buyPrice,
+      stocks[0].currentPrice,
+      stocks[0].splitReliable,
+      stocks[0].lowVolume,
+    ),
+  );
+});

--- a/tests/trend_predictions_test.ts
+++ b/tests/trend_predictions_test.ts
@@ -13,6 +13,7 @@
 // with small, hand-computable fixtures.
 import { assertAlmostEquals, assertEquals } from "@std/assert";
 import "../docs/projection.js";
+import "../docs/volume_recommend.js";
 import "../docs/trend_series.js";
 import "../docs/trend_predictions.js";
 

--- a/tests/volume_recommend_test.ts
+++ b/tests/volume_recommend_test.ts
@@ -1,0 +1,170 @@
+// Tests for the shared low-volume / liquidity helper (issue #576), the single
+// source of truth consumed by the exclusion (#577) and valuation (#578)
+// sub-issues. These exercise the real shipped module, published on
+// `globalThis.GRQVolume` by importing it, mirroring tests/format_test.ts.
+//
+// The volumeRecommend definition is ported from GRQ training so the dashboard
+// and the trainer agree; the cases below reproduce GRQ's outputs using DOLLAR
+// units (no `/100`) against BUDGET_DOLLARS = 10000.
+import { assertEquals } from "@std/assert";
+import "../docs/volume_recommend.js";
+
+const g = globalThis as unknown as {
+  GRQVolume: {
+    BUDGET_DOLLARS: number;
+    WEEKDAY_WINDOW: number;
+    toFinitePositive: (value: unknown) => number | null;
+    averageDollarVolume: (
+      window: Array<{ volume: unknown; lowPrice: unknown }> | unknown,
+    ) => number | null;
+    volumeRecommend: (
+      window: Array<{ volume: unknown; lowPrice: unknown }> | unknown,
+    ) => number | null;
+    isLowVolume: (
+      window: Array<{ volume: unknown; lowPrice: unknown }> | unknown,
+    ) => boolean;
+    buildTrailingVolumeWindow: (
+      series: unknown,
+      asOfDate: unknown,
+      weekdays?: number,
+    ) => Array<{ volume: unknown; lowPrice: unknown }>;
+  };
+};
+
+const {
+  BUDGET_DOLLARS,
+  volumeRecommend,
+  averageDollarVolume,
+  isLowVolume,
+  buildTrailingVolumeWindow,
+} = g.GRQVolume;
+
+// Build a flat window where every day shares one volume and lowPrice.
+function flatWindow(
+  days: number,
+  volume: number | null,
+  lowPrice: number | null,
+) {
+  return Array.from({ length: days }, () => ({ volume, lowPrice }));
+}
+
+Deno.test("volume_recommend publishes helpers on globalThis.GRQVolume", () => {
+  assertEquals(typeof volumeRecommend, "function");
+  assertEquals(typeof averageDollarVolume, "function");
+  assertEquals(typeof isLowVolume, "function");
+  assertEquals(typeof buildTrailingVolumeWindow, "function");
+});
+
+Deno.test("BUDGET_DOLLARS is the single threshold constant (10000 dollars)", () => {
+  assertEquals(BUDGET_DOLLARS, 10000);
+});
+
+Deno.test("below budget -> volumeRecommend is -1 (never recommend)", () => {
+  // 1000 shares * $5 = $5000/day average dollar volume < $10000.
+  const window = flatWindow(10, 1000, 5);
+  assertEquals(volumeRecommend(window), -1);
+  assertEquals(isLowVolume(window), true);
+});
+
+Deno.test("liquid name -> volumeRecommend approaches ~1 (not flagged)", () => {
+  // 10,000,000 shares * $50 = $500,000,000/day >> budget.
+  // marketPercentOfTrade = 1 - 10000/5e8 = 0.99998 (>= 0.99) -> min(.,1).
+  const window = flatWindow(10, 10_000_000, 50);
+  const recommend = volumeRecommend(window) as number;
+  assertEquals(recommend > 0.99 && recommend <= 1, true);
+  assertEquals(isLowVolume(window), false);
+});
+
+Deno.test("borderline (marketPercentOfTrade < 0.99) -> capped to 0.5", () => {
+  // averagePV = $1,000,000 -> marketPercentOfTrade = 1 - 10000/1e6 = 0.99.
+  // 0.99 is NOT < 0.99, so this lands on the >=0.99 branch (min with 1).
+  // Use $500,000 to get marketPercentOfTrade = 0.98 (< 0.99) -> capped 0.5.
+  const window = flatWindow(10, 100_000, 5); // 100000 * 5 = $500,000
+  assertEquals(averageDollarVolume(window), 500_000);
+  assertEquals(volumeRecommend(window), 0.5);
+  assertEquals(isLowVolume(window), false);
+});
+
+Deno.test("just above budget stays capped to 0.5 (small marketPercentOfTrade)", () => {
+  // averagePV = $20,000 -> marketPercentOfTrade = 0.5 -> min(0.5, 0.5) = 0.5.
+  const window = flatWindow(10, 2000, 10);
+  assertEquals(averageDollarVolume(window), 20_000);
+  assertEquals(volumeRecommend(window), 0.5);
+  assertEquals(isLowVolume(window), false);
+});
+
+Deno.test("unknown volume across whole window -> null (not flagged)", () => {
+  // Pre-volume-column CSVs: every day's volume is null. Insufficient data must
+  // NOT mass-exclude historical dates.
+  const window = flatWindow(10, null, 5);
+  assertEquals(averageDollarVolume(window), null);
+  assertEquals(volumeRecommend(window), null);
+  assertEquals(isLowVolume(window), false);
+});
+
+Deno.test("empty / non-array window -> null, not flagged", () => {
+  assertEquals(volumeRecommend([]), null);
+  assertEquals(volumeRecommend(null), null);
+  assertEquals(volumeRecommend(undefined), null);
+  assertEquals(isLowVolume([]), false);
+});
+
+Deno.test("present-but-tiny single day IS flagged (mix of known/unknown)", () => {
+  // Nine unknown days plus one tiny known day: averaged over the known day
+  // only ($3000 < budget) -> flagged. Distinguishes "tiny" from "unknown".
+  const window = [
+    ...flatWindow(9, null, 5),
+    { volume: 600, lowPrice: 5 }, // $3000
+  ];
+  assertEquals(averageDollarVolume(window), 3000);
+  assertEquals(volumeRecommend(window), -1);
+  assertEquals(isLowVolume(window), true);
+});
+
+Deno.test("non-numeric / zero volume cells are skipped in the average", () => {
+  const window = [
+    { volume: "not-a-number", lowPrice: 5 },
+    { volume: 0, lowPrice: 5 },
+    { volume: 1000, lowPrice: 5 }, // $5000, the only usable day
+  ];
+  assertEquals(averageDollarVolume(window), 5000);
+  assertEquals(volumeRecommend(window), -1);
+});
+
+Deno.test("buildTrailingVolumeWindow keeps last N rows on/before as-of date", () => {
+  const series = [
+    { date: new Date("2025-01-01"), low: 5, volume: 100 },
+    { date: new Date("2025-01-02"), low: 6, volume: 200 },
+    { date: new Date("2025-01-03"), low: 7, volume: 300 }, // as-of date
+    { date: new Date("2025-01-04"), low: 8, volume: 400 }, // after -> excluded
+  ];
+  const window = buildTrailingVolumeWindow(series, new Date("2025-01-03"), 2);
+  assertEquals(window, [
+    { volume: 200, lowPrice: 6 },
+    { volume: 300, lowPrice: 7 },
+  ]);
+});
+
+Deno.test("buildTrailingVolumeWindow honours an explicit lowPrice field", () => {
+  const series = [
+    { date: new Date("2025-01-01"), lowPrice: 9, volume: 100 },
+  ];
+  const window = buildTrailingVolumeWindow(series, new Date("2025-01-02"));
+  assertEquals(window, [{ volume: 100, lowPrice: 9 }]);
+});
+
+Deno.test("buildTrailingVolumeWindow returns [] for non-array series", () => {
+  assertEquals(buildTrailingVolumeWindow(null, new Date()), []);
+  assertEquals(buildTrailingVolumeWindow(undefined, new Date()), []);
+});
+
+Deno.test("end-to-end: trailing window of an illiquid series flags low-volume", () => {
+  const series = Array.from({ length: 12 }, (_, i) => ({
+    date: new Date(2025, 0, i + 1),
+    low: 4,
+    volume: 500, // 500 * 4 = $2000/day << budget
+  }));
+  const window = buildTrailingVolumeWindow(series, new Date(2025, 0, 31));
+  assertEquals(window.length, 10);
+  assertEquals(isLowVolume(window), true);
+});


### PR DESCRIPTION
# [#577] Flag and exclude low-volume stocks from the dashboard portfolio and aggregations

## Summary

Low-volume (illiquid) names are now **flagged** and **excluded** from the
dashboard portfolio and from **every** aggregate (equal-weight) figure —
notably the "Actual (After 90 Days)" line — so a name too thin to trade neither
helps nor hurts the Actual/Target lines. Flagged names stay **visible** via a
"Low volume" badge and a legend, rather than vanishing silently. **Closes #577.**

The liquidity decision reuses GRQ training's `volumeRecommend` definition as a
single source of truth (the #576 helper, added here since it was an unmet
dependency): over a trailing 10-weekday window, the average daily **dollar**
volume (`volume × low price`) below the `BUDGET_DOLLARS = 10000` trade budget
flags the stock. Per #576's units caveat, the dashboard CSVs store prices in
**dollars**, so dollar volume is computed directly (no `/100`).

When volume is **unknown** (older pre-volume-column CSVs — currently every
committed CSV, since #575 only added the column), the name is **not** flagged
("insufficient data ⇒ not flagged"), so historical dates are never
mass-excluded. The effect today is therefore a no-op on live data; the wiring
activates automatically once 8-column CSVs carry volume.

### What changed

- **`docs/volume_recommend.js` (new)** — the #576 single-source-of-truth helper:
  `BUDGET_DOLLARS`, `volumeRecommend(window)`, `isLowVolume(window)` and
  `buildTrailingVolumeWindow(series, asOfDate)`. Pure, published on
  `globalThis.GRQVolume`, loaded as a classic `<script>` and imported by tests.
- **`docs/projection.js`** — `isStockIncluded` gains a 4th `lowVolume` parameter
  (defaults `false`); the three equal-weight aggregators
  (`calculateIncludedPortfolioPerformance`, `…DividendYield`,
  `calculatePortfolioTargetPercentage`) honour `stock.lowVolume`.
- **`docs/app.js`** — parses the trailing volume column, adds
  `isStockLowVolume(symbol, scoreDate)` over a trailing 10-weekday window, and
  routes it through the **single** `isStockPriceable` gate that feeds the chart
  Actual / "Actual (After 90 Days)" line, the totals row and the dividend
  figures. Renders a **Low volume** badge and tags the row `low-volume-stock`.
- **`docs/trend_predictions.js` / `docs/trend_series.js`** — the Trend view
  parses volume, resolves a `lowVolume` flag, and excludes flagged names from
  its Actual/Target/count aggregates.
- **`docs/index.html` / `docs/trend.html`** — load `volume_recommend.js` before
  consumers; index adds the legend. **`docs/styles.css`** styles the badge.
  **`docs/sw.js`** precaches the new asset.
- **`scripts/*.ts` + affected tests** — import the new helper so the diagnostic
  sweeps that call `resolvePredictionStocks` keep working.

### Data flow

```mermaid
flowchart LR
    CSV[market CSV<br/>trailing volume col #575] --> W[buildTrailingVolumeWindow<br/>last 10 weekdays]
    W --> VR[volumeRecommend / isLowVolume<br/>BUDGET_DOLLARS = 10000 #576]
    VR -->|lowVolume| GATE[isStockIncluded / isStockPriceable]
    GATE -->|excluded| AGG[Actual / Target / dividend<br/>equal-weight aggregates]
    GATE -->|flagged| UI[Low volume badge + legend]
```

## Evidence

This is a dashboard (UI + data-pipeline) change. **Playwright MCP was not
available in this environment**, so no live screenshot was captured. The
behaviour is instead pinned by behavioural Deno tests against the real shipped
kernels, and the UI surfaces are verified to be present in the committed markup:

- Badge rendered in `docs/app.js` (`low-volume-badge`), styled in
  `docs/styles.css`, legend in `docs/index.html`.
- Because no committed CSV yet carries volume, no badge renders on live data
  today (the documented "insufficient data ⇒ not flagged" rule); the
  synthetic-fixture tests below exercise the flagged path end-to-end.

### Test results

- `deno test --allow-read tests/*.ts` → **1136 passed, 0 failed**.
- `deno fmt` / `deno lint` / `deno check` → clean.
- `cargo check` / `cargo clippy` → clean (no Rust changed).

> **Pre-existing, unrelated failure:** `quality.sh`'s `cargo test` step fails on
> `utils::tests::test_read_market_data`, which reads the external
> `../GRQ-shareprices2026Q2` repo and needs a "SEM" symbol file that is absent
> in this environment. The failure reproduces identically with the parent
> commit's unmodified `src/utils.rs` — this change touches **no** Rust — so it is
> environmental and out of scope for #577.

## Test Plan

New tests:

- `tests/volume_recommend_test.ts` — the #576 helper: below-budget → `-1`;
  liquid → ~1; borderline → capped 0.5; unknown volume → `null` (not flagged);
  present-but-tiny vs unknown; non-numeric/zero cells skipped; trailing-window
  builder.
- `tests/low_volume_exclusion_test.ts` — `isStockIncluded` drops a low-volume
  name and defaults `lowVolume` to false; low-volume names excluded from the
  Actual, Target and dividend aggregates; **a known-illiquid synthetic fixture
  is flagged and removed while the liquid name is unaffected**; a
  pre-volume-column CSV flags nothing (no mass-exclusion).
- `tests/js_syntax_test.ts` — `docs/volume_recommend.js` parses cleanly.

Updated imports so existing suites/scripts load the new helper:
`tests/trend_predictions_test.ts`, `tests/dashboard_actual_horizon_basis_test.ts`,
and six `scripts/*_diagnostic*.ts` / `scripts/residual_gap_reconciliation.ts`.

## Acceptance criteria

- ✅ Low-volume names excluded from portfolio membership and from aggregate
  (equal-weight) computations (single `isStockIncluded` / `isStockPriceable`
  gate).
- ✅ Visible indicator (Low volume badge + legend).
- ✅ A known-illiquid synthetic fixture is removed from the aggregate; liquid
  names unaffected (`tests/low_volume_exclusion_test.ts`).
- ✅ Unknown volume ⇒ not flagged — no accidental mass-exclusion of historical
  dates.
