### PR TITLE
Add repository metadata to Cargo.toml (Issue #691)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Nigel Leck nigel@stsoftware.com.au"]
 description = "A Rust program to process daily stock scores from TSV files"
 license = "Apache-2.0"
+repository = "https://github.com/stSoftwareAU/GRQ-validation"
 
 [lib]
 name = "grq_validation"

--- a/docs/archive/pr-summaries/pr-summary-691.md
+++ b/docs/archive/pr-summaries/pr-summary-691.md
@@ -1,0 +1,38 @@
+# PR Summary — Issue #691
+
+## Summary
+
+Added the canonical `repository` metadata field to the `[package]` table in
+`Cargo.toml`. The manifest previously declared `name`, `version`, `edition`,
+`authors`, `description`, and `license` but omitted `repository` — the
+source-location field that crates.io and `cargo doc` surface and that SBOM
+generators use for provenance. Its absence weakened the crate's provenance and
+traceability. Closes #691.
+
+```diff
+ description = "A Rust program to process daily stock scores from TSV files"
+ license = "Apache-2.0"
++repository = "https://github.com/stSoftwareAU/GRQ-validation"
+```
+
+## Evidence
+
+Backend/CLI metadata change only — no web interface to screenshot.
+
+`CARGO_PKG_REPOSITORY` is populated by Cargo from the `[package] repository`
+field at compile time, mirroring the existing `license_metadata_test.rs`
+pattern for `CARGO_PKG_LICENSE`. New tests assert the field is present and
+points at the canonical GitHub URL:
+
+- Before the fix: both tests failed (`CARGO_PKG_REPOSITORY` was empty).
+- After the fix: both tests pass, and the full Rust suite (all targets) passes.
+
+## Test Plan
+
+- Added `tests/repository_metadata_test.rs`:
+  - `manifest_declares_repository` — asserts the `repository` field is non-empty.
+  - `manifest_repository_is_canonical_github_url` — asserts it equals
+    `https://github.com/stSoftwareAU/GRQ-validation`.
+- `cargo fmt --all -- --check` — clean.
+- `cargo clippy --tests --all-features -- -D warnings` — clean.
+- `cargo test --all-targets --all-features` — all tests pass.

--- a/tests/repository_metadata_test.rs
+++ b/tests/repository_metadata_test.rs
@@ -1,0 +1,26 @@
+// Tests that the manifest declares a canonical `repository` URL (Issue #691).
+//
+// `CARGO_PKG_REPOSITORY` is populated by Cargo from the `[package] repository`
+// field at compile time — it is the source-location value that crates.io and
+// `cargo doc` surface, and that SBOM generators use for provenance. These tests
+// verify the manifest declares the field and that it points at the canonical
+// GitHub repository, so the crate's provenance cannot drift silently.
+
+/// The manifest must declare a non-empty `repository` field.
+#[test]
+fn manifest_declares_repository() {
+    assert!(
+        !env!("CARGO_PKG_REPOSITORY").is_empty(),
+        "Cargo.toml [package] repository must be set to the canonical source URL"
+    );
+}
+
+/// The declared repository must be the canonical GitHub URL for this crate.
+#[test]
+fn manifest_repository_is_canonical_github_url() {
+    assert_eq!(
+        env!("CARGO_PKG_REPOSITORY"),
+        "https://github.com/stSoftwareAU/GRQ-validation",
+        "Cargo.toml [package] repository must be the canonical GitHub URL"
+    );
+}


### PR DESCRIPTION
# PR Summary — Issue #691

## Summary

Added the canonical `repository` metadata field to the `[package]` table in
`Cargo.toml`. The manifest previously declared `name`, `version`, `edition`,
`authors`, `description`, and `license` but omitted `repository` — the
source-location field that crates.io and `cargo doc` surface and that SBOM
generators use for provenance. Its absence weakened the crate's provenance and
traceability. Closes #691.

```diff
 description = "A Rust program to process daily stock scores from TSV files"
 license = "Apache-2.0"
+repository = "https://github.com/stSoftwareAU/GRQ-validation"
```

## Evidence

Backend/CLI metadata change only — no web interface to screenshot.

`CARGO_PKG_REPOSITORY` is populated by Cargo from the `[package] repository`
field at compile time, mirroring the existing `license_metadata_test.rs`
pattern for `CARGO_PKG_LICENSE`. New tests assert the field is present and
points at the canonical GitHub URL:

- Before the fix: both tests failed (`CARGO_PKG_REPOSITORY` was empty).
- After the fix: both tests pass, and the full Rust suite (all targets) passes.

## Test Plan

- Added `tests/repository_metadata_test.rs`:
  - `manifest_declares_repository` — asserts the `repository` field is non-empty.
  - `manifest_repository_is_canonical_github_url` — asserts it equals
    `https://github.com/stSoftwareAU/GRQ-validation`.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --tests --all-features -- -D warnings` — clean.
- `cargo test --all-targets --all-features` — all tests pass.



## Milestone
This PR is part of the **security** milestone and targets the `milestone/security` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr3nwizp-cb42f1`<!-- vibe-worker-issue-691 -->