### PR TITLE
Default chart window to 180 days on all form factors (Issue #711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to
 
 ### Changed
 
+- Chart window now defaults to **180 days on every form factor** (previously 90
+  on mobile, 180 on desktop). A fresh device shows the full 180-day window; the
+  90/180 toggle, the per-device saved choice, and the transient `?window=` deep
+  link are unchanged, so a user can still opt into 90 (Issue #711).
 - `GRQProjection.deviceWindowDays`/`deviceWindowEnd` (`docs/projection.js`) now
   honour an explicit permitted window (90 or 180) on **either** device, relaxing
   the old desktop-180 lock so a desktop 90-day choice can take effect. Each

--- a/README.md
+++ b/README.md
@@ -406,9 +406,9 @@ deterministically — issue #281):
   index gains (issue #705); the cards carry an "as at `<date>`" caption of the
   exact 90-day close date. Like `?theme=`, the window override is **transient**:
   it wins over the saved per-device choice but is **never** persisted, so a reload
-  without the param returns to the saved window (desktop 180 / mobile 90); an
-  absent or invalid value falls back to the saved choice, then the device
-  default.
+  without the param returns to the saved window (180 on every form factor by
+  default, issue #711); an absent or invalid value falls back to the saved
+  choice, then the device default.
 - `?stars=0|1|2|3|4|5` — pre-select the shared minimum-star filter for that page
   load on **both** the portfolio and Trend views (issue #666). `0` means **All**
   (filter off); `1`–`5` keep only holdings whose average rating meets that whole

--- a/docs/app.js
+++ b/docs/app.js
@@ -85,13 +85,13 @@ class GRQValidator {
         return breakpoint === 'xs' || breakpoint === 'sm';
     }
 
-    // The user's chosen mobile chart window in days (issue #449): 90 by default,
-    // or the full 180 when opted in via the toggle. Read from the per-device
+    // The user's chosen mobile chart window in days (issue #449): 180 by default
+    // (issue #711), or 90 when opted in via the toggle. Read from the per-device
     // persistence helper (docs/chart_window_settings.js); guarded so a missing
-    // helper or unavailable storage falls back to 90 and never throws.
+    // helper or unavailable storage falls back to 180 and never throws.
     mobileWindowDays() {
         if (typeof GRQChartWindow === "undefined") {
-            return 90;
+            return 180;
         }
         return GRQChartWindow.readMobileWindowDays();
     }
@@ -100,7 +100,8 @@ class GRQValidator {
     // default, or 90 when opted in via the now-desktop-visible toggle. Read from
     // the per-device persistence helper; guarded so a missing helper or
     // unavailable storage falls back to 180 and never throws. Desktop keeps its
-    // OWN key, so a desktop choice can never regress mobile's 90 default (#457).
+    // OWN key, so each device persists its choice independently (issue #711
+    // makes both default to 180).
     desktopWindowDays() {
         if (typeof GRQChartWindow === "undefined") {
             return 180;
@@ -109,17 +110,17 @@ class GRQValidator {
     }
 
     // The effective chart window for THIS device (issue #466): the mobile choice
-    // on phones (default 90), the desktop choice otherwise (default 180). Every
-    // window-sizing call site (chart, summary, cost-of-capital floor) resolves
-    // through this single accessor so the chart and the summary always cover the
-    // identical window (#367) — a desktop 90 choice narrows both together.
+    // on phones, the desktop choice otherwise — both defaulting to 180 (issue
+    // #711). Every window-sizing call site (chart, summary, cost-of-capital
+    // floor) resolves through this single accessor so the chart and the summary
+    // always cover the identical window (#367) — a 90 choice narrows both together.
     //
     // A `?window=90|180` deep link (issue #467) takes precedence for THIS visit
     // only: the transient URL value (parsed by the shared #450 helper) wins over
     // the saved per-device choice, which wins over the device default. The URL
     // value is NEVER persisted, so a reload without the param returns to the
-    // saved/180 window and mobile's 90 default is never regressed. Guarded so a
-    // missing helper degrades cleanly to the saved per-device value.
+    // saved/180 window. Guarded so a missing helper degrades cleanly to the
+    // saved per-device value.
     currentWindowDays() {
         const saved = this.isMobileDevice()
             ? this.mobileWindowDays()
@@ -178,8 +179,9 @@ class GRQValidator {
     // change, persist it to THIS device's store and re-render the chart AND the
     // Market Performance summary together so they always cover the identical
     // window (issue #449, #466, #367). The control now renders on desktop too
-    // (issue #466); mobile and desktop keep separate stores and defaults, so a
-    // desktop flip writes the desktop key and never regresses mobile's 90.
+    // (issue #466); mobile and desktop keep separate stores, so a desktop flip
+    // writes the desktop key and never touches the mobile choice (both default
+    // to 180, issue #711).
     initChartWindowToggle() {
         const control = document.getElementById("chartWindowControl");
         if (!control) {
@@ -2134,8 +2136,8 @@ class GRQValidator {
         const isMobile = this.isMobileDevice();
         
         // Per-device visible window, honouring the user's 90/180 toggle on
-        // EITHER device (issue #449, #466): mobile defaults 90, desktop defaults
-        // 180, each opt-in-able to the other. Shared with the Market Performance
+        // EITHER device (issue #449, #466): both default to 180 (issue #711),
+        // each opt-in-able to 90. Shared with the Market Performance
         // summary via GRQProjection so the chart and the summary cover the
         // identical window and cannot disagree (issue #367).
         const windowDays = this.currentWindowDays();
@@ -2997,7 +2999,7 @@ class GRQValidator {
 
         // Per-device visible window, shared with the chart and summary via the
         // single source of truth (issue #367) — the user's per-device 90/180
-        // toggle choice (issue #449, #466): mobile defaults 90, desktop 180.
+        // toggle choice (issue #449, #466): both default to 180 (issue #711).
         const maxDays = GRQProjection.deviceWindowDays(isMobile, this.currentWindowDays());
         const maxDate = new Date(
             this.getScoreDate(this.selectedFile).getTime() + (maxDays * 24 * 60 * 60 * 1000)

--- a/docs/archive/pr-summaries/pr-summary-711.md
+++ b/docs/archive/pr-summaries/pr-summary-711.md
@@ -1,0 +1,96 @@
+# Default the chart window to 180 days on every form factor
+
+## Summary
+
+The dashboard chart/summary window used to default to **90 days on mobile** and
+**180 days on desktop**. Issue #711 asks for **180 days by default on all form
+factors** unless the user has specifically opted into 90. This PR makes 180 the
+single default everywhere while keeping the 90/180 toggle (and the per-device
+saved choice / `?window=` deep link) fully working.
+
+Closes #711.
+
+### What changed
+
+- `docs/chart_window_settings.js` — `MOBILE_WINDOW_DAYS_DEFAULT` raised from
+  `90` to `180`, so a fresh mobile device (or a corrupt/missing stored value)
+  now resolves to the full 180-day window, matching desktop. Mobile and desktop
+  keep their own separate storage keys, so an explicit per-device choice is
+  still honoured independently.
+- `docs/projection.js` — `deviceWindowDays()` now defaults to `180` on **either**
+  device (new `DEFAULT_WINDOW_DAYS` constant) instead of branching to 90 for
+  mobile. The two selectable window sizes (90 and 180) are unchanged, so an
+  explicit 90 opt-in still works on either device; `isMobile` is retained for
+  call-site compatibility but no longer changes the default.
+- `docs/app.js` — the `mobileWindowDays()` guard fallback (used when the storage
+  helper is unavailable) now returns `180`, and the surrounding comments were
+  corrected.
+- `docs/index.html` — the static `checked` attribute moved from the 90-day radio
+  to the 180-day radio, so the toggle shows 180 by default before JS runs and on
+  every device.
+- `README.md` — the `?window=` documentation now states the default is 180 on
+  every form factor.
+
+### Behaviour
+
+```mermaid
+flowchart TD
+    A[Page load] --> B{Saved per-device choice?}
+    B -- "yes (90 or 180)" --> C[Use saved choice]
+    B -- "no / corrupt" --> D[Default = 180 on ALL form factors]
+    A --> E{"?window=90|180 present?"}
+    E -- yes --> F[Transient override wins this visit only, never persisted]
+    E -- no --> B
+```
+
+## Evidence
+
+This is a front-end (docs) change with **no** web-driver available in this
+environment (Playwright MCP was not reachable), so visual capture was done by
+inspecting the shipped markup and by the behavioural Deno tests that import the
+real helpers.
+
+- The shipped toggle now defaults to 180: in `docs/index.html` the
+  `id="chartWindow180"` radio carries `checked` and `id="chartWindow90"` does
+  not. This is pinned by
+  `tests/chart_window_toggle_test.ts::index.html: default selection is 180 days`.
+- The persistence and window-resolution helpers default to 180 on both devices,
+  verified against the real modules (not mocks).
+
+## Test Plan
+
+Full Deno suite: **1317 passed, 0 failed**. `deno fmt`, `deno lint`, and
+`deno check` all clean.
+
+New / updated tests (business-logic change — the mobile default moved from 90 to
+180, so assertions that pinned the old 90 default were updated and documented):
+
+- `tests/chart_window_settings_test.ts` — mobile default is now 180 (empty /
+  corrupt / throwing / no-storage all resolve to 180); junk normalises to 180; an
+  explicit saved 90 is still honoured; new invariant test *"both mobile and
+  desktop default to 180"*.
+- `tests/projection_kernels_test.ts` — `deviceWindowDays`/`deviceWindowEnd`
+  default to 180 on either device; explicit 90 still honoured.
+- `tests/chart_summary_window_test.ts` — device default is 180; chart/summary
+  still land on the identical end date for every window; explicit 90 compared
+  explicitly.
+- `tests/chart_actuals_window_test.ts` — the after-90 tail now shows for the
+  mobile default (180) and for bad values (fall back to 180).
+- `tests/chart_single_stock_axis_window_test.ts` — a bad window falls back to the
+  180 default on both devices.
+- `tests/market_comparison_90day_window_test.ts` — the fixed 90-day judgement
+  window is now compared against an explicit 90-day chart window (the judgement
+  window is unchanged; only the chart default moved).
+- `tests/chart_window_toggle_test.ts` — default selection is now the 180-day
+  radio.
+
+## Notes
+
+- `quality.sh` reports one **pre-existing, environmental** cargo test failure:
+  `create_market_data_long_csv_writes_eight_column_rows` fails with *"No market
+  data rows written for 2025-04-15 — is ../GRQ-shareprices2026Q2 available and up
+  to date?"*. This depends on an external share-prices dataset that is not fresh
+  in this environment and is **unrelated** to this change — no Rust files were
+  touched. All other cargo checks and the entire Deno suite pass.
+- The incidental `Cargo.lock` churn produced by `cargo update` inside
+  `quality.sh` was reverted to keep this PR scoped to the front-end change.

--- a/docs/chart_window_settings.js
+++ b/docs/chart_window_settings.js
@@ -3,9 +3,10 @@
 //
 // This remembers, per device, the user's choice of chart window — 90 days or
 // the full 180 days — backed by localStorage under namespaced `grq.chart.*`
-// keys (mirroring `grq.trend.*`). Mobile and desktop have SEPARATE keys and
-// SEPARATE defaults (mobile 90, desktop 180) so a desktop choice can never
-// regress mobile's required 90-day default (parent invariant #457).
+// keys (mirroring `grq.trend.*`). Mobile and desktop keep SEPARATE keys so a
+// choice on one device never overwrites the other's saved choice, but BOTH now
+// default to 180 days (issue #711): the full window is the default on every
+// form factor unless the user has specifically opted into 90.
 //
 // Like docs/trend_settings.js and docs/theme.js this file is loaded as a
 // classic <script> and is also imported by the Deno tests. It uses no module
@@ -24,8 +25,10 @@
 (function () {
   "use strict";
 
-  // The user-facing default mobile chart window, in days (issue #447: 90).
-  const MOBILE_WINDOW_DAYS_DEFAULT = 90;
+  // The user-facing default mobile chart window, in days. Originally 90
+  // (issue #447); raised to 180 by issue #711 so every form factor defaults to
+  // the full window unless the user has opted into 90.
+  const MOBILE_WINDOW_DAYS_DEFAULT = 180;
 
   // The user-facing default desktop chart window, in days (issue #465: 180).
   const DESKTOP_WINDOW_DAYS_DEFAULT = 180;
@@ -38,15 +41,16 @@
 
   // Namespaced localStorage key for the per-device desktop choice (issue #465).
   // Desktop keeps its OWN key so a desktop write can never change what mobile
-  // reads — preserving mobile's required 90-day default (parent #457).
+  // reads — each device persists its own choice independently (issue #711 makes
+  // both default to 180).
   const DESKTOP_STORAGE_KEY = "grq.chart.desktopWindowDays";
 
   // Coerce an arbitrary value to one of the allowed windows, defaulting to the
   // supplied fallback so a missing / corrupt stored value never breaks the
   // view. Accepts both numbers and their string forms (localStorage only stores
-  // strings). The fallback is parameterised (issue #465) so mobile falls back
-  // to 90 and desktop falls back to 180; an omitted fallback keeps the original
-  // mobile-90 behaviour for existing callers.
+  // strings). The fallback is parameterised (issue #465) so callers can choose
+  // the default; an omitted fallback uses MOBILE_WINDOW_DAYS_DEFAULT, which is
+  // now 180 on every form factor (issue #711).
   function normaliseWindowDays(value, fallback) {
     const def = fallback === undefined ? MOBILE_WINDOW_DAYS_DEFAULT : fallback;
     const num = typeof value === "string" ? Number(value) : value;
@@ -106,8 +110,8 @@
 
   // --- desktop chart window --------------------------------------------------
   // Separate key + 180 default (issue #465). A missing / corrupt / out-of-range
-  // desktop value falls back to 180, NOT 90, and writing here never touches the
-  // mobile key.
+  // desktop value falls back to 180, and writing here never touches the mobile
+  // key. Mobile now shares the same 180 default (issue #711).
 
   function readDesktopWindowDays(storage) {
     return normaliseWindowDays(
@@ -152,9 +156,9 @@
   // Resolve the effective chart window for a visit, applying the visit-only
   // precedence (issue #467): a `?window=` URL override (transient, never
   // persisted) wins over `savedWindowDays` — the already-resolved saved
-  // per-device choice or device default (mobile 90 / desktop 180). An absent or
-  // invalid override leaves the saved value in place. Pure: writes nothing, so
-  // a URL-supplied window is honoured for the visit without persisting.
+  // per-device choice or device default (180 on every form factor, issue #711).
+  // An absent or invalid override leaves the saved value in place. Pure: writes
+  // nothing, so a URL-supplied window is honoured for the visit without persisting.
   function effectiveWindowDays(search, savedWindowDays) {
     const fromUrl = windowDaysFromSearch(search);
     return fromUrl === null ? savedWindowDays : fromUrl;

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.51">
+    <meta name="app-version" content="1.1.52">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.51"></script>
+    <script src="escape.js?v=1.1.52"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.51"></script>
+    <script src="projection.js?v=1.1.52"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.51"></script>
+    <script src="volume_recommend.js?v=1.1.52"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.51"></script>
+    <script src="chart_window_settings.js?v=1.1.52"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.51"></script>
+    <script src="star_filter_settings.js?v=1.1.52"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.51"></script>
+    <script src="color_key.js?v=1.1.52"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.51"></script>
+    <script src="series_label_colour.js?v=1.1.52"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.51"></script>
+    <script src="chart_theme.js?v=1.1.52"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.51"></script>
+    <script src="chart_title.js?v=1.1.52"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.51"></script>
+    <script src="format.js?v=1.1.52"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.51"></script>
+    <script src="market_index.js?v=1.1.52"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.51"></script>
+    <script src="stock_selection.js?v=1.1.52"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.51"></script>
+    <script src="yahoo_finance.js?v=1.1.52"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.51"></script>
+    <script src="date_selection.js?v=1.1.52"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.51"></script>
+    <script src="view_selection.js?v=1.1.52"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.51"></script>
+    <script src="popover_dismiss.js?v=1.1.52"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.51"></script>
+    <script src="popover_cleanup.js?v=1.1.52"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.51"></script>
+    <script src="chart_popout.js?v=1.1.52"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.51"></script>
+    <script src="share_link.js?v=1.1.52"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.51"></script>
+    <script src="field_label.js?v=1.1.52"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.51"></script>
+    <script src="freshness_text.js?v=1.1.52"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.51"></script>
+    <script src="dashboard_boot.js?v=1.1.52"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.51"></script>
+    <script src="sw-register.js?v=1.1.52"></script>
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -192,10 +192,10 @@
                            to desktop in issue #466). Shown on every device: it
                            switches the visible window between 90 and 180 days,
                            re-rendering the chart AND the Market Performance
-                           summary together (#367). Each device keeps its own
-                           default and store via GRQChartWindow (mobile 90,
-                           desktop 180); the static 90 default below is
-                           corrected per device on init. -->
+                           summary together (#367). Every form factor defaults
+                           to 180 (issue #711) via GRQChartWindow; the static 180
+                           default below is corrected per device on init if the
+                           user has opted into 90. -->
                       <div class="chart-window-control" id="chartWindowControl">
                         <!-- Issue #493: the visible "Chart window" label was
                              removed (the 90/180 buttons are self-explanatory).
@@ -220,7 +220,6 @@
                             value="90"
                             autocomplete="off"
                             aria-label="90 days"
-                            checked
                           />
                           <label
                             class="btn btn-outline-primary"
@@ -235,6 +234,7 @@
                             value="180"
                             autocomplete="off"
                             aria-label="180 days"
+                            checked
                           />
                           <label
                             class="btn btn-outline-primary"

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -20,15 +20,26 @@ function setDateToMidnight(date) {
     return d;
 }
 
-// Per-device chart/summary window (issue #367, milestone #333). The dashboard
-// chart truncates its visible benchmark series to a fixed window measured from
-// the score date — 90 days on mobile, 180 on desktop — so the "Market
-// Performance Comparison" summary must end on the SAME date or the two can
-// disagree in direction (chart down vs summary up). These pure helpers are the
-// single source of truth for that window, shared by prepareChartData (the
-// chart) and getMarketPerformanceData (the summary) so they cannot drift apart.
-const MOBILE_WINDOW_DAYS = 90;
-const DESKTOP_WINDOW_DAYS = 180;
+// The two permitted chart/summary window sizes (issue #367, milestone #333).
+// The dashboard chart truncates its visible benchmark series to a fixed window
+// measured from the score date, so the "Market Performance Comparison" summary
+// must end on the SAME date or the two can disagree in direction (chart down vs
+// summary up). These pure helpers are the single source of truth for that
+// window, shared by prepareChartData (the chart) and getMarketPerformanceData
+// (the summary) so they cannot drift apart. SHORT_WINDOW_DAYS / LONG_WINDOW_DAYS
+// name the two selectable sizes (90 and 180); they are NOT device defaults.
+const SHORT_WINDOW_DAYS = 90;
+const LONG_WINDOW_DAYS = 180;
+
+// The default chart window in days, now 180 on EVERY form factor (issue #711).
+// Previously mobile defaulted to 90 and desktop to 180; the full window is now
+// the default everywhere unless the user has opted into 90.
+const DEFAULT_WINDOW_DAYS = LONG_WINDOW_DAYS;
+
+// Back-compat aliases: earlier code (and the "actuals after 90" tail gate)
+// referred to these names as the short/long window sizes.
+const MOBILE_WINDOW_DAYS = SHORT_WINDOW_DAYS;
+const DESKTOP_WINDOW_DAYS = LONG_WINDOW_DAYS;
 
 // The chart window is selectable (issue #448, milestone #445; relaxed by #464,
 // milestone #457): the user may keep their device default or opt into the other
@@ -40,19 +51,19 @@ const PERMITTED_WINDOW_DAYS = [MOBILE_WINDOW_DAYS, DESKTOP_WINDOW_DAYS];
 // Days in the visible window for the current device.
 //
 // `windowDays` carries an explicit chosen window (90 or 180). An explicit
-// permitted value is honoured on EITHER device — desktop may now opt into 90
-// just as mobile may opt into 180 (issue #464 relaxes the old desktop-180 lock
-// from #448). When the value is missing (undefined) or not permitted, each
-// device keeps its own default: 90 on mobile, 180 on desktop.
-// projection.js stays pure: the caller supplies the value, this never reads
-// localStorage. Omitting the argument keeps every existing caller unchanged
+// permitted value is honoured on EITHER device — desktop may opt into 90 just
+// as mobile may opt into 180 (issue #464 relaxes the old desktop-180 lock from
+// #448). When the value is missing (undefined) or not permitted, the default is
+// 180 on EVERY form factor (issue #711) — mobile no longer defaults to 90.
+// `isMobile` is retained for call-site compatibility but no longer affects the
+// default. projection.js stays pure: the caller supplies the value, this never
+// reads localStorage. Omitting the argument keeps every existing caller working
 // (preserves the #367 single-source guarantee).
 function deviceWindowDays(isMobile, windowDays) {
-    const deviceDefault = isMobile ? MOBILE_WINDOW_DAYS : DESKTOP_WINDOW_DAYS;
-    if (windowDays === undefined) return deviceDefault;
+    if (windowDays === undefined) return DEFAULT_WINDOW_DAYS;
     return PERMITTED_WINDOW_DAYS.includes(windowDays)
         ? windowDays
-        : deviceDefault;
+        : DEFAULT_WINDOW_DAYS;
 }
 
 // The window's end date: scoreDate + resolved-device-days, at local midnight.

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.51")
+    navigator.serviceWorker.register("./sw.js?v=1.1.52")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.51";
+const APP_VERSION = "1.1.52";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.51">
+    <meta name="app-version" content="1.1.52">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.51"></script>
+    <script src="chart_theme.js?v=1.1.52"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.51"></script>
+    <script src="sw-register.js?v=1.1.52"></script>
   </body>
 </html>

--- a/tests/chart_actuals_window_test.ts
+++ b/tests/chart_actuals_window_test.ts
@@ -27,11 +27,12 @@ Deno.test("windowShowsActualsAfter90 - mobile 180-day window shows the after-90 
   assertEquals(GRQProjection.windowShowsActualsAfter90(true, 180), true);
 });
 
-Deno.test("windowShowsActualsAfter90 - mobile 90-day window omits the after-90 tail (unchanged)", () => {
-  // The 90-day mobile view ends at day 90, so there is no after-90 tail to draw.
+Deno.test("windowShowsActualsAfter90 - a 90-day window omits the after-90 tail", () => {
+  // A 90-day view ends at day 90, so there is no after-90 tail to draw.
   assertEquals(GRQProjection.windowShowsActualsAfter90(true, 90), false);
-  // Mobile default (no explicit window) resolves to 90 -> still omitted.
-  assertEquals(GRQProjection.windowShowsActualsAfter90(true, undefined), false);
+  // Mobile default (no explicit window) now resolves to 180 (issue #711), so the
+  // tail IS drawn — the mobile default view is the full window.
+  assertEquals(GRQProjection.windowShowsActualsAfter90(true, undefined), true);
 });
 
 Deno.test("windowShowsActualsAfter90 - desktop views are unchanged (180 shows, 90 omits)", () => {
@@ -55,10 +56,10 @@ Deno.test("windowShowsActualsAfter90 - mobile and desktop are in parity for the 
   }
 });
 
-Deno.test("windowShowsActualsAfter90 - bad stored window falls back to the device default", () => {
-  // A bad value can never widen the window, so it inherits the device default:
-  // mobile -> 90 (no tail), desktop -> 180 (tail). Mirrors deviceWindowDays.
-  assertEquals(GRQProjection.windowShowsActualsAfter90(true, 999), false);
+Deno.test("windowShowsActualsAfter90 - bad stored window falls back to the 180 default", () => {
+  // A bad value inherits the default, now 180 on every form factor (issue #711),
+  // so the after-90 tail is shown on both devices. Mirrors deviceWindowDays.
+  assertEquals(GRQProjection.windowShowsActualsAfter90(true, 999), true);
   assertEquals(GRQProjection.windowShowsActualsAfter90(false, 999), true);
 });
 

--- a/tests/chart_single_stock_axis_window_test.ts
+++ b/tests/chart_single_stock_axis_window_test.ts
@@ -83,16 +83,15 @@ Deno.test("singleStockAxisMax - tracks deviceWindowEnd (window end + 5-day paddi
   }
 });
 
-Deno.test("singleStockAxisMax - bad stored window falls back to device default", () => {
-  // A bad value can never widen the window: mobile -> 90 (end 95), desktop ->
-  // 180 (end 185). Mirrors deviceWindowDays/deviceWindowEnd.
+Deno.test("singleStockAxisMax - bad stored window falls back to the 180 default", () => {
+  // A bad value inherits the default, now 180 on every form factor (issue #711),
+  // so both devices land on the 180-day end (185 with padding). Mirrors
+  // deviceWindowDays/deviceWindowEnd.
   const mobile = GRQProjection.singleStockAxisMax(SCORE_DATE, true, 999);
   const desktop = GRQProjection.singleStockAxisMax(SCORE_DATE, false, 999);
-  // 999 is not permitted, so it inherits the device default: mobile 90, desktop
-  // 180 — exactly as if those defaults had been passed.
   assertEquals(
     mobile.getTime(),
-    GRQProjection.singleStockAxisMax(SCORE_DATE, true, 90).getTime(),
+    GRQProjection.singleStockAxisMax(SCORE_DATE, true, 180).getTime(),
   );
   assertEquals(
     desktop.getTime(),

--- a/tests/chart_summary_window_test.ts
+++ b/tests/chart_summary_window_test.ts
@@ -25,8 +25,8 @@ const GRQMarketIndex = g.GRQMarketIndex;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-Deno.test("deviceWindowDays - mobile is 90 days, desktop is 180 days", () => {
-  assertEquals(GRQProjection.deviceWindowDays(true), 90);
+Deno.test("deviceWindowDays - both mobile and desktop default to 180 days (issue #711)", () => {
+  assertEquals(GRQProjection.deviceWindowDays(true), 180);
   assertEquals(GRQProjection.deviceWindowDays(false), 180);
 });
 
@@ -36,22 +36,24 @@ Deno.test("deviceWindowEnd - end is scoreDate + per-device days at local midnigh
   const scoreDate = new Date("2026-01-01T13:45:00");
   const base = GRQProjection.setDateToMidnight(new Date("2026-01-01"));
 
-  const mobileEnd = GRQProjection.deviceWindowEnd(scoreDate, true);
-  const desktopEnd = GRQProjection.deviceWindowEnd(scoreDate, false);
+  // Issue #711: both devices now default to the 180-day window. Explicit 90 is
+  // still honoured and produces the shorter end date.
+  const defaultEnd = GRQProjection.deviceWindowEnd(scoreDate, true);
+  const shortEnd = GRQProjection.deviceWindowEnd(scoreDate, true, 90);
 
   // Mirror the production formula exactly so the assertion is DST-safe.
   assertEquals(
-    mobileEnd.getTime(),
+    shortEnd.getTime(),
     GRQProjection.setDateToMidnight(new Date(base.getTime() + 90 * DAY_MS))
       .getTime(),
   );
   assertEquals(
-    desktopEnd.getTime(),
+    defaultEnd.getTime(),
     GRQProjection.setDateToMidnight(new Date(base.getTime() + 180 * DAY_MS))
       .getTime(),
   );
-  assertEquals(mobileEnd.getHours(), 0);
-  assert(desktopEnd.getTime() > mobileEnd.getTime());
+  assertEquals(defaultEnd.getHours(), 0);
+  assert(defaultEnd.getTime() > shortEnd.getTime());
 });
 
 Deno.test("deviceWindowDays/deviceWindowEnd - selectable window keeps chart and summary on the SAME end date (issue #448; desktop-90 opt-in #464)", () => {
@@ -61,14 +63,14 @@ Deno.test("deviceWindowDays/deviceWindowEnd - selectable window keeps chart and 
   // identical calls proves they cannot drift for the selectable window.
   const scoreDate = new Date("2026-01-01T09:30:00");
   const pairs: Array<[boolean, number | undefined]> = [
-    [true, undefined], // mobile default -> 90
-    [true, 90], // mobile explicit 90
-    [true, 180], // mobile opting into the full window
-    [true, 999], // bad value -> falls back to mobile 90
+    [true, undefined], // mobile default -> 180 (issue #711)
+    [true, 90], // mobile opting into 90
+    [true, 180], // mobile explicit full window
+    [true, 999], // bad value -> falls back to the 180 default
     [false, undefined], // desktop default -> 180
     [false, 90], // desktop opting into 90 (the new #464 case)
     [false, 180], // desktop explicit 180
-    [false, 999], // bad value -> falls back to desktop 180
+    [false, 999], // bad value -> falls back to the 180 default
   ];
 
   for (const [isMobile, windowDays] of pairs) {
@@ -105,10 +107,11 @@ Deno.test("deviceWindowDays/deviceWindowEnd - selectable window keeps chart and 
   );
 
   // Symmetrically, a desktop (desktop, 90) window must land on the same end date
-  // the mobile default window does — the relaxed lock gives desktop the 90 window.
+  // an explicit mobile 90 window does — the relaxed lock gives desktop the 90
+  // window (mobile now defaults to 180, so 90 is compared explicitly, issue #711).
   assertEquals(
     GRQProjection.deviceWindowEnd(scoreDate, false, 90)!.getTime(),
-    GRQProjection.deviceWindowEnd(scoreDate, true)!.getTime(),
+    GRQProjection.deviceWindowEnd(scoreDate, true, 90)!.getTime(),
   );
 });
 
@@ -143,13 +146,14 @@ Deno.test("marketPerformanceData - summary follows the per-device window, not th
   );
   const marketIndexData = { sp500: series };
 
-  // Mobile (90 days): window ends 2026-04-01, inside the dip -> DOWN.
+  // Mobile default (180 days, issue #711): window ends 2026-06-30, still inside
+  // the dip (recovery is 2026-09-01) -> DOWN.
   const mobileEnd = GRQProjection.deviceWindowEnd(new Date(SCORE_DATE), true);
   const mobile = GRQMarketIndex.marketPerformanceData(
     marketIndexData,
     mobileEnd,
   );
-  assert(mobile.sp500.performance < 0, "mobile 90d summary must be negative");
+  assert(mobile.sp500.performance < 0, "mobile summary must be negative");
   assertEquals(mobile.sp500.currentPrice, 80);
 
   // Desktop (180 days): window ends 2026-06-30, still before the recovery -> DOWN.
@@ -177,7 +181,7 @@ Deno.test("marketPerformanceData - summary follows the per-device window, not th
 Deno.test("marketPerformanceData - a DESKTOP 90 choice narrows the summary to the dip (issue #466)", () => {
   // Issue #466: desktop may now opt into the 90-day window. With the same
   // #333-shaped fixture, a desktop 90 choice (deviceWindowEnd(scoreDate, false,
-  // 90)) must land inside the dip and read DOWN — exactly as mobile's default
+  // 90)) must land inside the dip and read DOWN — exactly as an explicit mobile
   // 90 does — and land on the IDENTICAL end date, proving chart and summary
   // narrow together to the same window.
   const series = GRQProjection.buildIndexSeriesFromMap(
@@ -204,8 +208,12 @@ Deno.test("marketPerformanceData - a DESKTOP 90 choice narrows the summary to th
   );
   assertEquals(desktop90.sp500.currentPrice, 80);
 
-  // Same end date as mobile's default 90 window — chart and summary coincide.
-  const mobile90End = GRQProjection.deviceWindowEnd(new Date(SCORE_DATE), true);
+  // Same end date as an explicit mobile 90 window — chart and summary coincide.
+  const mobile90End = GRQProjection.deviceWindowEnd(
+    new Date(SCORE_DATE),
+    true,
+    90,
+  );
   assertEquals(desktop90End!.getTime(), mobile90End!.getTime());
 
   // And strictly narrower than the desktop DEFAULT 180 window.

--- a/tests/chart_window_settings_test.ts
+++ b/tests/chart_window_settings_test.ts
@@ -70,7 +70,9 @@ Deno.test("GRQChartWindow is published on globalThis", () => {
     S,
     "chart_window_settings.js should publish globalThis.GRQChartWindow",
   );
-  assertEquals(S.MOBILE_WINDOW_DAYS_DEFAULT, 90);
+  // Issue #711: the mobile default is now 180 (the full window) on every form
+  // factor, matching desktop.
+  assertEquals(S.MOBILE_WINDOW_DAYS_DEFAULT, 180);
   assertEquals(S.ALLOWED_WINDOW_DAYS, [90, 180]);
 });
 
@@ -91,14 +93,16 @@ Deno.test("normaliseWindowDays coerces numeric strings", () => {
   assertEquals(S.normaliseWindowDays("180"), 180);
 });
 
-Deno.test("normaliseWindowDays falls back to 90 for junk", () => {
-  assertEquals(S.normaliseWindowDays("abc"), 90);
-  assertEquals(S.normaliseWindowDays(0), 90);
-  assertEquals(S.normaliseWindowDays(30), 90);
-  assertEquals(S.normaliseWindowDays(""), 90);
-  assertEquals(S.normaliseWindowDays(null), 90);
-  assertEquals(S.normaliseWindowDays(undefined), 90);
-  assertEquals(S.normaliseWindowDays({}), 90);
+// Issue #711: with no explicit fallback, junk now normalises to the 180 default
+// (previously 90).
+Deno.test("normaliseWindowDays falls back to 180 for junk", () => {
+  assertEquals(S.normaliseWindowDays("abc"), 180);
+  assertEquals(S.normaliseWindowDays(0), 180);
+  assertEquals(S.normaliseWindowDays(30), 180);
+  assertEquals(S.normaliseWindowDays(""), 180);
+  assertEquals(S.normaliseWindowDays(null), 180);
+  assertEquals(S.normaliseWindowDays(undefined), 180);
+  assertEquals(S.normaliseWindowDays({}), 180);
 });
 
 // --- round-trip ------------------------------------------------------------
@@ -117,19 +121,28 @@ Deno.test("write then read round-trips 180", () => {
   assertEquals(store._dump()[S.STORAGE_KEY], "180");
 });
 
-Deno.test("writeMobileWindowDays normalises junk to 90 before persisting", () => {
+Deno.test("writeMobileWindowDays normalises junk to 180 before persisting", () => {
+  // Issue #711: an out-of-range write falls back to the 180 default, not 90.
   const store = fakeStorage();
   assertEquals(S.writeMobileWindowDays(365, store), true);
-  assertEquals(store._dump()[S.STORAGE_KEY], "90");
-  assertEquals(S.readMobileWindowDays(store), 90);
+  assertEquals(store._dump()[S.STORAGE_KEY], "180");
+  assertEquals(S.readMobileWindowDays(store), 180);
 });
 
-Deno.test("readMobileWindowDays returns the default when storage is empty", () => {
-  assertEquals(S.readMobileWindowDays(fakeStorage()), 90);
+Deno.test("readMobileWindowDays returns the 180 default when storage is empty", () => {
+  // Issue #711: fresh device with nothing saved shows the full 180-day window.
+  assertEquals(S.readMobileWindowDays(fakeStorage()), 180);
 });
 
-Deno.test("readMobileWindowDays tolerates a corrupt stored value", () => {
+Deno.test("readMobileWindowDays tolerates a corrupt stored value (→180)", () => {
   const store = fakeStorage({ [S.STORAGE_KEY]: "garbage" });
+  assertEquals(S.readMobileWindowDays(store), 180);
+});
+
+Deno.test("readMobileWindowDays returns an explicit saved 90 (opt-in preserved)", () => {
+  // The user can still opt into 90; a valid saved choice is honoured over the
+  // new 180 default.
+  const store = fakeStorage({ [S.STORAGE_KEY]: "90" });
   assertEquals(S.readMobileWindowDays(store), 90);
 });
 
@@ -137,7 +150,7 @@ Deno.test("readMobileWindowDays tolerates a corrupt stored value", () => {
 
 Deno.test("read falls back to default when storage throws", () => {
   const store = throwingStorage();
-  assertEquals(S.readMobileWindowDays(store), 90);
+  assertEquals(S.readMobileWindowDays(store), 180);
 });
 
 Deno.test("write reports failure (not throw) when storage is unavailable", () => {
@@ -148,7 +161,7 @@ Deno.test("write reports failure (not throw) when storage is unavailable", () =>
 Deno.test("read/write fall back to default when no storage is available", () => {
   // Passing an explicit null storage models a non-browser / no-localStorage
   // environment without depending on the ambient global.
-  assertEquals(S.readMobileWindowDays(null), 90);
+  assertEquals(S.readMobileWindowDays(null), 180);
   assertEquals(S.writeMobileWindowDays(180, null), false);
 });
 
@@ -224,12 +237,13 @@ Deno.test("desktop write reports failure (not throw) when storage is unavailable
 
 Deno.test("writing the desktop key never changes readMobileWindowDays", () => {
   const store = fakeStorage();
-  assertEquals(S.writeDesktopWindowDays(180, store), true);
-  // Mobile still reads its own default — the desktop write did not touch it.
-  assertEquals(S.readMobileWindowDays(store), 90);
+  assertEquals(S.writeDesktopWindowDays(90, store), true);
+  // Mobile still reads its own default (180, issue #711) — the desktop write of
+  // 90 did not touch the mobile key.
+  assertEquals(S.readMobileWindowDays(store), 180);
   // Only the desktop key was written.
   assertEquals(store._dump()[S.STORAGE_KEY], undefined);
-  assertEquals(store._dump()[S.DESKTOP_STORAGE_KEY], "180");
+  assertEquals(store._dump()[S.DESKTOP_STORAGE_KEY], "90");
 });
 
 Deno.test("writing the mobile key never changes readDesktopWindowDays", () => {
@@ -247,4 +261,14 @@ Deno.test("desktop and mobile choices coexist independently", () => {
   assertEquals(S.writeDesktopWindowDays(90, store), true);
   assertEquals(S.readMobileWindowDays(store), 180);
   assertEquals(S.readDesktopWindowDays(store), 90);
+});
+
+// --- issue #711: 180 is the default on every form factor -------------------
+
+Deno.test("issue #711: both mobile and desktop default to 180 with nothing saved", () => {
+  const store = fakeStorage();
+  assertEquals(S.readMobileWindowDays(store), 180);
+  assertEquals(S.readDesktopWindowDays(store), 180);
+  assertEquals(S.MOBILE_WINDOW_DAYS_DEFAULT, 180);
+  assertEquals(S.DESKTOP_WINDOW_DAYS_DEFAULT, 180);
 });

--- a/tests/chart_window_toggle_test.ts
+++ b/tests/chart_window_toggle_test.ts
@@ -3,7 +3,7 @@
 //
 // Both phone (< 768px) and desktop now show the control, letting the user
 // switch the visible chart/summary window between 90 and 180 days. Each device
-// keeps its OWN default and store: mobile defaults to 90, desktop to 180. These
+// keeps its OWN store, but both default to 180 (issue #711). These
 // assertions pin:
 //   - the control markup in docs/index.html (present, accessible);
 //   - the CSS in docs/styles.css (shown on every device, phone reveal kept);
@@ -98,25 +98,25 @@ Deno.test("index.html: toggle offers both 90 and 180 day choices", () => {
   );
 });
 
-Deno.test("index.html: default selection is 90 days (reflects the stored default)", () => {
-  // The 90-day radio carries the `checked` attribute so a fresh device shows
-  // the 90-day default; the 180-day radio does not.
-  const ninety = html.slice(
-    html.indexOf('id="chartWindow90"'),
-    html.indexOf('id="chartWindow90"') + 260,
-  );
-  assert(
-    ninety.includes("checked"),
-    "the 90-day radio must default to checked",
-  );
-
+Deno.test("index.html: default selection is 180 days (reflects the stored default, issue #711)", () => {
+  // The 180-day radio carries the `checked` attribute so a fresh device shows
+  // the 180-day default on every form factor; the 90-day radio does not.
   const oneEighty = html.slice(
     html.indexOf('id="chartWindow180"'),
     html.indexOf('id="chartWindow180"') + 260,
   );
   assert(
-    !oneEighty.includes("checked"),
-    "the 180-day radio must NOT be checked by default",
+    oneEighty.includes("checked"),
+    "the 180-day radio must default to checked",
+  );
+
+  const ninety = html.slice(
+    html.indexOf('id="chartWindow90"'),
+    html.indexOf('id="chartWindow90"') + 260,
+  );
+  assert(
+    !ninety.includes("checked"),
+    "the 90-day radio must NOT be checked by default",
   );
 });
 

--- a/tests/market_comparison_90day_window_test.ts
+++ b/tests/market_comparison_90day_window_test.ts
@@ -42,15 +42,17 @@ Deno.test("judgementWindowEnd - independent of the chart/device window (the #705
   // desktop: it is a fixed 90-day mark so the cards match the portfolio.
   const scoreDate = new Date("2026-01-05T09:30:00");
   const judgement = GRQProjection.judgementWindowEnd(scoreDate);
-  // Always equals the mobile 90-day window, never the desktop 180-day one.
+  // Always equals an explicit 90-day chart window, never the 180-day default.
+  // (Issue #711 makes 180 the default on every device, so 90 is compared
+  // explicitly rather than via the old mobile default.)
   assertEquals(
     judgement.getTime(),
-    GRQProjection.deviceWindowEnd(scoreDate, true).getTime(),
+    GRQProjection.deviceWindowEnd(scoreDate, true, 90).getTime(),
   );
   assert(
     judgement.getTime() < GRQProjection.deviceWindowEnd(scoreDate, false)
       .getTime(),
-    "judgement window must be shorter than the desktop 180-day chart window",
+    "judgement window must be shorter than the 180-day default chart window",
   );
 });
 

--- a/tests/projection_kernels_test.ts
+++ b/tests/projection_kernels_test.ts
@@ -97,22 +97,22 @@ function makePoint(
 
 // --- selectable window (issue #448; desktop-180 lock relaxed by #464) -------
 
-Deno.test("deviceWindowDays honours an explicit permitted window on either device, each device keeps its own default", () => {
-  // Default mobile behaviour is unchanged (90 days).
-  assertEquals(GRQProjection.deviceWindowDays(true), 90);
-  // Mobile may opt into the full 180-day window.
-  assertEquals(GRQProjection.deviceWindowDays(true, 180), 180);
-  // Mobile explicit 90 stays 90.
+Deno.test("deviceWindowDays honours an explicit permitted window on either device, defaulting to 180 everywhere (issue #711)", () => {
+  // Issue #711: the default is now 180 on EVERY form factor, mobile included.
+  assertEquals(GRQProjection.deviceWindowDays(true), 180);
+  // Mobile explicit 90 stays 90 (opt-in preserved).
   assertEquals(GRQProjection.deviceWindowDays(true, 90), 90);
-  // A non-permitted value falls back to the mobile 90-day default.
-  assertEquals(GRQProjection.deviceWindowDays(true, 999), 90);
-  // Desktop default is preserved (180 days).
+  // Mobile explicit 180 stays 180.
+  assertEquals(GRQProjection.deviceWindowDays(true, 180), 180);
+  // A non-permitted value falls back to the 180 default.
+  assertEquals(GRQProjection.deviceWindowDays(true, 999), 180);
+  // Desktop default is 180 as before.
   assertEquals(GRQProjection.deviceWindowDays(false), 180);
-  // Desktop may now opt into 90 — the old #448 desktop-180 lock is relaxed (#464).
+  // Desktop may opt into 90 — the old #448 desktop-180 lock is relaxed (#464).
   assertEquals(GRQProjection.deviceWindowDays(false, 90), 90);
   // Desktop explicit 180 stays 180.
   assertEquals(GRQProjection.deviceWindowDays(false, 180), 180);
-  // A non-permitted value falls back to the desktop 180-day default.
+  // A non-permitted value falls back to the 180 default.
   assertEquals(GRQProjection.deviceWindowDays(false, 999), 180);
 });
 
@@ -125,15 +125,15 @@ Deno.test("deviceWindowEnd threads the chosen mobile window through to the end d
     GRQProjection.setDateToMidnight(new Date(base.getTime() + days * DAY_MS))
       .getTime();
 
-  // Mobile default stays 90 days.
+  // Mobile default is now 180 days (issue #711).
   assertEquals(
     GRQProjection.deviceWindowEnd(scoreDate, true)!.getTime(),
-    expectEnd(90),
-  );
-  // Mobile opting into 180 ends 180 days after the score date.
-  assertEquals(
-    GRQProjection.deviceWindowEnd(scoreDate, true, 180)!.getTime(),
     expectEnd(180),
+  );
+  // Mobile opting into 90 ends 90 days after the score date.
+  assertEquals(
+    GRQProjection.deviceWindowEnd(scoreDate, true, 90)!.getTime(),
+    expectEnd(90),
   );
   // Desktop default (no explicit value) still ends 180 days after.
   assertEquals(


### PR DESCRIPTION
# Default the chart window to 180 days on every form factor

## Summary

The dashboard chart/summary window used to default to **90 days on mobile** and
**180 days on desktop**. Issue #711 asks for **180 days by default on all form
factors** unless the user has specifically opted into 90. This PR makes 180 the
single default everywhere while keeping the 90/180 toggle (and the per-device
saved choice / `?window=` deep link) fully working.

Closes #711.

### What changed

- `docs/chart_window_settings.js` — `MOBILE_WINDOW_DAYS_DEFAULT` raised from
  `90` to `180`, so a fresh mobile device (or a corrupt/missing stored value)
  now resolves to the full 180-day window, matching desktop. Mobile and desktop
  keep their own separate storage keys, so an explicit per-device choice is
  still honoured independently.
- `docs/projection.js` — `deviceWindowDays()` now defaults to `180` on **either**
  device (new `DEFAULT_WINDOW_DAYS` constant) instead of branching to 90 for
  mobile. The two selectable window sizes (90 and 180) are unchanged, so an
  explicit 90 opt-in still works on either device; `isMobile` is retained for
  call-site compatibility but no longer changes the default.
- `docs/app.js` — the `mobileWindowDays()` guard fallback (used when the storage
  helper is unavailable) now returns `180`, and the surrounding comments were
  corrected.
- `docs/index.html` — the static `checked` attribute moved from the 90-day radio
  to the 180-day radio, so the toggle shows 180 by default before JS runs and on
  every device.
- `README.md` — the `?window=` documentation now states the default is 180 on
  every form factor.

### Behaviour

```mermaid
flowchart TD
    A[Page load] --> B{Saved per-device choice?}
    B -- "yes (90 or 180)" --> C[Use saved choice]
    B -- "no / corrupt" --> D[Default = 180 on ALL form factors]
    A --> E{"?window=90|180 present?"}
    E -- yes --> F[Transient override wins this visit only, never persisted]
    E -- no --> B
```

## Evidence

This is a front-end (docs) change with **no** web-driver available in this
environment (Playwright MCP was not reachable), so visual capture was done by
inspecting the shipped markup and by the behavioural Deno tests that import the
real helpers.

- The shipped toggle now defaults to 180: in `docs/index.html` the
  `id="chartWindow180"` radio carries `checked` and `id="chartWindow90"` does
  not. This is pinned by
  `tests/chart_window_toggle_test.ts::index.html: default selection is 180 days`.
- The persistence and window-resolution helpers default to 180 on both devices,
  verified against the real modules (not mocks).

## Test Plan

Full Deno suite: **1317 passed, 0 failed**. `deno fmt`, `deno lint`, and
`deno check` all clean.

New / updated tests (business-logic change — the mobile default moved from 90 to
180, so assertions that pinned the old 90 default were updated and documented):

- `tests/chart_window_settings_test.ts` — mobile default is now 180 (empty /
  corrupt / throwing / no-storage all resolve to 180); junk normalises to 180; an
  explicit saved 90 is still honoured; new invariant test *"both mobile and
  desktop default to 180"*.
- `tests/projection_kernels_test.ts` — `deviceWindowDays`/`deviceWindowEnd`
  default to 180 on either device; explicit 90 still honoured.
- `tests/chart_summary_window_test.ts` — device default is 180; chart/summary
  still land on the identical end date for every window; explicit 90 compared
  explicitly.
- `tests/chart_actuals_window_test.ts` — the after-90 tail now shows for the
  mobile default (180) and for bad values (fall back to 180).
- `tests/chart_single_stock_axis_window_test.ts` — a bad window falls back to the
  180 default on both devices.
- `tests/market_comparison_90day_window_test.ts` — the fixed 90-day judgement
  window is now compared against an explicit 90-day chart window (the judgement
  window is unchanged; only the chart default moved).
- `tests/chart_window_toggle_test.ts` — default selection is now the 180-day
  radio.

## Notes

- `quality.sh` reports one **pre-existing, environmental** cargo test failure:
  `create_market_data_long_csv_writes_eight_column_rows` fails with *"No market
  data rows written for 2025-04-15 — is ../GRQ-shareprices2026Q2 available and up
  to date?"*. This depends on an external share-prices dataset that is not fresh
  in this environment and is **unrelated** to this change — no Rust files were
  touched. All other cargo checks and the entire Deno suite pass.
- The incidental `Cargo.lock` churn produced by `cargo update` inside
  `quality.sh` was reverted to keep this PR scoped to the front-end change.
