### PR TITLE
Add behaviour tests for create_market_data_long_csv (Issue #634)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-634.md
+++ b/docs/archive/pr-summaries/pr-summary-634.md
@@ -1,0 +1,62 @@
+## Summary
+
+`create_market_data_long_csv` (`src/utils.rs:735`) — the primary long-format
+market-data writer on the batch critical path — had **no unconditional test**.
+Its only test-adjacent reference, the wrapper
+`create_market_data_long_csv_for_score_file`, early-returns unless an external
+`MARKET_DATA_BASE_PATH` repository exists, so on CI and most machines the
+8-column writer, the per-ticker skip handling, and the "no rows written →
+error" guard (`src/utils.rs:804-809`) were never asserted.
+
+This PR adds fixture-backed behaviour (WHAT) tests in
+`tests/create_market_data_long_csv_test.rs`, mirroring the short-format sibling
+`tests/create_market_data_csv_test.rs` (issue #265). No production code
+changed — this is a pure coverage gap fix.
+
+Closes #634.
+
+## Evidence
+
+Backend/CLI change with no web interface — no screenshot applicable.
+
+The tests drop a small, fully controlled market-data fixture at the location
+the function reads from (via an RAII guard that removes exactly what it
+created), so they run unconditionally without depending on the external data
+repository. Assertions pin the observable contract — the bytes written and the
+`Result` returned — not internal call order.
+
+```mermaid
+flowchart LR
+    A[install fixture<br/>under MARKET_DATA_BASE_PATH] --> B[call<br/>create_market_data_long_csv]
+    B --> C[read produced CSV]
+    C --> D{assert 8-column header<br/>+ mapped row<br/>+ window filter}
+    E[no fixture<br/>missing symbol] --> F[call writer]
+    F --> G{assert Err<br/>no rows written}
+```
+
+Test run:
+
+```
+running 2 tests
+test create_market_data_long_csv_errors_when_all_tickers_skipped ... ok
+test create_market_data_long_csv_writes_eight_column_rows ... ok
+
+test result: ok. 2 passed; 0 failed
+```
+
+`./quality.sh` passes cleanly (1185 tests, fmt/lint/check all green).
+
+## Test Plan
+
+Added `tests/create_market_data_long_csv_test.rs`:
+
+- `create_market_data_long_csv_writes_eight_column_rows` — installs a fixture
+  with distinct open/high/low/close/volume/split values for an in-window date
+  plus rows before and after the 180-day window, calls the writer, and asserts
+  the `date,ticker,high,low,open,close,split_coefficient,volume` header, the
+  fully-mapped in-window row (with the full exchange-prefixed ticker preserved),
+  and that out-of-window rows are excluded.
+- `create_market_data_long_csv_errors_when_all_tickers_skipped` — calls the
+  writer with a single synthetic ticker that has no market-data file, so every
+  ticker is skipped and no rows are written, then asserts the documented
+  "no rows written" error is returned (`src/utils.rs:804-809`).

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.35">
+    <meta name="app-version" content="1.1.36">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -491,78 +491,78 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.35"></script>
+    <script src="escape.js?v=1.1.36"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.35"></script>
+    <script src="projection.js?v=1.1.36"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.35"></script>
+    <script src="volume_recommend.js?v=1.1.36"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.35"></script>
+    <script src="chart_window_settings.js?v=1.1.36"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.35"></script>
+    <script src="color_key.js?v=1.1.36"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.35"></script>
+    <script src="series_label_colour.js?v=1.1.36"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.35"></script>
+    <script src="chart_theme.js?v=1.1.36"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.35"></script>
+    <script src="chart_title.js?v=1.1.36"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.35"></script>
+    <script src="format.js?v=1.1.36"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.35"></script>
+    <script src="market_index.js?v=1.1.36"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.35"></script>
+    <script src="stock_selection.js?v=1.1.36"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.35"></script>
+    <script src="yahoo_finance.js?v=1.1.36"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.35"></script>
+    <script src="date_selection.js?v=1.1.36"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.35"></script>
+    <script src="view_selection.js?v=1.1.36"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.35"></script>
+    <script src="popover_dismiss.js?v=1.1.36"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.35"></script>
+    <script src="popover_cleanup.js?v=1.1.36"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.35"></script>
+    <script src="chart_popout.js?v=1.1.36"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.35"></script>
+    <script src="share_link.js?v=1.1.36"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.35"></script>
+    <script src="field_label.js?v=1.1.36"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.35"></script>
+    <script src="freshness_text.js?v=1.1.36"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.35"></script>
+    <script src="dashboard_boot.js?v=1.1.36"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.35"></script>
+    <script src="sw-register.js?v=1.1.36"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.35")
+    navigator.serviceWorker.register("./sw.js?v=1.1.36")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.35";
+const APP_VERSION = "1.1.36";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.35">
+    <meta name="app-version" content="1.1.36">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -211,6 +211,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.35"></script>
+    <script src="sw-register.js?v=1.1.36"></script>
   </body>
 </html>

--- a/tests/create_market_data_long_csv_test.rs
+++ b/tests/create_market_data_long_csv_test.rs
@@ -1,0 +1,206 @@
+//! Behaviour tests for `create_market_data_long_csv` (issue #634).
+//!
+//! The long-format market-data writer previously had no unconditional test:
+//! its only test-adjacent reference (`create_market_data_long_csv_for_score_file`
+//! in `tests/market_data_tests.rs`) early-returns unless an external
+//! `MARKET_DATA_BASE_PATH` repository exists, so on CI and most machines it
+//! never runs. These tests drop a small, fully controlled market-data fixture
+//! at the location the function reads from and assert the observable contract —
+//! the 8-column `date,ticker,high,low,open,close,split_coefficient,volume`
+//! output and the "no rows written → error" guard — without caring how the
+//! writer is implemented. They mirror `tests/create_market_data_csv_test.rs`.
+
+use anyhow::Result;
+use grq_validation::utils::{create_market_data_long_csv, MARKET_DATA_BASE_PATH};
+use std::path::{Path, PathBuf};
+
+/// Clearly-synthetic symbol so a fixture can never collide with a real symbol
+/// in an existing `MARKET_DATA_BASE_PATH` data repository.
+const FIXTURE_SYMBOL: &str = "GRQVTEST634A";
+
+/// Full ticker code as it appears in a scores file. The long writer keeps the
+/// whole code (exchange prefix included) in the `ticker` column.
+const FIXTURE_TICKER: &str = "NYSE:GRQVTEST634A";
+
+/// Score-file date used by the happy-path test; the 180-day window therefore
+/// runs from `2025-04-15` to `2025-10-12` inclusive.
+const SCORE_DATE: &str = "2025-04-15";
+
+/// RAII guard that installs a market-data fixture for a given symbol under
+/// `MARKET_DATA_BASE_PATH` and removes exactly what it created on drop, so the
+/// test leaves no trace whether or not the external data repository pre-exists.
+struct MarketDataFixture {
+    json_path: PathBuf,
+    /// The outermost directory this guard created (and must remove on drop), or
+    /// `None` when the whole tree already existed.
+    created_root: Option<PathBuf>,
+}
+
+impl MarketDataFixture {
+    /// Writes a fixture for `symbol` whose daily series contains one row inside
+    /// the 180-day window, one row before it, and one row after it, so a test
+    /// can assert both inclusion and exclusion.
+    fn install(symbol: &str) -> Result<Self> {
+        let base = Path::new(MARKET_DATA_BASE_PATH);
+        let first_letter = symbol.chars().next().unwrap().to_string();
+        let symbol_dir = base.join("data").join(&first_letter);
+
+        let created_root = first_missing_ancestor(&symbol_dir);
+        std::fs::create_dir_all(&symbol_dir)?;
+
+        let json_path = symbol_dir.join(format!("{symbol}.json"));
+        std::fs::write(&json_path, fixture_json(symbol))?;
+
+        Ok(Self {
+            json_path,
+            created_root,
+        })
+    }
+}
+
+impl Drop for MarketDataFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.json_path);
+
+        // Prune the directories we created, bottom-up, removing each only when
+        // it is empty. `remove_dir` (not `remove_dir_all`) means a directory
+        // shared with a concurrently-running test's fixture is left intact
+        // until that test has cleaned up too, so cleanup never races.
+        if let Some(root) = &self.created_root {
+            let mut dir = self.json_path.parent().map(Path::to_path_buf);
+            while let Some(current) = dir {
+                if std::fs::remove_dir(&current).is_err() {
+                    break; // non-empty (another fixture present) or already gone
+                }
+                if current == *root {
+                    break;
+                }
+                dir = current.parent().map(Path::to_path_buf);
+            }
+        }
+    }
+}
+
+/// Returns the shallowest ancestor of `dir` (including `dir` itself) that does
+/// not yet exist, i.e. the outermost directory `create_dir_all` would create.
+/// Returns `None` when `dir` already exists.
+fn first_missing_ancestor(dir: &Path) -> Option<PathBuf> {
+    if dir.exists() {
+        return None;
+    }
+    let mut candidate = dir.to_path_buf();
+    while let Some(parent) = candidate.parent() {
+        if parent.exists() {
+            return Some(candidate);
+        }
+        candidate = parent.to_path_buf();
+    }
+    Some(candidate)
+}
+
+/// Builds an Alpha Vantage-shaped market-data JSON document with three dated
+/// rows: before, inside, and after the 180-day window from [`SCORE_DATE`]. The
+/// in-window row uses distinct open/high/low/close/volume/split values so a
+/// test can verify each long-format column is mapped to the right field.
+fn fixture_json(symbol: &str) -> String {
+    fn daily(
+        open: &str,
+        high: &str,
+        low: &str,
+        close: &str,
+        volume: &str,
+        split: &str,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "1. open": open,
+            "2. high": high,
+            "3. low": low,
+            "4. close": close,
+            "5. adjusted close": close,
+            "6. volume": volume,
+            "7. dividend amount": "0.0",
+            "8. split coefficient": split,
+        })
+    }
+
+    serde_json::json!({
+        "Meta Data": {
+            "1. Information": "Daily Prices (fixture)",
+            "2. Symbol": symbol,
+            "3. Last Refreshed": "2025-10-12",
+            "4. Output Size": "Full size",
+            "5. Time Zone": "US/Eastern",
+        },
+        "Time Series (Daily)": {
+            // before the window -> excluded
+            "2024-01-01": daily("1.0", "1.0", "1.0", "1.0", "10", "1.0"),
+            // window start (inclusive) -> included, with distinct columns
+            "2025-04-15": daily("100.5", "105.25", "98.75", "102.0", "123456", "1.0"),
+            // after the window -> excluded
+            "2025-12-01": daily("9.0", "9.0", "9.0", "9.0", "20", "1.0"),
+        },
+    })
+    .to_string()
+}
+
+#[test]
+fn create_market_data_long_csv_writes_eight_column_rows() -> Result<()> {
+    let _fixture = MarketDataFixture::install(FIXTURE_SYMBOL)?;
+
+    let out_dir = tempfile::tempdir()?;
+    let out_path = out_dir.path().join("long.csv");
+    let out = out_path.to_str().expect("temp path is valid UTF-8");
+
+    create_market_data_long_csv(&[FIXTURE_TICKER.to_string()], SCORE_DATE, out)?;
+
+    let csv = std::fs::read_to_string(&out_path)?;
+
+    // 8-column header contract.
+    assert_eq!(
+        csv.lines().next().unwrap(),
+        "date,ticker,high,low,open,close,split_coefficient,volume",
+        "unexpected long-format CSV header in:\n{csv}"
+    );
+
+    // In-window row present with each column mapped to its field. The ticker
+    // column keeps the full code (exchange prefix included).
+    assert!(
+        csv.contains(&format!(
+            "2025-04-15,{FIXTURE_TICKER},105.25,98.75,100.5,102.0,1.0,123456"
+        )),
+        "expected the fully-mapped window-start row in:\n{csv}"
+    );
+
+    // Out-of-window rows excluded (both before and after the 180-day window).
+    assert!(
+        !csv.contains("2024-01-01"),
+        "row before the window must be excluded in:\n{csv}"
+    );
+    assert!(
+        !csv.contains("2025-12-01"),
+        "row after the window must be excluded in:\n{csv}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn create_market_data_long_csv_errors_when_all_tickers_skipped() -> Result<()> {
+    // No fixture installed: the symbol has no market-data file, so the only
+    // ticker is skipped and no data rows are written. The documented guard at
+    // `src/utils.rs` must turn this into an error rather than a silent
+    // header-only CSV. A synthetic symbol guarantees no real data file exists.
+    let out_dir = tempfile::tempdir()?;
+    let out_path = out_dir.path().join("empty.csv");
+    let out = out_path.to_str().expect("temp path is valid UTF-8");
+
+    let result =
+        create_market_data_long_csv(&["NYSE:GRQVTEST634MISSING".to_string()], SCORE_DATE, out);
+
+    assert!(
+        result.is_err(),
+        "expected an error when every ticker is skipped and no rows are written"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`create_market_data_long_csv` (`src/utils.rs:735`) — the primary long-format
market-data writer on the batch critical path — had **no unconditional test**.
Its only test-adjacent reference, the wrapper
`create_market_data_long_csv_for_score_file`, early-returns unless an external
`MARKET_DATA_BASE_PATH` repository exists, so on CI and most machines the
8-column writer, the per-ticker skip handling, and the "no rows written →
error" guard (`src/utils.rs:804-809`) were never asserted.

This PR adds fixture-backed behaviour (WHAT) tests in
`tests/create_market_data_long_csv_test.rs`, mirroring the short-format sibling
`tests/create_market_data_csv_test.rs` (issue #265). No production code
changed — this is a pure coverage gap fix.

Closes #634.

## Evidence

Backend/CLI change with no web interface — no screenshot applicable.

The tests drop a small, fully controlled market-data fixture at the location
the function reads from (via an RAII guard that removes exactly what it
created), so they run unconditionally without depending on the external data
repository. Assertions pin the observable contract — the bytes written and the
`Result` returned — not internal call order.

```mermaid
flowchart LR
    A[install fixture<br/>under MARKET_DATA_BASE_PATH] --> B[call<br/>create_market_data_long_csv]
    B --> C[read produced CSV]
    C --> D{assert 8-column header<br/>+ mapped row<br/>+ window filter}
    E[no fixture<br/>missing symbol] --> F[call writer]
    F --> G{assert Err<br/>no rows written}
```

Test run:

```
running 2 tests
test create_market_data_long_csv_errors_when_all_tickers_skipped ... ok
test create_market_data_long_csv_writes_eight_column_rows ... ok

test result: ok. 2 passed; 0 failed
```

`./quality.sh` passes cleanly (1185 tests, fmt/lint/check all green).

## Test Plan

Added `tests/create_market_data_long_csv_test.rs`:

- `create_market_data_long_csv_writes_eight_column_rows` — installs a fixture
  with distinct open/high/low/close/volume/split values for an in-window date
  plus rows before and after the 180-day window, calls the writer, and asserts
  the `date,ticker,high,low,open,close,split_coefficient,volume` header, the
  fully-mapped in-window row (with the full exchange-prefixed ticker preserved),
  and that out-of-window rows are excluded.
- `create_market_data_long_csv_errors_when_all_tickers_skipped` — calls the
  writer with a single synthetic ticker that has no market-data file, so every
  ticker is skipped and no rows are written, then asserts the documented
  "no rows written" error is returned (`src/utils.rs:804-809`).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqyini66-5738e2`<!-- vibe-worker-issue-634 -->