### PR TITLE
Type diagnostic score/market rows with shared interfaces (Issue #692)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-692.md
+++ b/docs/archive/pr-summaries/pr-summary-692.md
@@ -1,0 +1,98 @@
+# Replace `any` with shared row interfaces in diagnostic APIs (Issue #692)
+
+## Summary
+
+The exported diagnostic functions across five milestone #544 scripts accepted
+`any` / `any[]` / `Record<string, any[]>` for their score, market, dividend and
+resolved-stock rows, each guarded by a per-line
+`// deno-lint-ignore no-explicit-any`. With `any` at the module boundary the row
+shapes were untyped, so property typos (e.g. `stock.buyPrice`) went uncaught at
+compile time.
+
+This change defines the row shapes **once** in a new shared module
+`scripts/diagnostic_types.ts` and uses them in the exported signatures,
+removing the `any` annotations and their `deno-lint-ignore` suppressions. The
+rows are locally-parsed CSV/TSV produced by the shipped kernels
+(`parseScoreTsv`, `parseMarketCsv`, `parseDividendCsv`,
+`resolvePredictionStocks`) — this is a maintainability typing, not a trust
+boundary.
+
+`Closes #692.`
+
+### Shared interfaces (`scripts/diagnostic_types.ts`)
+
+- `ScoreRow` — one parsed score-file (TSV) row (`stock` required; parser fields
+  the diagnostics never read are optional so synthetic callers may omit them).
+- `MarketPoint` — one parsed market-data (CSV) point.
+- `DividendPoint` — one `{ exDivDate, amount }` dividend record (shared by the
+  in-window map and the trailing-history map).
+- `ResolvedStock` — a per-stock projection row from `resolvePredictionStocks`
+  (`buyPrice`/`currentPrice` accurately typed `number | null`).
+
+No index signature is used, so a mistyped property name is still a compile
+error — the whole point of the change.
+
+### Files updated to consume the interfaces
+
+- `scripts/residual_gap_reconciliation.ts` — `hasUsableTarget(stock)` and
+  `aggregateDate(...)`.
+- `scripts/buy_price_denominator_diagnostic.ts` — `aggregateDate(...)`.
+- `scripts/dividend_basis_diagnostic.ts` — `aggregateDate(...)` (and the local
+  `fullHistory` map). Added an explicit `buyPrice === null` narrowing guard: the
+  upstream `isStockIncluded` gate already guarantees a positive numeric buy
+  price, so the guard narrows `number | null` to `number` for the divisions
+  below without changing behaviour (the null branch is unreachable).
+- `scripts/horizon_split_parity_diagnostic.ts` — `aggregateDate(...)`.
+- `scripts/price_basis_diagnostic.ts` — `aggregateDate(...)`.
+
+The two `const P/TP = (globalThis as any).GRQ*` casts at the top of each file
+are a distinct, unavoidable globalThis-access pattern (not a score/market row
+signature) and are intentionally left untouched — outside this issue's scope.
+
+## Evidence
+
+Backend/CLI TypeScript change — no web interface to screenshot. Verified via the
+Deno quality gates:
+
+- `deno check tests/*.ts scripts/*.ts` — passes (the exported signatures now
+  reject a mistyped row and `number | null` is honoured; this is the
+  compile-time gate that proves the `any` is gone).
+- `deno test --allow-read tests/*.ts` — **1276 passed, 0 failed**, including the
+  6 new tests.
+- `deno lint` and `deno fmt --check` — clean across `scripts/` and `tests/`.
+
+The Rust crate is untouched by this TypeScript-only change, so the cargo steps
+of `quality.sh` are orthogonal.
+
+```mermaid
+flowchart LR
+    subgraph before[Before]
+        A1["aggregateDate(scoreRows: any[],<br/>marketData: Record&lt;string, any[]&gt;)"]
+    end
+    subgraph after[After]
+        T["scripts/diagnostic_types.ts<br/>ScoreRow · MarketPoint ·<br/>DividendPoint · ResolvedStock"]
+        A2["aggregateDate(scoreRows: ScoreRow[],<br/>marketData: Record&lt;string, MarketPoint[]&gt;)"]
+        T --> A2
+    end
+    before -->|"remove any + deno-lint-ignore"| after
+```
+
+## Test Plan
+
+New `tests/diagnostic_types_test.ts` (6 tests) constructs **strongly typed**
+inputs (`ScoreRow[]`, `Record<string, MarketPoint[]>`, `ResolvedStock`, …) with
+**no `as any` casts** and drives each exported signature against the real
+shipped kernels, asserting on the computed results:
+
+- `hasUsableTarget` accepts a typed `ResolvedStock` (included / null-target /
+  unpriceable cases).
+- `aggregateDate` from each of the five scripts accepts the typed row shapes and
+  returns the expected aggregate figures.
+
+Existing diagnostic tests
+(`residual_gap_reconciliation_test.ts`, `price_basis_diagnostic_test.ts`,
+`buy_price_denominator_diagnostic_test.ts`,
+`horizon_split_parity_diagnostic_test.ts`,
+`dividend_basis_diagnostic_test.ts`) are unchanged and still pass; the
+non-consumed parser fields are typed optional precisely so their synthetic
+literals continue to compile.

--- a/scripts/buy_price_denominator_diagnostic.ts
+++ b/scripts/buy_price_denominator_diagnostic.ts
@@ -17,6 +17,13 @@ import "../docs/projection.js";
 import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
+import type {
+  DividendPoint,
+  MarketPoint,
+  ResolvedStock,
+  ScoreRow,
+} from "./diagnostic_types.ts";
+
 // deno-lint-ignore no-explicit-any
 const P = (globalThis as any).GRQProjection;
 // deno-lint-ignore no-explicit-any
@@ -80,15 +87,12 @@ export interface DateAggregate {
 // supplies already-parsed score rows and the market-data map.
 export function aggregateDate(
   date: string,
-  // deno-lint-ignore no-explicit-any
-  scoreRows: any[],
-  // deno-lint-ignore no-explicit-any
-  marketData: Record<string, any[]>,
-  // deno-lint-ignore no-explicit-any
-  dividendData: Record<string, any[]>,
+  scoreRows: ScoreRow[],
+  marketData: Record<string, MarketPoint[]>,
+  dividendData: Record<string, DividendPoint[]>,
   scoreDate: Date,
 ): DateAggregate {
-  const midStocks = TP.resolvePredictionStocks(
+  const midStocks: ResolvedStock[] = TP.resolvePredictionStocks(
     scoreRows,
     marketData,
     dividendData,
@@ -96,8 +100,7 @@ export function aggregateDate(
   );
 
   const rowOffsetsPp: number[] = [];
-  // deno-lint-ignore no-explicit-any
-  const closeStocks = midStocks.map((stock: any, i: number) => {
+  const closeStocks = midStocks.map((stock, i) => {
     const points = marketData[scoreRows[i].stock];
     const closeObj = P.buyPriceCloseBasis(points, scoreDate);
     const buyPriceClose = closeObj ? closeObj.price : null;

--- a/scripts/diagnostic_types.ts
+++ b/scripts/diagnostic_types.ts
@@ -1,0 +1,61 @@
+// Shared row-shape interfaces for the milestone #544 diagnostic scripts
+// (issue #692). These describe the objects produced by the SHIPPED kernels
+// published on globalThis by docs/projection.js and docs/trend_predictions.js
+// (parseScoreTsv, parseMarketCsv, parseDividendCsv and resolvePredictionStocks).
+//
+// The values originate from locally-parsed CSV/TSV, not from an external
+// attacker, so this is a maintainability typing rather than a trust boundary:
+// naming the row shapes at the exported diagnostic signatures replaces the
+// per-line `// deno-lint-ignore no-explicit-any` and lets property typos (e.g.
+// `stock.buyPrice`) be caught at compile time.
+//
+// Fields the diagnostics never read are marked OPTIONAL so a synthetic caller
+// (a unit test) may omit them; the real parsers always populate them. No index
+// signature is used, so a mistyped property name is still a compile error.
+
+/** One parsed score-file (TSV) row, as produced by `parseScoreTsv`. */
+export interface ScoreRow {
+  /** Ticker; the only field the diagnostics read directly. */
+  stock: string;
+  score?: number;
+  target?: number;
+  exDividendDate?: string | null;
+  dividendPerShare?: number;
+  notes?: string;
+  intrinsicValuePerShareBasic?: number | null;
+  intrinsicValuePerShareAdjusted?: number | null;
+}
+
+/** One parsed market-data (CSV) point for a ticker, from `parseMarketCsv`. */
+export interface MarketPoint {
+  date: Date;
+  high: number;
+  low: number;
+  open: number;
+  close: number;
+  splitCoefficient: number;
+  /** Trailing volume column; absent on pre-#575 (7-column) CSVs. */
+  volume?: number | null;
+}
+
+/**
+ * One parsed dividend record for a ticker. Both the in-window dividend map from
+ * `parseDividendCsv` and the full trailing history loaded from the
+ * GRQ-dividends tree share this `{ exDivDate, amount }` shape.
+ */
+export interface DividendPoint {
+  exDivDate: Date;
+  amount: number;
+}
+
+/** A per-stock projection row resolved by `resolvePredictionStocks`. */
+export interface ResolvedStock {
+  buyPrice: number | null;
+  currentPrice: number | null;
+  splitReliable: boolean;
+  adjustedTarget: number | null;
+  totalDividends?: number;
+  stock?: string;
+  lowVolume?: boolean;
+  avgStars?: number | null;
+}

--- a/scripts/dividend_basis_diagnostic.ts
+++ b/scripts/dividend_basis_diagnostic.ts
@@ -22,6 +22,13 @@ import "../docs/projection.js";
 import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
+import type {
+  DividendPoint,
+  MarketPoint,
+  ResolvedStock,
+  ScoreRow,
+} from "./diagnostic_types.ts";
+
 // deno-lint-ignore no-explicit-any
 const P = (globalThis as any).GRQProjection;
 // deno-lint-ignore no-explicit-any
@@ -96,19 +103,15 @@ export interface DateAggregate {
 // dividend history keyed by stripped symbol (the training-credit source).
 export function aggregateDate(
   date: string,
-  // deno-lint-ignore no-explicit-any
-  scoreRows: any[],
-  // deno-lint-ignore no-explicit-any
-  marketData: Record<string, any[]>,
-  // deno-lint-ignore no-explicit-any
-  windowedDividends: Record<string, any[]>,
-  // deno-lint-ignore no-explicit-any
-  fullHistory: Record<string, any[]>,
+  scoreRows: ScoreRow[],
+  marketData: Record<string, MarketPoint[]>,
+  windowedDividends: Record<string, DividendPoint[]>,
+  fullHistory: Record<string, DividendPoint[]>,
   scoreDate: Date,
 ): DateAggregate {
   // Shipped resolver: gives buyPrice, currentPrice, splitReliable and the
   // realised in-window `totalDividends` — exactly the dashboard's Actual credit.
-  const stocks = TP.resolvePredictionStocks(
+  const stocks: ResolvedStock[] = TP.resolvePredictionStocks(
     scoreRows,
     marketData,
     windowedDividends,
@@ -121,8 +124,7 @@ export function aggregateDate(
   let windowedZeroCount = 0;
   let includedCount = 0;
 
-  // deno-lint-ignore no-explicit-any
-  stocks.forEach((stock: any, i: number) => {
+  stocks.forEach((stock, i) => {
     if (
       !P.isStockIncluded(
         stock.buyPrice,
@@ -134,6 +136,14 @@ export function aggregateDate(
     }
     includedCount += 1;
 
+    // `isStockIncluded` above already guarantees a positive numeric buyPrice, so
+    // this narrows `number | null` to `number` for the divisions below rather
+    // than adding new business logic (the null branch is unreachable here).
+    const buyPrice = stock.buyPrice;
+    if (buyPrice === null) {
+      return;
+    }
+
     const history = fullHistory[stripSymbol(scoreRows[i].stock)] || [];
     const flatCredit = P.trailingAnnualDividends(history, scoreDate) / 4;
     const windowedCredit = stock.totalDividends || 0;
@@ -141,14 +151,14 @@ export function aggregateDate(
     const diff = P.dividendBasisDifferencePercent(
       flatCredit,
       windowedCredit,
-      stock.buyPrice,
+      buyPrice,
     );
     if (diff === null) {
       return;
     }
     rowDiffsPp.push(diff);
-    flatYieldsPct.push((flatCredit / stock.buyPrice) * 100);
-    windowedYieldsPct.push((windowedCredit / stock.buyPrice) * 100);
+    flatYieldsPct.push((flatCredit / buyPrice) * 100);
+    windowedYieldsPct.push((windowedCredit / buyPrice) * 100);
     if (windowedCredit === 0) {
       windowedZeroCount += 1;
     }
@@ -351,17 +361,13 @@ export async function computeDividendBasisDiagnostic(
     const windowedDividends = TP.parseDividendCsv(divText);
 
     // Full trailing history per ticker on this date (cached across dates).
-    // deno-lint-ignore no-explicit-any
-    const fullHistory: Record<string, any[]> = {};
+    const fullHistory: Record<string, DividendPoint[]> = {};
     for (const row of scoreRows) {
       const sym = stripSymbol(row.stock);
       if (!historyCache.has(sym)) {
         historyCache.set(sym, await loadDividendHistory(dividendsRoot, sym));
       }
-      fullHistory[sym] = historyCache.get(sym) as {
-        exDivDate: Date;
-        amount: number;
-      }[];
+      fullHistory[sym] = historyCache.get(sym) as DividendPoint[];
     }
 
     aggregates.push(

--- a/scripts/horizon_split_parity_diagnostic.ts
+++ b/scripts/horizon_split_parity_diagnostic.ts
@@ -25,6 +25,13 @@ import "../docs/projection.js";
 import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
+import type {
+  DividendPoint,
+  MarketPoint,
+  ResolvedStock,
+  ScoreRow,
+} from "./diagnostic_types.ts";
+
 // deno-lint-ignore no-explicit-any
 const P = (globalThis as any).GRQProjection;
 // deno-lint-ignore no-explicit-any
@@ -89,15 +96,12 @@ export interface DateAggregate {
 // and the market-data map.
 export function aggregateDate(
   date: string,
-  // deno-lint-ignore no-explicit-any
-  scoreRows: any[],
-  // deno-lint-ignore no-explicit-any
-  marketData: Record<string, any[]>,
-  // deno-lint-ignore no-explicit-any
-  dividendData: Record<string, any[]>,
+  scoreRows: ScoreRow[],
+  marketData: Record<string, MarketPoint[]>,
+  dividendData: Record<string, DividendPoint[]>,
   scoreDate: Date,
 ): DateAggregate {
-  const rawStocks = TP.resolvePredictionStocks(
+  const rawStocks: ResolvedStock[] = TP.resolvePredictionStocks(
     scoreRows,
     marketData,
     dividendData,
@@ -107,8 +111,7 @@ export function aggregateDate(
   const rowOffsetsPp: number[] = [];
   let splitAffectedRows = 0;
   let includedRows = 0;
-  // deno-lint-ignore no-explicit-any
-  const currentBasisStocks = rawStocks.map((stock: any, i: number) => {
+  const currentBasisStocks = rawStocks.map((stock, i) => {
     const points = marketData[scoreRows[i].stock];
     const currentBasisMid = P.horizonPriceCurrentBasis(points, scoreDate);
     const offset = P.horizonAsOfBasisOffsetPercent(

--- a/scripts/price_basis_diagnostic.ts
+++ b/scripts/price_basis_diagnostic.ts
@@ -9,6 +9,13 @@ import "../docs/projection.js";
 import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
+import type {
+  DividendPoint,
+  MarketPoint,
+  ResolvedStock,
+  ScoreRow,
+} from "./diagnostic_types.ts";
+
 // deno-lint-ignore no-explicit-any
 const P = (globalThis as any).GRQProjection;
 // deno-lint-ignore no-explicit-any
@@ -68,15 +75,12 @@ export interface DateAggregate {
 // caller supplies already-parsed score rows and the market-data map.
 export function aggregateDate(
   date: string,
-  // deno-lint-ignore no-explicit-any
-  scoreRows: any[],
-  // deno-lint-ignore no-explicit-any
-  marketData: Record<string, any[]>,
-  // deno-lint-ignore no-explicit-any
-  dividendData: Record<string, any[]>,
+  scoreRows: ScoreRow[],
+  marketData: Record<string, MarketPoint[]>,
+  dividendData: Record<string, DividendPoint[]>,
   scoreDate: Date,
 ): DateAggregate {
-  const midStocks = TP.resolvePredictionStocks(
+  const midStocks: ResolvedStock[] = TP.resolvePredictionStocks(
     scoreRows,
     marketData,
     dividendData,
@@ -84,8 +88,7 @@ export function aggregateDate(
   );
 
   const rowOffsetsPp: number[] = [];
-  // deno-lint-ignore no-explicit-any
-  const lowStocks = midStocks.map((stock: any, i: number) => {
+  const lowStocks = midStocks.map((stock, i) => {
     const points = marketData[scoreRows[i].stock];
     const low = P.lowPriceAtNinetyDayHorizon(points, scoreDate);
     const offset = P.priceBasisOffsetPercent(

--- a/scripts/residual_gap_reconciliation.ts
+++ b/scripts/residual_gap_reconciliation.ts
@@ -24,6 +24,13 @@ import "../docs/projection.js";
 import "../docs/volume_recommend.js";
 import "../docs/trend_predictions.js";
 
+import type {
+  DividendPoint,
+  MarketPoint,
+  ResolvedStock,
+  ScoreRow,
+} from "./diagnostic_types.ts";
+
 // deno-lint-ignore no-explicit-any
 const P = (globalThis as any).GRQProjection;
 // deno-lint-ignore no-explicit-any
@@ -101,8 +108,7 @@ export const FAMILY_CONTRIBUTIONS: GapContribution[] = [
 ];
 
 /** Whether a stock has BOTH a usable Actual (included) AND a usable target. */
-// deno-lint-ignore no-explicit-any
-export function hasUsableTarget(stock: any): boolean {
+export function hasUsableTarget(stock: ResolvedStock): boolean {
   if (
     !P.isStockIncluded(stock.buyPrice, stock.currentPrice, stock.splitReliable)
   ) {
@@ -134,23 +140,18 @@ export interface DateAggregate {
 // target-present subset so the target-availability skew can be read off.
 export function aggregateDate(
   date: string,
-  // deno-lint-ignore no-explicit-any
-  scoreRows: any[],
-  // deno-lint-ignore no-explicit-any
-  marketData: Record<string, any[]>,
-  // deno-lint-ignore no-explicit-any
-  dividendData: Record<string, any[]>,
+  scoreRows: ScoreRow[],
+  marketData: Record<string, MarketPoint[]>,
+  dividendData: Record<string, DividendPoint[]>,
   scoreDate: Date,
 ): DateAggregate {
-  const stocks = TP.resolvePredictionStocks(
+  const stocks: ResolvedStock[] = TP.resolvePredictionStocks(
     scoreRows,
     marketData,
     dividendData,
     scoreDate,
   );
 
-  // `stocks` is the (untyped) kernel output, so `s` is implicitly any here —
-  // no explicit-any annotation needed.
   let includedRows = 0;
   for (const s of stocks) {
     if (P.isStockIncluded(s.buyPrice, s.currentPrice, s.splitReliable)) {

--- a/tests/diagnostic_types_test.ts
+++ b/tests/diagnostic_types_test.ts
@@ -1,0 +1,167 @@
+// Tests for the issue #692 shared diagnostic row interfaces.
+//
+// These construct STRONGLY TYPED inputs (ScoreRow[], Record<string,
+// MarketPoint[]>, ResolvedStock, ...) with NO `as any` casts and pass them to
+// the exported diagnostic signatures, asserting on the computed results. If the
+// exported signatures still used `any` the interfaces would be redundant; if
+// they used an incompatible shape `deno check` would fail. Together they pin the
+// module-boundary typing while exercising the real shipped kernels.
+
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../docs/projection.js";
+import "../docs/trend_predictions.js";
+
+import type {
+  DividendPoint,
+  MarketPoint,
+  ResolvedStock,
+  ScoreRow,
+} from "../scripts/diagnostic_types.ts";
+
+import {
+  aggregateDate as residualAggregate,
+  hasUsableTarget,
+} from "../scripts/residual_gap_reconciliation.ts";
+import { aggregateDate as priceBasisAggregate } from "../scripts/price_basis_diagnostic.ts";
+import { aggregateDate as buyPriceAggregate } from "../scripts/buy_price_denominator_diagnostic.ts";
+import { aggregateDate as horizonAggregate } from "../scripts/horizon_split_parity_diagnostic.ts";
+import { aggregateDate as dividendAggregate } from "../scripts/dividend_basis_diagnostic.ts";
+
+function midnight(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+// Build a typed one-day score set: a target-bearing winner (AAA, +20% actual,
+// +50% target) and a target-less loser (BBB, -20% actual). No splits.
+function typedDate(): {
+  scoreDate: Date;
+  scoreRows: ScoreRow[];
+  marketData: Record<string, MarketPoint[]>;
+  dividendData: Record<string, DividendPoint[]>;
+} {
+  const scoreDate = midnight("2026-01-01");
+  const row = (stock: string, target: number): ScoreRow => ({
+    stock,
+    score: 0.5,
+    target,
+    exDividendDate: null,
+    dividendPerShare: 0,
+    notes: "",
+    intrinsicValuePerShareBasic: null,
+    intrinsicValuePerShareAdjusted: null,
+  });
+  const point = (
+    date: string,
+    high: number,
+    low: number,
+    close: number,
+  ): MarketPoint => ({
+    date: midnight(date),
+    high,
+    low,
+    open: close,
+    close,
+    splitCoefficient: 1,
+    volume: null,
+  });
+  const scoreRows: ScoreRow[] = [row("AAA", 150), row("BBB", NaN)];
+  const marketData: Record<string, MarketPoint[]> = {
+    AAA: [
+      point("2026-01-02", 110, 90, 100), // mid 100 buy
+      point("2026-03-30", 130, 110, 120), // mid 120 actual +20%
+    ],
+    BBB: [
+      point("2026-01-02", 110, 90, 100),
+      point("2026-03-30", 90, 70, 80), // mid 80 actual -20%
+    ],
+  };
+  const dividendData: Record<string, DividendPoint[]> = {};
+  return { scoreDate, scoreRows, marketData, dividendData };
+}
+
+// --- hasUsableTarget accepts a typed ResolvedStock ---------------------------
+
+Deno.test("hasUsableTarget accepts a typed ResolvedStock", () => {
+  const included: ResolvedStock = {
+    stock: "AAA",
+    buyPrice: 100,
+    currentPrice: 120,
+    totalDividends: 0,
+    adjustedTarget: 150,
+    splitReliable: true,
+    lowVolume: false,
+    avgStars: null,
+  };
+  assert(hasUsableTarget(included));
+  assert(!hasUsableTarget({ ...included, adjustedTarget: null }));
+  assert(!hasUsableTarget({ ...included, buyPrice: 0 }));
+});
+
+// --- each exported aggregateDate accepts the typed row shapes ----------------
+
+Deno.test("residual aggregateDate accepts typed rows and counts included/target rows", () => {
+  const { scoreDate, scoreRows, marketData, dividendData } = typedDate();
+  const agg = residualAggregate(
+    "2026-01-01",
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+  assertEquals(agg.includedRows, 2);
+  assertEquals(agg.targetRows, 1);
+  assertAlmostEquals(agg.actualPct as number, 0, 1e-9);
+  assertAlmostEquals(agg.matchedActualPct as number, 20, 1e-9);
+});
+
+Deno.test("price-basis aggregateDate accepts typed rows", () => {
+  const { scoreDate, scoreRows, marketData, dividendData } = typedDate();
+  const agg = priceBasisAggregate(
+    "2026-01-01",
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+  assertAlmostEquals(agg.actualMidPct as number, 0, 1e-9);
+});
+
+Deno.test("buy-price aggregateDate accepts typed rows", () => {
+  const { scoreDate, scoreRows, marketData, dividendData } = typedDate();
+  const agg = buyPriceAggregate(
+    "2026-01-01",
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+  assertAlmostEquals(agg.actualMidPct as number, 0, 1e-9);
+});
+
+Deno.test("horizon-split aggregateDate accepts typed rows", () => {
+  const { scoreDate, scoreRows, marketData, dividendData } = typedDate();
+  const agg = horizonAggregate(
+    "2026-01-01",
+    scoreRows,
+    marketData,
+    dividendData,
+    scoreDate,
+  );
+  assertAlmostEquals(agg.actualRawPct as number, 0, 1e-9);
+  assertEquals(agg.includedRows, 2);
+});
+
+Deno.test("dividend-basis aggregateDate accepts typed rows and full-history map", () => {
+  const { scoreDate, scoreRows, marketData, dividendData } = typedDate();
+  const fullHistory: Record<string, DividendPoint[]> = {};
+  const agg = dividendAggregate(
+    "2026-01-01",
+    scoreRows,
+    marketData,
+    dividendData,
+    fullHistory,
+    scoreDate,
+  );
+  assertEquals(agg.includedCount, 2);
+});


### PR DESCRIPTION
# Replace `any` with shared row interfaces in diagnostic APIs (Issue #692)

## Summary

The exported diagnostic functions across five milestone #544 scripts accepted
`any` / `any[]` / `Record<string, any[]>` for their score, market, dividend and
resolved-stock rows, each guarded by a per-line
`// deno-lint-ignore no-explicit-any`. With `any` at the module boundary the row
shapes were untyped, so property typos (e.g. `stock.buyPrice`) went uncaught at
compile time.

This change defines the row shapes **once** in a new shared module
`scripts/diagnostic_types.ts` and uses them in the exported signatures,
removing the `any` annotations and their `deno-lint-ignore` suppressions. The
rows are locally-parsed CSV/TSV produced by the shipped kernels
(`parseScoreTsv`, `parseMarketCsv`, `parseDividendCsv`,
`resolvePredictionStocks`) — this is a maintainability typing, not a trust
boundary.

`Closes #692.`

### Shared interfaces (`scripts/diagnostic_types.ts`)

- `ScoreRow` — one parsed score-file (TSV) row (`stock` required; parser fields
  the diagnostics never read are optional so synthetic callers may omit them).
- `MarketPoint` — one parsed market-data (CSV) point.
- `DividendPoint` — one `{ exDivDate, amount }` dividend record (shared by the
  in-window map and the trailing-history map).
- `ResolvedStock` — a per-stock projection row from `resolvePredictionStocks`
  (`buyPrice`/`currentPrice` accurately typed `number | null`).

No index signature is used, so a mistyped property name is still a compile
error — the whole point of the change.

### Files updated to consume the interfaces

- `scripts/residual_gap_reconciliation.ts` — `hasUsableTarget(stock)` and
  `aggregateDate(...)`.
- `scripts/buy_price_denominator_diagnostic.ts` — `aggregateDate(...)`.
- `scripts/dividend_basis_diagnostic.ts` — `aggregateDate(...)` (and the local
  `fullHistory` map). Added an explicit `buyPrice === null` narrowing guard: the
  upstream `isStockIncluded` gate already guarantees a positive numeric buy
  price, so the guard narrows `number | null` to `number` for the divisions
  below without changing behaviour (the null branch is unreachable).
- `scripts/horizon_split_parity_diagnostic.ts` — `aggregateDate(...)`.
- `scripts/price_basis_diagnostic.ts` — `aggregateDate(...)`.

The two `const P/TP = (globalThis as any).GRQ*` casts at the top of each file
are a distinct, unavoidable globalThis-access pattern (not a score/market row
signature) and are intentionally left untouched — outside this issue's scope.

## Evidence

Backend/CLI TypeScript change — no web interface to screenshot. Verified via the
Deno quality gates:

- `deno check tests/*.ts scripts/*.ts` — passes (the exported signatures now
  reject a mistyped row and `number | null` is honoured; this is the
  compile-time gate that proves the `any` is gone).
- `deno test --allow-read tests/*.ts` — **1276 passed, 0 failed**, including the
  6 new tests.
- `deno lint` and `deno fmt --check` — clean across `scripts/` and `tests/`.

The Rust crate is untouched by this TypeScript-only change, so the cargo steps
of `quality.sh` are orthogonal.

```mermaid
flowchart LR
    subgraph before[Before]
        A1["aggregateDate(scoreRows: any[],<br/>marketData: Record&lt;string, any[]&gt;)"]
    end
    subgraph after[After]
        T["scripts/diagnostic_types.ts<br/>ScoreRow · MarketPoint ·<br/>DividendPoint · ResolvedStock"]
        A2["aggregateDate(scoreRows: ScoreRow[],<br/>marketData: Record&lt;string, MarketPoint[]&gt;)"]
        T --> A2
    end
    before -->|"remove any + deno-lint-ignore"| after
```

## Test Plan

New `tests/diagnostic_types_test.ts` (6 tests) constructs **strongly typed**
inputs (`ScoreRow[]`, `Record<string, MarketPoint[]>`, `ResolvedStock`, …) with
**no `as any` casts** and drives each exported signature against the real
shipped kernels, asserting on the computed results:

- `hasUsableTarget` accepts a typed `ResolvedStock` (included / null-target /
  unpriceable cases).
- `aggregateDate` from each of the five scripts accepts the typed row shapes and
  returns the expected aggregate figures.

Existing diagnostic tests
(`residual_gap_reconciliation_test.ts`, `price_basis_diagnostic_test.ts`,
`buy_price_denominator_diagnostic_test.ts`,
`horizon_split_parity_diagnostic_test.ts`,
`dividend_basis_diagnostic_test.ts`) are unchanged and still pass; the
non-consumed parser fields are typed optional precisely so their synthetic
literals continue to compile.



## Milestone
This PR is part of the **security** milestone and targets the `milestone/security` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mr3nwizp-cb42f1`<!-- vibe-worker-issue-692 -->