### PR TITLE
Replace magic threshold bounds in schw_projection_test (Issue #637)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-637.md
+++ b/docs/archive/pr-summaries/pr-summary-637.md
@@ -1,0 +1,65 @@
+## Summary
+
+`tests/schw_projection_test.ts` carried two fixture-coupled **magic lower-bound
+thresholds** with no spec derivation — the same anti-pattern the file's own
+header criticises and replaces for the 90-day projection assertion. This PR
+rewrites both to assert what the spec actually requires instead of the number
+the maths happens to emit against the frozen SCHW fixture. Closes #637.
+
+- **Current performance** (`currentPerformance > 15`, line 294): replaced with
+  the meaningful qualitative contract that the SCHW position is in profit
+  (`> 0`). The `> 15` magnitude was tied to the value the current
+  buy-price/smoothing maths emits (~17.2%) and would need rewriting on any
+  benign retune even while the position is still correctly profitable. The
+  precise projection magnitude is already pinned spec-derived by the adjacent
+  90-day projection step (`projected = currentPerformance * 90 / daysElapsed`).
+- **Trend-line fit** (`rSquared > 0.3`, line 342): replaced with the
+  fixture-independent mathematical invariant that an R-squared is a valid
+  coefficient of determination in `[0, 1]` (catches NaN / out-of-range maths
+  regressions). The 0.3 bound sat arbitrarily under the fixture's ~0.76 fit and
+  gave a weak signal. The upward-trend intent is carried entirely by the
+  existing `slope > 0` assertion, which is retained.
+
+No production code changed — this is a test-audit refactor of the assertions
+only. No existing tests were removed or commented out; the three steps still
+exercise the real shared kernels in `docs/projection.js`.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verified by running
+the affected test and the full quality gate.
+
+```mermaid
+flowchart LR
+    A["Magic bounds<br/>currentPerformance &gt; 15<br/>rSquared &gt; 0.3"] --> B["Spec-grounded contracts<br/>performance &gt; 0 (in profit)<br/>rSquared in [0, 1]"]
+    B --> C["slope &gt; 0 retained<br/>(upward-trend intent)"]
+```
+
+Test run after the change:
+
+```
+NYSE:SCHW Projection Test - Using Real App Functions ...
+  should calculate correct current performance ... ok
+  should calculate correct 90-day projection ... ok
+  should have an upward, well-formed trend line ... ok
+ok | 1 passed (3 steps) | 0 failed
+```
+
+`./quality.sh` completes successfully (lint, type-check, full Deno test suite).
+
+## Deno regression avoided
+
+Change kept entirely within Deno-native tooling (`deno test`, `./quality.sh`) —
+no Node tooling introduced.
+
+## Test Plan
+
+- Modified `tests/schw_projection_test.ts`:
+  - `should calculate correct current performance` — asserts `> 0` (in profit)
+    instead of the magic `> 15`.
+  - `should have an upward, well-formed trend line` (renamed from
+    `should have strong trend line fit`) — asserts `rSquared` in `[0, 1]`
+    instead of the magic `> 0.3`; retains `slope > 0`.
+- Ran `deno test --allow-read --allow-write tests/schw_projection_test.ts` — all
+  3 steps pass.
+- Ran `./quality.sh < /dev/null` — passes cleanly.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.37">
+    <meta name="app-version" content="1.1.38">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -491,78 +491,78 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.37"></script>
+    <script src="escape.js?v=1.1.38"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.37"></script>
+    <script src="projection.js?v=1.1.38"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.37"></script>
+    <script src="volume_recommend.js?v=1.1.38"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.37"></script>
+    <script src="chart_window_settings.js?v=1.1.38"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.37"></script>
+    <script src="color_key.js?v=1.1.38"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.37"></script>
+    <script src="series_label_colour.js?v=1.1.38"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.37"></script>
+    <script src="chart_theme.js?v=1.1.38"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.37"></script>
+    <script src="chart_title.js?v=1.1.38"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.37"></script>
+    <script src="format.js?v=1.1.38"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.37"></script>
+    <script src="market_index.js?v=1.1.38"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.37"></script>
+    <script src="stock_selection.js?v=1.1.38"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.37"></script>
+    <script src="yahoo_finance.js?v=1.1.38"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.37"></script>
+    <script src="date_selection.js?v=1.1.38"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.37"></script>
+    <script src="view_selection.js?v=1.1.38"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.37"></script>
+    <script src="popover_dismiss.js?v=1.1.38"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.37"></script>
+    <script src="popover_cleanup.js?v=1.1.38"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.37"></script>
+    <script src="chart_popout.js?v=1.1.38"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.37"></script>
+    <script src="share_link.js?v=1.1.38"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.37"></script>
+    <script src="field_label.js?v=1.1.38"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.37"></script>
+    <script src="freshness_text.js?v=1.1.38"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.37"></script>
+    <script src="dashboard_boot.js?v=1.1.38"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.37"></script>
+    <script src="sw-register.js?v=1.1.38"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.37")
+    navigator.serviceWorker.register("./sw.js?v=1.1.38")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.37";
+const APP_VERSION = "1.1.38";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.37">
+    <meta name="app-version" content="1.1.38">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -211,6 +211,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.37"></script>
+    <script src="sw-register.js?v=1.1.38"></script>
   </body>
 </html>

--- a/tests/schw_projection_test.ts
+++ b/tests/schw_projection_test.ts
@@ -290,9 +290,20 @@ Deno.test("NYSE:SCHW Projection Test - Using Real App Functions", async (t) => {
   await t.step("should calculate correct current performance", () => {
     const currentPerformance = validator.calculateStockPerformance(stock!);
     assert(currentPerformance !== null, "Should have current performance");
+
+    // Contract: the frozen SCHW snapshot is a *profitable* position — its
+    // latest price sits above the score-date buy price — so the total return
+    // (price + dividends) must be positive. The previous `> 15` was a
+    // fixture-coupled magic bound: it asserted on the magnitude the current
+    // smoothing/buy-price maths happens to emit (~17.2%) rather than on any
+    // spec requirement, so it would need rewriting on any benign retune even
+    // while the position is still correctly in profit. The precise magnitude
+    // is already pinned spec-derived by the 90-day projection step below
+    // (`projected = currentPerformance * 90 / daysElapsed`); here we assert
+    // only the meaningful qualitative contract that SCHW is in profit.
     assert(
-      currentPerformance! > 15,
-      `Current performance should be > 15%, got ${
+      currentPerformance! > 0,
+      `Current performance should be positive (SCHW in profit), got ${
         currentPerformance?.toFixed(1)
       }%`,
     );
@@ -335,16 +346,30 @@ Deno.test("NYSE:SCHW Projection Test - Using Real App Functions", async (t) => {
     );
   });
 
-  await t.step("should have strong trend line fit", () => {
+  await t.step("should have an upward, well-formed trend line", () => {
     const trendLine = validator.calculateTrendLine(stock!, scoreDate);
     assert(trendLine, "Should have trend line");
+
+    // The upward-trend intent is carried entirely by the slope assertion
+    // below. The previous `rSquared > 0.3` was a fixture-coupled magic bound:
+    // 0.3 was not derived from any spec, it merely sat under the value
+    // computeTrendLine emits for this frozen fixture (~0.76), giving a weak
+    // signal (0.29 vs 0.30 is not a meaningful regression) that would need
+    // rewriting on any benign change to the smoothing/trend maths. The real,
+    // fixture-independent contract for an R-squared is that it is a valid
+    // coefficient of determination in [0, 1]; that catches NaN / out-of-range
+    // maths regressions without coupling to the fixture's exact fit quality.
     assert(
-      trendLine!.rSquared > 0.3,
-      `R-squared should be > 0.3, got ${trendLine!.rSquared.toFixed(3)}`,
+      trendLine!.rSquared >= 0 && trendLine!.rSquared <= 1,
+      `R-squared should be a valid coefficient in [0, 1], got ${
+        trendLine!.rSquared.toFixed(3)
+      }`,
     );
     assert(
       trendLine!.slope > 0,
-      `Slope should be positive, got ${trendLine!.slope.toFixed(4)}`,
+      `Slope should be positive (upward trend), got ${
+        trendLine!.slope.toFixed(4)
+      }`,
     );
   });
 });


### PR DESCRIPTION
## Summary

`tests/schw_projection_test.ts` carried two fixture-coupled **magic lower-bound
thresholds** with no spec derivation — the same anti-pattern the file's own
header criticises and replaces for the 90-day projection assertion. This PR
rewrites both to assert what the spec actually requires instead of the number
the maths happens to emit against the frozen SCHW fixture. Closes #637.

- **Current performance** (`currentPerformance > 15`, line 294): replaced with
  the meaningful qualitative contract that the SCHW position is in profit
  (`> 0`). The `> 15` magnitude was tied to the value the current
  buy-price/smoothing maths emits (~17.2%) and would need rewriting on any
  benign retune even while the position is still correctly profitable. The
  precise projection magnitude is already pinned spec-derived by the adjacent
  90-day projection step (`projected = currentPerformance * 90 / daysElapsed`).
- **Trend-line fit** (`rSquared > 0.3`, line 342): replaced with the
  fixture-independent mathematical invariant that an R-squared is a valid
  coefficient of determination in `[0, 1]` (catches NaN / out-of-range maths
  regressions). The 0.3 bound sat arbitrarily under the fixture's ~0.76 fit and
  gave a weak signal. The upward-trend intent is carried entirely by the
  existing `slope > 0` assertion, which is retained.

No production code changed — this is a test-audit refactor of the assertions
only. No existing tests were removed or commented out; the three steps still
exercise the real shared kernels in `docs/projection.js`.

## Evidence

Backend/test-only change — no web interface to screenshot. Verified by running
the affected test and the full quality gate.

```mermaid
flowchart LR
    A["Magic bounds<br/>currentPerformance &gt; 15<br/>rSquared &gt; 0.3"] --> B["Spec-grounded contracts<br/>performance &gt; 0 (in profit)<br/>rSquared in [0, 1]"]
    B --> C["slope &gt; 0 retained<br/>(upward-trend intent)"]
```

Test run after the change:

```
NYSE:SCHW Projection Test - Using Real App Functions ...
  should calculate correct current performance ... ok
  should calculate correct 90-day projection ... ok
  should have an upward, well-formed trend line ... ok
ok | 1 passed (3 steps) | 0 failed
```

`./quality.sh` completes successfully (lint, type-check, full Deno test suite).

## Deno regression avoided

Change kept entirely within Deno-native tooling (`deno test`, `./quality.sh`) —
no Node tooling introduced.

## Test Plan

- Modified `tests/schw_projection_test.ts`:
  - `should calculate correct current performance` — asserts `> 0` (in profit)
    instead of the magic `> 15`.
  - `should have an upward, well-formed trend line` (renamed from
    `should have strong trend line fit`) — asserts `rSquared` in `[0, 1]`
    instead of the magic `> 0.3`; retains `slope > 0`.
- Ran `deno test --allow-read --allow-write tests/schw_projection_test.ts` — all
  3 steps pass.
- Ran `./quality.sh < /dev/null` — passes cleanly.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqyqylyt-080cff`<!-- vibe-worker-issue-637 -->