### PR TITLE
Remove dead Mermaid-validation steps in markdown-lint.yml (Issue #665)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -39,21 +39,3 @@ jobs:
         run: npm install -g --ignore-scripts markdownlint-cli2@0.22.1
       - name: Run markdownlint-cli2
         run: markdownlint-cli2
-      # Optional: mirror the local check-mermaid quality gate when Deno
-      # and the worker module are available in the repo (Issue #1683).
-      - name: Detect Deno worker module
-        id: detect-deno
-        run: |
-          if [ -f worker/deno/mod.ts ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-          fi
-      # denoland/setup-deno@v2
-      - if: steps.detect-deno.outputs.present == 'true'
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
-        with:
-          deno-version: v2.x
-      - if: steps.detect-deno.outputs.present == 'true'
-        name: Validate Mermaid blocks
-        run: deno run --allow-read --allow-env=DEBUG,LOG_LEVEL,CONFIG_PATH,OUTPUT_JSON worker/deno/mod.ts check-mermaid

--- a/docs/archive/pr-summaries/pr-summary-665.md
+++ b/docs/archive/pr-summaries/pr-summary-665.md
@@ -1,0 +1,51 @@
+## Summary
+
+Removed the dead "optional Mermaid validation" block from the `markdownlint`
+job in `.github/workflows/markdown-lint.yml`. The three steps —
+`Detect Deno worker module`, the conditional `denoland/setup-deno`, and
+`Validate Mermaid blocks` — were a cross-repo template artefact: they gate on
+`worker/deno/mod.ts`, a path that does not exist anywhere in this repository.
+The detect step always emitted `present=false`, so the two guarded steps could
+never run. The `markdownlint` job now ends cleanly after `Run markdownlint-cli2`.
+
+This keeps the CI configuration honest about what it actually executes and
+removes a latent footgun: if `worker/deno/mod.ts` were ever added for an
+unrelated reason, an unreviewed `deno run` step would have silently activated.
+
+Closes #665.
+
+## Evidence
+
+This is a CI-configuration-only change — no Rust or Deno source code is
+touched, so there is no web interface to screenshot and no unit function to
+exercise. Verification performed:
+
+- Confirmed there is no `worker/` directory in the repository (the detect step
+  could only ever produce `present=false`).
+- Confirmed no remaining references to `detect-deno` or `worker/deno` anywhere
+  under `.github/`.
+- Validated that the edited workflow still parses as valid YAML
+  (`yaml.safe_load` → `YAML OK`).
+
+### Job structure before/after
+
+```mermaid
+flowchart TD
+    subgraph Before
+        A1[checkout] --> A2[setup-node] --> A3[Install markdownlint-cli2] --> A4[Run markdownlint-cli2]
+        A4 --> A5[Detect Deno worker module] --> A6{present == true?}
+        A6 -- always false --> A7[skipped: setup-deno]
+        A6 -- always false --> A8[skipped: Validate Mermaid blocks]
+    end
+    subgraph After
+        B1[checkout] --> B2[setup-node] --> B3[Install markdownlint-cli2] --> B4[Run markdownlint-cli2]
+    end
+```
+
+## Test Plan
+
+No automated tests apply to a workflow-YAML deletion. Manual verification:
+
+- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/markdown-lint.yml'))"` → `YAML OK`
+- `grep -rn "detect-deno\|worker/deno" .github` → no matches
+- `ls worker` → no such directory

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.40">
+    <meta name="app-version" content="1.1.41">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -517,82 +517,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.40"></script>
+    <script src="escape.js?v=1.1.41"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.40"></script>
+    <script src="projection.js?v=1.1.41"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.40"></script>
+    <script src="volume_recommend.js?v=1.1.41"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.40"></script>
+    <script src="chart_window_settings.js?v=1.1.41"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.40"></script>
+    <script src="star_filter_settings.js?v=1.1.41"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.40"></script>
+    <script src="color_key.js?v=1.1.41"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.40"></script>
+    <script src="series_label_colour.js?v=1.1.41"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.40"></script>
+    <script src="chart_theme.js?v=1.1.41"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.40"></script>
+    <script src="chart_title.js?v=1.1.41"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.40"></script>
+    <script src="format.js?v=1.1.41"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.40"></script>
+    <script src="market_index.js?v=1.1.41"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.40"></script>
+    <script src="stock_selection.js?v=1.1.41"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.40"></script>
+    <script src="yahoo_finance.js?v=1.1.41"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.40"></script>
+    <script src="date_selection.js?v=1.1.41"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.40"></script>
+    <script src="view_selection.js?v=1.1.41"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.40"></script>
+    <script src="popover_dismiss.js?v=1.1.41"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.40"></script>
+    <script src="popover_cleanup.js?v=1.1.41"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.40"></script>
+    <script src="chart_popout.js?v=1.1.41"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.40"></script>
+    <script src="share_link.js?v=1.1.41"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.40"></script>
+    <script src="field_label.js?v=1.1.41"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.40"></script>
+    <script src="freshness_text.js?v=1.1.41"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.40"></script>
+    <script src="dashboard_boot.js?v=1.1.41"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.40"></script>
+    <script src="sw-register.js?v=1.1.41"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.40")
+    navigator.serviceWorker.register("./sw.js?v=1.1.41")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.40";
+const APP_VERSION = "1.1.41";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.40">
+    <meta name="app-version" content="1.1.41">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,6 +239,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.40"></script>
+    <script src="sw-register.js?v=1.1.41"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Removed the dead "optional Mermaid validation" block from the `markdownlint`
job in `.github/workflows/markdown-lint.yml`. The three steps —
`Detect Deno worker module`, the conditional `denoland/setup-deno`, and
`Validate Mermaid blocks` — were a cross-repo template artefact: they gate on
`worker/deno/mod.ts`, a path that does not exist anywhere in this repository.
The detect step always emitted `present=false`, so the two guarded steps could
never run. The `markdownlint` job now ends cleanly after `Run markdownlint-cli2`.

This keeps the CI configuration honest about what it actually executes and
removes a latent footgun: if `worker/deno/mod.ts` were ever added for an
unrelated reason, an unreviewed `deno run` step would have silently activated.

Closes #665.

## Evidence

This is a CI-configuration-only change — no Rust or Deno source code is
touched, so there is no web interface to screenshot and no unit function to
exercise. Verification performed:

- Confirmed there is no `worker/` directory in the repository (the detect step
  could only ever produce `present=false`).
- Confirmed no remaining references to `detect-deno` or `worker/deno` anywhere
  under `.github/`.
- Validated that the edited workflow still parses as valid YAML
  (`yaml.safe_load` → `YAML OK`).

### Job structure before/after

```mermaid
flowchart TD
    subgraph Before
        A1[checkout] --> A2[setup-node] --> A3[Install markdownlint-cli2] --> A4[Run markdownlint-cli2]
        A4 --> A5[Detect Deno worker module] --> A6{present == true?}
        A6 -- always false --> A7[skipped: setup-deno]
        A6 -- always false --> A8[skipped: Validate Mermaid blocks]
    end
    subgraph After
        B1[checkout] --> B2[setup-node] --> B3[Install markdownlint-cli2] --> B4[Run markdownlint-cli2]
    end
```

## Test Plan

No automated tests apply to a workflow-YAML deletion. Manual verification:

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/markdown-lint.yml'))"` → `YAML OK`
- `grep -rn "detect-deno\|worker/deno" .github` → no matches
- `ls worker` → no such directory
