### PR TITLE
Fix Portfolio Target popover per-stock % for split-adjusted stocks (#629)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3882,11 +3882,25 @@ class GRQValidator {
         // function. Build the per-stock {buyPrice, currentPrice, adjustedTarget}
         // inputs here, then delegate; the shared helper applies the same
         // inclusion gate (issue #289) and 20.0% fallback.
+        return GRQProjection.calculatePortfolioTargetPercentage(
+            this.buildPortfolioTargetStocks(),
+        );
+    }
+
+    // Build the per-stock {buyPrice, currentPrice, score, adjustedTarget, stock}
+    // inputs for the shared portfolio-target helpers (issue #429, #629). Single
+    // source of truth so the headline (calculatePortfolioTargetPercentage) and
+    // the "show the working" popover (calculatePortfolioTargetWorking) consume
+    // IDENTICAL inputs — the popover per-stock %, its Total and the headline
+    // reconcile by construction. The target is the split/dilution-adjusted value
+    // (current basis), never the raw `stock.target`.
+    buildPortfolioTargetStocks() {
         const scoreDate = this.getScoreDate(this.selectedFile);
-        const stocks = this.scoreData.map((stock) => {
+        return this.scoreData.map((stock) => {
             const buyPriceObj = this.getBuyPrice(stock.stock, scoreDate);
             const hasTarget = stock.target !== null && !isNaN(stock.target);
             return {
+                stock: stock.stock,
                 buyPrice: buyPriceObj ? buyPriceObj.price : null,
                 currentPrice: GRQProjection.currentPriceFromLatest(
                     this.marketData[stock.stock],
@@ -3903,8 +3917,6 @@ class GRQValidator {
                     : null,
             };
         });
-
-        return GRQProjection.calculatePortfolioTargetPercentage(stocks);
     }
 
     // Whether a stock counts towards portfolio aggregates (issue #289): it must
@@ -4073,42 +4085,25 @@ class GRQValidator {
         if (field === "portfolio-target") {
             const portfolioTargetValue = this
                 .calculatePortfolioTargetPercentage();
-            const scoreDate = this.getScoreDate(this.selectedFile);
 
-            // Calculate individual stock targets for display
-            let targetDetails = [];
-            let totalTarget = 0;
-            let validStocks = 0;
-
-            this.scoreData.forEach((stock) => {
-                // Mirror the exclusion applied in calculatePortfolioTargetPercentage
-                // so the popover's per-stock list and count reflect only the
-                // included (priceable) stocks (issue #289).
-                if (!this.isStockPriceable(stock.stock, scoreDate)) {
-                    return;
-                }
-                if (stock.target !== null && !isNaN(stock.target)) {
-                    const buyPrice = this.getBuyPrice(
-                        stock.stock,
-                        scoreDate,
-                    );
-                    if (buyPrice !== null) {
-                        const targetPercentage =
-                            ((stock.target - buyPrice.price) / buyPrice.price) * 100;
-                        targetDetails.push(
-                            `${stock.stock}: ${targetPercentage.toFixed(1)}%`,
-                        );
-                        totalTarget += targetPercentage;
-                        validStocks++;
-                    }
-                }
-            });
+            // Reuse the shared per-stock working helper (issue #629). It consumes
+            // the SAME split/dilution-adjusted inputs as the headline
+            // (calculatePortfolioTargetPercentage), so each stock's % uses the
+            // adjusted target basis — never the raw `stock.target` divided by a
+            // split-adjusted buy price — and the per-stock list, Total and the
+            // headline reconcile by construction.
+            const working = GRQProjection.calculatePortfolioTargetWorking(
+                this.buildPortfolioTargetStocks(),
+            );
+            const targetDetails = working.details.map(
+                (d) => `${d.stock}: ${d.targetPercentage.toFixed(1)}%`,
+            );
 
             return `Portfolio Target working:\n= Average target of all stocks in portfolio\n= Individual targets:\n  ${
                 targetDetails.join("\n  ")
             }\n= Total: ${
-                totalTarget.toFixed(1)
-            }% / ${validStocks} stocks\n= Portfolio target: ${
+                working.total.toFixed(1)
+            }% / ${working.validStocks} stocks\n= Portfolio target: ${
                 portfolioTargetValue.toFixed(1)
             }%`;
         }

--- a/docs/app.js
+++ b/docs/app.js
@@ -3879,9 +3879,9 @@ class GRQValidator {
         // Portfolio target = equal-weight mean of the included stocks' target
         // percentages. The maths lives in the shared projection module
         // (issue #429) so the dashboard chart and the trend view call ONE
-        // function. Build the per-stock {buyPrice, currentPrice, adjustedTarget}
-        // inputs here, then delegate; the shared helper applies the same
-        // inclusion gate (issue #289) and 20.0% fallback.
+        // function. Build the per-stock inputs via the shared
+        // buildPortfolioTargetStocks() helper, then delegate; the shared helper
+        // applies the same inclusion gate (issue #289) and 20.0% fallback.
         return GRQProjection.calculatePortfolioTargetPercentage(
             this.buildPortfolioTargetStocks(),
         );

--- a/docs/archive/pr-summaries/pr-summary-629.md
+++ b/docs/archive/pr-summaries/pr-summary-629.md
@@ -1,0 +1,69 @@
+## Summary
+
+Fixed the Portfolio Target "show the working" popover, which listed wrong
+per-stock targets for split/dilution-adjusted stocks (e.g. **NYSE:DD −64.4%**
+instead of the correct **+6.8%**). Closes #629.
+
+The popover's per-stock loop (`docs/app.js`, `getWorking`, field
+`portfolio-target`) computed each stock's % from the **raw** `stock.target`
+divided by the **split-adjusted** buy price — mixing bases. For NYSE:DD, which
+had a 1:3 reverse split (`split_coefficient` 0.3333), it did
+`43.67 ÷ (40.90 ÷ 0.3333 = 122.74) = −64.4%`, whereas the correct adjusted
+basis is `(43.67 ÷ 0.3333 = 131.04) vs 122.74 = +6.8%`. Every other consumer
+(table target, chart dot, per-stock Target popover, headline) already adjusts
+the target via the shared `adjustHistoricalPriceToCurrent` path.
+
+### Fix (DRY — single source of truth)
+
+- Added `calculatePortfolioTargetWorking(stocks)` to `docs/projection.js`. It
+  returns `{ details, total, validStocks }` from the **same** split/dilution
+  adjusted inputs the headline uses, and `calculatePortfolioTargetPercentage`
+  now delegates to it — so the per-stock list, the `Total ÷ N stocks` line and
+  the `Portfolio target` headline reconcile **by construction**.
+- Extracted `buildPortfolioTargetStocks()` in `docs/app.js` so the headline and
+  the popover consume identical inputs (the adjusted target, never raw
+  `stock.target`). The popover branch now calls the shared helper instead of
+  recomputing from raw values.
+- Bumped `APP_VERSION` 1.1.29 → **1.1.30** (`sw.js`, `index.html`, `trend.html`,
+  `sw-register.js`) via `scripts/bump_version.ts` so cached clients pick up the
+  fix.
+
+```mermaid
+flowchart TD
+    SD[scoreData] --> B[buildPortfolioTargetStocks<br/>adjustedTarget = adjustHistoricalPriceToCurrent]
+    B --> H[calculatePortfolioTargetPercentage<br/>headline]
+    B --> W[calculatePortfolioTargetWorking<br/>popover per-stock list + Total]
+    H -. reconcile by construction .- W
+```
+
+## Evidence
+
+Playwright MCP browser tools were not available in this environment, so a
+popover screenshot could not be captured. The fix is a pure calculation change
+verified by unit tests driving the **real shipped helper** with a DD-style
+reverse-split fixture (coeff 0.3333):
+
+- `calculatePortfolioTargetWorking` returns **+6.8%** for the DD-style stock
+  using the adjusted basis (the old code produced −64.4%).
+- The popover `Total ÷ validStocks` equals `calculatePortfolioTargetPercentage`
+  (the headline) to within 1e-9 — confirming reconciliation.
+
+All related Deno suites pass (`portfolio_target_working_test.ts`,
+`portfolio_target_tests.ts`, `portfolio_actual_dividends_popover_test.ts`,
+`projection_module_test.ts`, `js_syntax_test.ts`).
+
+> Note: the Rust suite has one pre-existing, environment-dependent failure
+> (`utils::tests::test_read_market_data`) that requires an external market-data
+> repository absent from this machine. It is unrelated to this JS-only change.
+
+## Test Plan
+
+- Added `tests/portfolio_target_working_test.ts`:
+  - `reverse-split stock uses adjusted basis (not raw target)` — DD-style coeff
+    0.3333 yields +6.8%, reproducing #629.
+  - `Total reconciles with the headline` — popover Total ÷ N equals
+    `calculatePortfolioTargetPercentage`.
+  - `excludes unpriceable stocks from the list` — exclusion/inclusion gate.
+  - `empty / non-array inputs are safe` — defensive edge cases.
+- Existing `tests/portfolio_target_tests.ts` continues to pass against the
+  refactored `calculatePortfolioTargetPercentage`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.29">
+    <meta name="app-version" content="1.1.30">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -563,6 +563,6 @@
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.29"></script>
+    <script src="sw-register.js?v=1.1.30"></script>
   </body>
 </html>

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -920,11 +920,26 @@ function calculateTargetPercentage(buyPrice, adjustedTarget) {
 // same fallback the dashboard's totals row applies). Returns 20.0 for a missing
 // or empty list so callers always have a usable figure.
 function calculatePortfolioTargetPercentage(stocks) {
-    if (!Array.isArray(stocks)) {
-        return 20.0;
-    }
-    let totalTarget = 0;
+    const { total, validStocks } = calculatePortfolioTargetWorking(stocks);
+    return validStocks > 0 ? total / validStocks : 20.0;
+}
+
+// Per-stock breakdown behind the Portfolio Target "show the working" popover
+// (issue #629). Single source of truth shared with
+// calculatePortfolioTargetPercentage, so the popover's per-stock % list, its
+// `Total ÷ N stocks` line and the `Portfolio target` headline all reconcile by
+// construction. Each input stock carries the SAME gate fields used by the
+// headline (`buyPrice`, `currentPrice`, `splitReliable`, `lowVolume`, `score`)
+// plus the split/dilution-adjusted `adjustedTarget` — never the raw target —
+// and an optional `stock` ticker for labelling. Returns
+// `{ details: [{ stock, targetPercentage }], total, validStocks }`.
+function calculatePortfolioTargetWorking(stocks) {
+    const details = [];
+    let total = 0;
     let validStocks = 0;
+    if (!Array.isArray(stocks)) {
+        return { details, total, validStocks };
+    }
     for (const stock of stocks) {
         const buyPrice = stock && stock.buyPrice;
         const currentPrice = stock && stock.currentPrice;
@@ -954,11 +969,15 @@ function calculatePortfolioTargetPercentage(stocks) {
             adjustedTarget,
         );
         if (targetPercentage !== null) {
-            totalTarget += targetPercentage;
+            details.push({
+                stock: stock && stock.stock,
+                targetPercentage,
+            });
+            total += targetPercentage;
             validStocks++;
         }
     }
-    return validStocks > 0 ? totalTarget / validStocks : 20.0;
+    return { details, total, validStocks };
 }
 
 // Fair-value display band for a stock's analysis. Pure given the analysis
@@ -1416,6 +1435,7 @@ globalThis.GRQProjection = {
     dividendBasisDifferencePercent,
     calculateTargetPercentage,
     calculatePortfolioTargetPercentage,
+    calculatePortfolioTargetWorking,
     getFairValueRange,
     getTargetPriceColor,
     calculateRSquared,

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.29")
+    navigator.serviceWorker.register("./sw.js?v=1.1.30")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.29";
+const APP_VERSION = "1.1.30";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.29">
+    <meta name="app-version" content="1.1.30">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -211,6 +211,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.29"></script>
+    <script src="sw-register.js?v=1.1.30"></script>
   </body>
 </html>

--- a/tests/portfolio_target_working_test.ts
+++ b/tests/portfolio_target_working_test.ts
@@ -1,0 +1,138 @@
+// Regression tests for the Portfolio Target "show the working" popover
+// (issue #629).
+//
+// The popover's per-stock % list previously divided each stock's RAW
+// `stock.target` by the split-adjusted buy price — mixing bases. For a
+// reverse-split stock (e.g. NYSE:DD, split_coefficient 0.3333) that produced a
+// wildly wrong figure (DD: -64.4% instead of +6.8%). The fix routes the popover
+// through the shared `calculatePortfolioTargetWorking` helper, which consumes
+// the SAME split/dilution-adjusted inputs as the headline
+// `calculatePortfolioTargetPercentage`, so the per-stock %, the Total and the
+// headline reconcile by construction.
+//
+// These drive the REAL shipped helper from docs/projection.js with fixture
+// inputs and assert on its RETURN VALUES.
+
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+
+const g = globalThis as unknown as {
+  GRQProjection: {
+    calculatePortfolioTargetWorking: (
+      stocks: Array<{
+        stock?: string;
+        buyPrice: number | null;
+        currentPrice: number | null;
+        adjustedTarget: number | null;
+        score?: number | null;
+      }>,
+    ) => {
+      details: Array<{ stock?: string; targetPercentage: number }>;
+      total: number;
+      validStocks: number;
+    };
+    calculatePortfolioTargetPercentage: (
+      stocks: Array<{
+        buyPrice: number | null;
+        currentPrice: number | null;
+        adjustedTarget: number | null;
+      }>,
+    ) => number;
+  };
+};
+const GRQProjection = g.GRQProjection;
+
+// NYSE:DD reverse split (1:3, split_coefficient 0.3333) on 2025-12-29 data.
+// Raw target $43.67, score-date mid $40.90. Both are restated to the current
+// post-split basis BEFORE reaching the helper:
+//   buyPrice      = 40.90 / 0.3333 = 122.74
+//   adjustedTarget = 43.67 / 0.3333 = 131.04
+// Correct per-stock target = (131.04 - 122.74) / 122.74 = +6.8%.
+// The OLD popover did 43.67 / 122.74 = -64.4% (raw target / adjusted buy price).
+const DD_BUY_PRICE = 40.90 / 0.3333;
+const DD_ADJUSTED_TARGET = 43.67 / 0.3333;
+
+Deno.test("calculatePortfolioTargetWorking - reverse-split stock uses adjusted basis (not raw target)", () => {
+  const { details } = GRQProjection.calculatePortfolioTargetWorking([
+    {
+      stock: "NYSE:DD",
+      buyPrice: DD_BUY_PRICE,
+      currentPrice: 130,
+      adjustedTarget: DD_ADJUSTED_TARGET,
+    },
+  ]);
+
+  assertEquals(details.length, 1);
+  assertEquals(details[0].stock, "NYSE:DD");
+  // The correct adjusted figure is +6.8%, NOT the buggy -64.4%.
+  assertAlmostEquals(details[0].targetPercentage, 6.8, 0.1);
+});
+
+Deno.test("calculatePortfolioTargetWorking - Total reconciles with the headline", () => {
+  // A reverse-split name alongside two ordinary names: the popover's
+  // Total ÷ validStocks must equal the headline calculatePortfolioTargetPercentage.
+  const stocks = [
+    {
+      stock: "NYSE:DD",
+      buyPrice: DD_BUY_PRICE,
+      currentPrice: 130,
+      adjustedTarget: DD_ADJUSTED_TARGET,
+    },
+    {
+      stock: "NYSE:AAA",
+      buyPrice: 100,
+      currentPrice: 110,
+      adjustedTarget: 120,
+    }, // 20%
+    { stock: "NYSE:BBB", buyPrice: 50, currentPrice: 55, adjustedTarget: 60 }, // 20%
+  ];
+
+  const working = GRQProjection.calculatePortfolioTargetWorking(stocks);
+  const headline = GRQProjection.calculatePortfolioTargetPercentage(stocks);
+
+  assertEquals(working.validStocks, 3);
+  assertAlmostEquals(working.total / working.validStocks, headline, 1e-9);
+});
+
+Deno.test("calculatePortfolioTargetWorking - excludes unpriceable stocks from the list", () => {
+  const { details, validStocks } = GRQProjection
+    .calculatePortfolioTargetWorking([
+      {
+        stock: "NYSE:AAA",
+        buyPrice: 100,
+        currentPrice: 130,
+        adjustedTarget: 150,
+      }, // 50%
+      {
+        stock: "NYSE:BAD",
+        buyPrice: 100,
+        currentPrice: 0,
+        adjustedTarget: 999,
+      }, // excluded
+      {
+        stock: "NYSE:NOTGT",
+        buyPrice: 100,
+        currentPrice: 110,
+        adjustedTarget: null,
+      }, // no target
+    ]);
+
+  assertEquals(validStocks, 1);
+  assertEquals(details.length, 1);
+  assertEquals(details[0].stock, "NYSE:AAA");
+  assertAlmostEquals(details[0].targetPercentage, 50.0);
+});
+
+Deno.test("calculatePortfolioTargetWorking - empty / non-array inputs are safe", () => {
+  assertEquals(GRQProjection.calculatePortfolioTargetWorking([]), {
+    details: [],
+    total: 0,
+    validStocks: 0,
+  });
+  assertEquals(
+    GRQProjection.calculatePortfolioTargetWorking(
+      null as unknown as [],
+    ),
+    { details: [], total: 0, validStocks: 0 },
+  );
+});


### PR DESCRIPTION
## Summary

Fixed the Portfolio Target "show the working" popover, which listed wrong
per-stock targets for split/dilution-adjusted stocks (e.g. **NYSE:DD −64.4%**
instead of the correct **+6.8%**). Closes #629.

The popover's per-stock loop (`docs/app.js`, `getWorking`, field
`portfolio-target`) computed each stock's % from the **raw** `stock.target`
divided by the **split-adjusted** buy price — mixing bases. For NYSE:DD, which
had a 1:3 reverse split (`split_coefficient` 0.3333), it did
`43.67 ÷ (40.90 ÷ 0.3333 = 122.74) = −64.4%`, whereas the correct adjusted
basis is `(43.67 ÷ 0.3333 = 131.04) vs 122.74 = +6.8%`. Every other consumer
(table target, chart dot, per-stock Target popover, headline) already adjusts
the target via the shared `adjustHistoricalPriceToCurrent` path.

### Fix (DRY — single source of truth)

- Added `calculatePortfolioTargetWorking(stocks)` to `docs/projection.js`. It
  returns `{ details, total, validStocks }` from the **same** split/dilution
  adjusted inputs the headline uses, and `calculatePortfolioTargetPercentage`
  now delegates to it — so the per-stock list, the `Total ÷ N stocks` line and
  the `Portfolio target` headline reconcile **by construction**.
- Extracted `buildPortfolioTargetStocks()` in `docs/app.js` so the headline and
  the popover consume identical inputs (the adjusted target, never raw
  `stock.target`). The popover branch now calls the shared helper instead of
  recomputing from raw values.
- Bumped `APP_VERSION` 1.1.29 → **1.1.30** (`sw.js`, `index.html`, `trend.html`,
  `sw-register.js`) via `scripts/bump_version.ts` so cached clients pick up the
  fix.

```mermaid
flowchart TD
    SD[scoreData] --> B[buildPortfolioTargetStocks<br/>adjustedTarget = adjustHistoricalPriceToCurrent]
    B --> H[calculatePortfolioTargetPercentage<br/>headline]
    B --> W[calculatePortfolioTargetWorking<br/>popover per-stock list + Total]
    H -. reconcile by construction .- W
```

## Evidence

Playwright MCP browser tools were not available in this environment, so a
popover screenshot could not be captured. The fix is a pure calculation change
verified by unit tests driving the **real shipped helper** with a DD-style
reverse-split fixture (coeff 0.3333):

- `calculatePortfolioTargetWorking` returns **+6.8%** for the DD-style stock
  using the adjusted basis (the old code produced −64.4%).
- The popover `Total ÷ validStocks` equals `calculatePortfolioTargetPercentage`
  (the headline) to within 1e-9 — confirming reconciliation.

All related Deno suites pass (`portfolio_target_working_test.ts`,
`portfolio_target_tests.ts`, `portfolio_actual_dividends_popover_test.ts`,
`projection_module_test.ts`, `js_syntax_test.ts`).

> Note: the Rust suite has one pre-existing, environment-dependent failure
> (`utils::tests::test_read_market_data`) that requires an external market-data
> repository absent from this machine. It is unrelated to this JS-only change.

## Test Plan

- Added `tests/portfolio_target_working_test.ts`:
  - `reverse-split stock uses adjusted basis (not raw target)` — DD-style coeff
    0.3333 yields +6.8%, reproducing #629.
  - `Total reconciles with the headline` — popover Total ÷ N equals
    `calculatePortfolioTargetPercentage`.
  - `excludes unpriceable stocks from the list` — exclusion/inclusion gate.
  - `empty / non-array inputs are safe` — defensive edge cases.
- Existing `tests/portfolio_target_tests.ts` continues to pass against the
  refactored `calculatePortfolioTargetPercentage`.
