### PR TITLE
Remove device debug info line from dashboard footer (#619)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-619.md
+++ b/docs/archive/pr-summaries/pr-summary-619.md
@@ -1,0 +1,62 @@
+# Remove device debug info line from dashboard footer
+
+## Summary
+
+The dashboard footer rendered a responsive device debug readout —
+`Bootstrap: <bp> | Mobile: <bool> | Width: <n>px | UA: <ua>...` — into a
+`#debug-info` element, driven by `docs/dashboard_boot.js`. This debug line is no
+longer wanted. Removed the element, its updater logic, and its now-dead CSS,
+while keeping the useful application version line. Closes #619.
+
+Changes:
+
+- `docs/index.html` — dropped the `#debug-info` span (and its `<br>`) from the
+  footer; the `v<span id="version">` line is retained.
+- `docs/dashboard_boot.js` — removed `updateDebugInfo()` and its
+  `load`/`resize` listeners; the module still loads `app.js` with the
+  cache-busting version query.
+- `docs/styles.css` — removed the now-unused `#debug-info` and `.debug-info`
+  rules.
+
+## Evidence
+
+This is a front-end (HTML/CSS/JS) change. Playwright MCP and a local headless
+browser were unavailable in this environment, so a rendered screenshot could
+not be captured. Instead the change was verified by serving `docs/` over a
+local HTTP server and inspecting the rendered footer:
+
+```
+$ curl -s http://localhost:8765/index.html | grep -A3 'Version display'
+    <!-- Version display -->
+    <div class="text-center text-muted small py-2">
+      v<span id="version"></span>
+    </div>
+
+$ curl -s http://localhost:8765/index.html | grep -c 'debug-info'
+0          # debug-info element removed; version line retained
+```
+
+```mermaid
+flowchart TD
+    A[Dashboard footer] --> B["v&lt;version&gt; (kept)"]
+    A -.removed.-> C["Bootstrap | Mobile | Width | UA debug line"]
+```
+
+## Test Plan
+
+- Added `tests/debug_info_removed_test.ts` (TDD — written failing first, then
+  made to pass):
+  - `index.html no longer contains the debug-info element`
+  - `index.html keeps the application version display`
+  - `dashboard_boot.js no longer maintains the debug readout`
+  - `dashboard_boot.js still loads app.js with the version query`
+- Full Deno suite: `deno test --allow-read tests/*.ts` → 1210 passed, 0 failed.
+- `deno fmt`, `deno lint`, and `deno check` pass on the changed files.
+
+### Pre-existing unrelated failure
+
+`quality.sh` reports one Rust failure, `utils::tests::test_read_market_data`,
+because the external market-data repo (`../GRQ-shareprices2026Q2`) is present
+but empty in this environment (no `SEM` data file). This failure reproduces on
+a clean checkout **without** these changes and is unrelated to this docs-only
+change.

--- a/docs/dashboard_boot.js
+++ b/docs/dashboard_boot.js
@@ -1,9 +1,12 @@
 // Dashboard page bootstrap (issue #189).
 //
-// Loads app.js with a cache-busting version query and maintains the responsive
-// debug readout. Extracted from an inline <script> so docs/index.html can
-// enforce a strict Content-Security-Policy without 'unsafe-inline'. Relies on
-// globalThis.VERSION, set earlier by version.js.
+// Loads app.js with a cache-busting version query. Extracted from an inline
+// <script> so docs/index.html can enforce a strict Content-Security-Policy
+// without 'unsafe-inline'. Relies on globalThis.VERSION, set earlier by
+// version.js.
+//
+// The responsive device debug readout (Bootstrap breakpoint | Mobile | Width |
+// UA) was removed in issue #619 — only the application version line remains.
 (function () {
   "use strict";
 
@@ -13,33 +16,4 @@
   const script = document.createElement("script");
   script.src = `app.js?v=${VERSION}`;
   document.head.appendChild(script);
-
-  // Show responsive debug info using Bootstrap's breakpoints.
-  function updateDebugInfo() {
-    const width = window.innerWidth;
-    let breakpoint;
-    if (width >= 1400) breakpoint = "xxl";
-    else if (width >= 1200) breakpoint = "xl";
-    else if (width >= 992) breakpoint = "lg";
-    else if (width >= 768) breakpoint = "md";
-    else if (width >= 576) breakpoint = "sm";
-    else breakpoint = "xs";
-
-    const isMobile = breakpoint === "xs" || breakpoint === "sm";
-
-    const debugInfo = document.getElementById("debug-info");
-    if (debugInfo) {
-      debugInfo.textContent =
-        `Bootstrap: ${breakpoint} | Mobile: ${isMobile} | Width: ${window.innerWidth}px | UA: ${
-          navigator.userAgent.substring(0, 60)
-        }...`;
-      console.log("Debug info updated:", debugInfo.textContent);
-    } else {
-      console.error("Debug info element not found!");
-    }
-  }
-
-  updateDebugInfo();
-  window.addEventListener("load", updateDebugInfo);
-  window.addEventListener("resize", updateDebugInfo);
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -461,8 +461,6 @@
     <!-- Version display -->
     <div class="text-center text-muted small py-2">
       v<span id="version"></span>
-      <br>
-      <span id="debug-info" class="text-muted" style="font-size: 0.7rem;"></span>
     </div>
 
     <!-- Bootstrap 5 JS (version-pinned with Subresource Integrity) -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.24">
+    <meta name="app-version" content="1.1.25">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -543,6 +543,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.24"></script>
+    <script src="sw-register.js?v=1.1.25"></script>
   </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -948,26 +948,6 @@ body.chart-popout-open {
   color: inherit;
 }
 
-/* Ensure debug info is always visible */
-#debug-info {
-  display: block !important;
-  visibility: visible !important;
-  opacity: 1 !important;
-  font-size: 0.7rem !important;
-  color: var(--grq-neutral, #565e64) !important;
-  word-break: break-word;
-  max-width: 100%;
-  overflow-wrap: break-word;
-}
-
-/* Mobile adjustments for debug info */
-@media (max-width: 768px) {
-  #debug-info {
-    font-size: 0.6rem !important;
-    padding: 0 0.5rem;
-  }
-}
-
 /* Mobile-specific styles */
 @media (max-width: 768px) {
     .chart-container {
@@ -988,15 +968,6 @@ body.chart-popout-open {
     .chart-container canvas + div {
         display: none !important;
     }
-}
-
-/* Ensure debug info is always visible */
-.debug-info {
-    display: block !important;
-    visibility: visible !important;
-    opacity: 1 !important;
-    position: static !important;
-    z-index: 9999 !important;
 }
 
 /* ===========================================================================

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.24")
+    navigator.serviceWorker.register("./sw.js?v=1.1.25")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.24";
+const APP_VERSION = "1.1.25";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.24">
+    <meta name="app-version" content="1.1.25">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -211,6 +211,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.24"></script>
+    <script src="sw-register.js?v=1.1.25"></script>
   </body>
 </html>

--- a/tests/debug_info_removed_test.ts
+++ b/tests/debug_info_removed_test.ts
@@ -1,0 +1,51 @@
+// Regression test for issue #619.
+//
+// The dashboard footer used to render a "device debug info" line
+// (Bootstrap breakpoint | Mobile | Width | UA), driven by
+// docs/dashboard_boot.js writing into a #debug-info element in
+// docs/index.html. That readout is no longer wanted — but the
+// application version line must stay, since it is useful.
+//
+// These tests assert the debug-info element and its updater are gone,
+// while the #version display is retained.
+
+import { assert } from "@std/assert";
+
+const html = await Deno.readTextFile("docs/index.html");
+const boot = await Deno.readTextFile("docs/dashboard_boot.js");
+
+Deno.test("index.html no longer contains the debug-info element", () => {
+  assert(
+    !html.includes('id="debug-info"'),
+    "docs/index.html must not render the device debug info line",
+  );
+});
+
+Deno.test("index.html keeps the application version display", () => {
+  assert(
+    html.includes('id="version"'),
+    "docs/index.html must keep the application version display",
+  );
+});
+
+Deno.test("dashboard_boot.js no longer maintains the debug readout", () => {
+  assert(
+    !boot.includes("debug-info"),
+    "dashboard_boot.js must not reference the debug-info element",
+  );
+  assert(
+    !boot.includes("updateDebugInfo"),
+    "dashboard_boot.js must not define updateDebugInfo",
+  );
+  assert(
+    !boot.includes("navigator.userAgent"),
+    "dashboard_boot.js must not read navigator.userAgent for debug output",
+  );
+});
+
+Deno.test("dashboard_boot.js still loads app.js with the version query", () => {
+  assert(
+    boot.includes("app.js?v="),
+    "dashboard_boot.js must still load app.js with a cache-busting version",
+  );
+});


### PR DESCRIPTION
# Remove device debug info line from dashboard footer

## Summary

The dashboard footer rendered a responsive device debug readout —
`Bootstrap: <bp> | Mobile: <bool> | Width: <n>px | UA: <ua>...` — into a
`#debug-info` element, driven by `docs/dashboard_boot.js`. This debug line is no
longer wanted. Removed the element, its updater logic, and its now-dead CSS,
while keeping the useful application version line. Closes #619.

Changes:

- `docs/index.html` — dropped the `#debug-info` span (and its `<br>`) from the
  footer; the `v<span id="version">` line is retained.
- `docs/dashboard_boot.js` — removed `updateDebugInfo()` and its
  `load`/`resize` listeners; the module still loads `app.js` with the
  cache-busting version query.
- `docs/styles.css` — removed the now-unused `#debug-info` and `.debug-info`
  rules.

## Evidence

This is a front-end (HTML/CSS/JS) change. Playwright MCP and a local headless
browser were unavailable in this environment, so a rendered screenshot could
not be captured. Instead the change was verified by serving `docs/` over a
local HTTP server and inspecting the rendered footer:

```
$ curl -s http://localhost:8765/index.html | grep -A3 'Version display'
    <!-- Version display -->
    <div class="text-center text-muted small py-2">
      v<span id="version"></span>
    </div>

$ curl -s http://localhost:8765/index.html | grep -c 'debug-info'
0          # debug-info element removed; version line retained
```

```mermaid
flowchart TD
    A[Dashboard footer] --> B["v&lt;version&gt; (kept)"]
    A -.removed.-> C["Bootstrap | Mobile | Width | UA debug line"]
```

## Test Plan

- Added `tests/debug_info_removed_test.ts` (TDD — written failing first, then
  made to pass):
  - `index.html no longer contains the debug-info element`
  - `index.html keeps the application version display`
  - `dashboard_boot.js no longer maintains the debug readout`
  - `dashboard_boot.js still loads app.js with the version query`
- Full Deno suite: `deno test --allow-read tests/*.ts` → 1210 passed, 0 failed.
- `deno fmt`, `deno lint`, and `deno check` pass on the changed files.

### Pre-existing unrelated failure

`quality.sh` reports one Rust failure, `utils::tests::test_read_market_data`,
because the external market-data repo (`../GRQ-shareprices2026Q2`) is present
but empty in this environment (no `SEM` data file). This failure reproduces on
a clean checkout **without** these changes and is unrelated to this docs-only
change.
