### PR TITLE
Drop unused export on bumpVersionFiles (Issue #631)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-631.md
+++ b/docs/archive/pr-summaries/pr-summary-631.md
@@ -1,0 +1,42 @@
+## Summary
+
+Removed the redundant `export` modifier from the `bumpVersionFiles` function in
+`scripts/bump_version.ts`, narrowing it to a file-local function. The symbol is
+still live code — it is called internally by the CLI `main` flow — but no other
+module in the repository imports it, so its `export` was dead surface area.
+Closes #631.
+
+A whole-repo `.ts` token sweep confirmed the only references are the declaration
+and one internal call site:
+
+```
+scripts/bump_version.ts:136:async function bumpVersionFiles(
+scripts/bump_version.ts:190:  const result = await bumpVersionFiles(docsDir, baseVersion);
+```
+
+No barrel/`mod.ts` re-exports it, `deno.json` declares no `exports` map, and no
+dynamic/reflective access was found, so dropping the `export` cannot break any
+in-repo or downstream importer.
+
+## Evidence
+
+Backend/CLI change with no web interface to screenshot. Verified via the repo
+quality gate (`./quality.sh`), which runs `deno lint`, `deno check`, and the full
+test suite — all passed cleanly. The existing tests in
+`tests/bump_version_test.ts` exercise the pure helper `bumpVersionContents`
+(which `bumpVersionFiles` wraps) and continue to pass, confirming behaviour is
+unchanged.
+
+No new test was added: the change only removes an `export` modifier with no
+behavioural effect, and the only way to "test" an export's absence is to grep
+source text, which the testing guidelines explicitly forbid. The CLI flow that
+uses `bumpVersionFiles` internally remains covered by
+`tests/version_bump_workflow_test.ts`.
+
+## Test Plan
+
+- `./quality.sh` — lint, type-check, and full test suite pass.
+- `tests/bump_version_test.ts` — existing coverage of `bumpVersionContents` and
+  the pure helpers, unchanged and passing.
+- `tests/version_bump_workflow_test.ts` — existing subprocess coverage of the
+  CLI `main` flow that calls `bumpVersionFiles`, unchanged and passing.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.32">
+    <meta name="app-version" content="1.1.33">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -491,78 +491,78 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.32"></script>
+    <script src="escape.js?v=1.1.33"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.32"></script>
+    <script src="projection.js?v=1.1.33"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.32"></script>
+    <script src="volume_recommend.js?v=1.1.33"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.32"></script>
+    <script src="chart_window_settings.js?v=1.1.33"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.32"></script>
+    <script src="color_key.js?v=1.1.33"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.32"></script>
+    <script src="series_label_colour.js?v=1.1.33"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.32"></script>
+    <script src="chart_theme.js?v=1.1.33"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.32"></script>
+    <script src="chart_title.js?v=1.1.33"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.32"></script>
+    <script src="format.js?v=1.1.33"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.32"></script>
+    <script src="market_index.js?v=1.1.33"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.32"></script>
+    <script src="stock_selection.js?v=1.1.33"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.32"></script>
+    <script src="yahoo_finance.js?v=1.1.33"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.32"></script>
+    <script src="date_selection.js?v=1.1.33"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.32"></script>
+    <script src="view_selection.js?v=1.1.33"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.32"></script>
+    <script src="popover_dismiss.js?v=1.1.33"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.32"></script>
+    <script src="popover_cleanup.js?v=1.1.33"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.32"></script>
+    <script src="chart_popout.js?v=1.1.33"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.32"></script>
+    <script src="share_link.js?v=1.1.33"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.32"></script>
+    <script src="field_label.js?v=1.1.33"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.32"></script>
+    <script src="freshness_text.js?v=1.1.33"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.32"></script>
+    <script src="dashboard_boot.js?v=1.1.33"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.32"></script>
+    <script src="sw-register.js?v=1.1.33"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.32")
+    navigator.serviceWorker.register("./sw.js?v=1.1.33")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.32";
+const APP_VERSION = "1.1.33";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.32">
+    <meta name="app-version" content="1.1.33">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -211,6 +211,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.32"></script>
+    <script src="sw-register.js?v=1.1.33"></script>
   </body>
 </html>

--- a/scripts/bump_version.ts
+++ b/scripts/bump_version.ts
@@ -132,8 +132,11 @@ export function bumpVersionContents(
  *
  * Thin I/O wrapper around {@link bumpVersionContents}; only writes when a bump
  * actually occurs.
+ *
+ * File-local: only the CLI `main` flow below calls it. The pure, unit-tested
+ * helper is {@link bumpVersionContents}.
  */
-export async function bumpVersionFiles(
+async function bumpVersionFiles(
   docsDir: string,
   baseVersion?: string,
 ): Promise<BumpResult> {


### PR DESCRIPTION
## Summary

Removed the redundant `export` modifier from the `bumpVersionFiles` function in
`scripts/bump_version.ts`, narrowing it to a file-local function. The symbol is
still live code — it is called internally by the CLI `main` flow — but no other
module in the repository imports it, so its `export` was dead surface area.
Closes #631.

A whole-repo `.ts` token sweep confirmed the only references are the declaration
and one internal call site:

```
scripts/bump_version.ts:136:async function bumpVersionFiles(
scripts/bump_version.ts:190:  const result = await bumpVersionFiles(docsDir, baseVersion);
```

No barrel/`mod.ts` re-exports it, `deno.json` declares no `exports` map, and no
dynamic/reflective access was found, so dropping the `export` cannot break any
in-repo or downstream importer.

## Evidence

Backend/CLI change with no web interface to screenshot. Verified via the repo
quality gate (`./quality.sh`), which runs `deno lint`, `deno check`, and the full
test suite — all passed cleanly. The existing tests in
`tests/bump_version_test.ts` exercise the pure helper `bumpVersionContents`
(which `bumpVersionFiles` wraps) and continue to pass, confirming behaviour is
unchanged.

No new test was added: the change only removes an `export` modifier with no
behavioural effect, and the only way to "test" an export's absence is to grep
source text, which the testing guidelines explicitly forbid. The CLI flow that
uses `bumpVersionFiles` internally remains covered by
`tests/version_bump_workflow_test.ts`.

## Test Plan

- `./quality.sh` — lint, type-check, and full test suite pass.
- `tests/bump_version_test.ts` — existing coverage of `bumpVersionContents` and
  the pure helpers, unchanged and passing.
- `tests/version_bump_workflow_test.ts` — existing subprocess coverage of the
  CLI `main` flow that calls `bumpVersionFiles`, unchanged and passing.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqy8yim0-7a505c`<!-- vibe-worker-issue-631 -->