### PR TITLE
Document how the GRQ model is trained (Issue #602)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,144 @@ When the guard trips it names both newest dates and the gap, e.g.
 `benchmark indices are stale: newest index date 2026-06-08 lags the newest
 actuals date 2026-06-18 by 7 trading days (tolerance is 3 trading days)`.
 
+## How the GRQ model is trained
+
+> **High-level overview for general readers.** This section explains, at a
+> conceptual level, how the predictions this repository validates are produced.
+> It deliberately contains **no** proprietary code, hyper-parameters or private
+> endpoints — only the publicly describable shape of the process. The model is
+> trained **outside** this repository; `GRQ-validation` only checks the
+> resulting predictions against a 90-day horizon.
+
+The GRQ prediction model is an evolved neural network produced by the public
+**NEAT-AI** project — a Deno/TypeScript implementation of NeuroEvolution of
+Augmenting Topologies (NEAT). Rather than training a fixed-shape network by
+gradient descent alone, NEAT-AI **evolves** both the structure and the weights
+of many candidate networks ("creatures"), keeping those that predict best and
+breeding the next generation from them. The score files this repository ingests
+are the matured predictions of the current champion network.
+
+```mermaid
+flowchart LR
+    subgraph Feeds[Market data feeds]
+        AV[Alpha Vantage]
+        FRED[FRED macro data]
+        WUI[World Uncertainty Index]
+    end
+    Feeds --> TD[Training-data production<br/>OHLCV, fundamentals, FX,<br/>news sentiment, insider data]
+    TD --> EV[Multi-node continuous learning<br/>evolve + train creatures]
+    EV --> SC[NEAT-AI-scorer<br/>fitness score]
+    SC --> PRED[Champion network<br/>emits predictions]
+    PRED --> VAL[GRQ-validation<br/>90-day validation]
+```
+
+### Training data production — the major market feeds
+
+The training data is assembled from several public and commercial feeds, then
+normalised into the time series the network learns from. The full pipeline spans
+more than headline prices:
+
+- **Prices / OHLCV** — daily open/high/low/close/volume for each listed
+  security, sourced chiefly from **Alpha Vantage**, covering the US exchanges
+  (**NYSE**, **NASDAQ**), the Australian exchange (**ASX**), OTC names and a
+  range of international markets.
+- **Company fundamentals** — company overviews and quarterly **earnings** (also
+  via Alpha Vantage), so the model sees each business, not just its chart.
+- **Macro indicators** — **Federal Reserve Economic Data (FRED)** series such as
+  the VIX volatility index and CPI, giving the model the broader economic
+  backdrop.
+- **Global risk** — the **World Uncertainty Index**, a published measure of
+  worldwide economic and political uncertainty.
+- **Foreign exchange** — rates across 50+ currency pairs, so internationally
+  listed names and non-USD cash flows are compared on a like-for-like basis.
+- **News sentiment** — published sentiment signals (via Alpha Vantage) attached
+  to each security.
+- **Insider data** — disclosed insider-transaction activity for each company.
+
+Each feed is fetched on a schedule, validated, and folded into a per-security
+training set. No raw API keys, private endpoints or proprietary collection code
+are described here — only the publicly nameable providers above.
+
+### Key observations
+
+A few observations shape how the data is used:
+
+- **Predict the move, not the price.** The model is trained to anticipate how a
+  stock moves over a forward window, which is exactly what this repository then
+  validates against the **90-day** horizon.
+- **Liquidity matters.** Names too thin to trade are screened out during
+  training via the same `volumeRecommend` definition the dashboard reuses (see
+  _Low-Volume Exclusion_ above) — a stock whose average daily **dollar** volume
+  falls below the trade budget should never surface as a recommendation.
+- **Fundamentals and macro context add signal.** Combining per-company
+  fundamentals with macro and global-risk indicators lets the network weigh a
+  name against its economic backdrop rather than its price history alone.
+- **Survivorship and splits are handled at validation time.** Stock splits are
+  reconciled inside the 90-day window so a corporate action never masquerades as
+  a return (see _Split-Aware Returns_ above).
+
+### Multi-node continuous learning
+
+Training is **continuous**, not a one-off batch. A fleet of machines runs around
+the clock, each node evolving and training candidate networks against the latest
+market data. Nodes coordinate through distributed locks so they collaborate on a
+shared population without standing on each other's work, and the best-performing
+creatures propagate across the fleet. As new market data arrives daily, the
+population keeps adapting — yesterday's champion is continually challenged by
+freshly evolved rivals. The private coordination, health-monitoring and logging
+services that run this fleet are intentionally left unnamed.
+
+```mermaid
+flowchart TD
+    subgraph Fleet[Continuous-learning fleet]
+        N1[Node 1<br/>evolve + train]
+        N2[Node 2<br/>evolve + train]
+        N3[Node N<br/>evolve + train]
+    end
+    DL[(Distributed locks<br/>coordination)] --- N1
+    DL --- N2
+    DL --- N3
+    N1 --> POP[Shared population<br/>of creatures]
+    N2 --> POP
+    N3 --> POP
+    POP --> CH[Champion selected<br/>by fitness]
+    CH -->|emits predictions| GRQ[GRQ-validation score files]
+```
+
+### How a score is generated
+
+Candidate networks are ranked by the public **NEAT-AI-scorer** CLI (the "scorer
+script"). It runs a forward pass over the training data and emits a **fitness**
+score in the range 0–1 (higher is better):
+
+```text
+fitness = 1 − error − complexityPenalty − versionPenalty
+```
+
+The `error` term rewards accurate predictions, the **complexity** penalty
+discourages needlessly large networks (favouring simpler, more general models),
+and the **version** penalty keeps the champion current. The scorer emits the
+result as JSON, which this repository captures for 90-day validation.
+
+### The public NEAT-AI repositories
+
+The training machinery is open source and can be explored directly. The data
+that feeds it and the live coordination infrastructure remain private, but the
+engine itself is public:
+
+- [`NEAT-AI`](https://github.com/stSoftwareAU/NEAT-AI) — the Deno/TypeScript
+  orchestrator: evolution, training and inference.
+- [`NEAT-AI-core`](https://github.com/stSoftwareAU/NEAT-AI-core) — Rust/WASM
+  numerics and cost functions.
+- [`NEAT-AI-Discovery`](https://github.com/stSoftwareAU/NEAT-AI-Discovery) — the
+  Rust structural-mutation engine that grows network topologies.
+- [`NEAT-AI-scorer`](https://github.com/stSoftwareAU/NEAT-AI-scorer) — the Rust
+  scoring CLI that computes the fitness score above.
+- [`NEAT-AI-Examples`](https://github.com/stSoftwareAU/NEAT-AI-Examples) —
+  worked examples.
+- [`NEAT-AI-Explore`](https://github.com/stSoftwareAU/NEAT-AI-Explore) —
+  visualisation tools.
+
 ## Quick Start
 
 ### Prerequisites

--- a/docs/archive/pr-summaries/pr-summary-602.md
+++ b/docs/archive/pr-summaries/pr-summary-602.md
@@ -1,0 +1,49 @@
+## Summary
+
+Added a **"How the GRQ model is trained"** section to `README.md` giving a
+high-level, conceptual overview (for general readers / investors) of how the
+predictions this repository validates are produced. The section covers the four
+requested topics — training-data production, key observations, multi-node
+continuous learning, and the major market feeds — names the data providers
+explicitly (Alpha Vantage, FRED, World Uncertainty Index, plus the
+NYSE/NASDAQ/ASX exchanges), references the public NEAT-AI repositories, and
+explains how the NEAT-AI-scorer fitness score is generated. No proprietary
+code, hyper-parameters or private-repo references are disclosed. Closes #602.
+
+The content is purely documentation — no Rust or dashboard behaviour changed.
+Australian English throughout, with two Mermaid diagrams (training pipeline and
+the continuous-learning fleet).
+
+## Evidence
+
+This is a documentation-only change (no web UI altered), so a screenshot is not
+applicable. Correctness is verified by a new Deno test that asserts the
+documented requirements are present.
+
+Training/validation flow now documented in the README:
+
+```mermaid
+flowchart LR
+    subgraph Feeds[Market data feeds]
+        AV[Alpha Vantage]
+        FRED[FRED macro data]
+        WUI[World Uncertainty Index]
+    end
+    Feeds --> TD[Training-data production]
+    TD --> EV[Multi-node continuous learning]
+    EV --> SC[NEAT-AI-scorer fitness]
+    SC --> PRED[Champion network predictions]
+    PRED --> VAL[GRQ-validation 90-day validation]
+```
+
+## Test Plan
+
+- Added `tests/training_documentation_test.ts` (7 tests) verifying the README
+  training section exists and covers: the four required topics, the named data
+  providers, the named exchanges, the public NEAT-AI repositories, the fitness
+  score formula, and the presence of a Mermaid diagram. These failed before the
+  README edit and pass after it.
+- `tests/documentation_accuracy_test.ts` — existing README accuracy tests still
+  pass (no stale/placeholder references introduced).
+- Full Deno suite: `deno test --allow-read tests/*.ts` → 1195 passed, 0 failed.
+- `markdownlint-cli2 README.md` → 0 errors; `deno fmt` applied.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.20">
+    <meta name="app-version" content="1.1.21">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -543,6 +543,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.20"></script>
+    <script src="sw-register.js?v=1.1.21"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.20")
+    navigator.serviceWorker.register("./sw.js?v=1.1.21")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.20";
+const APP_VERSION = "1.1.21";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.20">
+    <meta name="app-version" content="1.1.21">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -211,6 +211,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.20"></script>
+    <script src="sw-register.js?v=1.1.21"></script>
   </body>
 </html>

--- a/tests/training_documentation_test.ts
+++ b/tests/training_documentation_test.ts
@@ -1,0 +1,118 @@
+// Tests for the model-training documentation section (Issue #602).
+//
+// The README gains a high-level, conceptual overview of how the GRQ
+// prediction model is trained and the processes around it: training-data
+// production, key observations, multi-node continuous learning, and the major
+// market feeds. These tests assert that the required topics, the public
+// NEAT-AI repositories, and the named data providers are present — derivable
+// requirements from the issue's accepted scope rather than brittle prose
+// matches.
+
+import { assert } from "@std/assert";
+
+const README = "README.md";
+
+async function readReadme(): Promise<string> {
+  return await Deno.readTextFile(README);
+}
+
+// Return only the body of the training section, so the assertions below verify
+// the content lives in that section rather than coincidentally elsewhere.
+async function trainingSection(): Promise<string> {
+  const text = await readReadme();
+  const start = text.indexOf("## How the GRQ model is trained");
+  assert(
+    start !== -1,
+    "README.md must contain a '## How the GRQ model is trained' section",
+  );
+  // The section runs until the next top-level (## ) heading, or end of file.
+  const rest = text.slice(start + 3);
+  const nextHeading = rest.indexOf("\n## ");
+  return nextHeading === -1 ? text.slice(start) : rest.slice(0, nextHeading);
+}
+
+Deno.test("README documents the model-training section", async () => {
+  const section = await trainingSection();
+  assert(section.length > 0, "training section must not be empty");
+});
+
+Deno.test("README training section covers the four required topics", async () => {
+  const section = (await trainingSection()).toLowerCase();
+  for (
+    const topic of [
+      "training data", // training-data production
+      "observation", // key observations
+      "continuous learning", // multi-node continuous learning
+      "market feed", // the major market feeds
+    ]
+  ) {
+    assert(
+      section.includes(topic),
+      `training section must cover "${topic}"`,
+    );
+  }
+});
+
+Deno.test("README training section names the major data providers", async () => {
+  const section = await trainingSection();
+  for (
+    const provider of [
+      "Alpha Vantage",
+      "FRED", // Federal Reserve Economic Data
+      "World Uncertainty Index",
+    ]
+  ) {
+    assert(
+      section.includes(provider),
+      `training section must name the "${provider}" data provider`,
+    );
+  }
+});
+
+Deno.test("README training section names the major exchanges", async () => {
+  const section = await trainingSection();
+  for (const exchange of ["NYSE", "NASDAQ", "ASX"]) {
+    assert(
+      section.includes(exchange),
+      `training section must name the "${exchange}" exchange`,
+    );
+  }
+});
+
+Deno.test("README training section references the public NEAT-AI repositories", async () => {
+  const section = await trainingSection();
+  for (
+    const repo of [
+      "NEAT-AI",
+      "NEAT-AI-core",
+      "NEAT-AI-Discovery",
+      "NEAT-AI-scorer",
+    ]
+  ) {
+    assert(
+      section.includes(repo),
+      `training section must reference the public "${repo}" repository`,
+    );
+  }
+});
+
+Deno.test("README training section explains the fitness score formula", async () => {
+  const section = (await trainingSection()).toLowerCase();
+  // The scorer emits fitness = 1 − error − complexityPenalty − versionPenalty.
+  assert(
+    section.includes("fitness"),
+    "training section must describe the fitness score",
+  );
+  assert(
+    section.includes("complexity") && section.includes("version"),
+    "training section must mention the complexity and version penalties",
+  );
+});
+
+Deno.test("README training section includes a Mermaid diagram", async () => {
+  const section = await trainingSection();
+  assert(
+    section.includes("```mermaid"),
+    "training section must include a Mermaid diagram",
+  );
+});


### PR DESCRIPTION
## Summary

Added a **"How the GRQ model is trained"** section to `README.md` giving a
high-level, conceptual overview (for general readers / investors) of how the
predictions this repository validates are produced. The section covers the four
requested topics — training-data production, key observations, multi-node
continuous learning, and the major market feeds — names the data providers
explicitly (Alpha Vantage, FRED, World Uncertainty Index, plus the
NYSE/NASDAQ/ASX exchanges), references the public NEAT-AI repositories, and
explains how the NEAT-AI-scorer fitness score is generated. No proprietary
code, hyper-parameters or private-repo references are disclosed. Closes #602.

The content is purely documentation — no Rust or dashboard behaviour changed.
Australian English throughout, with two Mermaid diagrams (training pipeline and
the continuous-learning fleet).

## Evidence

This is a documentation-only change (no web UI altered), so a screenshot is not
applicable. Correctness is verified by a new Deno test that asserts the
documented requirements are present.

Training/validation flow now documented in the README:

```mermaid
flowchart LR
    subgraph Feeds[Market data feeds]
        AV[Alpha Vantage]
        FRED[FRED macro data]
        WUI[World Uncertainty Index]
    end
    Feeds --> TD[Training-data production]
    TD --> EV[Multi-node continuous learning]
    EV --> SC[NEAT-AI-scorer fitness]
    SC --> PRED[Champion network predictions]
    PRED --> VAL[GRQ-validation 90-day validation]
```

## Test Plan

- Added `tests/training_documentation_test.ts` (7 tests) verifying the README
  training section exists and covers: the four required topics, the named data
  providers, the named exchanges, the public NEAT-AI repositories, the fitness
  score formula, and the presence of a Mermaid diagram. These failed before the
  README edit and pass after it.
- `tests/documentation_accuracy_test.ts` — existing README accuracy tests still
  pass (no stale/placeholder references introduced).
- Full Deno suite: `deno test --allow-read tests/*.ts` → 1195 passed, 0 failed.
- `markdownlint-cli2 README.md` → 0 errors; `deno fmt` applied.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mqv3pd13-f35642`<!-- vibe-worker-issue-602 -->