### PR TITLE
fix: harden Pages deploy against duplicate github-pages artifacts (#706)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,26 +232,72 @@ jobs:
       needs.check-changes.outputs.docs-changed == 'true'
     # A per-job block fully overrides the top-level default, so contents: read
     # is restated here for the checkout step alongside the Pages elevation.
+    # actions: write is needed so the cleanup step below can delete stale
+    # github-pages* artifacts left by an earlier attempt (Issue #706).
     permissions:
       contents: read
       pages: write
       id-token: write
+      actions: write
     steps:
     - name: Checkout code
       # actions/checkout@v4.2.2
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      
+
     - name: Setup Pages
       # actions/configure-pages@v4.0.0
       uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
-      
+
+    # Belt-and-braces against the duplicate-artifact failure (Issue #706).
+    # `deploy-pages` hard-fails when a run holds more than one `github-pages`
+    # artifact ("Multiple artifacts named github-pages … Artifact count is 2").
+    # A manual re-run reuses the same run id, so an earlier attempt's artifact
+    # lingers. Delete any leftover github-pages* artifacts on this run before
+    # uploading a fresh one.
+    - name: Delete stale github-pages artifacts from this run
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        artifacts=$(gh api \
+          "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+          --paginate \
+          --jq '.artifacts[] | select(.name | startswith("github-pages")) | .id')
+        for id in $artifacts; do
+          echo "Deleting stale artifact $id"
+          gh api -X DELETE "repos/${{ github.repository }}/actions/artifacts/$id"
+        done
+
+    # Upload under a per-attempt name so a re-run never collides with an
+    # earlier attempt's artifact (Issue #706).
     - name: Upload artifact
       # actions/upload-pages-artifact@v3.0.1
       uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
       with:
         path: ./docs
-      
+        name: github-pages-${{ github.run_attempt }}
+
+    # First deploy attempt. continue-on-error keeps the job alive so a
+    # GitHub-side transient (as seen in Issue #706 attempt 1) can be retried.
     - name: Deploy to GitHub Pages
       id: deployment
+      continue-on-error: true
       # actions/deploy-pages@v4.0.5
       uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+      with:
+        artifact_name: github-pages-${{ github.run_attempt }}
+
+    # Short pause before the single automatic retry so a transient can clear.
+    - name: Wait before retrying deploy
+      if: steps.deployment.outcome == 'failure'
+      run: sleep 30
+
+    # One automatic retry so unattended daily deploys self-recover. If this
+    # attempt fails the step (and job) fails as normal.
+    - name: Retry deploy to GitHub Pages
+      id: deployment_retry
+      if: steps.deployment.outcome == 'failure'
+      # actions/deploy-pages@v4.0.5
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+      with:
+        artifact_name: github-pages-${{ github.run_attempt }}

--- a/docs/archive/pr-summaries/pr-summary-706.md
+++ b/docs/archive/pr-summaries/pr-summary-706.md
@@ -1,0 +1,78 @@
+# Pages deploy re-runs no longer fail on duplicate github-pages artifacts
+
+## Summary
+
+Re-running a failed CI/CD run deterministically failed because
+`upload-pages-artifact` added a second `github-pages` artifact onto the same
+run and `deploy-pages` hard-fails when it finds more than one (`Multiple
+artifacts named github-pages … Artifact count is 2`). Attempt 1 of the
+triggering run had also failed on a GitHub-side transient, so an unattended
+daily deploy had no way to self-recover.
+
+This hardens the `deploy-pages` job in `.github/workflows/ci.yml` (belt and
+braces):
+
+- **Per-attempt artifact name** — upload as
+  {% raw %}`github-pages-${{ github.run_attempt }}`{% endraw %} and point
+  `deploy-pages` at the same `artifact_name`, so a re-run never collides with an
+  earlier attempt's artifact.
+- **Stale-artifact cleanup** — before upload, delete any leftover
+  `github-pages*` artifacts on the current run via the Actions API. The job now
+  also grants `actions: write` for this.
+- **One automatic retry** — the first deploy uses `continue-on-error`, a 30 s
+  wait follows, then a single retry step runs only when the first attempt
+  failed. Transient GitHub-side failures self-recover; a second failure fails
+  the job as normal.
+
+The check/test/build jobs are unchanged, and `deploy-pages` stays main-only.
+
+Closes #706.
+
+## Evidence
+
+Backend/workflow-only change — no web UI to screenshot. Verified via the new
+Deno tests that parse the workflow as structured data (not source-text greps)
+plus the existing CI workflow suite; all pass.
+
+```mermaid
+flowchart TD
+    A[Setup Pages] --> B[Delete stale github-pages* artifacts on this run]
+    B --> C[Upload artifact as github-pages-RUN_ATTEMPT]
+    C --> D[Deploy attempt 1<br/>continue-on-error]
+    D -->|success| E[Done]
+    D -->|failure| F[sleep 30]
+    F --> G[Retry deploy once]
+    G -->|success| E
+    G -->|failure| H[Job fails]
+```
+
+Test run:
+
+```
+deno test --allow-read tests/pages_deploy_rerun_test.ts tests/ci_workflow_test.ts
+ok | 19 passed | 0 failed
+```
+
+Full suite: `deno test --allow-read tests/*.ts` → `1310 passed | 0 failed`.
+
+## Test Plan
+
+Added `tests/pages_deploy_rerun_test.ts`, which reproduces the failure mode and
+verifies the fix:
+
+- `deploy-pages job grants actions: write for artifact cleanup`
+- `deploy-pages preserves its existing elevated permissions`
+- `upload-pages-artifact uses a per-attempt artifact name`
+- `deploy-pages targets the same per-attempt artifact name`
+- `deploy-pages deletes stale github-pages artifacts before upload`
+- `deploy step is retried once after a wait on transient failure`
+
+Existing `tests/ci_workflow_test.ts` continues to pass unchanged, confirming no
+regression to SHA pinning, permissions scoping, concurrency, triggers, or the
+main-only Pages guard.
+
+## Note
+
+Re-running the original failed run (28620059487) replays the old workflow
+snapshot and will still fail; the live site catches up on the next fresh push
+to `main`. The fix applies to future runs.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.49">
+    <meta name="app-version" content="1.1.50">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.49"></script>
+    <script src="escape.js?v=1.1.50"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.49"></script>
+    <script src="projection.js?v=1.1.50"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.49"></script>
+    <script src="volume_recommend.js?v=1.1.50"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.49"></script>
+    <script src="chart_window_settings.js?v=1.1.50"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.49"></script>
+    <script src="star_filter_settings.js?v=1.1.50"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.49"></script>
+    <script src="color_key.js?v=1.1.50"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.49"></script>
+    <script src="series_label_colour.js?v=1.1.50"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.49"></script>
+    <script src="chart_theme.js?v=1.1.50"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.49"></script>
+    <script src="chart_title.js?v=1.1.50"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.49"></script>
+    <script src="format.js?v=1.1.50"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.49"></script>
+    <script src="market_index.js?v=1.1.50"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.49"></script>
+    <script src="stock_selection.js?v=1.1.50"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.49"></script>
+    <script src="yahoo_finance.js?v=1.1.50"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.49"></script>
+    <script src="date_selection.js?v=1.1.50"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.49"></script>
+    <script src="view_selection.js?v=1.1.50"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.49"></script>
+    <script src="popover_dismiss.js?v=1.1.50"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.49"></script>
+    <script src="popover_cleanup.js?v=1.1.50"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.49"></script>
+    <script src="chart_popout.js?v=1.1.50"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.49"></script>
+    <script src="share_link.js?v=1.1.50"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.49"></script>
+    <script src="field_label.js?v=1.1.50"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.49"></script>
+    <script src="freshness_text.js?v=1.1.50"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.49"></script>
+    <script src="dashboard_boot.js?v=1.1.50"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.49"></script>
+    <script src="sw-register.js?v=1.1.50"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.49")
+    navigator.serviceWorker.register("./sw.js?v=1.1.50")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.49";
+const APP_VERSION = "1.1.50";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.49">
+    <meta name="app-version" content="1.1.50">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -241,6 +241,6 @@
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.49"></script>
+    <script src="sw-register.js?v=1.1.50"></script>
   </body>
 </html>

--- a/tests/pages_deploy_rerun_test.ts
+++ b/tests/pages_deploy_rerun_test.ts
@@ -1,0 +1,153 @@
+// Tests for the Pages deploy re-run hardening in the CI/CD workflow
+// (Issue #706).
+//
+// Re-running a failed CI/CD run previously failed deterministically:
+// `upload-pages-artifact` uploaded a second `github-pages` artifact onto the
+// same run and `deploy-pages` hard-fails when it finds more than one
+// ("Multiple artifacts named github-pages … Artifact count is 2"). The
+// workflow must therefore:
+//   * upload under a per-attempt artifact name keyed on github.run_attempt,
+//   * point deploy-pages at that same per-attempt name,
+//   * delete any leftover github-pages* artifacts on the current run before
+//     uploading (requires actions: write), and
+//   * retry the deploy step once after a short wait so unattended daily
+//     deploys self-recover from GitHub-side transients.
+//
+// These assertions operate on the parsed workflow (structured data), not on
+// source-text greps, so behaviour-preserving edits do not break them.
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  commandSegments,
+  loadWorkflow,
+  type WorkflowStep,
+  workflowSteps,
+} from "./workflow_assertions.ts";
+
+const WORKFLOW_PATH = ".github/workflows/ci.yml";
+
+function deploySteps(steps: WorkflowStep[]): WorkflowStep[] {
+  return steps.filter((s) =>
+    typeof s.uses === "string" && s.uses.startsWith("actions/deploy-pages@")
+  );
+}
+
+function uploadStep(steps: WorkflowStep[]): WorkflowStep | undefined {
+  return steps.find((s) =>
+    typeof s.uses === "string" &&
+    s.uses.startsWith("actions/upload-pages-artifact@")
+  );
+}
+
+Deno.test("deploy-pages job grants actions: write for artifact cleanup", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  const perms = doc.jobs?.["deploy-pages"]?.permissions;
+  assert(perms, "deploy-pages must declare its own permissions block");
+  assertEquals(
+    perms.actions,
+    "write",
+    "deploy-pages needs actions: write to delete stale artifacts",
+  );
+});
+
+Deno.test("deploy-pages preserves its existing elevated permissions", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  const perms = doc.jobs?.["deploy-pages"]?.permissions ?? {};
+  assertEquals(perms.pages, "write", "deploy-pages still needs pages: write");
+  assertEquals(
+    perms["id-token"],
+    "write",
+    "deploy-pages still needs id-token: write",
+  );
+  assertEquals(
+    perms.contents,
+    "read",
+    "deploy-pages still needs contents: read for checkout",
+  );
+});
+
+Deno.test("upload-pages-artifact uses a per-attempt artifact name", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  const steps = workflowSteps(doc, "deploy-pages");
+  const upload = uploadStep(steps);
+  assert(upload, "deploy-pages must upload a Pages artifact");
+  const name = String(upload.with?.name ?? "");
+  assert(
+    name.includes("github.run_attempt"),
+    `upload artifact name must be keyed on run_attempt, got "${name}"`,
+  );
+});
+
+Deno.test("deploy-pages targets the same per-attempt artifact name", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  const steps = workflowSteps(doc, "deploy-pages");
+  const upload = uploadStep(steps);
+  const deploys = deploySteps(steps);
+  assert(deploys.length > 0, "deploy-pages must run actions/deploy-pages");
+  const uploadName = String(upload?.with?.name ?? "");
+  for (const deploy of deploys) {
+    const artifactName = String(deploy.with?.artifact_name ?? "");
+    assertEquals(
+      artifactName,
+      uploadName,
+      "deploy-pages artifact_name must match the uploaded per-attempt name",
+    );
+  }
+});
+
+Deno.test("deploy-pages deletes stale github-pages artifacts before upload", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  const steps = workflowSteps(doc, "deploy-pages");
+  const uploadIdx = steps.findIndex((s) =>
+    typeof s.uses === "string" &&
+    s.uses.startsWith("actions/upload-pages-artifact@")
+  );
+  assert(uploadIdx >= 0, "upload step must exist");
+
+  const cleanupIdx = steps.findIndex((s) => {
+    const segments = commandSegments(s.run ?? "");
+    // A cleanup segment invokes `gh api` with a DELETE against artifacts.
+    return segments.some((seg) => {
+      const tokens = seg.split(/\s+/);
+      return tokens.includes("gh") && tokens.includes("api") &&
+        /delete/i.test(seg) && /artifact/i.test(seg);
+    });
+  });
+  assert(
+    cleanupIdx >= 0,
+    "a step must delete stale github-pages artifacts via the Actions API",
+  );
+  assert(
+    cleanupIdx < uploadIdx,
+    "artifact cleanup must run before the upload step",
+  );
+});
+
+Deno.test("deploy step is retried once after a wait on transient failure", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  const steps = workflowSteps(doc, "deploy-pages");
+  const deploys = deploySteps(steps);
+  assert(
+    deploys.length >= 2,
+    "there must be an initial deploy and a retry deploy step",
+  );
+
+  const [first, second] = deploys;
+  assertEquals(
+    first["continue-on-error" as keyof WorkflowStep] ??
+      (first as Record<string, unknown>)["continue-on-error"],
+    true,
+    "the first deploy must not fail the job so the retry can run",
+  );
+  const retryIf = String((second as Record<string, unknown>).if ?? "");
+  assert(
+    retryIf.includes("failure"),
+    "the retry deploy must be conditioned on the first attempt failing",
+  );
+
+  // A wait must separate the two attempts so a GitHub-side transient can clear.
+  const hasWait = steps.some((s) =>
+    commandSegments(s.run ?? "").some((seg) => /\bsleep\b/.test(seg))
+  );
+  assert(hasWait, "a wait (sleep) must separate the deploy attempts");
+});


### PR DESCRIPTION
# Pages deploy re-runs no longer fail on duplicate github-pages artifacts

## Summary

Re-running a failed CI/CD run deterministically failed because
`upload-pages-artifact` added a second `github-pages` artifact onto the same
run and `deploy-pages` hard-fails when it finds more than one (`Multiple
artifacts named github-pages … Artifact count is 2`). Attempt 1 of the
triggering run had also failed on a GitHub-side transient, so an unattended
daily deploy had no way to self-recover.

This hardens the `deploy-pages` job in `.github/workflows/ci.yml` (belt and
braces):

- **Per-attempt artifact name** — upload as
  {% raw %}`github-pages-${{ github.run_attempt }}`{% endraw %} and point
  `deploy-pages` at the same `artifact_name`, so a re-run never collides with an
  earlier attempt's artifact.
- **Stale-artifact cleanup** — before upload, delete any leftover
  `github-pages*` artifacts on the current run via the Actions API. The job now
  also grants `actions: write` for this.
- **One automatic retry** — the first deploy uses `continue-on-error`, a 30 s
  wait follows, then a single retry step runs only when the first attempt
  failed. Transient GitHub-side failures self-recover; a second failure fails
  the job as normal.

The check/test/build jobs are unchanged, and `deploy-pages` stays main-only.

Closes #706.

## Evidence

Backend/workflow-only change — no web UI to screenshot. Verified via the new
Deno tests that parse the workflow as structured data (not source-text greps)
plus the existing CI workflow suite; all pass.

```mermaid
flowchart TD
    A[Setup Pages] --> B[Delete stale github-pages* artifacts on this run]
    B --> C[Upload artifact as github-pages-RUN_ATTEMPT]
    C --> D[Deploy attempt 1<br/>continue-on-error]
    D -->|success| E[Done]
    D -->|failure| F[sleep 30]
    F --> G[Retry deploy once]
    G -->|success| E
    G -->|failure| H[Job fails]
```

Test run:

```
deno test --allow-read tests/pages_deploy_rerun_test.ts tests/ci_workflow_test.ts
ok | 19 passed | 0 failed
```

Full suite: `deno test --allow-read tests/*.ts` → `1310 passed | 0 failed`.

## Test Plan

Added `tests/pages_deploy_rerun_test.ts`, which reproduces the failure mode and
verifies the fix:

- `deploy-pages job grants actions: write for artifact cleanup`
- `deploy-pages preserves its existing elevated permissions`
- `upload-pages-artifact uses a per-attempt artifact name`
- `deploy-pages targets the same per-attempt artifact name`
- `deploy-pages deletes stale github-pages artifacts before upload`
- `deploy step is retried once after a wait on transient failure`

Existing `tests/ci_workflow_test.ts` continues to pass unchanged, confirming no
regression to SHA pinning, permissions scoping, concurrency, triggers, or the
main-only Pages guard.

## Note

Re-running the original failed run (28620059487) replays the old workflow
snapshot and will still fail; the live site catches up on the next fresh push
to `main`. The fix applies to future runs.
