### PR TITLE
Fix portfolio-target popover per-stock % for split-adjusted stocks (#629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ and this project adheres to
 
 ### Fixed
 
+- Portfolio Target "show working" popover now lists each stock's
+  split/dilution-adjusted target %. The per-stock loop in `docs/app.js`
+  (`getWorking`, `portfolio-target`) divided the **raw** `stock.target` by the
+  already split-adjusted buy price — mixed bases — so a reverse-split stock such
+  as NYSE:DD (1:3 split) showed **-64.4%** instead of its true **+6.8%**. It now
+  reuses the shared `calculateTargetPercentage`, so the per-stock list, the Total
+  line and the Portfolio target headline reconcile with the table and chart
+  (Issue #629).
 - Footer **🔗 Share** button now copies a deep-link to the clipboard. The
   link-builder and clipboard/fallback handling shipped in `docs/share_link.js`
   (Issue #495) but the dashboard never called `GRQShare.initShareButton(...)`,

--- a/docs/app.js
+++ b/docs/app.js
@@ -4088,13 +4088,19 @@ class GRQValidator {
                     return;
                 }
                 if (stock.target !== null && !isNaN(stock.target)) {
-                    const buyPrice = this.getBuyPrice(
-                        stock.stock,
+                    // Reuse the shared split/dilution-adjusted target path
+                    // (issue #629). The old loop divided the RAW stock.target by
+                    // the already split-adjusted buy price — mixed bases — which
+                    // showed e.g. NYSE:DD as -64.4% (a 1:3 reverse split) instead
+                    // of its true +6.8%. calculateTargetPercentage adjusts the
+                    // target too, so the per-stock %, the Total line and the
+                    // Portfolio target headline all share one source of truth
+                    // with the table and chart.
+                    const targetPercentage = this.calculateTargetPercentage(
+                        stock,
                         scoreDate,
                     );
-                    if (buyPrice !== null) {
-                        const targetPercentage =
-                            ((stock.target - buyPrice.price) / buyPrice.price) * 100;
+                    if (targetPercentage !== null) {
                         targetDetails.push(
                             `${stock.stock}: ${targetPercentage.toFixed(1)}%`,
                         );

--- a/docs/archive/pr-summaries/pr-summary-629.md
+++ b/docs/archive/pr-summaries/pr-summary-629.md
@@ -1,0 +1,73 @@
+# Fix Portfolio Target "show working" per-stock % for split-adjusted stocks
+
+## Summary
+
+The Portfolio Target "show working" popover listed the wrong per-stock target %
+for a split-adjusted stock — **NYSE:DD** showed **-64.4%** when its true target
+is **+6.8%** (DD had a 1:3 reverse split, `split_coefficient` 0.3333, on
+2026-06-24).
+
+Root cause: the popover's per-stock loop in `docs/app.js`
+(`getWorking`, field `portfolio-target`) divided the **raw** `stock.target` by
+the **already split-adjusted** buy price — mixed bases. Every other consumer
+(table target, chart target dot, per-stock Target popover, and the headline)
+adjusts the target too via the shared `calculateTargetPercentage` →
+`adjustHistoricalPriceToCurrent` path.
+
+The fix replaces the raw recomputation with a call to the shared
+`this.calculateTargetPercentage(stock, scoreDate)`, so the popover's per-stock
+list, its `Total ÷ N stocks` line, and the `Portfolio target` headline all share
+one source of truth with the table and chart. The `sw.js` `APP_VERSION` and the
+`app-version` meta (plus the `sw-register.js`/`trend.html` references) are bumped
+`1.1.29 → 1.1.30` so cached clients pick up the fix.
+
+Closes #629.
+
+```mermaid
+flowchart TD
+    subgraph Before [Before — mixed bases]
+        A1[raw stock.target $43.67] --> C1["÷ split-adjusted buy $122.74"]
+        C1 --> D1["= -64.4% ❌"]
+    end
+    subgraph After [After — shared adjusted path]
+        A2[stock.target] --> B2["calculateTargetPercentage<br/>(adjusts target too)"]
+        B2 --> D2["= +6.8% ✓ matches table & chart"]
+    end
+```
+
+## Evidence
+
+Playwright MCP was unavailable in this environment, so the fix is verified
+numerically against the **real** committed market-data series rather than by
+screenshot.
+
+Driving the real shared helpers (`getBuyPrice`,
+`adjustHistoricalPriceToCurrent`, `calculateTargetPercentage`) over DD's actual
+series in `docs/scores/2025/December/29.csv`:
+
+| Quantity | Value |
+| --- | --- |
+| Split factor (score date → now) | 0.3333 |
+| Adjusted buy price | $122.71 |
+| Adjusted target | $131.01 |
+| **Fixed per-stock %** | **+6.8%** |
+| Old buggy per-stock % | -64.4% |
+
+The fixed figure (+6.8%) matches the issue's stated correct value; the old
+mixed-base figure (-64.4%) matches the reported screenshot.
+
+## Test Plan
+
+- Added `tests/portfolio_target_popover_split_test.ts`:
+  - `portfolio-target popover uses the split-adjusted per-stock % (issue #629)` —
+    drives the **real shipped** `GRQValidator.getWorking` method (extracted from
+    `docs/app.js` without its DOM-bound constructor) over a reverse-split fixture
+    where the adjusted path (+6.8%) and the old raw path (-64.4%) differ
+    visibly. Asserts the popover shows `NYSE:DD: 6.8%`, never `-64.4`, and that
+    the `Total ÷ N` line reconciles with the `Portfolio target` headline. This
+    test **fails against the unfixed `app.js`** and passes with the fix.
+  - `calculateTargetPercentage drives the popover via the shared adjusted helper`
+    — anchors the +6.8% adjusted figure (and the -64.4% buggy figure) to the
+    shared `GRQProjection.calculateTargetPercentage` kernel.
+- Full suite: `deno test --allow-read tests/*.ts` → **1221 passed, 0 failed**.
+- `deno lint` and `deno check` over `tests/*.ts` pass clean.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.29">
+    <meta name="app-version" content="1.1.30">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -563,6 +563,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.29"></script>
+    <script src="sw-register.js?v=1.1.30"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.29")
+    navigator.serviceWorker.register("./sw.js?v=1.1.30")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.29";
+const APP_VERSION = "1.1.30";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.29">
+    <meta name="app-version" content="1.1.30">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -211,6 +211,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.29"></script>
+    <script src="sw-register.js?v=1.1.30"></script>
   </body>
 </html>

--- a/tests/portfolio_target_popover_split_test.ts
+++ b/tests/portfolio_target_popover_split_test.ts
@@ -1,0 +1,134 @@
+// Regression test for issue #629 — the Portfolio Target "show working" popover
+// listed the wrong per-stock % for a split-adjusted stock (NYSE:DD showed
+// -64.4% instead of its true +6.8% after a 1:3 reverse split).
+//
+// Root cause: the popover's per-stock loop in GRQValidator.getWorking divided
+// the RAW stock.target by the already split-adjusted buy price (mixed bases),
+// instead of reusing the shared, split/dilution-adjusted
+// calculateTargetPercentage path used by the table, chart and the headline.
+//
+// This drives the REAL shipped getWorking method from docs/app.js. The class is
+// extracted and evaluated without running its DOM-bound constructor, then the
+// portfolio-target branch is exercised with a fixture in which the two code
+// paths give visibly different answers (adjusted +6.8% vs raw -64.4%), so the
+// test is sensitive to which path getWorking actually takes.
+
+import { assert, assertAlmostEquals } from "@std/assert";
+import "../docs/projection.js";
+
+// --- Extract the real GRQValidator class from app.js -----------------------
+// The file ends with `const validator = new GRQValidator();` plus DOM-bound
+// bootstrap code, so we slice off everything from that instantiation onward and
+// evaluate only the class definition. Direct eval shares this module's scope, so
+// the trailing `GRQValidator` expression returns the class object.
+const GRQProjection = (globalThis as unknown as { GRQProjection: unknown })
+  .GRQProjection;
+
+async function loadGRQValidatorClass(): Promise<
+  new () => Record<string, unknown>
+> {
+  const source = await Deno.readTextFile("docs/app.js");
+  const cut = source.indexOf("const validator = new GRQValidator();");
+  assert(cut !== -1, "could not find the validator bootstrap in app.js");
+  const classSource = source.slice(0, cut);
+  // `GRQProjection` is referenced as a bare identifier inside the class; bind it
+  // locally so the eval'd method bodies resolve it.
+  // deno-lint-ignore no-eval
+  return eval(
+    `const GRQProjection = globalThis.GRQProjection;\n${classSource}\n; GRQValidator`,
+  );
+}
+
+interface FixtureStock {
+  stock: string;
+  target: number;
+}
+
+Deno.test("portfolio-target popover uses the split-adjusted per-stock % (issue #629)", async () => {
+  const GRQValidator = await loadGRQValidatorClass();
+  // Avoid the DOM-bound constructor: build an instance off the prototype and
+  // inject only the dependencies the portfolio-target branch consults.
+  const v = Object.create(GRQValidator.prototype) as Record<
+    string,
+    // deno-lint-ignore no-explicit-any
+    any
+  >;
+
+  const scoreDate = new Date(2025, 11, 29); // 2025-12-29
+  // NYSE:DD — a 1:3 reverse split (coeff 0.3333). Raw target $43.67, but its
+  // buy price is already restated into post-split terms ($40.90 ÷ 0.3333 ≈
+  // $122.74). The adjusted target ($43.67 ÷ 0.3333 ≈ $131.04) vs $122.74 = +6.8%.
+  const scoreData: FixtureStock[] = [
+    { stock: "NYSE:DD", target: 43.67 },
+    { stock: "NYSE:ABC", target: 120 },
+  ];
+  v.selectedFile = "2025/December/29.csv";
+  v.scoreData = scoreData;
+  v.getScoreDate = () => scoreDate;
+  v.isStockPriceable = () => true;
+  // Headline figure = equal-weight mean of the adjusted per-stock targets.
+  v.calculatePortfolioTargetPercentage = () => 13.4;
+  // The OLD loop used getBuyPrice + raw stock.target; the adjusted buy prices
+  // here make that path yield DD -64.4% / ABC +20.0% — distinct from the fix.
+  v.getBuyPrice = (symbol: string) => ({
+    price: symbol === "NYSE:DD" ? 122.74 : 100,
+  });
+  // The shared, split-adjusted path the fix must use.
+  v.calculateTargetPercentage = (stock: FixtureStock) =>
+    stock.stock === "NYSE:DD" ? 6.8 : 20.0;
+
+  const working = v.getWorking("portfolio-target", "", scoreData) as string;
+
+  // Per-stock % uses the adjusted basis, not the raw mixed-base figure.
+  assert(
+    working.includes("NYSE:DD: 6.8%"),
+    `DD per-stock target should be the adjusted +6.8%, got:\n${working}`,
+  );
+  assert(
+    !working.includes("-64.4"),
+    `the raw mixed-base -64.4% must not appear, got:\n${working}`,
+  );
+  assert(working.includes("NYSE:ABC: 20.0%"), "ABC should be +20.0%");
+
+  // The Total line and the headline reconcile: 6.8 + 20.0 = 26.8 over 2 stocks,
+  // mean 13.4, matching the Portfolio target headline.
+  assert(
+    working.includes("Total: 26.8% / 2 stocks"),
+    `Total should sum the adjusted per-stock %, got:\n${working}`,
+  );
+  assert(
+    working.includes("Portfolio target: 13.4%"),
+    `headline should be the adjusted mean, got:\n${working}`,
+  );
+  assertAlmostEquals(
+    26.8 / 2,
+    13.4,
+    1e-9,
+    "Total ÷ N reconciles with headline",
+  );
+});
+
+Deno.test("calculateTargetPercentage drives the popover via the shared adjusted helper", () => {
+  // Anchor the expected adjusted figure to the shared projection kernel so this
+  // test fails if the split/dilution maths regresses. DD's adjusted basis:
+  // target 43.67 ÷ 0.3333 vs buy 40.90 ÷ 0.3333 → +6.8%.
+  const g = GRQProjection as {
+    calculateTargetPercentage: (
+      buyPrice: number | null,
+      adjustedTarget: number | null,
+    ) => number | null;
+  };
+  const splitCoefficient = 0.3333;
+  const adjustedBuy = 40.90 / splitCoefficient;
+  const adjustedTarget = 43.67 / splitCoefficient;
+  const pct = g.calculateTargetPercentage(
+    adjustedBuy,
+    adjustedTarget,
+  ) as number;
+  assertAlmostEquals(pct, 6.8, 0.1, "adjusted DD target should be ~+6.8%");
+
+  // The buggy mixed-base computation (raw target ÷ adjusted buy) gives ~-64.4%,
+  // demonstrating why the popover must adjust the target too.
+  const buggy = ((43.67 - adjustedBuy) / adjustedBuy) * 100;
+  assertAlmostEquals(buggy, -64.4, 0.2, "raw mixed-base figure is the old bug");
+});


### PR DESCRIPTION
# Fix Portfolio Target "show working" per-stock % for split-adjusted stocks

## Summary

The Portfolio Target "show working" popover listed the wrong per-stock target %
for a split-adjusted stock — **NYSE:DD** showed **-64.4%** when its true target
is **+6.8%** (DD had a 1:3 reverse split, `split_coefficient` 0.3333, on
2026-06-24).

Root cause: the popover's per-stock loop in `docs/app.js`
(`getWorking`, field `portfolio-target`) divided the **raw** `stock.target` by
the **already split-adjusted** buy price — mixed bases. Every other consumer
(table target, chart target dot, per-stock Target popover, and the headline)
adjusts the target too via the shared `calculateTargetPercentage` →
`adjustHistoricalPriceToCurrent` path.

The fix replaces the raw recomputation with a call to the shared
`this.calculateTargetPercentage(stock, scoreDate)`, so the popover's per-stock
list, its `Total ÷ N stocks` line, and the `Portfolio target` headline all share
one source of truth with the table and chart. The `sw.js` `APP_VERSION` and the
`app-version` meta (plus the `sw-register.js`/`trend.html` references) are bumped
`1.1.29 → 1.1.30` so cached clients pick up the fix.

Closes #629.

```mermaid
flowchart TD
    subgraph Before [Before — mixed bases]
        A1[raw stock.target $43.67] --> C1["÷ split-adjusted buy $122.74"]
        C1 --> D1["= -64.4% ❌"]
    end
    subgraph After [After — shared adjusted path]
        A2[stock.target] --> B2["calculateTargetPercentage<br/>(adjusts target too)"]
        B2 --> D2["= +6.8% ✓ matches table & chart"]
    end
```

## Evidence

Playwright MCP was unavailable in this environment, so the fix is verified
numerically against the **real** committed market-data series rather than by
screenshot.

Driving the real shared helpers (`getBuyPrice`,
`adjustHistoricalPriceToCurrent`, `calculateTargetPercentage`) over DD's actual
series in `docs/scores/2025/December/29.csv`:

| Quantity | Value |
| --- | --- |
| Split factor (score date → now) | 0.3333 |
| Adjusted buy price | $122.71 |
| Adjusted target | $131.01 |
| **Fixed per-stock %** | **+6.8%** |
| Old buggy per-stock % | -64.4% |

The fixed figure (+6.8%) matches the issue's stated correct value; the old
mixed-base figure (-64.4%) matches the reported screenshot.

## Test Plan

- Added `tests/portfolio_target_popover_split_test.ts`:
  - `portfolio-target popover uses the split-adjusted per-stock % (issue #629)` —
    drives the **real shipped** `GRQValidator.getWorking` method (extracted from
    `docs/app.js` without its DOM-bound constructor) over a reverse-split fixture
    where the adjusted path (+6.8%) and the old raw path (-64.4%) differ
    visibly. Asserts the popover shows `NYSE:DD: 6.8%`, never `-64.4`, and that
    the `Total ÷ N` line reconciles with the `Portfolio target` headline. This
    test **fails against the unfixed `app.js`** and passes with the fix.
  - `calculateTargetPercentage drives the popover via the shared adjusted helper`
    — anchors the +6.8% adjusted figure (and the -64.4% buggy figure) to the
    shared `GRQProjection.calculateTargetPercentage` kernel.
- Full suite: `deno test --allow-read tests/*.ts` → **1221 passed, 0 failed**.
- `deno lint` and `deno check` over `tests/*.ts` pass clean.
