### PR TITLE
Test diffUses Actions bump-diffing logic (Issue #635)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-635.md
+++ b/docs/archive/pr-summaries/pr-summary-635.md
@@ -1,0 +1,37 @@
+## Summary
+
+Added unit tests for the previously untested exported function `diffUses`
+(`helpers/bump_quarantine_gate.ts:193`), the GitHub Actions analog of the
+already-tested `diffCargoLock`. The function parses `uses:` action refs from
+two workflow-file snapshots and emits a `Bump[]` for each newly-added or
+re-pinned action. It was reached only through untested I/O glue
+(`collectBumps`), leaving its classification logic without a safety net while
+the parallel Cargo path was well covered. No production code changed — this is
+a test-only gap fix. Closes #635.
+
+## Evidence
+
+Backend/CLI change with no web interface — verified via the test suite. All
+three new cases assert on the observable `Bump[]` return value, not internals:
+
+- `diffUses reports re-pinned and newly-added actions` — a re-pin (different
+  SHA) and a brand-new action are both reported; an unchanged action is not;
+  ecosystem is `github-actions`.
+- `diffUses reports nothing when the workflows are unchanged` — empty `Bump[]`.
+- `diffUses reports every action as new against an empty old snapshot` — every
+  `uses:` ref counts as a new bump with `publishedAt: null`.
+
+```
+deno test tests/bump_quarantine_gate_test.ts
+ok | 22 passed | 0 failed
+```
+
+`./quality.sh` passes cleanly.
+
+## Test Plan
+
+- Added three `diffUses` cases to `tests/bump_quarantine_gate_test.ts`
+  mirroring the existing `diffCargoLock` coverage (re-pin + add, no-change,
+  all-new).
+- Imported `diffUses` alongside the existing `diffCargoLock`/`parseUses`
+  imports.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.36">
+    <meta name="app-version" content="1.1.37">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -491,78 +491,78 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.36"></script>
+    <script src="escape.js?v=1.1.37"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.36"></script>
+    <script src="projection.js?v=1.1.37"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.36"></script>
+    <script src="volume_recommend.js?v=1.1.37"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.36"></script>
+    <script src="chart_window_settings.js?v=1.1.37"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.36"></script>
+    <script src="color_key.js?v=1.1.37"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.36"></script>
+    <script src="series_label_colour.js?v=1.1.37"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.36"></script>
+    <script src="chart_theme.js?v=1.1.37"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.36"></script>
+    <script src="chart_title.js?v=1.1.37"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.36"></script>
+    <script src="format.js?v=1.1.37"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.36"></script>
+    <script src="market_index.js?v=1.1.37"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.36"></script>
+    <script src="stock_selection.js?v=1.1.37"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.36"></script>
+    <script src="yahoo_finance.js?v=1.1.37"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.36"></script>
+    <script src="date_selection.js?v=1.1.37"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.36"></script>
+    <script src="view_selection.js?v=1.1.37"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.36"></script>
+    <script src="popover_dismiss.js?v=1.1.37"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.36"></script>
+    <script src="popover_cleanup.js?v=1.1.37"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.36"></script>
+    <script src="chart_popout.js?v=1.1.37"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.36"></script>
+    <script src="share_link.js?v=1.1.37"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.36"></script>
+    <script src="field_label.js?v=1.1.37"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.36"></script>
+    <script src="freshness_text.js?v=1.1.37"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.36"></script>
+    <script src="dashboard_boot.js?v=1.1.37"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.36"></script>
+    <script src="sw-register.js?v=1.1.37"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.36")
+    navigator.serviceWorker.register("./sw.js?v=1.1.37")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.36";
+const APP_VERSION = "1.1.37";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.36">
+    <meta name="app-version" content="1.1.37">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -211,6 +211,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.36"></script>
+    <script src="sw-register.js?v=1.1.37"></script>
   </body>
 </html>

--- a/tests/bump_quarantine_gate_test.ts
+++ b/tests/bump_quarantine_gate_test.ts
@@ -18,6 +18,7 @@ import {
   ageInHours,
   type Bump,
   diffCargoLock,
+  diffUses,
   evaluateBump,
   evaluateBumps,
   isInternal,
@@ -233,4 +234,65 @@ Deno.test("parseUses ignores lines without a uses directive", () => {
     parseUses("jobs:\n  x:\n    steps:\n      - run: echo hi\n").size,
     0,
   );
+});
+
+// --- diffUses -------------------------------------------------------------
+
+// Old snapshot: checkout pinned to one SHA, setup-deno present.
+const USES_OLD = `name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+      - run: echo hello
+`;
+
+// New snapshot: checkout re-pinned to a different SHA, upload-artifact newly
+// added, setup-deno unchanged.
+const USES_NEW = `name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+      - run: echo hello
+`;
+
+Deno.test("diffUses reports re-pinned and newly-added actions", () => {
+  const bumps = diffUses(USES_OLD, USES_NEW);
+  const byName = new Map(bumps.map((b) => [b.name, b.version]));
+  // checkout re-pinned, upload-artifact added; setup-deno unchanged.
+  assertEquals(
+    byName.get("actions/checkout"),
+    "11bd71901bbe5b1630ceea73d27597364c9af683",
+  );
+  assertEquals(
+    byName.get("actions/upload-artifact"),
+    "65462800fd760344b1a7b4382951275a0abb4808",
+  );
+  assert(
+    !byName.has("denoland/setup-deno"),
+    "unchanged actions must not be reported",
+  );
+  assertEquals(bumps.length, 2);
+  for (const b of bumps) assertEquals(b.ecosystem, "github-actions");
+});
+
+Deno.test("diffUses reports nothing when the workflows are unchanged", () => {
+  assertEquals(diffUses(USES_OLD, USES_OLD).length, 0);
+});
+
+Deno.test("diffUses reports every action as new against an empty old snapshot", () => {
+  const bumps = diffUses("", USES_NEW);
+  assertEquals(bumps.length, 3);
+  for (const b of bumps) {
+    assertEquals(b.ecosystem, "github-actions");
+    assertEquals(b.publishedAt, null);
+  }
 });


### PR DESCRIPTION
## Summary

Added unit tests for the previously untested exported function `diffUses`
(`helpers/bump_quarantine_gate.ts:193`), the GitHub Actions analog of the
already-tested `diffCargoLock`. The function parses `uses:` action refs from
two workflow-file snapshots and emits a `Bump[]` for each newly-added or
re-pinned action. It was reached only through untested I/O glue
(`collectBumps`), leaving its classification logic without a safety net while
the parallel Cargo path was well covered. No production code changed — this is
a test-only gap fix. Closes #635.

## Evidence

Backend/CLI change with no web interface — verified via the test suite. All
three new cases assert on the observable `Bump[]` return value, not internals:

- `diffUses reports re-pinned and newly-added actions` — a re-pin (different
  SHA) and a brand-new action are both reported; an unchanged action is not;
  ecosystem is `github-actions`.
- `diffUses reports nothing when the workflows are unchanged` — empty `Bump[]`.
- `diffUses reports every action as new against an empty old snapshot` — every
  `uses:` ref counts as a new bump with `publishedAt: null`.

```
deno test tests/bump_quarantine_gate_test.ts
ok | 22 passed | 0 failed
```

`./quality.sh` passes cleanly.

## Test Plan

- Added three `diffUses` cases to `tests/bump_quarantine_gate_test.ts`
  mirroring the existing `diffCargoLock` coverage (re-pin + add, no-change,
  all-new).
- Imported `diffUses` alongside the existing `diffCargoLock`/`parseUses`
  imports.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqyini66-5738e2`<!-- vibe-worker-issue-635 -->