### PR TITLE
Include star filter in shared URL (#666)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Visit `http://localhost:8000` to access the dashboard.
 
 #### Deep-link URL parameters
 
-The dashboard reads nine optional query parameters so a specific view can be
+The dashboard reads ten optional query parameters so a specific view can be
 linked directly (and so the automated accessibility check can audit each view
 deterministically — issue #281):
 
@@ -384,6 +384,15 @@ deterministically — issue #281):
   without the param returns to the saved window (desktop 180 / mobile 90). Both
   windows end on the same date (#367); an absent or invalid value falls back to
   the saved choice, then the device default.
+- `?stars=0|1|2|3|4|5` — pre-select the shared minimum-star filter for that page
+  load on **both** the portfolio and Trend views (issue #666). `0` means **All**
+  (filter off); `1`–`5` keep only holdings whose average rating meets that whole
+  star threshold. Unlike `?theme=`/`?window=`, the star filter is the **shared,
+  persisted** setting (`grq.filter.minStars`), so a supplied value is applied
+  **and** persisted via the normal `setMinStars` path — keeping every view in
+  sync. An absent, blank or out-of-range value (e.g. `?stars=6`) leaves the
+  saved choice untouched. This is the param the footer **🔗 Share** button emits
+  so a shared link reproduces the sharer's filtered view.
 - `?view=portfolio|trend` — deep-link straight to a top-level view (issue #479).
   `?view=trend` routes to the Prediction Trend page (`trend.html`);
   `?view=portfolio` routes back to the aggregate dashboard (`index.html`). Like
@@ -418,7 +427,8 @@ deterministically — issue #281):
 
 A low-prominence **🔗 Share** button in the page footer does the inverse: it
 builds an absolute URL encoding the current selections (score file, stock,
-theme, 90/180 window, and the transient mobile pop-out flag) and copies it to
+theme, 90/180 window, the shared min-star filter, and the transient mobile
+pop-out flag) and copies it to
 the clipboard (issue #495). It is **read-only** — generating a link never
 mutates your saved settings — and degrades to a select-the-text fallback where
 the async Clipboard API is unavailable. Pasting the link into a fresh tab

--- a/docs/app.js
+++ b/docs/app.js
@@ -141,7 +141,8 @@ class GRQValidator {
     // helpers, never writing storage. The theme is read from the applied <body>
     // class (what the user actually sees) so a forced light/dark mode is
     // reproduced; "auto" is left implicit. fullscreen is set only while the
-    // mobile chart pop-out owns the canvas (issue #482/#451).
+    // mobile chart pop-out owns the canvas (issue #482/#451). stars carries the
+    // shared min-star filter threshold so a share reproduces it (issue #666).
     shareState() {
         let theme = "auto";
         if (typeof document !== "undefined" && document.body) {
@@ -158,11 +159,17 @@ class GRQValidator {
             GRQChartPopout.isPopoutOpen(
                 typeof document !== "undefined" ? document : undefined,
             );
+        const stars =
+            (typeof GRQStarFilter !== "undefined" &&
+                    typeof GRQStarFilter.getMinStars === "function")
+                ? GRQStarFilter.getMinStars()
+                : 0;
         return {
             file: this.selectedFile || null,
             stock: this.selectedStock || null,
             theme,
             window: this.currentWindowDays(),
+            stars,
             fullscreen,
         };
     }
@@ -214,6 +221,19 @@ class GRQValidator {
         const select = document.getElementById("starFilterSelect");
         if (!select || typeof GRQStarFilter === "undefined") {
             return;
+        }
+        // Apply a `?stars=` deep-link override (issue #666) so a shared URL
+        // reproduces the sharer's filtered view. Persisting via setMinStars keeps
+        // every view (chart, table, Trend) honouring the same threshold; an
+        // absent / invalid param leaves the persisted choice untouched.
+        if (typeof GRQStarFilter.minStarsFromSearch === "function") {
+            const search = (typeof window !== "undefined" && window.location)
+                ? window.location.search
+                : "";
+            const fromUrl = GRQStarFilter.minStarsFromSearch(search);
+            if (fromUrl !== null) {
+                GRQStarFilter.setMinStars(fromUrl);
+            }
         }
         select.value = String(GRQStarFilter.getMinStars());
         select.addEventListener("change", (event) => {

--- a/docs/archive/pr-summaries/pr-summary-666.md
+++ b/docs/archive/pr-summaries/pr-summary-666.md
@@ -1,0 +1,64 @@
+## Summary
+
+The footer **🔗 Share** deep-link omitted the shared minimum-star filter, so a
+link built while a 1–5 star filter was active reproduced the recipient's own
+default (All) instead of the sharer's filtered view. This wires the star filter
+through the share flow in both directions. Closes #666.
+
+- **Emit on share** — `buildShareQuery` (`docs/share_link.js`) now appends
+  `stars=<1..5>` when a forced threshold is set. `0` ("All") is the default and
+  is emitted by absence, keeping unfiltered links clean; out-of-range values are
+  dropped. `shareState()` in `docs/app.js` supplies the live threshold from
+  `GRQStarFilter.getMinStars()`.
+- **Read on load** — a new pure helper `GRQStarFilter.minStarsFromSearch(search)`
+  (`docs/star_filter_settings.js`) parses `?stars=`, returning `0..5` for a valid
+  value or `null` for absent / blank / out-of-range input. Both the portfolio
+  (`docs/app.js`) and Trend (`docs/trend.js`) star-filter controls apply it on
+  init via the normal `setMinStars` path, so a shared link reproduces the
+  filtered view and every view stays in sync.
+
+Because the star filter is the **shared, persisted** setting (`grq.filter.minStars`),
+a supplied param is applied and persisted (unlike the transient `?theme=`/`?window=`
+overrides). An absent or invalid `?stars=` leaves the saved choice untouched, so
+existing behaviour is unchanged when the param is missing.
+
+## Evidence
+
+This is a deep-link serialisation/parsing change with no new visual element — the
+on-screen result of `?stars=3` is identical to a user manually selecting "3★+" in
+the existing, unchanged star-filter control. Playwright MCP was unavailable in
+this environment, so verification is via the unit tests below; the dashboard was
+served locally and confirmed to load `share_link.js`, `star_filter_settings.js`
+and the `#starFilterSelect` control.
+
+```mermaid
+sequenceDiagram
+    participant Sharer
+    participant Share as share_link.js
+    participant URL as Shared URL
+    participant Load as app.js / trend.js
+    participant Filter as star_filter_settings.js
+    Sharer->>Share: buildShareQuery({stars: 3})
+    Share->>URL: ...&stars=3
+    URL->>Load: open ?stars=3
+    Load->>Filter: minStarsFromSearch("?stars=3") → 3
+    Load->>Filter: setMinStars(3) (persist + dispatch)
+    Filter-->>Load: grq:star-filter-change → re-render filtered view
+```
+
+## Test Plan
+
+- `tests/share_link_test.ts`:
+  - `buildShareQuery emits ?stars for a forced 1..5 filter (issue #666)`
+  - `buildShareQuery omits ?stars for the 0 (All) default`
+  - `buildShareQuery drops an out-of-range ?stars value`
+  - `buildShareQuery places ?stars after ?window and before ?fullscreen`
+- `tests/star_filter_settings_test.ts`:
+  - `minStarsFromSearch reads a forced 0..5 ?stars value`
+  - `minStarsFromSearch trims surrounding whitespace`
+  - `minStarsFromSearch returns null when the param is absent`
+  - `minStarsFromSearch returns null for out-of-range / junk values`
+  - `minStarsFromSearch distinguishes a forced All (0) from absence`
+- `tests/deeplink_docs_test.ts` — README lead-in count updated to **ten**
+  documented parameters (now includes `?stars=`); existing assertion passes.
+- Full Deno suite: `deno test --allow-read tests/*.ts` → **1249 passed, 0 failed**.

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.41">
+    <meta name="app-version" content="1.1.42">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -517,82 +517,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.41"></script>
+    <script src="escape.js?v=1.1.42"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.41"></script>
+    <script src="projection.js?v=1.1.42"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.41"></script>
+    <script src="volume_recommend.js?v=1.1.42"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.41"></script>
+    <script src="chart_window_settings.js?v=1.1.42"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.41"></script>
+    <script src="star_filter_settings.js?v=1.1.42"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.41"></script>
+    <script src="color_key.js?v=1.1.42"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.41"></script>
+    <script src="series_label_colour.js?v=1.1.42"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.41"></script>
+    <script src="chart_theme.js?v=1.1.42"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.41"></script>
+    <script src="chart_title.js?v=1.1.42"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.41"></script>
+    <script src="format.js?v=1.1.42"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.41"></script>
+    <script src="market_index.js?v=1.1.42"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.41"></script>
+    <script src="stock_selection.js?v=1.1.42"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.41"></script>
+    <script src="yahoo_finance.js?v=1.1.42"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.41"></script>
+    <script src="date_selection.js?v=1.1.42"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.41"></script>
+    <script src="view_selection.js?v=1.1.42"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.41"></script>
+    <script src="popover_dismiss.js?v=1.1.42"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.41"></script>
+    <script src="popover_cleanup.js?v=1.1.42"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.41"></script>
+    <script src="chart_popout.js?v=1.1.42"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.41"></script>
+    <script src="share_link.js?v=1.1.42"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.41"></script>
+    <script src="field_label.js?v=1.1.42"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.41"></script>
+    <script src="freshness_text.js?v=1.1.42"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.41"></script>
+    <script src="dashboard_boot.js?v=1.1.42"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.41"></script>
+    <script src="sw-register.js?v=1.1.42"></script>
   </body>
 </html>

--- a/docs/share_link.js
+++ b/docs/share_link.js
@@ -30,6 +30,11 @@
   // The only two windows the app understands (mirrors GRQChartWindow).
   const ALLOWED_WINDOW_DAYS = [90, 180];
 
+  // The min-star filter thresholds worth sharing: 1..5 (issue #666). 0 ("All")
+  // is the default off-state, emitted by absence to keep links clean — mirroring
+  // GRQStarFilter.ALLOWED_MIN_STARS minus the 0 default.
+  const SHAREABLE_MIN_STARS = [1, 2, 3, 4, 5];
+
   // Append a param only when `value` is a non-empty string, coercing to string.
   function setIfPresent(params, key, value) {
     if (value === undefined || value === null) {
@@ -49,6 +54,8 @@
   //   - theme is emitted only for a forced light/dark mode (auto = absence);
   //   - window is always emitted when valid so the recipient's device default
   //     cannot silently change the window the sharer saw;
+  //   - stars is emitted only for a forced 1..5 min-star filter (0 = All =
+  //     absence) so a shared link reproduces the sharer's filtered view (#666);
   //   - view / indices / group are emitted only when the caller supplies a
   //     non-empty value (forward-compatible with the #483 view-state params);
   //   - fullscreen emits "1" only when the user is in the mobile pop-out (#482).
@@ -73,6 +80,13 @@
     const windowNum = typeof s.window === "string" ? Number(s.window) : s.window;
     if (ALLOWED_WINDOW_DAYS.includes(windowNum)) {
       params.set("window", String(windowNum));
+    }
+
+    // Min-star filter (issue #666): emit only a forced 1..5 threshold; 0 ("All")
+    // is the default and emitted by absence so an unfiltered share stays clean.
+    const starsNum = typeof s.stars === "string" ? Number(s.stars) : s.stars;
+    if (SHAREABLE_MIN_STARS.includes(starsNum)) {
+      params.set("stars", String(starsNum));
     }
 
     // Optional view-state params (sibling docs issue #483). Emitted verbatim
@@ -101,6 +115,7 @@
   globalThis.GRQShare = {
     SHAREABLE_THEMES,
     ALLOWED_WINDOW_DAYS,
+    SHAREABLE_MIN_STARS,
     buildShareQuery,
     buildShareUrl,
   };

--- a/docs/star_filter_settings.js
+++ b/docs/star_filter_settings.js
@@ -112,6 +112,34 @@
     return safeSet(storage, STORAGE_KEY, String(normaliseMinStars(value)));
   }
 
+  // --- deep-link parameter (shared "Share" URL, issue #666) ------------------
+
+  // Read a min-star threshold override from a URL query string, e.g.
+  // `?stars=3`. Returns 0..5 when the value is a permitted whole-star threshold,
+  // else null (absent / blank / disallowed) so callers fall back to the
+  // persisted choice. Mirrors chart_window_settings.js's windowDaysFromSearch
+  // and theme.js's preferenceFromSearch — guarded so malformed input never
+  // throws. The footer "Share" deep-link (issue #666) emits this param so a
+  // recipient reproduces the sharer's star-filtered view.
+  function minStarsFromSearch(search) {
+    try {
+      const value = new URLSearchParams(search || "").get("stars");
+      if (value === null) {
+        return null;
+      }
+      // A blank value (`?stars=`) is treated as absent — Number("") is 0, which
+      // would otherwise be mistaken for an explicit "All" override.
+      const trimmed = String(value).trim();
+      if (trimmed === "") {
+        return null;
+      }
+      const num = Number(trimmed);
+      return ALLOWED_MIN_STARS.includes(num) ? num : null;
+    } catch (_err) {
+      return null;
+    }
+  }
+
   // --- accessor contract (ambient storage + change event) --------------------
 
   // Public getter: the current threshold from the ambient localStorage (0 for
@@ -157,6 +185,7 @@
     DEFAULT_MIN_STARS,
     ALLOWED_MIN_STARS,
     normaliseMinStars,
+    minStarsFromSearch,
     readMinStars,
     writeMinStars,
     getMinStars,

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.41")
+    navigator.serviceWorker.register("./sw.js?v=1.1.42")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.41";
+const APP_VERSION = "1.1.42";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.41">
+    <meta name="app-version" content="1.1.42">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,6 +239,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.41"></script>
+    <script src="sw-register.js?v=1.1.42"></script>
   </body>
 </html>

--- a/docs/trend.js
+++ b/docs/trend.js
@@ -147,6 +147,19 @@
             if (!select || typeof globalThis.GRQStarFilter === "undefined") {
                 return;
             }
+            // Honour a `?stars=` deep-link override (issue #666) so a shared URL
+            // reproduces the sharer's filtered view here too; the threshold is
+            // persisted/shared, so an absent or invalid param leaves it untouched.
+            if (typeof GRQStarFilter.minStarsFromSearch === "function") {
+                const search =
+                    (typeof globalThis !== "undefined" && globalThis.location)
+                        ? globalThis.location.search
+                        : "";
+                const fromUrl = GRQStarFilter.minStarsFromSearch(search);
+                if (fromUrl !== null) {
+                    GRQStarFilter.setMinStars(fromUrl);
+                }
+            }
             select.value = String(GRQStarFilter.getMinStars());
             select.addEventListener("change", () => {
                 GRQStarFilter.setMinStars(Number(select.value));

--- a/tests/share_link_test.ts
+++ b/tests/share_link_test.ts
@@ -97,6 +97,28 @@ Deno.test("buildShareQuery emits ?fullscreen=1 only when in the pop-out", () => 
   assertEquals(S.buildShareQuery({ fullscreen: false }), "");
 });
 
+Deno.test("buildShareQuery emits ?stars for a forced 1..5 filter (issue #666)", () => {
+  // A min-star filter the sharer set must travel in the link so the recipient
+  // sees the same filtered subset, not their own default.
+  for (const n of [1, 2, 3, 4, 5]) {
+    assertEquals(S.buildShareQuery({ stars: n }), `stars=${n}`);
+    assertEquals(S.buildShareQuery({ stars: String(n) }), `stars=${n}`);
+  }
+});
+
+Deno.test("buildShareQuery omits ?stars for the 0 (All) default", () => {
+  // 0 ("All") is the off/default state — emitted by absence to keep links clean.
+  assertEquals(S.buildShareQuery({ stars: 0 }), "");
+  assertEquals(S.buildShareQuery({ stars: "0" }), "");
+});
+
+Deno.test("buildShareQuery drops an out-of-range ?stars value", () => {
+  assertEquals(S.buildShareQuery({ stars: 6 }), "");
+  assertEquals(S.buildShareQuery({ stars: -1 }), "");
+  assertEquals(S.buildShareQuery({ stars: 2.5 }), "");
+  assertEquals(S.buildShareQuery({ stars: "abc" }), "");
+});
+
 Deno.test("buildShareQuery composes all selections in a stable order", () => {
   const query = S.buildShareQuery({
     file: "2026/March/23.tsv",
@@ -108,6 +130,21 @@ Deno.test("buildShareQuery composes all selections in a stable order", () => {
   assertEquals(
     query,
     "file=2026%2FMarch%2F23.tsv&stock=NASDAQ%3AMGRC&theme=dark&window=180&fullscreen=1",
+  );
+});
+
+Deno.test("buildShareQuery places ?stars after ?window and before ?fullscreen", () => {
+  const query = S.buildShareQuery({
+    file: "2026/March/23.tsv",
+    stock: "NASDAQ:MGRC",
+    theme: "dark",
+    window: 180,
+    stars: 3,
+    fullscreen: true,
+  });
+  assertEquals(
+    query,
+    "file=2026%2FMarch%2F23.tsv&stock=NASDAQ%3AMGRC&theme=dark&window=180&stars=3&fullscreen=1",
   );
 });
 

--- a/tests/star_filter_settings_test.ts
+++ b/tests/star_filter_settings_test.ts
@@ -22,6 +22,7 @@ const g = globalThis as unknown as {
     DEFAULT_MIN_STARS: number;
     ALLOWED_MIN_STARS: number[];
     normaliseMinStars: (value: unknown) => number;
+    minStarsFromSearch: (search: unknown) => number | null;
     readMinStars: (storage?: unknown) => number;
     writeMinStars: (value: unknown, storage?: unknown) => boolean;
     getMinStars: () => number;
@@ -107,6 +108,42 @@ Deno.test("normaliseMinStars falls back to 0 for out-of-range / junk", () => {
   assertEquals(S.normaliseMinStars(null), 0);
   assertEquals(S.normaliseMinStars(undefined), 0);
   assertEquals(S.normaliseMinStars({}), 0);
+});
+
+// --- minStarsFromSearch (deep-link param, issue #666) ----------------------
+
+Deno.test("minStarsFromSearch reads a forced 0..5 ?stars value", () => {
+  for (const n of [0, 1, 2, 3, 4, 5]) {
+    assertEquals(S.minStarsFromSearch(`?stars=${n}`), n);
+    // Leading "?" is optional; URLSearchParams tolerates either form.
+    assertEquals(S.minStarsFromSearch(`stars=${n}`), n);
+  }
+});
+
+Deno.test("minStarsFromSearch trims surrounding whitespace", () => {
+  assertEquals(S.minStarsFromSearch("?stars=%203%20"), 3);
+});
+
+Deno.test("minStarsFromSearch returns null when the param is absent", () => {
+  assertEquals(S.minStarsFromSearch("?window=180"), null);
+  assertEquals(S.minStarsFromSearch(""), null);
+  assertEquals(S.minStarsFromSearch(null), null);
+  assertEquals(S.minStarsFromSearch(undefined), null);
+});
+
+Deno.test("minStarsFromSearch returns null for out-of-range / junk values", () => {
+  assertEquals(S.minStarsFromSearch("?stars=6"), null);
+  assertEquals(S.minStarsFromSearch("?stars=-1"), null);
+  assertEquals(S.minStarsFromSearch("?stars=2.5"), null);
+  assertEquals(S.minStarsFromSearch("?stars=abc"), null);
+  assertEquals(S.minStarsFromSearch("?stars="), null);
+});
+
+Deno.test("minStarsFromSearch distinguishes a forced All (0) from absence", () => {
+  // ?stars=0 is an explicit, valid "All" override (returns 0); a missing param
+  // returns null so callers keep the persisted choice.
+  assertEquals(S.minStarsFromSearch("?stars=0"), 0);
+  assertEquals(S.minStarsFromSearch("?other=1"), null);
 });
 
 // --- round-trip ------------------------------------------------------------


### PR DESCRIPTION
## Summary

The footer **🔗 Share** deep-link omitted the shared minimum-star filter, so a
link built while a 1–5 star filter was active reproduced the recipient's own
default (All) instead of the sharer's filtered view. This wires the star filter
through the share flow in both directions. Closes #666.

- **Emit on share** — `buildShareQuery` (`docs/share_link.js`) now appends
  `stars=<1..5>` when a forced threshold is set. `0` ("All") is the default and
  is emitted by absence, keeping unfiltered links clean; out-of-range values are
  dropped. `shareState()` in `docs/app.js` supplies the live threshold from
  `GRQStarFilter.getMinStars()`.
- **Read on load** — a new pure helper `GRQStarFilter.minStarsFromSearch(search)`
  (`docs/star_filter_settings.js`) parses `?stars=`, returning `0..5` for a valid
  value or `null` for absent / blank / out-of-range input. Both the portfolio
  (`docs/app.js`) and Trend (`docs/trend.js`) star-filter controls apply it on
  init via the normal `setMinStars` path, so a shared link reproduces the
  filtered view and every view stays in sync.

Because the star filter is the **shared, persisted** setting (`grq.filter.minStars`),
a supplied param is applied and persisted (unlike the transient `?theme=`/`?window=`
overrides). An absent or invalid `?stars=` leaves the saved choice untouched, so
existing behaviour is unchanged when the param is missing.

## Evidence

This is a deep-link serialisation/parsing change with no new visual element — the
on-screen result of `?stars=3` is identical to a user manually selecting "3★+" in
the existing, unchanged star-filter control. Playwright MCP was unavailable in
this environment, so verification is via the unit tests below; the dashboard was
served locally and confirmed to load `share_link.js`, `star_filter_settings.js`
and the `#starFilterSelect` control.

```mermaid
sequenceDiagram
    participant Sharer
    participant Share as share_link.js
    participant URL as Shared URL
    participant Load as app.js / trend.js
    participant Filter as star_filter_settings.js
    Sharer->>Share: buildShareQuery({stars: 3})
    Share->>URL: ...&stars=3
    URL->>Load: open ?stars=3
    Load->>Filter: minStarsFromSearch("?stars=3") → 3
    Load->>Filter: setMinStars(3) (persist + dispatch)
    Filter-->>Load: grq:star-filter-change → re-render filtered view
```

## Test Plan

- `tests/share_link_test.ts`:
  - `buildShareQuery emits ?stars for a forced 1..5 filter (issue #666)`
  - `buildShareQuery omits ?stars for the 0 (All) default`
  - `buildShareQuery drops an out-of-range ?stars value`
  - `buildShareQuery places ?stars after ?window and before ?fullscreen`
- `tests/star_filter_settings_test.ts`:
  - `minStarsFromSearch reads a forced 0..5 ?stars value`
  - `minStarsFromSearch trims surrounding whitespace`
  - `minStarsFromSearch returns null when the param is absent`
  - `minStarsFromSearch returns null for out-of-range / junk values`
  - `minStarsFromSearch distinguishes a forced All (0) from absence`
- `tests/deeplink_docs_test.ts` — README lead-in count updated to **ten**
  documented parameters (now includes `?stars=`); existing assertion passes.
- Full Deno suite: `deno test --allow-read tests/*.ts` → **1249 passed, 0 failed**.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mqzpf4aa-af9cb0`<!-- vibe-worker-issue-666 -->