### PR TITLE
fix: re-theme live charts on theme switch (Issue #708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ and this project adheres to
 
 ### Fixed
 
+- Charts no longer keep the previous theme's colours after a theme switch,
+  which left the canvas-drawn axis ticks, axis titles and legend unreadable
+  (near-white text on a light page after switching to light; dark-on-dark after
+  switching to dark). Chart.js paints those colours once at build, so the fix
+  adds `GRQChartTheme.applyChartTheme(chart, theme)` — the single source of
+  truth that re-sources every canvas colour from the theme and repaints the
+  live chart — and calls it on the theme-toggle click and the
+  `prefers-color-scheme` change for the main dashboard chart (which the mobile
+  pop-out re-parents) and the trend chart, in both switch directions
+  (Issue #708).
 - Re-restored the 161 market-data CSVs under `docs/scores/2026/` (and their
   `index.json` performance figures) after a fresh "Auto commit models" push
   (`642eb620`, author `scorer 3`) re-wiped every one back to a lone header row —

--- a/docs/app.js
+++ b/docs/app.js
@@ -5287,14 +5287,28 @@ class GRQValidator {
 // Initialize the validator
 const validator = new GRQValidator();
 
-// Re-derive the market title colours when the theme changes so they stay
-// AA-contrast-compliant against the new background (issue #278). The chart is
-// not rebuilt on a theme switch, so without this the titles would keep the
-// other theme's colours. Handlers are attached via addEventListener (no inline
+// Re-theme the live charts and re-derive the market title colours when the
+// theme changes so both stay legible and AA-contrast-compliant against the new
+// background (issues #278, #708). Chart.js paints the canvas title, axis
+// titles, tick labels, legend and grid ONCE at build, so without re-applying
+// the theme here the chart keeps the previous theme's colours — unreadable text
+// after a switch. GRQChartTheme.applyChartTheme re-sources every colour from the
+// theme and repaints the live chart (which the mobile pop-out re-parents, so
+// this covers it too). Handlers are attached via addEventListener (no inline
 // on* handlers, issue #268) and deferred so theme.js updates the <body> class
 // before we read it.
+function reapplyChartTheme() {
+    if (!globalThis.GRQChartTheme || !validator.chart) return;
+    globalThis.GRQChartTheme.applyChartTheme(
+        validator.chart,
+        validator.detectTheme(),
+    );
+}
 function reapplyMarketTitleColours() {
-    setTimeout(() => validator.applyMarketTitleColours(), 0);
+    setTimeout(() => {
+        reapplyChartTheme();
+        validator.applyMarketTitleColours();
+    }, 0);
 }
 const themeToggle = document.getElementById("theme-toggle");
 if (themeToggle) {

--- a/docs/archive/pr-summaries/pr-summary-708.md
+++ b/docs/archive/pr-summaries/pr-summary-708.md
@@ -1,0 +1,91 @@
+# Re-theme live charts on theme switch (Issue #708)
+
+## Summary
+
+The dashboard charts kept the **previous** theme's colours after the theme
+changed, leaving the canvas-drawn axis ticks, axis titles and desktop legend
+unreadable — near-white text on a white page after switching to light, and
+dark text on a dark page after switching to dark.
+
+**Root cause:** Chart.js paints axis ticks, axis titles, the legend and grid
+lines **once** at chart build from `GRQChartTheme.chartTheme(detectTheme())`
+(`docs/app.js`, `docs/trend.js`). The existing theme-change handlers
+(`docs/app.js`, the toggle click + `prefers-color-scheme` listener) only
+re-derived the DOM market-card **title** colours — the code comment there even
+noted "the chart is not rebuilt on a theme switch". DOM-based accessibility
+gates (pa11y) structurally cannot inspect canvas pixels, so nothing caught it.
+
+**Fix:** add `GRQChartTheme.applyChartTheme(chart, theme)` — the single source
+of truth that re-sources **every** canvas colour (default text, canvas title,
+legend labels, per-axis titles/ticks, grid lines) from the theme and repaints
+the live chart via `chart.update()`. It is wired into both theme-change signals
+(the header theme-toggle click and the OS `prefers-color-scheme` change), in
+**both** switch directions, for:
+
+- the main dashboard chart (`docs/app.js`) — which the mobile chart pop-out
+  **re-parents** rather than rebuilding, so re-theming the one live instance
+  covers the pop-out too;
+- the trend chart (`docs/trend.js`, new `wireThemeChange()`).
+
+`chart_theme.js` is now also loaded on `trend.html`, and `APP_VERSION` is bumped
+`1.1.50 → 1.1.51` (via `scripts/bump_version.ts`) so the service worker cache
+key changes and stale clients refetch the fix.
+
+Fixes #708.
+
+## Evidence
+
+Playwright MCP browser tools were not available in this run, so a live
+screenshot could not be captured. The fix is verified by a behavioural
+regression test that exercises the real shipped helper
+(`GRQChartTheme.applyChartTheme`) rather than the implementation text: it builds
+a chart coloured for one theme, switches it to the other, and asserts **no**
+stale colours remain and the chart repainted. It fails on the pre-fix code
+(the helper does not exist) and passes with the fix.
+
+```
+deno test --allow-read tests/chart_theme_reapply_test.ts
+running 5 tests from ./tests/chart_theme_reapply_test.ts
+applyChartTheme is published on GRQChartTheme ... ok
+light chart switched to dark keeps NO stale light colours ... ok
+dark chart switched to light keeps NO stale dark colours ... ok
+an unknown theme falls back to the readable light palette ... ok
+applyChartTheme is a safe no-op for a missing/half-built chart ... ok
+ok | 5 passed | 0 failed
+```
+
+Full suite: `deno test --allow-read tests/*.ts` → **1315 passed, 0 failed**.
+
+### Theme-switch flow (after the fix)
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Theme as theme.js (sets body class)
+    participant Handler as theme-change handler
+    participant Helper as GRQChartTheme.applyChartTheme
+    participant Chart as live Chart.js instance
+
+    User->>Theme: click toggle / OS prefers-color-scheme change
+    Theme->>Theme: update <body> light/dark class
+    Handler->>Handler: setTimeout(0) — let body class settle
+    Handler->>Helper: applyChartTheme(chart, detectTheme())
+    Helper->>Chart: re-source text/title/legend/ticks/grid colours
+    Helper->>Chart: chart.update() → repaint canvas
+    Note over Chart: no stale colours; axis text stays readable
+```
+
+## Test Plan
+
+- **Added** `tests/chart_theme_reapply_test.ts` — behavioural regression for
+  #708:
+  - `applyChartTheme` is published on `GRQChartTheme`.
+  - light→dark switch leaves no stale light colours (text + grid) and repaints.
+  - dark→light switch leaves no stale dark colours (text + grid) and repaints.
+  - an unknown theme falls back to the readable light palette.
+  - a missing/half-built chart is a safe no-op (no throw).
+- **Existing** `tests/chart_theme_contrast_test.ts`,
+  `tests/sw_precache_list_test.ts`, `tests/trend_view_wiring_test.ts` all still
+  pass (version alignment + trend asset wiring).
+- Full Deno suite: 1315 passed, 0 failed. `deno fmt`, `deno lint`, `deno check`
+  clean.

--- a/docs/chart_theme.js
+++ b/docs/chart_theme.js
@@ -71,6 +71,47 @@
         return { text: TEXT[t], grid: GRID[t], background: BACKGROUNDS[t] };
     }
 
+    // Re-apply the theme's colours to a LIVE Chart.js instance and repaint it
+    // (issue #708). Chart.js paints the canvas title, axis titles, tick labels,
+    // legend labels and grid lines ONCE at build from the colours above, so a
+    // theme switch after build otherwise leaves the previous theme's colours
+    // frozen on the canvas — unreadable text (near-white on a light page, or
+    // dark-on-dark after switching to dark). DOM accessibility gates cannot see
+    // canvas pixels, so nothing catches it. Every colour is re-sourced from the
+    // theme here, keeping this file the single source of truth. A missing or
+    // half-built chart (no options yet) is a silent no-op returning false.
+    function applyChartTheme(chart, theme) {
+        if (!chart || !chart.options) return false;
+        const t = chartTheme(theme);
+        const options = chart.options;
+
+        // Default colour Chart.js falls back to for any element without an
+        // explicit `color` (e.g. the desktop legend renders from this default).
+        options.color = t.text;
+
+        const plugins = options.plugins;
+        if (plugins) {
+            if (plugins.title) plugins.title.color = t.text;
+            if (plugins.legend && plugins.legend.labels) {
+                plugins.legend.labels.color = t.text;
+            }
+        }
+
+        const scales = options.scales;
+        if (scales) {
+            for (const key of Object.keys(scales)) {
+                const scale = scales[key];
+                if (!scale) continue;
+                if (scale.title) scale.title.color = t.text;
+                if (scale.ticks) scale.ticks.color = t.text;
+                if (scale.grid) scale.grid.color = t.grid;
+            }
+        }
+
+        if (typeof chart.update === "function") chart.update();
+        return true;
+    }
+
     globalThis.GRQChartTheme = {
         BACKGROUNDS,
         TEXT,
@@ -80,5 +121,6 @@
         chartGridColour,
         chartBackground,
         chartTheme,
+        applyChartTheme,
     };
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.50">
+    <meta name="app-version" content="1.1.51">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.50"></script>
+    <script src="escape.js?v=1.1.51"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.50"></script>
+    <script src="projection.js?v=1.1.51"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.50"></script>
+    <script src="volume_recommend.js?v=1.1.51"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.50"></script>
+    <script src="chart_window_settings.js?v=1.1.51"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.50"></script>
+    <script src="star_filter_settings.js?v=1.1.51"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.50"></script>
+    <script src="color_key.js?v=1.1.51"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.50"></script>
+    <script src="series_label_colour.js?v=1.1.51"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.50"></script>
+    <script src="chart_theme.js?v=1.1.51"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.50"></script>
+    <script src="chart_title.js?v=1.1.51"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.50"></script>
+    <script src="format.js?v=1.1.51"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.50"></script>
+    <script src="market_index.js?v=1.1.51"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.50"></script>
+    <script src="stock_selection.js?v=1.1.51"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.50"></script>
+    <script src="yahoo_finance.js?v=1.1.51"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.50"></script>
+    <script src="date_selection.js?v=1.1.51"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.50"></script>
+    <script src="view_selection.js?v=1.1.51"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.50"></script>
+    <script src="popover_dismiss.js?v=1.1.51"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.50"></script>
+    <script src="popover_cleanup.js?v=1.1.51"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.50"></script>
+    <script src="chart_popout.js?v=1.1.51"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.50"></script>
+    <script src="share_link.js?v=1.1.51"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.50"></script>
+    <script src="field_label.js?v=1.1.51"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.50"></script>
+    <script src="freshness_text.js?v=1.1.51"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.50"></script>
+    <script src="dashboard_boot.js?v=1.1.51"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.50"></script>
+    <script src="sw-register.js?v=1.1.51"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.50")
+    navigator.serviceWorker.register("./sw.js?v=1.1.51")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.50";
+const APP_VERSION = "1.1.51";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.50">
+    <meta name="app-version" content="1.1.51">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -237,10 +237,14 @@
          them to forward the selected ?date= onto the "← Dashboard" link. -->
     <script src="date_selection.js"></script>
 
+    <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
+         before trend.js, which re-themes the chart on a theme switch. -->
+    <script src="chart_theme.js?v=1.1.51"></script>
+
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.50"></script>
+    <script src="sw-register.js?v=1.1.51"></script>
   </body>
 </html>

--- a/docs/trend.js
+++ b/docs/trend.js
@@ -105,6 +105,7 @@
             this.buildGroupingControl();
             this.buildStarFilterControl();
             this.buildOverlayControls();
+            this.wireThemeChange();
             try {
                 await this.loadData();
             } catch (error) {
@@ -279,6 +280,34 @@
             this.scoreDates = matured.map((entry) => entry.date);
             this.marketIndices = await fetchJson("market-indices.json");
             this.rebuildSeries();
+        }
+
+        // Re-theme the live trend chart when the theme changes (issue #708).
+        // Chart.js paints axis/tick/title/legend/grid colours ONCE at build, so
+        // without this the chart keeps the previous theme's colours after a
+        // switch — unreadable text. Listen to both the header theme-toggle click
+        // and the OS prefers-color-scheme change, in both directions, and defer
+        // so theme.js updates the <body> class before we re-read it.
+        wireThemeChange() {
+            const reapply = () =>
+                setTimeout(() => {
+                    if (globalThis.GRQChartTheme && this.chart) {
+                        GRQChartTheme.applyChartTheme(
+                            this.chart,
+                            this.detectTheme(),
+                        );
+                    }
+                }, 0);
+            const toggle = typeof document !== "undefined"
+                ? document.getElementById("theme-toggle")
+                : null;
+            if (toggle && typeof toggle.addEventListener === "function") {
+                toggle.addEventListener("click", reapply);
+            }
+            if (typeof globalThis.matchMedia === "function") {
+                globalThis.matchMedia("(prefers-color-scheme: dark)")
+                    .addEventListener("change", reapply);
+            }
         }
 
         // Active theme ("light"/"dark"), matching styles.css, so the chart text

--- a/tests/chart_theme_reapply_test.ts
+++ b/tests/chart_theme_reapply_test.ts
@@ -1,0 +1,170 @@
+// Behavioural regression guard for issue #708: charts kept the previous theme's
+// colours after a theme switch, leaving canvas-drawn axis/tick/legend/title text
+// unreadable (near-white on white after switching to light; dark-on-dark after
+// switching to dark).
+//
+// Root cause: Chart.js paints those colours ONCE at chart build from
+// GRQChartTheme.chartTheme(detectTheme()). The theme-change handlers re-themed
+// only the DOM market-card titles, never the live chart — the code even noted
+// "the chart is not rebuilt on a theme switch". DOM accessibility gates cannot
+// inspect canvas pixels, so nothing caught it.
+//
+// The fix adds GRQChartTheme.applyChartTheme(chart, theme): the single source of
+// truth that re-applies every theme-sourced colour (default text, title, legend
+// labels, per-axis titles/ticks, grid lines) to a LIVE Chart.js instance and
+// repaints it. app.js, trend.js and the shared pop-out chart all call it on the
+// theme-toggle click and the prefers-color-scheme change, in both directions.
+//
+// These tests build a chart-like object coloured for one theme, switch it to the
+// other, and assert NO stale colours remain and the chart repainted. They fail
+// on the pre-fix code (no applyChartTheme) and pass with the fix — no
+// source-text greps, real shipped helper exercised.
+import { assert, assertEquals } from "@std/assert";
+import "../docs/chart_theme.js";
+
+interface ScaleLike {
+  title?: { color?: string };
+  ticks?: { color?: string };
+  grid?: { color?: string };
+}
+
+interface ChartLike {
+  updateCount: number;
+  update: () => void;
+  options: {
+    color?: string;
+    plugins?: {
+      title?: { color?: string };
+      legend?: { labels?: { color?: string } };
+    };
+    scales?: Record<string, ScaleLike>;
+  };
+}
+
+const g = globalThis as unknown as {
+  GRQChartTheme: {
+    TEXT: { light: string; dark: string };
+    GRID: { light: string; dark: string };
+    applyChartTheme: (chart: unknown, theme: unknown) => boolean;
+  };
+};
+
+const theme = g.GRQChartTheme;
+
+// A chart built the way docs/app.js builds the main dashboard chart: default
+// text colour, canvas title, desktop legend, both visible axes (title + ticks +
+// grid) — every colour sourced from the given theme bundle.
+function buildChart(t: "light" | "dark"): ChartLike {
+  const text = theme.TEXT[t];
+  const grid = theme.GRID[t];
+  const chart: ChartLike = {
+    updateCount: 0,
+    update() {
+      this.updateCount++;
+    },
+    options: {
+      color: text,
+      plugins: {
+        title: { color: text },
+        legend: { labels: { color: text } },
+      },
+      scales: {
+        x: {
+          title: { color: text },
+          ticks: { color: text },
+          grid: { color: grid },
+        },
+        y: {
+          title: { color: text },
+          ticks: { color: text },
+          grid: { color: grid },
+        },
+      },
+    },
+  };
+  return chart;
+}
+
+// Every theme-sourced colour on the chart, flattened for assertions.
+function textColours(chart: ChartLike): string[] {
+  const o = chart.options;
+  const out: string[] = [];
+  if (o.color !== undefined) out.push(o.color);
+  if (o.plugins?.title?.color !== undefined) out.push(o.plugins.title.color);
+  if (o.plugins?.legend?.labels?.color !== undefined) {
+    out.push(o.plugins.legend.labels.color);
+  }
+  for (const key of Object.keys(o.scales ?? {})) {
+    const s = (o.scales ?? {})[key];
+    if (s.title?.color !== undefined) out.push(s.title.color);
+    if (s.ticks?.color !== undefined) out.push(s.ticks.color);
+  }
+  return out;
+}
+
+function gridColours(chart: ChartLike): string[] {
+  const o = chart.options;
+  const out: string[] = [];
+  for (const key of Object.keys(o.scales ?? {})) {
+    const s = (o.scales ?? {})[key];
+    if (s.grid?.color !== undefined) out.push(s.grid.color);
+  }
+  return out;
+}
+
+Deno.test("applyChartTheme is published on GRQChartTheme", () => {
+  assert(typeof theme.applyChartTheme === "function");
+});
+
+Deno.test("light chart switched to dark keeps NO stale light colours", () => {
+  const chart = buildChart("light");
+  // Sanity: it really starts as a light-themed chart.
+  assert(textColours(chart).every((c) => c === theme.TEXT.light));
+
+  const changed = theme.applyChartTheme(chart, "dark");
+  assertEquals(changed, true);
+
+  // Every canvas text colour is now the dark colour — the reported bug (stale
+  // near-white text on a light page, or here light text left behind) is gone.
+  for (const c of textColours(chart)) {
+    assertEquals(c, theme.TEXT.dark);
+  }
+  for (const c of gridColours(chart)) {
+    assertEquals(c, theme.GRID.dark);
+  }
+  // The live chart was repainted.
+  assertEquals(chart.updateCount, 1);
+});
+
+Deno.test("dark chart switched to light keeps NO stale dark colours", () => {
+  const chart = buildChart("dark");
+  assert(textColours(chart).every((c) => c === theme.TEXT.dark));
+
+  const changed = theme.applyChartTheme(chart, "light");
+  assertEquals(changed, true);
+
+  for (const c of textColours(chart)) {
+    assertEquals(c, theme.TEXT.light);
+  }
+  for (const c of gridColours(chart)) {
+    assertEquals(c, theme.GRID.light);
+  }
+  assertEquals(chart.updateCount, 1);
+});
+
+Deno.test("an unknown theme falls back to the readable light palette", () => {
+  const chart = buildChart("dark");
+  theme.applyChartTheme(chart, "midnight");
+  for (const c of textColours(chart)) {
+    assertEquals(c, theme.TEXT.light);
+  }
+});
+
+Deno.test("applyChartTheme is a safe no-op for a missing/half-built chart", () => {
+  assertEquals(theme.applyChartTheme(null, "dark"), false);
+  assertEquals(theme.applyChartTheme({}, "dark"), false);
+  // A chart with no update() must not throw.
+  const noUpdate = { options: { color: theme.TEXT.light } };
+  assertEquals(theme.applyChartTheme(noUpdate, "dark"), true);
+  assertEquals(noUpdate.options.color, theme.TEXT.dark);
+});


### PR DESCRIPTION
# Re-theme live charts on theme switch (Issue #708)

## Summary

The dashboard charts kept the **previous** theme's colours after the theme
changed, leaving the canvas-drawn axis ticks, axis titles and desktop legend
unreadable — near-white text on a white page after switching to light, and
dark text on a dark page after switching to dark.

**Root cause:** Chart.js paints axis ticks, axis titles, the legend and grid
lines **once** at chart build from `GRQChartTheme.chartTheme(detectTheme())`
(`docs/app.js`, `docs/trend.js`). The existing theme-change handlers
(`docs/app.js`, the toggle click + `prefers-color-scheme` listener) only
re-derived the DOM market-card **title** colours — the code comment there even
noted "the chart is not rebuilt on a theme switch". DOM-based accessibility
gates (pa11y) structurally cannot inspect canvas pixels, so nothing caught it.

**Fix:** add `GRQChartTheme.applyChartTheme(chart, theme)` — the single source
of truth that re-sources **every** canvas colour (default text, canvas title,
legend labels, per-axis titles/ticks, grid lines) from the theme and repaints
the live chart via `chart.update()`. It is wired into both theme-change signals
(the header theme-toggle click and the OS `prefers-color-scheme` change), in
**both** switch directions, for:

- the main dashboard chart (`docs/app.js`) — which the mobile chart pop-out
  **re-parents** rather than rebuilding, so re-theming the one live instance
  covers the pop-out too;
- the trend chart (`docs/trend.js`, new `wireThemeChange()`).

`chart_theme.js` is now also loaded on `trend.html`, and `APP_VERSION` is bumped
`1.1.50 → 1.1.51` (via `scripts/bump_version.ts`) so the service worker cache
key changes and stale clients refetch the fix.

Fixes #708.

## Evidence

Playwright MCP browser tools were not available in this run, so a live
screenshot could not be captured. The fix is verified by a behavioural
regression test that exercises the real shipped helper
(`GRQChartTheme.applyChartTheme`) rather than the implementation text: it builds
a chart coloured for one theme, switches it to the other, and asserts **no**
stale colours remain and the chart repainted. It fails on the pre-fix code
(the helper does not exist) and passes with the fix.

```
deno test --allow-read tests/chart_theme_reapply_test.ts
running 5 tests from ./tests/chart_theme_reapply_test.ts
applyChartTheme is published on GRQChartTheme ... ok
light chart switched to dark keeps NO stale light colours ... ok
dark chart switched to light keeps NO stale dark colours ... ok
an unknown theme falls back to the readable light palette ... ok
applyChartTheme is a safe no-op for a missing/half-built chart ... ok
ok | 5 passed | 0 failed
```

Full suite: `deno test --allow-read tests/*.ts` → **1315 passed, 0 failed**.

### Theme-switch flow (after the fix)

```mermaid
sequenceDiagram
    participant User
    participant Theme as theme.js (sets body class)
    participant Handler as theme-change handler
    participant Helper as GRQChartTheme.applyChartTheme
    participant Chart as live Chart.js instance

    User->>Theme: click toggle / OS prefers-color-scheme change
    Theme->>Theme: update <body> light/dark class
    Handler->>Handler: setTimeout(0) — let body class settle
    Handler->>Helper: applyChartTheme(chart, detectTheme())
    Helper->>Chart: re-source text/title/legend/ticks/grid colours
    Helper->>Chart: chart.update() → repaint canvas
    Note over Chart: no stale colours; axis text stays readable
```

## Test Plan

- **Added** `tests/chart_theme_reapply_test.ts` — behavioural regression for
  #708:
  - `applyChartTheme` is published on `GRQChartTheme`.
  - light→dark switch leaves no stale light colours (text + grid) and repaints.
  - dark→light switch leaves no stale dark colours (text + grid) and repaints.
  - an unknown theme falls back to the readable light palette.
  - a missing/half-built chart is a safe no-op (no throw).
- **Existing** `tests/chart_theme_contrast_test.ts`,
  `tests/sw_precache_list_test.ts`, `tests/trend_view_wiring_test.ts` all still
  pass (version alignment + trend asset wiring).
- Full Deno suite: 1315 passed, 0 failed. `deno fmt`, `deno lint`, `deno check`
  clean.
