### PR TITLE
Make market-data CSV writes non-destructive (Issue #687)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,26 @@ cargo build --release
 ./target/release/grq-validation --docs-path docs --date 2025-01-15
 ```
 
+#### Non-destructive market-data writes
+
+Regenerating a date's market-data CSV is **non-destructive**: the generator
+builds the new CSV in memory and only replaces the file on disk — atomically,
+via a temporary file and rename — when it actually has price rows to write. When
+the upstream share-price repository is unavailable for a date, the existing
+populated CSV is **left untouched** rather than being truncated to a bare header
+row (issue #687). This stops a data-source outage from wiping the dashboard's
+market data down to "Limited data mode".
+
+```mermaid
+flowchart TD
+    A[Regenerate DD.csv for a date] --> B[Build CSV rows in memory]
+    B --> C{Any price rows written?}
+    C -- yes --> D[Atomic replace: write temp file, rename over DD.csv]
+    C -- no --> E{Existing DD.csv already populated?}
+    E -- yes --> F[Preserve existing rows; log + return 'no fresh data' error]
+    E -- no --> G[Write header-only placeholder; return error]
+```
+
 ### Web Interface
 
 ```bash

--- a/docs/archive/pr-summaries/pr-summary-687.md
+++ b/docs/archive/pr-summaries/pr-summary-687.md
@@ -1,0 +1,78 @@
+# Durably stop the 2026 market-data CSVs being wiped to a header row
+
+## Summary
+
+The 2026 market-data CSVs under `docs/scores/2026/` kept being reduced to a lone
+header row, forcing the dashboard into **"Limited data mode"** for every 2026
+date (recurrences #672, #674, #685).
+
+**Root cause — in this repo, not the external pipeline.** The wipe was traced to
+this repo's own generator. `src/utils.rs::create_market_data_long_csv` wrote
+straight to `File::create(output_path)`, which **truncates the destination CSV
+immediately** — *before* the existing "no rows written" guard runs. When the
+upstream share-price repository was unavailable for a date, the already-populated
+CSV was destroyed and left as a bare header row. The error was returned, but
+`src/main.rs` logs per-file errors and continues, so the run still "succeeded"
+and the external scorer's `worker/validation.sh` (`model_checkin.sh
+GRQ-validation`, default message *"Auto commit models"*) committed the wiped
+files straight to `main`.
+
+**Fix — issue Option 2 ("never overwrite a non-empty CSV with a header-only file
+when it has no fresh market data").** The writer now builds the CSV in memory and
+only touches the destination when it actually has price rows:
+
+- **Rows written → atomic replace.** The new content is staged in a sibling
+  temp file and `rename`d over the destination, so a crash mid-write can never
+  leave a truncated CSV.
+- **Zero rows + existing populated CSV → preserve.** The existing rows are left
+  completely untouched; the "no fresh data" error is still returned so the
+  upstream gap is visible to the operator.
+- **Zero rows + no/empty existing CSV → header-only placeholder** (unchanged
+  behaviour for genuinely-new dates), then the same error is surfaced.
+
+This makes the generator non-destructive by construction, so a share-price
+outage can no longer wipe committed market data regardless of how the external
+pipeline invokes it.
+
+Closes #687.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via the Rust test
+suite and the full local quality gates.
+
+```mermaid
+flowchart TD
+    A[Regenerate DD.csv for a date] --> B[Build CSV rows in memory]
+    B --> C{Any price rows written?}
+    C -- yes --> D[Atomic replace: write temp file, rename over DD.csv]
+    C -- no --> E{Existing DD.csv already populated?}
+    E -- yes --> F[Preserve existing rows; log + return 'no fresh data' error]
+    E -- no --> G[Write header-only placeholder; return error]
+```
+
+Before this fix the `C -- no` branch always ran `File::create` first, truncating
+`DD.csv` to a header row before any check — the wipe.
+
+## Test Plan
+
+New regression tests in `tests/create_market_data_long_csv_test.rs`:
+
+- `create_market_data_long_csv_preserves_existing_rows_when_no_fresh_data` —
+  writes a populated CSV, calls the generator with an unavailable ticker (zero
+  rows), and asserts the file is byte-for-byte unchanged and an error is still
+  returned. **Fails against the pre-fix code** (which truncated it to a header
+  row) and passes after the fix.
+- `create_market_data_long_csv_replaces_existing_when_fresh_data_available` —
+  asserts stale content is fully replaced by fresh data with no leftover
+  `.tmp` file (atomic-write path).
+
+Existing tests unchanged and green, including
+`create_market_data_long_csv_errors_when_all_tickers_skipped`,
+`create_market_data_long_csv_writes_eight_column_rows`, and the
+`tests/regression_2026_market_data_test.rs` presence regressions.
+
+Gates run locally: `cargo fmt --check`, `cargo clippy --all-targets`
+(+ `--tests`) `-D warnings`, `cargo test --all-targets` (88 lib + all
+integration tests pass), `cargo build --release`, `deno test` (1266 passed),
+`deno fmt/lint/check`, and `markdownlint-cli2` (0 errors).

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.45">
+    <meta name="app-version" content="1.1.46">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -517,82 +517,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.45"></script>
+    <script src="escape.js?v=1.1.46"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.45"></script>
+    <script src="projection.js?v=1.1.46"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.45"></script>
+    <script src="volume_recommend.js?v=1.1.46"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.45"></script>
+    <script src="chart_window_settings.js?v=1.1.46"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.45"></script>
+    <script src="star_filter_settings.js?v=1.1.46"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.45"></script>
+    <script src="color_key.js?v=1.1.46"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.45"></script>
+    <script src="series_label_colour.js?v=1.1.46"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.45"></script>
+    <script src="chart_theme.js?v=1.1.46"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.45"></script>
+    <script src="chart_title.js?v=1.1.46"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.45"></script>
+    <script src="format.js?v=1.1.46"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.45"></script>
+    <script src="market_index.js?v=1.1.46"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.45"></script>
+    <script src="stock_selection.js?v=1.1.46"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.45"></script>
+    <script src="yahoo_finance.js?v=1.1.46"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.45"></script>
+    <script src="date_selection.js?v=1.1.46"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.45"></script>
+    <script src="view_selection.js?v=1.1.46"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.45"></script>
+    <script src="popover_dismiss.js?v=1.1.46"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.45"></script>
+    <script src="popover_cleanup.js?v=1.1.46"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.45"></script>
+    <script src="chart_popout.js?v=1.1.46"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.45"></script>
+    <script src="share_link.js?v=1.1.46"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.45"></script>
+    <script src="field_label.js?v=1.1.46"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.45"></script>
+    <script src="freshness_text.js?v=1.1.46"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.45"></script>
+    <script src="dashboard_boot.js?v=1.1.46"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.45"></script>
+    <script src="sw-register.js?v=1.1.46"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.45")
+    navigator.serviceWorker.register("./sw.js?v=1.1.46")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.45";
+const APP_VERSION = "1.1.46";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.45">
+    <meta name="app-version" content="1.1.46">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,6 +239,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.45"></script>
+    <script src="sw-register.js?v=1.1.46"></script>
   </body>
 </html>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -758,14 +758,18 @@ pub fn create_market_data_long_csv(
 ) -> Result<()> {
     use crate::utils::extract_symbol_from_ticker;
     use csv::Writer;
-    use std::fs::File;
 
     let score_date = NaiveDate::parse_from_str(score_file_date, "%Y-%m-%d")?;
     let end_date = score_date + Duration::days(180);
     let end_date_str = end_date.format("%Y-%m-%d").to_string();
 
-    let file = File::create(output_path)?;
-    let mut writer = Writer::from_writer(file);
+    // Build the CSV in memory first so the destination file is only touched once
+    // we know whether we actually have data. The previous implementation wrote
+    // straight to `File::create(output_path)`, which truncated the existing CSV
+    // *before* the "no rows written" guard ran — so a run with no upstream data
+    // wiped an already-populated file down to a bare header row (issue #687,
+    // recurrences #672/#674/#685). Buffering keeps the write non-destructive.
+    let mut writer = Writer::from_writer(Vec::new());
     writer.write_record([
         "date",
         "ticker",
@@ -819,14 +823,70 @@ pub fn create_market_data_long_csv(
         }
     }
     writer.flush()?;
+    let csv_bytes = writer
+        .into_inner()
+        .map_err(|error| anyhow!("failed to finalise market-data CSV buffer: {error}"))?;
 
-    if !tickers.is_empty() && rows_written == 0 {
-        return Err(anyhow!(
-            "No market data rows written for {score_file_date} — \
-             is {MARKET_DATA_BASE_PATH} available and up to date?"
-        ));
+    if rows_written == 0 {
+        // No fresh data for this date. Never overwrite an already-populated CSV
+        // with a header-only file (issue #687): leave the existing rows intact
+        // so the dashboard keeps working, while still surfacing the "no data"
+        // error so the operator sees the upstream gap.
+        if !is_market_data_csv_empty(output_path) {
+            log::warn!(
+                "Preserving existing market data at {output_path}: no fresh rows for {score_file_date}"
+            );
+            if !tickers.is_empty() {
+                return Err(anyhow!(
+                    "No market data rows written for {score_file_date} — existing CSV at \
+                     {output_path} preserved; is {MARKET_DATA_BASE_PATH} available and up to date?"
+                ));
+            }
+            return Ok(());
+        }
+
+        // Nothing worth preserving (missing or already header-only): write the
+        // header-only placeholder as before so a genuinely-new date still gets a
+        // file, then surface the same error the caller expects.
+        write_atomically(output_path, &csv_bytes)?;
+        if !tickers.is_empty() {
+            return Err(anyhow!(
+                "No market data rows written for {score_file_date} — \
+                 is {MARKET_DATA_BASE_PATH} available and up to date?"
+            ));
+        }
+        return Ok(());
     }
 
+    // We have real data: replace the destination atomically so a crash mid-write
+    // can never leave a truncated CSV behind.
+    write_atomically(output_path, &csv_bytes)?;
+
+    Ok(())
+}
+
+/// Writes `bytes` to `path` atomically by staging them in a sibling temporary
+/// file and renaming it over `path`. A rename on the same filesystem is atomic,
+/// so neither a concurrent reader nor a crash ever observes a partially written
+/// or truncated file — the destination holds either the previous content or the
+/// complete new content. The market-data writer relies on this so a failed or
+/// interrupted regeneration can never wipe an existing populated CSV (issue
+/// #687).
+///
+/// # Errors
+///
+/// Returns an error if the temporary file cannot be created/written or the
+/// rename over `path` fails.
+fn write_atomically(path: &str, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+
+    let tmp_path = format!("{path}.tmp");
+    {
+        let mut tmp = std::fs::File::create(&tmp_path)?;
+        tmp.write_all(bytes)?;
+        tmp.flush()?;
+    }
+    std::fs::rename(&tmp_path, path)?;
     Ok(())
 }
 

--- a/tests/create_market_data_long_csv_test.rs
+++ b/tests/create_market_data_long_csv_test.rs
@@ -204,3 +204,84 @@ fn create_market_data_long_csv_errors_when_all_tickers_skipped() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn create_market_data_long_csv_preserves_existing_rows_when_no_fresh_data() -> Result<()> {
+    // Regression for issue #687 (recurrences #672/#674/#685): when the upstream
+    // share-price data is unavailable for a date, the writer must NOT clobber an
+    // already-populated CSV with a bare header row. The external scorer pipeline
+    // runs this generator and commits its output straight to `main`, so a
+    // destructive truncation here wipes the dashboard's market data and forces
+    // "Limited data mode".
+    let out_dir = tempfile::tempdir()?;
+    let out_path = out_dir.path().join("populated.csv");
+    let out = out_path.to_str().expect("temp path is valid UTF-8");
+
+    // A pre-existing, populated market-data CSV (as produced by an earlier run).
+    let existing = "date,ticker,high,low,open,close,split_coefficient,volume\n\
+        2026-04-02,NYSE:GRQVTEST687,10.0,9.0,9.5,9.8,1.0,1000\n";
+    std::fs::write(&out_path, existing)?;
+
+    // No fixture installed -> the only ticker is skipped -> zero rows written.
+    let result =
+        create_market_data_long_csv(&["NYSE:GRQVTEST687MISSING".to_string()], SCORE_DATE, out);
+
+    // The writer still signals that no fresh data was available...
+    assert!(
+        result.is_err(),
+        "expected an error when no fresh rows are written and data is unavailable"
+    );
+
+    // ...but the existing populated CSV must be left completely untouched.
+    let after = std::fs::read_to_string(&out_path)?;
+    assert_eq!(
+        after, existing,
+        "existing market-data rows must be preserved when no fresh data is available"
+    );
+
+    // No stray temporary file must be left behind next to the destination.
+    assert!(
+        !Path::new(&format!("{out}.tmp")).exists(),
+        "the atomic-write temp file must not linger after a preserve"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn create_market_data_long_csv_replaces_existing_when_fresh_data_available() -> Result<()> {
+    // Complement to the preservation test: when fresh data IS available, the
+    // destination is replaced atomically with the new content — no stale rows
+    // and no leftover temp file (issue #687).
+    let _fixture = MarketDataFixture::install(FIXTURE_SYMBOL)?;
+
+    let out_dir = tempfile::tempdir()?;
+    let out_path = out_dir.path().join("replace.csv");
+    let out = out_path.to_str().expect("temp path is valid UTF-8");
+
+    // Stale content that must be fully replaced by the fresh write.
+    std::fs::write(&out_path, "stale,garbage\n1,2\n")?;
+
+    create_market_data_long_csv(&[FIXTURE_TICKER.to_string()], SCORE_DATE, out)?;
+
+    let csv = std::fs::read_to_string(&out_path)?;
+    assert_eq!(
+        csv.lines().next().unwrap(),
+        "date,ticker,high,low,open,close,split_coefficient,volume",
+        "unexpected header after replacement in:\n{csv}"
+    );
+    assert!(
+        csv.contains(&format!("2025-04-15,{FIXTURE_TICKER}")),
+        "expected the fresh window-start row after replacement in:\n{csv}"
+    );
+    assert!(
+        !csv.contains("stale,garbage"),
+        "stale content must be fully replaced in:\n{csv}"
+    );
+    assert!(
+        !Path::new(&format!("{out}.tmp")).exists(),
+        "the atomic-write temp file must not linger after a successful write"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
# Durably stop the 2026 market-data CSVs being wiped to a header row

## Summary

The 2026 market-data CSVs under `docs/scores/2026/` kept being reduced to a lone
header row, forcing the dashboard into **"Limited data mode"** for every 2026
date (recurrences #672, #674, #685).

**Root cause — in this repo, not the external pipeline.** The wipe was traced to
this repo's own generator. `src/utils.rs::create_market_data_long_csv` wrote
straight to `File::create(output_path)`, which **truncates the destination CSV
immediately** — *before* the existing "no rows written" guard runs. When the
upstream share-price repository was unavailable for a date, the already-populated
CSV was destroyed and left as a bare header row. The error was returned, but
`src/main.rs` logs per-file errors and continues, so the run still "succeeded"
and the external scorer's `worker/validation.sh` (`model_checkin.sh
GRQ-validation`, default message *"Auto commit models"*) committed the wiped
files straight to `main`.

**Fix — issue Option 2 ("never overwrite a non-empty CSV with a header-only file
when it has no fresh market data").** The writer now builds the CSV in memory and
only touches the destination when it actually has price rows:

- **Rows written → atomic replace.** The new content is staged in a sibling
  temp file and `rename`d over the destination, so a crash mid-write can never
  leave a truncated CSV.
- **Zero rows + existing populated CSV → preserve.** The existing rows are left
  completely untouched; the "no fresh data" error is still returned so the
  upstream gap is visible to the operator.
- **Zero rows + no/empty existing CSV → header-only placeholder** (unchanged
  behaviour for genuinely-new dates), then the same error is surfaced.

This makes the generator non-destructive by construction, so a share-price
outage can no longer wipe committed market data regardless of how the external
pipeline invokes it.

Closes #687.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via the Rust test
suite and the full local quality gates.

```mermaid
flowchart TD
    A[Regenerate DD.csv for a date] --> B[Build CSV rows in memory]
    B --> C{Any price rows written?}
    C -- yes --> D[Atomic replace: write temp file, rename over DD.csv]
    C -- no --> E{Existing DD.csv already populated?}
    E -- yes --> F[Preserve existing rows; log + return 'no fresh data' error]
    E -- no --> G[Write header-only placeholder; return error]
```

Before this fix the `C -- no` branch always ran `File::create` first, truncating
`DD.csv` to a header row before any check — the wipe.

## Test Plan

New regression tests in `tests/create_market_data_long_csv_test.rs`:

- `create_market_data_long_csv_preserves_existing_rows_when_no_fresh_data` —
  writes a populated CSV, calls the generator with an unavailable ticker (zero
  rows), and asserts the file is byte-for-byte unchanged and an error is still
  returned. **Fails against the pre-fix code** (which truncated it to a header
  row) and passes after the fix.
- `create_market_data_long_csv_replaces_existing_when_fresh_data_available` —
  asserts stale content is fully replaced by fresh data with no leftover
  `.tmp` file (atomic-write path).

Existing tests unchanged and green, including
`create_market_data_long_csv_errors_when_all_tickers_skipped`,
`create_market_data_long_csv_writes_eight_column_rows`, and the
`tests/regression_2026_market_data_test.rs` presence regressions.

Gates run locally: `cargo fmt --check`, `cargo clippy --all-targets`
(+ `--tests`) `-D warnings`, `cargo test --all-targets` (88 lib + all
integration tests pass), `cargo build --release`, `deno test` (1266 passed),
`deno fmt/lint/check`, and `markdownlint-cli2` (0 errors).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr1o0wqu-65c528`<!-- vibe-worker-issue-687 -->