### PR TITLE
[#578] Fold low volume into the valuation/scoring of predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Pages.
   volume is unknown — older pre-volume-column CSVs — the name is **not** flagged
   (insufficient data ⇒ not flagged), so historical dates are never
   mass-excluded.
+- **Low-Volume Valuation Cap** — beyond excluding illiquid names from aggregates,
+  low volume is folded into the **valuation** of each prediction so an illiquid
+  name can never surface as a strong recommendation (issue #578). The displayed
+  Score is capped via `min(volumeRecommend, score, 1)` — mirroring GRQ training's
+  `Math.min(core.volumeRecommend, priceRecommend, 1)` — using the same #576
+  helper (`docs/volume_recommend.js`, `volumeCappedScore`). A flagged name's
+  price-based score is suppressed to a never-recommend value (and the detail view
+  shows a **Low volume — not recommended** badge), partial illiquidity
+  proportionally down-weights, and unknown volume leaves the score unchanged.
 - **Dividend Tracking** — calculate dividend income and total returns.
 - **Web Dashboard** — interactive charts and tables for performance analysis,
   served as a static site from `docs/`. On mobile, a pop-out control expands the

--- a/docs/app.js
+++ b/docs/app.js
@@ -2965,6 +2965,23 @@ class GRQValidator {
                 // Escape untrusted TSV-derived fields before interpolation (issue #63).
                 const safeStock = escapeHtml(stock.stock);
                 const safeNotes = escapeHtml(stock.notes);
+                // Fold low volume into the displayed valuation (issue #578): an
+                // illiquid name's price-based score is capped so it can never
+                // surface as a strong recommendation. A flagged name carries a
+                // visible "Low volume — not recommended" badge alongside the
+                // suppressed (negative) score.
+                const cappedScore = this.volumeCappedScore(
+                    stock.stock,
+                    stock.score,
+                    scoreDate,
+                );
+                const detailLowVolume = this.isStockLowVolume(
+                    stock.stock,
+                    scoreDate,
+                );
+                const scoreBadge = detailLowVolume
+                    ? ` <span class="badge bg-warning text-dark low-volume-badge" title="Low volume — never recommended; the price-based score is capped via the shared volumeRecommend helper (issue #578)">Low volume — not recommended</span>`
+                    : "";
                 stockCard.innerHTML = `
             <div class="card-header">
               <h5 class="card-title mb-0">${safeStock} - Detailed Information</h5>
@@ -2975,7 +2992,7 @@ class GRQValidator {
                   <h6 class="text-muted text-uppercase mb-3">Basic Information</h6>
                   <div class="row mb-2">
                     <div class="col-6"><strong>Score:</strong></div>
-                    <div class="col-6">${stock.score.toFixed(3)}</div>
+                    <div class="col-6">${cappedScore.toFixed(3)}${scoreBadge}</div>
                   </div>
                   <div class="row mb-2">
                     <div class="col-6"><strong>Buy Price:</strong></div>
@@ -3824,6 +3841,21 @@ class GRQValidator {
         }
         const window = GRQVolume.buildTrailingVolumeWindow(series, scoreDate);
         return GRQVolume.isLowVolume(window);
+    }
+
+    // Volume-capped prediction score (issue #578): folds low volume into the
+    // valuation so an illiquid name can never surface as a strong recommendation,
+    // mirroring GRQ training's Math.min(volumeRecommend, priceRecommend, 1). Falls
+    // back to the raw score when volume is unknown (no market data loaded, or a
+    // pre-volume-column CSV), matching the exclusion path's "insufficient data ⇒
+    // not flagged" rule. The shared #576 helper is the single source of truth.
+    volumeCappedScore(stockSymbol, baseScore, scoreDate) {
+        const series = this.marketData ? this.marketData[stockSymbol] : null;
+        if (!series) {
+            return baseScore;
+        }
+        const window = GRQVolume.buildTrailingVolumeWindow(series, scoreDate);
+        return GRQVolume.volumeCappedScore(baseScore, window);
     }
 
     isStockPriceable(stockSymbol, scoreDate) {

--- a/docs/archive/pr-summaries/pr-summary-578.md
+++ b/docs/archive/pr-summaries/pr-summary-578.md
@@ -1,0 +1,88 @@
+# [#578] Fold low volume into the valuation/scoring of predictions
+
+## Summary
+
+Beyond **excluding** low-volume names from aggregates (#577), low volume is now
+folded into the **valuation** of each prediction, so an illiquid name can never
+score as a strong recommendation — satisfying the "never recommend such names"
+requirement from #563. This mirrors GRQ training, where the score is capped via
+`Math.min(core.volumeRecommend, priceRecommend, 1)` (`GRQ/src/LearnUtil.ts:155`).
+
+The dashboard's displayed prediction Score is now passed through a
+volume-cap: `score = min(volumeRecommend, baseScore, 1)`. A flagged low-volume
+name (`volumeRecommend === -1`) is forced to a never-recommend value regardless
+of its price-based score; partial illiquidity proportionally down-weights; and
+unknown volume (pre-volume-column CSVs) leaves the score unchanged
+(`insufficient data ⇒ not flagged`), matching the exclusion path. The cap
+reuses the #576 shared helper as the single source of truth — **no new
+threshold**. **Closes #578.**
+
+### What changed
+
+- **`docs/volume_recommend.js`** — add `volumeCappedScore(baseScore, window)`,
+  the ported GRQ cap, published on `globalThis.GRQVolume`. Returns `baseScore`
+  unchanged when it is non-finite or when volume is unknown
+  (`volumeRecommend === null`); otherwise `Math.min(volumeRecommend, baseScore, 1)`.
+- **`docs/app.js`** — add `volumeCappedScore(symbol, baseScore, scoreDate)` over
+  the trailing 10-weekday window (reusing `buildTrailingVolumeWindow`), and
+  render the **capped** score plus a **Low volume — not recommended** badge on
+  the stock detail card. Falls back to the raw score when no market data is
+  loaded.
+- **`README.md`** — document the low-volume valuation cap.
+- **`tests/volume_recommend_test.ts`** — new unit + fixture tests.
+
+This is complementary to #577 (exclusion vs. valuation are distinct effects
+against the same shared helper). As with #577, the effect is a **no-op on the
+current committed data** (CSVs do not yet carry the volume column from #575); it
+activates automatically once 8-column CSVs carry volume.
+
+## Evidence
+
+This is a frontend valuation/display change. Playwright MCP and a local browser
+were unavailable in this environment, and the badge only renders once CSVs carry
+volume (a no-op on live data today, as with #577). The shipped helper's exact
+display behaviour is reproduced below by driving the real
+`docs/volume_recommend.js` over synthetic market series (illiquid, liquid, and
+unknown-volume), reproducing the `docs/app.js` detail-card Score cell branch:
+
+```text
+ILLIQUID:   raw score 0.970 -> displayed -1.000 [Low volume — not recommended]
+LIQUID:     raw score 0.970 -> displayed 0.970
+UNKNOWNVOL: raw score 0.970 -> displayed 0.970
+```
+
+An illiquid name with a strong `0.970` price-based score is suppressed to the
+never-recommend value `-1.000` and badged; an equally-strong liquid name is
+unchanged; and an unknown-volume name (pre-volume CSV) is left untouched.
+
+### Valuation flow
+
+```mermaid
+flowchart LR
+    A[Prediction score<br/>price-based] --> C{volumeRecommend<br/>trailing 10wd window}
+    C -- "null (unknown)" --> D[score unchanged]
+    C -- "-1 (low volume)" --> E[min(-1, score, 1) = -1<br/>never recommended]
+    C -- "(0,1] partial" --> F[min(recommend, score, 1)<br/>down-weighted]
+    D --> G[Displayed Score]
+    E --> G
+    F --> G
+```
+
+## Test Plan
+
+All tests exercise the real shipped `docs/volume_recommend.js`:
+
+- `tests/volume_recommend_test.ts`:
+  - `volumeCappedScore is published on GRQVolume`
+  - `volumeCappedScore: low-volume name suppresses a high price-based score`
+  - `volumeCappedScore: liquid name keeps its price-based score unchanged`
+  - `volumeCappedScore: partial illiquidity down-weights proportionally`
+  - `volumeCappedScore: never exceeds 1, even for an out-of-range score`
+  - `volumeCappedScore: unknown volume leaves the score unchanged (not flagged)`
+  - `volumeCappedScore: empty / non-array window leaves the score unchanged`
+  - `volumeCappedScore: non-finite base score is returned unchanged`
+  - `volumeCappedScore: numeric-string base score is coerced and capped`
+  - `fixture: illiquid name's high score is suppressed, liquid name unchanged`
+    (the acceptance-criterion fixture: series → trailing window → capped score)
+
+Full suite: `deno test --allow-read tests/*.ts` → **1152 passed, 0 failed**.

--- a/docs/volume_recommend.js
+++ b/docs/volume_recommend.js
@@ -94,6 +94,35 @@ function isLowVolume(window) {
     return typeof recommend === "number" && recommend < 0;
 }
 
+// Fold low volume into a prediction's VALUATION (issue #578). Ported from GRQ
+// training's score cap `Math.min(core.volumeRecommend, priceRecommend, 1)`
+// (GRQ/src/LearnUtil.ts:155) so the dashboard's recommendation strength and the
+// trainer agree on ONE definition — an illiquid name can never score as a
+// strong recommendation. `baseScore` is the dashboard's price-based prediction
+// score; `window` is a trailing volume window (buildTrailingVolumeWindow).
+//
+// Returns:
+//   - baseScore UNCHANGED when it is not a finite number (nothing to cap), OR
+//     when volume is unknown across the whole window (volumeRecommend === null)
+//     — the "insufficient data ⇒ not flagged" rule shared with the exclusion
+//     path, so pre-volume-column history is never suppressed;
+//   - Math.min(volumeRecommend, baseScore, 1) otherwise, so:
+//       * volumeRecommend === -1 (low volume) forces a never-recommend value
+//         (<= -1) regardless of how strong the price-based score is;
+//       * a partial volumeRecommend in (0, 1] proportionally DOWN-weights a
+//         strong score while leaving an already-weak score alone.
+function volumeCappedScore(baseScore, window) {
+    const base = typeof baseScore === "number" ? baseScore : Number(baseScore);
+    if (!Number.isFinite(base)) {
+        return baseScore;
+    }
+    const recommend = volumeRecommend(window);
+    if (recommend === null) {
+        return base;
+    }
+    return Math.min(recommend, base, 1);
+}
+
 // Build a trailing WEEKDAY_WINDOW window of { volume, lowPrice } from a daily
 // market-data series, ready for volumeRecommend/isLowVolume. `series` is the
 // dashboard's per-ticker array of points; each point exposes a `date` (Date or
@@ -139,5 +168,6 @@ globalThis.GRQVolume = {
     averageDollarVolume,
     volumeRecommend,
     isLowVolume,
+    volumeCappedScore,
     buildTrailingVolumeWindow,
 };

--- a/tests/volume_recommend_test.ts
+++ b/tests/volume_recommend_test.ts
@@ -28,6 +28,10 @@ const g = globalThis as unknown as {
       asOfDate: unknown,
       weekdays?: number,
     ) => Array<{ volume: unknown; lowPrice: unknown }>;
+    volumeCappedScore: (
+      baseScore: unknown,
+      window: Array<{ volume: unknown; lowPrice: unknown }> | unknown,
+    ) => number;
   };
 };
 
@@ -37,6 +41,7 @@ const {
   averageDollarVolume,
   isLowVolume,
   buildTrailingVolumeWindow,
+  volumeCappedScore,
 } = g.GRQVolume;
 
 // Build a flat window where every day shares one volume and lowPrice.
@@ -167,4 +172,105 @@ Deno.test("end-to-end: trailing window of an illiquid series flags low-volume", 
   const window = buildTrailingVolumeWindow(series, new Date(2025, 0, 31));
   assertEquals(window.length, 10);
   assertEquals(isLowVolume(window), true);
+});
+
+// --- volumeCappedScore: fold low volume into the valuation (issue #578) ---
+// Mirrors GRQ training's score cap Math.min(volumeRecommend, priceRecommend, 1)
+// so an illiquid name can never surface as a strong recommendation.
+
+Deno.test("volumeCappedScore is published on GRQVolume", () => {
+  assertEquals(typeof volumeCappedScore, "function");
+});
+
+Deno.test("volumeCappedScore: low-volume name suppresses a high price-based score", () => {
+  // Illiquid: 1000 * $5 = $5000/day < budget -> volumeRecommend === -1.
+  const illiquid = flatWindow(10, 1000, 5);
+  assertEquals(volumeRecommend(illiquid), -1);
+  // A strong 0.95 price-based score is capped to the never-recommend value.
+  assertEquals(volumeCappedScore(0.95, illiquid), -1);
+  // Even a perfect score is suppressed, regardless of the price-based value.
+  assertEquals(volumeCappedScore(1, illiquid), -1);
+});
+
+Deno.test("volumeCappedScore: liquid name keeps its price-based score unchanged", () => {
+  // Liquid: volumeRecommend approaches ~1, so min(recommend, score, 1) === score.
+  const liquid = flatWindow(10, 10_000_000, 50);
+  assertEquals(volumeCappedScore(0.8, liquid), 0.8);
+  assertEquals(volumeCappedScore(0.95, liquid), 0.95);
+});
+
+Deno.test("volumeCappedScore: partial illiquidity down-weights proportionally", () => {
+  // averagePV = $500,000 -> volumeRecommend === 0.5 (capped). A 0.95 score is
+  // pulled down to 0.5; a score already below 0.5 is left alone.
+  const partial = flatWindow(10, 100_000, 5);
+  assertEquals(volumeRecommend(partial), 0.5);
+  assertEquals(volumeCappedScore(0.95, partial), 0.5);
+  assertEquals(volumeCappedScore(0.3, partial), 0.3);
+});
+
+Deno.test("volumeCappedScore: never exceeds 1, even for an out-of-range score", () => {
+  // A score above 1 is bounded by min(volumeRecommend, score, 1). For a liquid
+  // window volumeRecommend (~0.99998) dominates, and the result can never top 1.
+  const liquid = flatWindow(10, 10_000_000, 50);
+  const recommend = volumeRecommend(liquid) as number;
+  assertEquals(volumeCappedScore(1.5, liquid), recommend);
+  assertEquals((volumeCappedScore(1.5, liquid) as number) <= 1, true);
+});
+
+Deno.test("volumeCappedScore: unknown volume leaves the score unchanged (not flagged)", () => {
+  // Pre-volume-column CSVs: volumeRecommend === null -> no cap applied.
+  const unknown = flatWindow(10, null, 5);
+  assertEquals(volumeRecommend(unknown), null);
+  assertEquals(volumeCappedScore(0.95, unknown), 0.95);
+});
+
+Deno.test("volumeCappedScore: empty / non-array window leaves the score unchanged", () => {
+  assertEquals(volumeCappedScore(0.95, []), 0.95);
+  assertEquals(volumeCappedScore(0.95, null), 0.95);
+  assertEquals(volumeCappedScore(0.95, undefined), 0.95);
+});
+
+Deno.test("volumeCappedScore: non-finite base score is returned unchanged", () => {
+  const illiquid = flatWindow(10, 1000, 5);
+  assertEquals(Number.isNaN(volumeCappedScore(NaN, illiquid) as number), true);
+});
+
+Deno.test("volumeCappedScore: numeric-string base score is coerced and capped", () => {
+  const illiquid = flatWindow(10, 1000, 5);
+  assertEquals(volumeCappedScore("0.95", illiquid), -1);
+});
+
+Deno.test("fixture: illiquid name's high score is suppressed, liquid name unchanged", () => {
+  // End-to-end as the dashboard wires it (issue #578): a daily market-data
+  // series -> trailing volume window -> volume-capped score. Both names carry
+  // an identical strong price-based score of 0.97.
+  const baseScore = 0.97;
+
+  // Illiquid: 800 shares * $6 = $4800/day << $10000 budget.
+  const illiquidSeries = Array.from({ length: 12 }, (_, i) => ({
+    date: new Date(2025, 0, i + 1),
+    low: 6,
+    volume: 800,
+  }));
+  const illiquidWindow = buildTrailingVolumeWindow(
+    illiquidSeries,
+    new Date(2025, 0, 31),
+  );
+  // The strong score is suppressed to the never-recommend value.
+  assertEquals(isLowVolume(illiquidWindow), true);
+  assertEquals(volumeCappedScore(baseScore, illiquidWindow), -1);
+
+  // Liquid: 5,000,000 shares * $40 = $200,000,000/day >> budget.
+  const liquidSeries = Array.from({ length: 12 }, (_, i) => ({
+    date: new Date(2025, 0, i + 1),
+    low: 40,
+    volume: 5_000_000,
+  }));
+  const liquidWindow = buildTrailingVolumeWindow(
+    liquidSeries,
+    new Date(2025, 0, 31),
+  );
+  // The liquid name keeps its price-based score unchanged.
+  assertEquals(isLowVolume(liquidWindow), false);
+  assertEquals(volumeCappedScore(baseScore, liquidWindow), baseScore);
 });


### PR DESCRIPTION
# [#578] Fold low volume into the valuation/scoring of predictions

## Summary

Beyond **excluding** low-volume names from aggregates (#577), low volume is now
folded into the **valuation** of each prediction, so an illiquid name can never
score as a strong recommendation — satisfying the "never recommend such names"
requirement from #563. This mirrors GRQ training, where the score is capped via
`Math.min(core.volumeRecommend, priceRecommend, 1)` (`GRQ/src/LearnUtil.ts:155`).

The dashboard's displayed prediction Score is now passed through a
volume-cap: `score = min(volumeRecommend, baseScore, 1)`. A flagged low-volume
name (`volumeRecommend === -1`) is forced to a never-recommend value regardless
of its price-based score; partial illiquidity proportionally down-weights; and
unknown volume (pre-volume-column CSVs) leaves the score unchanged
(`insufficient data ⇒ not flagged`), matching the exclusion path. The cap
reuses the #576 shared helper as the single source of truth — **no new
threshold**. **Closes #578.**

### What changed

- **`docs/volume_recommend.js`** — add `volumeCappedScore(baseScore, window)`,
  the ported GRQ cap, published on `globalThis.GRQVolume`. Returns `baseScore`
  unchanged when it is non-finite or when volume is unknown
  (`volumeRecommend === null`); otherwise `Math.min(volumeRecommend, baseScore, 1)`.
- **`docs/app.js`** — add `volumeCappedScore(symbol, baseScore, scoreDate)` over
  the trailing 10-weekday window (reusing `buildTrailingVolumeWindow`), and
  render the **capped** score plus a **Low volume — not recommended** badge on
  the stock detail card. Falls back to the raw score when no market data is
  loaded.
- **`README.md`** — document the low-volume valuation cap.
- **`tests/volume_recommend_test.ts`** — new unit + fixture tests.

This is complementary to #577 (exclusion vs. valuation are distinct effects
against the same shared helper). As with #577, the effect is a **no-op on the
current committed data** (CSVs do not yet carry the volume column from #575); it
activates automatically once 8-column CSVs carry volume.

## Evidence

This is a frontend valuation/display change. Playwright MCP and a local browser
were unavailable in this environment, and the badge only renders once CSVs carry
volume (a no-op on live data today, as with #577). The shipped helper's exact
display behaviour is reproduced below by driving the real
`docs/volume_recommend.js` over synthetic market series (illiquid, liquid, and
unknown-volume), reproducing the `docs/app.js` detail-card Score cell branch:

```text
ILLIQUID:   raw score 0.970 -> displayed -1.000 [Low volume — not recommended]
LIQUID:     raw score 0.970 -> displayed 0.970
UNKNOWNVOL: raw score 0.970 -> displayed 0.970
```

An illiquid name with a strong `0.970` price-based score is suppressed to the
never-recommend value `-1.000` and badged; an equally-strong liquid name is
unchanged; and an unknown-volume name (pre-volume CSV) is left untouched.

### Valuation flow

```mermaid
flowchart LR
    A[Prediction score<br/>price-based] --> C{volumeRecommend<br/>trailing 10wd window}
    C -- "null (unknown)" --> D[score unchanged]
    C -- "-1 (low volume)" --> E[min(-1, score, 1) = -1<br/>never recommended]
    C -- "(0,1] partial" --> F[min(recommend, score, 1)<br/>down-weighted]
    D --> G[Displayed Score]
    E --> G
    F --> G
```

## Test Plan

All tests exercise the real shipped `docs/volume_recommend.js`:

- `tests/volume_recommend_test.ts`:
  - `volumeCappedScore is published on GRQVolume`
  - `volumeCappedScore: low-volume name suppresses a high price-based score`
  - `volumeCappedScore: liquid name keeps its price-based score unchanged`
  - `volumeCappedScore: partial illiquidity down-weights proportionally`
  - `volumeCappedScore: never exceeds 1, even for an out-of-range score`
  - `volumeCappedScore: unknown volume leaves the score unchanged (not flagged)`
  - `volumeCappedScore: empty / non-array window leaves the score unchanged`
  - `volumeCappedScore: non-finite base score is returned unchanged`
  - `volumeCappedScore: numeric-string base score is coerced and capped`
  - `fixture: illiquid name's high score is suppressed, liquid name unchanged`
    (the acceptance-criterion fixture: series → trailing window → capped score)

Full suite: `deno test --allow-read tests/*.ts` → **1152 passed, 0 failed**.