### PR TITLE
Add static <title> to dashboard pages (Issue #694)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-694.md
+++ b/docs/archive/pr-summaries/pr-summary-694.md
@@ -1,0 +1,61 @@
+# PR Summary — Static `<title>` on dashboard pages (Issue #694)
+
+## Summary
+
+`docs/index.html` and `docs/trend.html` carried no static `<title>` element —
+the document title was injected solely at runtime by `version.js`. Any consumer
+that read the page before script execution (some crawlers, view-source, no-JS
+contexts) therefore saw no title, failing the HTML best-practices requirement
+for a present, descriptive `<title>`.
+
+This PR adds a descriptive static `<title>` to each `<head>`
+(`GRQ Validation Dashboard` and `GRQ Validation Trend`) and changes
+`version.js` to **augment** that static title — appending the version — rather
+than being the sole source. When no static title is present it still falls back
+to the `app-title` meta, and it never emits a dangling `" v"` suffix when the
+version is unknown. The rendered, JS-enabled title is unchanged
+(e.g. `GRQ Validation Dashboard v1.1.47`).
+
+Closes #694.
+
+## Evidence
+
+Static titles are now present before any script runs. Served locally via a
+static file server and fetched with `curl` (no JS execution):
+
+```text
+$ curl -s http://localhost:8080/index.html | grep -o '<title>[^<]*</title>'
+<title>GRQ Validation Dashboard</title>
+$ curl -s http://localhost:8080/trend.html | grep -o '<title>[^<]*</title>'
+<title>GRQ Validation Trend</title>
+```
+
+Title bootstrap flow:
+
+```mermaid
+flowchart LR
+    A["Static &lt;title&gt; in &lt;head&gt;"] --> B{JS enabled?}
+    B -- No --> C["Crawler / view-source<br/>sees descriptive title"]
+    B -- Yes --> D["version.js appends<br/>&quot; v&lt;VERSION&gt;&quot;"]
+    D --> E["Tab shows<br/>'... vX.Y.Z'"]
+```
+
+Playwright MCP browser tooling was unavailable in this run, so runtime
+behaviour was verified programmatically instead: `tests/static_title_test.ts`
+executes `docs/version.js` against a minimal document stub and asserts the
+augmented `document.title`.
+
+## Test Plan
+
+Added `tests/static_title_test.ts`:
+
+- `docs/index.html` / `docs/trend.html` each contain a static, descriptive
+  `<title>` inside `<head>`.
+- `version.js` augments a static `<title>` with the version
+  (`GRQ Validation Dashboard` → `GRQ Validation Dashboard v1.2.3`).
+- `version.js` does not blank a static title nor append an empty `" v"` when no
+  `app-version` meta is present.
+- `version.js` falls back to the `app-title` meta when the document has no
+  static title.
+
+All tests pass and `./quality.sh` completes cleanly.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Static, descriptive title (issue #694); version.js appends the version. -->
+    <title>GRQ Validation Dashboard</title>
     <!--
       Content-Security-Policy as defence-in-depth against DOM XSS from
       untrusted, TSV-derived score data rendered into innerHTML (issue #189).

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Static, descriptive title (issue #694); version.js appends the version. -->
+    <title>GRQ Validation Trend</title>
     <!--
       Content-Security-Policy as defence-in-depth, mirroring docs/index.html
       (issue #189). All scripts are external so script-src omits 'unsafe-inline'.

--- a/docs/version.js
+++ b/docs/version.js
@@ -11,9 +11,16 @@
   const VERSION = versionMeta ? versionMeta.getAttribute("content") || "" : "";
   globalThis.VERSION = VERSION;
 
+  // Augment the static <title> with the version (issue #694). Each page now
+  // carries a descriptive static <title> in its <head>, so no-JS/crawler/
+  // view-source contexts always see a title. Here we append the version to
+  // that base, falling back to the app-title meta if the document has no
+  // static title. Never emit a dangling " v" when the version is unknown.
   const titleMeta = document.querySelector('meta[name="app-title"]');
-  if (titleMeta) {
-    document.title = `${titleMeta.getAttribute("content")} v${VERSION}`;
+  const metaTitle = titleMeta ? titleMeta.getAttribute("content") || "" : "";
+  const baseTitle = document.title || metaTitle;
+  if (baseTitle) {
+    document.title = VERSION ? `${baseTitle} v${VERSION}` : baseTitle;
   }
 
   // Populate the footer version label once the DOM is parsed.

--- a/tests/static_title_test.ts
+++ b/tests/static_title_test.ts
@@ -1,0 +1,120 @@
+// Tests for static <title> elements on the published dashboard pages
+// (issue #694).
+//
+// The HTML best-practices bucket requires a present, descriptive <title> in
+// each <head>. Historically the title was injected solely at runtime by
+// version.js, so any consumer that read the page before script execution
+// (crawlers, view-source, no-JS contexts) saw no title. These tests pin a
+// static <title> into each page and verify that version.js *augments* that
+// static title with the version rather than being its sole source.
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+
+const PAGES = [
+  { path: "docs/index.html", title: "GRQ Validation Dashboard" },
+  { path: "docs/trend.html", title: "GRQ Validation Trend" },
+];
+
+/** Extract the <head>…</head> section of an HTML document. */
+function headOf(html: string): string {
+  const m = html.match(/<head\b[^>]*>([\s\S]*?)<\/head>/i);
+  assert(m, "document must have a <head>");
+  return m[1];
+}
+
+/** Text content of the first <title> element, or null if absent. */
+function titleText(html: string): string | null {
+  const m = html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+  return m ? m[1].trim() : null;
+}
+
+for (const page of PAGES) {
+  Deno.test(`${page.path} has a static, descriptive <title> in <head>`, async () => {
+    const html = await Deno.readTextFile(page.path);
+    const head = headOf(html);
+    const title = titleText(head);
+    assert(title !== null, `${page.path} <head> must contain a <title>`);
+    assertEquals(
+      title,
+      page.title,
+      `${page.path} <title> must be the descriptive static text`,
+    );
+    assert(
+      (title as string).length > 0,
+      `${page.path} <title> must be non-empty`,
+    );
+  });
+}
+
+/**
+ * Minimal document stub so we can execute docs/version.js in Deno and observe
+ * the document.title it produces, without a full DOM.
+ */
+function makeDoc(
+  metas: Record<string, string>,
+  staticTitle: string,
+) {
+  return {
+    title: staticTitle,
+    querySelector(sel: string) {
+      const m = sel.match(/meta\[name="([^"]+)"\]/);
+      if (m && metas[m[1]] !== undefined) {
+        const name = m[1];
+        return {
+          getAttribute: (attr: string) =>
+            attr === "content" ? metas[name] : null,
+        };
+      }
+      return null;
+    },
+    addEventListener() {},
+    getElementById() {
+      return null;
+    },
+  };
+}
+
+function runVersionJs(
+  code: string,
+  doc: ReturnType<typeof makeDoc>,
+) {
+  const fakeGlobal: Record<string, unknown> = {};
+  // version.js references `document` and `globalThis` as free variables; pass
+  // both as parameters so the IIFE runs against our stubs in isolation.
+  new Function("document", "globalThis", code)(doc, fakeGlobal);
+  return fakeGlobal;
+}
+
+Deno.test("version.js augments a static <title> with the version", async () => {
+  const code = await Deno.readTextFile("docs/version.js");
+  const doc = makeDoc(
+    { "app-version": "1.2.3", "app-title": "GRQ Validation Dashboard" },
+    "GRQ Validation Dashboard",
+  );
+  const g = runVersionJs(code, doc);
+  assertEquals(doc.title, "GRQ Validation Dashboard v1.2.3");
+  assertEquals(g.VERSION, "1.2.3");
+});
+
+Deno.test("version.js does not blank a static <title> when version is empty", async () => {
+  const code = await Deno.readTextFile("docs/version.js");
+  const doc = makeDoc(
+    { "app-title": "GRQ Validation Dashboard" },
+    "GRQ Validation Trend",
+  );
+  runVersionJs(code, doc);
+  // No app-version meta → keep the static title intact (no dangling " v").
+  assertEquals(doc.title, "GRQ Validation Trend");
+  assert(!doc.title.includes(" v"), "must not append an empty version suffix");
+});
+
+Deno.test("version.js falls back to app-title meta when no static title", async () => {
+  const code = await Deno.readTextFile("docs/version.js");
+  const doc = makeDoc(
+    { "app-version": "9.9.9", "app-title": "GRQ Validation Trend" },
+    "",
+  );
+  runVersionJs(code, doc);
+  assertStringIncludes(doc.title, "GRQ Validation Trend");
+  assertStringIncludes(doc.title, "v9.9.9");
+});


### PR DESCRIPTION
# PR Summary — Static `<title>` on dashboard pages (Issue #694)

## Summary

`docs/index.html` and `docs/trend.html` carried no static `<title>` element —
the document title was injected solely at runtime by `version.js`. Any consumer
that read the page before script execution (some crawlers, view-source, no-JS
contexts) therefore saw no title, failing the HTML best-practices requirement
for a present, descriptive `<title>`.

This PR adds a descriptive static `<title>` to each `<head>`
(`GRQ Validation Dashboard` and `GRQ Validation Trend`) and changes
`version.js` to **augment** that static title — appending the version — rather
than being the sole source. When no static title is present it still falls back
to the `app-title` meta, and it never emits a dangling `" v"` suffix when the
version is unknown. The rendered, JS-enabled title is unchanged
(e.g. `GRQ Validation Dashboard v1.1.47`).

Closes #694.

## Evidence

Static titles are now present before any script runs. Served locally via a
static file server and fetched with `curl` (no JS execution):

```text
$ curl -s http://localhost:8080/index.html | grep -o '<title>[^<]*</title>'
<title>GRQ Validation Dashboard</title>
$ curl -s http://localhost:8080/trend.html | grep -o '<title>[^<]*</title>'
<title>GRQ Validation Trend</title>
```

Title bootstrap flow:

```mermaid
flowchart LR
    A["Static &lt;title&gt; in &lt;head&gt;"] --> B{JS enabled?}
    B -- No --> C["Crawler / view-source<br/>sees descriptive title"]
    B -- Yes --> D["version.js appends<br/>&quot; v&lt;VERSION&gt;&quot;"]
    D --> E["Tab shows<br/>'... vX.Y.Z'"]
```

Playwright MCP browser tooling was unavailable in this run, so runtime
behaviour was verified programmatically instead: `tests/static_title_test.ts`
executes `docs/version.js` against a minimal document stub and asserts the
augmented `document.title`.

## Test Plan

Added `tests/static_title_test.ts`:

- `docs/index.html` / `docs/trend.html` each contain a static, descriptive
  `<title>` inside `<head>`.
- `version.js` augments a static `<title>` with the version
  (`GRQ Validation Dashboard` → `GRQ Validation Dashboard v1.2.3`).
- `version.js` does not blank a static title nor append an empty `" v"` when no
  `app-version` meta is present.
- `version.js` falls back to the `app-title` meta when the document has no
  static title.

All tests pass and `./quality.sh` completes cleanly.
