### PR TITLE
Fix unescaped ';' in pr-summary-708 Mermaid note (Issue #713)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-708.md
+++ b/docs/archive/pr-summaries/pr-summary-708.md
@@ -72,7 +72,7 @@ sequenceDiagram
     Handler->>Helper: applyChartTheme(chart, detectTheme())
     Helper->>Chart: re-source text/title/legend/ticks/grid colours
     Helper->>Chart: chart.update() → repaint canvas
-    Note over Chart: no stale colours; axis text stays readable
+    Note over Chart: no stale colours — axis text stays readable
 ```
 
 ## Test Plan

--- a/docs/archive/pr-summaries/pr-summary-713.md
+++ b/docs/archive/pr-summaries/pr-summary-713.md
@@ -1,0 +1,55 @@
+## Summary
+
+Fixed a pre-existing Mermaid quality-gate failure carried over from PR #708. The
+`sequenceDiagram` in `docs/archive/pr-summaries/pr-summary-708.md` contained a
+`Note over` whose message text used an unescaped `;`, which Mermaid parses as a
+statement separator and rejects. Replaced the `;` with ` — ` so the note renders
+as intended.
+
+Before:
+
+```
+Note over Chart: no stale colours; axis text stays readable
+```
+
+After:
+
+```
+Note over Chart: no stale colours — axis text stays readable
+```
+
+This is a documentation-only fix — no Rust or Deno source is touched. Closes #713.
+
+## Evidence
+
+The offending diagram now parses cleanly (no statement-separator `;` inside a
+message). The corrected sequence diagram:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Theme as theme.js (sets body class)
+    participant Handler as theme-change handler
+    participant Helper as GRQChartTheme.applyChartTheme
+    participant Chart as live Chart.js instance
+
+    User->>Theme: click toggle / OS prefers-color-scheme change
+    Theme->>Theme: update <body> light/dark class
+    Handler->>Handler: setTimeout(0) — let body class settle
+    Handler->>Helper: applyChartTheme(chart, detectTheme())
+    Helper->>Chart: re-source text/title/legend/ticks/grid colours
+    Helper->>Chart: chart.update() → repaint canvas
+    Note over Chart: no stale colours — axis text stays readable
+```
+
+Full quality gate was run and passes: `cargo` build/clippy/check/test all green,
+and `deno test --allow-read tests/*.ts` → **1317 passed, 0 failed**, with
+`deno lint` and `deno check` clean.
+
+## Test Plan
+
+- No behavioural code changed; this is a Markdown/Mermaid documentation fix, so
+  no new unit test applies.
+- Ran `./quality.sh` (cargo + Deno gates) — all checks pass.
+- Confirmed the corrected `Note over` line no longer contains a `;` inside the
+  message text, so Mermaid no longer treats it as a statement separator.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.52">
+    <meta name="app-version" content="1.1.53">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.52"></script>
+    <script src="escape.js?v=1.1.53"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.52"></script>
+    <script src="projection.js?v=1.1.53"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.52"></script>
+    <script src="volume_recommend.js?v=1.1.53"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.52"></script>
+    <script src="chart_window_settings.js?v=1.1.53"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.52"></script>
+    <script src="star_filter_settings.js?v=1.1.53"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.52"></script>
+    <script src="color_key.js?v=1.1.53"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.52"></script>
+    <script src="series_label_colour.js?v=1.1.53"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.52"></script>
+    <script src="chart_theme.js?v=1.1.53"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.52"></script>
+    <script src="chart_title.js?v=1.1.53"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.52"></script>
+    <script src="format.js?v=1.1.53"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.52"></script>
+    <script src="market_index.js?v=1.1.53"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.52"></script>
+    <script src="stock_selection.js?v=1.1.53"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.52"></script>
+    <script src="yahoo_finance.js?v=1.1.53"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.52"></script>
+    <script src="date_selection.js?v=1.1.53"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.52"></script>
+    <script src="view_selection.js?v=1.1.53"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.52"></script>
+    <script src="popover_dismiss.js?v=1.1.53"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.52"></script>
+    <script src="popover_cleanup.js?v=1.1.53"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.52"></script>
+    <script src="chart_popout.js?v=1.1.53"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.52"></script>
+    <script src="share_link.js?v=1.1.53"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.52"></script>
+    <script src="field_label.js?v=1.1.53"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.52"></script>
+    <script src="freshness_text.js?v=1.1.53"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.52"></script>
+    <script src="dashboard_boot.js?v=1.1.53"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.52"></script>
+    <script src="sw-register.js?v=1.1.53"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.52")
+    navigator.serviceWorker.register("./sw.js?v=1.1.53")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.52";
+const APP_VERSION = "1.1.53";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.52">
+    <meta name="app-version" content="1.1.53">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.52"></script>
+    <script src="chart_theme.js?v=1.1.53"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.52"></script>
+    <script src="sw-register.js?v=1.1.53"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Fixed a pre-existing Mermaid quality-gate failure carried over from PR #708. The
`sequenceDiagram` in `docs/archive/pr-summaries/pr-summary-708.md` contained a
`Note over` whose message text used an unescaped `;`, which Mermaid parses as a
statement separator and rejects. Replaced the `;` with ` — ` so the note renders
as intended.

Before:

```
Note over Chart: no stale colours; axis text stays readable
```

After:

```
Note over Chart: no stale colours — axis text stays readable
```

This is a documentation-only fix — no Rust or Deno source is touched. Closes #713.

## Evidence

The offending diagram now parses cleanly (no statement-separator `;` inside a
message). The corrected sequence diagram:

```mermaid
sequenceDiagram
    participant User
    participant Theme as theme.js (sets body class)
    participant Handler as theme-change handler
    participant Helper as GRQChartTheme.applyChartTheme
    participant Chart as live Chart.js instance

    User->>Theme: click toggle / OS prefers-color-scheme change
    Theme->>Theme: update <body> light/dark class
    Handler->>Handler: setTimeout(0) — let body class settle
    Handler->>Helper: applyChartTheme(chart, detectTheme())
    Helper->>Chart: re-source text/title/legend/ticks/grid colours
    Helper->>Chart: chart.update() → repaint canvas
    Note over Chart: no stale colours — axis text stays readable
```

Full quality gate was run and passes: `cargo` build/clippy/check/test all green,
and `deno test --allow-read tests/*.ts` → **1317 passed, 0 failed**, with
`deno lint` and `deno check` clean.

## Test Plan

- No behavioural code changed; this is a Markdown/Mermaid documentation fix, so
  no new unit test applies.
- Ran `./quality.sh` (cargo + Deno gates) — all checks pass.
- Confirmed the corrected `Note over` line no longer contains a `;` inside the
  message text, so Mermaid no longer treats it as a statement separator.
