### PR TITLE
Add scope="col" to #stockTable data-table headers (Issue #696)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3320,15 +3320,15 @@ class GRQValidator {
                 "#stockTable thead tr",
             );
             thead.innerHTML = `
-          <th>Stock</th>
-          <th>Buy Price</th>
-          <th>Stars</th>
-          <th>90-Day Target</th>
-          <th>90-Day Actual</th>
-          <th>Gain/Loss (%)</th>
-          <th title="${RETURN_ABOVE_COST_OF_CAPITAL_DEFINITION}">${RETURN_ABOVE_COST_OF_CAPITAL_LABEL}</th>
-          <th>Status/Projection</th>
-          <th>Dividends</th>
+          <th scope="col">Stock</th>
+          <th scope="col">Buy Price</th>
+          <th scope="col">Stars</th>
+          <th scope="col">90-Day Target</th>
+          <th scope="col">90-Day Actual</th>
+          <th scope="col">Gain/Loss (%)</th>
+          <th scope="col" title="${RETURN_ABOVE_COST_OF_CAPITAL_DEFINITION}">${RETURN_ABOVE_COST_OF_CAPITAL_LABEL}</th>
+          <th scope="col">Status/Projection</th>
+          <th scope="col">Dividends</th>
         `;
 
             let totalPerformance = 0;
@@ -3574,14 +3574,14 @@ class GRQValidator {
         // Update table headers for basic view (no market data)
         const thead = document.querySelector("#stockTable thead tr");
         thead.innerHTML = `
-            <th>Stock</th>
-            <th>Score</th>
-            <th>90-Day Target</th>
-            <th>Ex-Dividend Date</th>
-            <th>Dividend Per Share</th>
-            <th>Intrinsic Value (Basic)</th>
-            <th>Intrinsic Value (Adjusted)</th>
-            <th>Notes</th>
+            <th scope="col">Stock</th>
+            <th scope="col">Score</th>
+            <th scope="col">90-Day Target</th>
+            <th scope="col">Ex-Dividend Date</th>
+            <th scope="col">Dividend Per Share</th>
+            <th scope="col">Intrinsic Value (Basic)</th>
+            <th scope="col">Intrinsic Value (Adjusted)</th>
+            <th scope="col">Notes</th>
         `;
 
         // Show all stocks with basic score data

--- a/docs/archive/pr-summaries/pr-summary-696.md
+++ b/docs/archive/pr-summaries/pr-summary-696.md
@@ -1,0 +1,59 @@
+# Data table `#stockTable` headers now declare `scope="col"`
+
+## Summary
+
+`#stockTable` is a genuine data table (score / price / target columns) but its
+column-header `<th>` cells carried no `scope`, weakening cell-to-header
+association for screen readers. This PR adds `scope="col"` to every
+column-header `<th>`.
+
+The header row lives in **three** places that must stay consistent, so all
+three were fixed — otherwise the runtime rebuild would silently drop the
+attribute the static markup added:
+
+1. `docs/index.html` — the static `#stockTable <thead>` (initial render).
+2. `docs/app.js` — the **aggregate market view** `thead.innerHTML` rebuild.
+3. `docs/app.js` — the **basic (no-market-data) view** `thead.innerHTML` rebuild.
+
+The `#stockTableBody` rows contain only `<td>` data cells — there are no `<th>`
+row-header cells — so the finding's optional `scope="row"` suggestion has no
+applicable cells and no `<td>`→`<th>` conversion was made (that would have
+changed the first-column visual styling via the `.stock-table th` rule).
+
+Closes #696.
+
+## Evidence
+
+Purely additive semantic-accessibility attribute — `scope="col"` produces **no
+visual change**, so a screenshot is not meaningful here. Evidence is behavioural:
+
+- New Deno tests (below) parse the real committed markup and assert every
+  `<th>` in each of the three header templates carries `scope="col"`.
+- Served-page check confirmed the attribute reaches the browser: `docs/app.js`
+  serves 17 `scope="col"` occurrences and `docs/index.html`'s `#stockTable`
+  `<thead>` renders each header with `scope="col"`.
+- Full suite: `deno test --allow-read tests/*.ts` → **1296 passed, 0 failed**.
+
+```mermaid
+flowchart LR
+    A["docs/index.html<br/>static &lt;thead&gt;"] -->|initial render| T["#stockTable header row"]
+    B["app.js aggregate-view<br/>thead.innerHTML"] -->|market view rebuild| T
+    C["app.js basic-view<br/>thead.innerHTML"] -->|no-market-data rebuild| T
+    T --> S["every &lt;th&gt; carries scope=&quot;col&quot;"]
+```
+
+## Test Plan
+
+Added `tests/stock_table_header_scope_test.ts`:
+
+- `index.html: static #stockTable headers all carry scope=col` — parses the
+  static `<thead>` and asserts every `<th>` has `scope="col"`.
+- `app.js: aggregate-view header rebuild carries scope=col` — extracts the
+  market-view `thead.innerHTML` template and asserts the same.
+- `app.js: basic-view header rebuild carries scope=col` — extracts the
+  basic-view template and asserts the same.
+- `thCells: counts and isolates top-level <th> cells` — unit test for the
+  cell-splitting helper.
+
+These fail against the pre-fix markup (all three header locations lacked
+`scope`) and pass after the change.

--- a/docs/index.html
+++ b/docs/index.html
@@ -368,23 +368,24 @@
                       >
                         <thead>
                           <tr>
-                            <th>Stock</th>
-                            <th>Score</th>
-                            <th>Buy Price</th>
-                            <th>Stars</th>
-                            <th>90-Day Target</th>
-                            <th>90-Day Actual</th>
-                            <th>Gain/Loss (%)</th>
+                            <th scope="col">Stock</th>
+                            <th scope="col">Score</th>
+                            <th scope="col">Buy Price</th>
+                            <th scope="col">Stars</th>
+                            <th scope="col">90-Day Target</th>
+                            <th scope="col">90-Day Actual</th>
+                            <th scope="col">Gain/Loss (%)</th>
                             <th
+                              scope="col"
                               title="Return above the 10% annualised cost-of-capital hurdle, pro-rated by days elapsed. Positive = beating the hurdle."
                             >Return above Cost of Capital</th>
-                            <th>Judgement (90-day)</th>
-                            <th>Intrinsic Value (Basic)</th>
-                            <th>Intrinsic Value (Adjusted)</th>
-                            <th>Ex-Dividend Date</th>
-                            <th>Average Dividend (90-day)</th>
-                            <th>Total Dividends (90-day)</th>
-                            <th>Notes</th>
+                            <th scope="col">Judgement (90-day)</th>
+                            <th scope="col">Intrinsic Value (Basic)</th>
+                            <th scope="col">Intrinsic Value (Adjusted)</th>
+                            <th scope="col">Ex-Dividend Date</th>
+                            <th scope="col">Average Dividend (90-day)</th>
+                            <th scope="col">Total Dividends (90-day)</th>
+                            <th scope="col">Notes</th>
                           </tr>
                         </thead>
                         <tbody id="stockTableBody"></tbody>

--- a/tests/stock_table_header_scope_test.ts
+++ b/tests/stock_table_header_scope_test.ts
@@ -1,0 +1,117 @@
+// Tests for `scope="col"` on the #stockTable column headers (issue #696).
+//
+// The HTML bucket requires data-table `<th>` header cells to carry an explicit
+// `scope` so screen readers can associate each data cell with its column
+// header. `#stockTable` is a genuine data table (score/price/target columns),
+// so every column-header `<th>` must declare `scope="col"`.
+//
+// The header row exists in THREE places that must stay consistent:
+//   1. the static markup in docs/index.html (initial render), and
+//   2. two `thead.innerHTML` templates in docs/app.js that REBUILD the header
+//      at runtime — the aggregate market view and the basic (no-market-data)
+//      view. If only the static markup were fixed, the runtime rebuild would
+//      silently drop the scope again, so all three are asserted here.
+//
+// These assertions parse the REAL committed markup, not source keywords, and
+// verify the structural invariant: within each header template, every `<th>`
+// carries `scope="col"`.
+
+import { assert, assertEquals } from "@std/assert";
+
+const INDEX_HTML = "docs/index.html";
+const APP_JS = "docs/app.js";
+
+/** Split a run of markup into its top-level `<th>` cells. `<th>` cells are
+ *  never nested in this markup, so each open tag begins exactly one cell. */
+function thCells(html: string): string[] {
+  return html.split(/<th[\s>]/).slice(1);
+}
+
+/** Assert every `<th>` cell in `headerHtml` carries `scope="col"`. */
+function assertAllHaveScopeCol(headerHtml: string, label: string): void {
+  const cells = thCells(headerHtml);
+  assert(cells.length > 0, `${label}: expected at least one <th> cell`);
+  cells.forEach((cell, i) => {
+    // The cell chunk starts immediately after `<th` (the split consumed the
+    // trailing whitespace/`>`); the attributes run up to the first `>`.
+    const attrs = cell.slice(0, cell.indexOf(">"));
+    assert(
+      /\bscope\s*=\s*"col"/.test(attrs),
+      `${label}: <th> #${i + 1} lacks scope="col" — attrs were: <th ${attrs}>`,
+    );
+  });
+}
+
+/** Extract the static #stockTable <thead> ... </thead> from docs/index.html. */
+function extractStaticThead(html: string): string {
+  const tableStart = html.indexOf('id="stockTable"');
+  assert(tableStart !== -1, "could not find #stockTable in index.html");
+  const theadStart = html.indexOf("<thead", tableStart);
+  const theadEnd = html.indexOf("</thead>", theadStart);
+  assert(
+    theadStart !== -1 && theadEnd !== -1,
+    "could not find #stockTable <thead>",
+  );
+  return html.slice(theadStart, theadEnd);
+}
+
+/** Extract the first `thead.innerHTML = \`...\`` template body in `src` whose
+ *  body contains every marker in `must` (disambiguates the two templates). */
+function extractHeadTemplate(src: string, must: string[]): string {
+  const marker = "thead.innerHTML = `";
+  let from = 0;
+  while (true) {
+    const start = src.indexOf(marker, from);
+    assert(
+      start !== -1,
+      `could not find thead.innerHTML template matching ${must}`,
+    );
+    const bodyStart = start + marker.length;
+    const end = src.indexOf("`", bodyStart);
+    assert(end !== -1, "unterminated template literal");
+    const body = src.slice(bodyStart, end);
+    if (must.every((m) => body.includes(m))) return body;
+    from = end + 1;
+  }
+}
+
+Deno.test("index.html: static #stockTable headers all carry scope=col", async () => {
+  const html = await Deno.readTextFile(INDEX_HTML);
+  const thead = extractStaticThead(html);
+  // Sanity: the header we expect is present so we are asserting the right table.
+  assert(
+    thead.includes("Stock"),
+    "static thead should include the Stock column",
+  );
+  assert(
+    thead.includes("Notes"),
+    "static thead should include the Notes column",
+  );
+  assertAllHaveScopeCol(thead, "index.html static thead");
+});
+
+Deno.test("app.js: aggregate-view header rebuild carries scope=col", async () => {
+  const src = await Deno.readTextFile(APP_JS);
+  const template = extractHeadTemplate(src, [
+    "Buy Price",
+    "Stars",
+    "Gain/Loss",
+    "Dividends",
+  ]);
+  assertAllHaveScopeCol(template, "app.js aggregate-view thead");
+});
+
+Deno.test("app.js: basic-view header rebuild carries scope=col", async () => {
+  const src = await Deno.readTextFile(APP_JS);
+  const template = extractHeadTemplate(src, [
+    "Dividend Per Share",
+    "Intrinsic Value (Basic)",
+    "Notes",
+  ]);
+  assertAllHaveScopeCol(template, "app.js basic-view thead");
+});
+
+Deno.test("thCells: counts and isolates top-level <th> cells", () => {
+  const cells = thCells(`<th scope="col">A</th><th>B</th>`);
+  assertEquals(cells.length, 2);
+});


### PR DESCRIPTION
# Data table `#stockTable` headers now declare `scope="col"`

## Summary

`#stockTable` is a genuine data table (score / price / target columns) but its
column-header `<th>` cells carried no `scope`, weakening cell-to-header
association for screen readers. This PR adds `scope="col"` to every
column-header `<th>`.

The header row lives in **three** places that must stay consistent, so all
three were fixed — otherwise the runtime rebuild would silently drop the
attribute the static markup added:

1. `docs/index.html` — the static `#stockTable <thead>` (initial render).
2. `docs/app.js` — the **aggregate market view** `thead.innerHTML` rebuild.
3. `docs/app.js` — the **basic (no-market-data) view** `thead.innerHTML` rebuild.

The `#stockTableBody` rows contain only `<td>` data cells — there are no `<th>`
row-header cells — so the finding's optional `scope="row"` suggestion has no
applicable cells and no `<td>`→`<th>` conversion was made (that would have
changed the first-column visual styling via the `.stock-table th` rule).

Closes #696.

## Evidence

Purely additive semantic-accessibility attribute — `scope="col"` produces **no
visual change**, so a screenshot is not meaningful here. Evidence is behavioural:

- New Deno tests (below) parse the real committed markup and assert every
  `<th>` in each of the three header templates carries `scope="col"`.
- Served-page check confirmed the attribute reaches the browser: `docs/app.js`
  serves 17 `scope="col"` occurrences and `docs/index.html`'s `#stockTable`
  `<thead>` renders each header with `scope="col"`.
- Full suite: `deno test --allow-read tests/*.ts` → **1296 passed, 0 failed**.

```mermaid
flowchart LR
    A["docs/index.html<br/>static &lt;thead&gt;"] -->|initial render| T["#stockTable header row"]
    B["app.js aggregate-view<br/>thead.innerHTML"] -->|market view rebuild| T
    C["app.js basic-view<br/>thead.innerHTML"] -->|no-market-data rebuild| T
    T --> S["every &lt;th&gt; carries scope=&quot;col&quot;"]
```

## Test Plan

Added `tests/stock_table_header_scope_test.ts`:

- `index.html: static #stockTable headers all carry scope=col` — parses the
  static `<thead>` and asserts every `<th>` has `scope="col"`.
- `app.js: aggregate-view header rebuild carries scope=col` — extracts the
  market-view `thead.innerHTML` template and asserts the same.
- `app.js: basic-view header rebuild carries scope=col` — extracts the
  basic-view template and asserts the same.
- `thCells: counts and isolates top-level <th> cells` — unit test for the
  cell-splitting helper.

These fail against the pre-fix markup (all three header locations lacked
`scope`) and pass after the change.
