### PR TITLE
Add <main> landmark to dashboard pages (#693)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-693.md
+++ b/docs/archive/pr-summaries/pr-summary-693.md
@@ -1,0 +1,51 @@
+# Add `<main>` landmark to dashboard pages
+
+## Summary
+
+The dashboard pages `docs/index.html` and `docs/trend.html` wrapped their
+primary content region only in generic `<div>`s, leaving assistive-technology
+users with no "skip to main content" target and no programmatic main-content
+boundary. The HTML best-practices bucket requires exactly one `<main>` landmark
+per page.
+
+Fixed by promoting each page's top-level `container-fluid` wrapper from a
+generic `<div>` to `<main class="container-fluid">` (with the matching close
+tag). The Bootstrap class — and therefore all styling — is unchanged, so this
+is a purely semantic swap with no visual difference. The page `<footer>`, the
+mobile chart pop-out overlay and the version chrome remain siblings of `<main>`,
+so each page has exactly **one** main landmark. Closes #693.
+
+```mermaid
+flowchart TD
+    body[body.bg-light]
+    body --> main["main.container-fluid — primary content (was div)"]
+    body --> popout["div#chartPopout — mobile overlay (index only)"]
+    body --> footer["footer.share-footer (index only)"]
+    body --> version["div.version chrome (trend only)"]
+```
+
+## Evidence
+
+This is a semantic HTML change with no visual impact — the `container-fluid`
+class and all styling are preserved, so the rendered pages look identical.
+Playwright MCP was unavailable in this run, so no screenshot was captured;
+instead the change was verified by:
+
+- Serving `docs/` locally and confirming both pages emit
+  `<main class="container-fluid">` in the rendered HTML.
+- New automated assertions in `tests/main_landmark_test.ts` reading the real
+  committed HTML.
+
+## Test Plan
+
+Added `tests/main_landmark_test.ts`, which verifies against the real committed
+HTML:
+
+- `docs/index.html` / `docs/trend.html`: each has exactly one `<main>` open and
+  one `</main>` close tag.
+- Each page exposes the primary content region as `<main class="container-fluid">`.
+- The `<main>` opens inside `<body>` before it closes.
+- `index.html`: the page `<footer>` sits outside (after) the `<main>` landmark.
+
+All 7 new tests pass, and the full Deno suite (`deno test --allow-read tests/*.ts`)
+passes with 1283 tests green.

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,7 +103,7 @@
 
   </head>
   <body class="bg-light">
-    <div class="container-fluid">
+    <main class="container-fluid">
       <div class="row">
         <div class="col-12">
           <div class="card shadow-sm border-0">
@@ -435,7 +435,7 @@
           </div>
         </div>
       </div>
-    </div>
+    </main>
 
     <!-- Mobile chart pop-out overlay (issue #451). Hidden by default; the live
          #performanceChart canvas is re-parented into #chartPopoutBody while

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -70,7 +70,7 @@
     <link rel="stylesheet" href="styles.css">
   </head>
   <body class="bg-light">
-    <div class="container-fluid">
+    <main class="container-fluid">
       <div class="row">
         <div class="col-12">
           <div class="card shadow-sm border-0">
@@ -183,7 +183,7 @@
           </div>
         </div>
       </div>
-    </div>
+    </main>
 
     <!-- Version display -->
     <div class="text-center text-muted small py-2">

--- a/tests/main_landmark_test.ts
+++ b/tests/main_landmark_test.ts
@@ -1,0 +1,67 @@
+// Tests for the <main> landmark on the dashboard pages (issue #693).
+//
+// The HTML bucket requires exactly one <main> landmark per page so that
+// assistive-technology users get a programmatic main-content boundary and a
+// "skip to main content" target. Previously the primary content region was
+// wrapped only in generic <div>s. These assertions read the REAL committed
+// HTML so they verify the rendered structure, not the method.
+
+import { assert, assertStringIncludes } from "@std/assert";
+
+const PAGES = ["docs/index.html", "docs/trend.html"];
+
+/** Count non-overlapping occurrences of `needle` in `haystack`. */
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+for (const page of PAGES) {
+  Deno.test(`${page}: has exactly one <main> landmark`, async () => {
+    const html = await Deno.readTextFile(page);
+    const opens = count(html, "<main");
+    const closes = count(html, "</main>");
+    assert(
+      opens === 1,
+      `${page} must have exactly one <main> open tag; found ${opens}`,
+    );
+    assert(
+      closes === 1,
+      `${page} must have exactly one </main> close tag; found ${closes}`,
+    );
+  });
+
+  Deno.test(`${page}: primary content region is the <main> landmark`, async () => {
+    const html = await Deno.readTextFile(page);
+    // The container-fluid wrapper is the primary content region; it must now be
+    // the <main> landmark rather than a generic <div>.
+    assertStringIncludes(
+      html,
+      '<main class="container-fluid">',
+      `${page} must expose the primary content region as <main>`,
+    );
+  });
+
+  Deno.test(`${page}: <main> opens inside <body> before it closes`, async () => {
+    const html = await Deno.readTextFile(page);
+    const bodyAt = html.indexOf("<body");
+    const mainAt = html.indexOf("<main");
+    const mainCloseAt = html.indexOf("</main>");
+    assert(bodyAt !== -1, `${page} must have a <body>`);
+    assert(
+      bodyAt < mainAt && mainAt < mainCloseAt,
+      `${page} <main> must open after <body> and close after it opens`,
+    );
+  });
+}
+
+Deno.test("index.html: footer sits outside the <main> landmark", async () => {
+  const html = await Deno.readTextFile("docs/index.html");
+  const mainCloseAt = html.indexOf("</main>");
+  const footerAt = html.indexOf("<footer");
+  assert(mainCloseAt !== -1, "index.html must close its <main>");
+  assert(footerAt !== -1, "index.html must have a <footer>");
+  assert(
+    footerAt > mainCloseAt,
+    "the page <footer> must be a sibling of <main>, not nested inside it",
+  );
+});


### PR DESCRIPTION
# Add `<main>` landmark to dashboard pages

## Summary

The dashboard pages `docs/index.html` and `docs/trend.html` wrapped their
primary content region only in generic `<div>`s, leaving assistive-technology
users with no "skip to main content" target and no programmatic main-content
boundary. The HTML best-practices bucket requires exactly one `<main>` landmark
per page.

Fixed by promoting each page's top-level `container-fluid` wrapper from a
generic `<div>` to `<main class="container-fluid">` (with the matching close
tag). The Bootstrap class — and therefore all styling — is unchanged, so this
is a purely semantic swap with no visual difference. The page `<footer>`, the
mobile chart pop-out overlay and the version chrome remain siblings of `<main>`,
so each page has exactly **one** main landmark. Closes #693.

```mermaid
flowchart TD
    body[body.bg-light]
    body --> main["main.container-fluid — primary content (was div)"]
    body --> popout["div#chartPopout — mobile overlay (index only)"]
    body --> footer["footer.share-footer (index only)"]
    body --> version["div.version chrome (trend only)"]
```

## Evidence

This is a semantic HTML change with no visual impact — the `container-fluid`
class and all styling are preserved, so the rendered pages look identical.
Playwright MCP was unavailable in this run, so no screenshot was captured;
instead the change was verified by:

- Serving `docs/` locally and confirming both pages emit
  `<main class="container-fluid">` in the rendered HTML.
- New automated assertions in `tests/main_landmark_test.ts` reading the real
  committed HTML.

## Test Plan

Added `tests/main_landmark_test.ts`, which verifies against the real committed
HTML:

- `docs/index.html` / `docs/trend.html`: each has exactly one `<main>` open and
  one `</main>` close tag.
- Each page exposes the primary content region as `<main class="container-fluid">`.
- The `<main>` opens inside `<body>` before it closes.
- `index.html`: the page `<footer>` sits outside (after) the `<main>` landmark.

All 7 new tests pass, and the full Deno suite (`deno test --allow-read tests/*.ts`)
passes with 1283 tests green.
