### PR TITLE
🟠 Missing CI lint gate for `github-actions` (Issue #725)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -51,9 +51,9 @@ jobs:
           set -euo pipefail
           git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.sha }} > changed_files.txt
           if grep -E "^(docs/)" changed_files.txt > /dev/null; then
-            echo "docs=true" >> $GITHUB_OUTPUT
+            echo "docs=true" >> "$GITHUB_OUTPUT"
           else
-            echo "docs=false" >> $GITHUB_OUTPUT
+            echo "docs=false" >> "$GITHUB_OUTPUT"
           fi
 
   pa11y:
@@ -87,7 +87,7 @@ jobs:
           # Deno.args[0] (default 8000), so passing 8080 keeps the health check
           # and pa11yci.json target URLs unchanged.
           deno run --allow-net --allow-read helpers/server.ts 8080 &
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -sSf http://localhost:8080/index.html >/dev/null 2>&1; then
               echo "Static server is up"
               break

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,47 @@
+name: Actionlint
+
+# Lint gate for the workflow YAML itself (Issue #725).
+#
+# actionlint is the standard linter for GitHub Actions workflows: it catches
+# syntax errors, invalid `${{ }}` expressions, unknown runner labels, and —
+# through its bundled shellcheck integration — shell issues inside `run:`
+# blocks. Running it on every pull request fails the build when a workflow
+# regression is introduced, mirroring the shellcheck, markdown-lint, gitleaks
+# and semgrep gates already in this repo.
+#
+# The official rhysd/actionlint image is pinned to an immutable sha256 digest
+# rather than a mutable tag, matching the container pinning in semgrep.yml
+# (supply-chain hardening — Issue #72). Refresh the digest deliberately when
+# bumping the linter; resolve a new one with
+# `docker buildx imagetools inspect rhysd/actionlint:<version>`.
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: [main, master]
+
+# Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
+# queue redundant scans that each hold a runner. Keying on workflow + ref with
+# cancel-in-progress leaves only the latest run for a given ref alive.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      # rhysd/actionlint 1.7.9 official image, entrypoint `actionlint`, pinned
+      # to an immutable sha256 digest (Issue #72). The image bundles shellcheck
+      # so `run:` blocks are linted too. `-color` keeps annotations readable.
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint@sha256:a0383f60d92601e2694e24b24d37df7b6a40bed7cedbc447611c50009bf02d94
+        with:
+          args: -color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,16 +65,16 @@ jobs:
         
         # Check if Rust files changed
         if grep -E "^(src/|Cargo\.toml|Cargo\.lock|tests/)" changed_files.txt > /dev/null; then
-          echo "rust=true" >> $GITHUB_OUTPUT
+          echo "rust=true" >> "$GITHUB_OUTPUT"
         else
-          echo "rust=false" >> $GITHUB_OUTPUT
+          echo "rust=false" >> "$GITHUB_OUTPUT"
         fi
         
         # Check if docs changed
         if grep -E "^(docs/)" changed_files.txt > /dev/null; then
-          echo "docs=true" >> $GITHUB_OUTPUT
+          echo "docs=true" >> "$GITHUB_OUTPUT"
         else
-          echo "docs=false" >> $GITHUB_OUTPUT
+          echo "docs=false" >> "$GITHUB_OUTPUT"
         fi
         
         echo "Changed files:"

--- a/README.md
+++ b/README.md
@@ -602,6 +602,11 @@ covering continuous integration, security scanning, and dependency hygiene.
 12. **Version Bump** (`version-bump.yml`) — on every pull request, runs
     `scripts/bump_version.ts` to increment the dashboard app version and commits
     the change back to the PR branch (see _Dashboard versioning_ below).
+13. **Actionlint** (`actionlint.yml`) — lints the workflow YAML itself on every
+    pull request with `actionlint`, catching syntax errors, invalid `${{ }}`
+    expressions, unknown runner labels, and — via its bundled `shellcheck`
+    integration — shell issues inside `run:` blocks, so workflow regressions
+    fail the build.
 
 ### Dashboard versioning
 

--- a/docs/archive/pr-summaries/pr-summary-725.md
+++ b/docs/archive/pr-summaries/pr-summary-725.md
@@ -1,0 +1,69 @@
+# Add CI lint gate for `github-actions` (actionlint)
+
+## Summary
+
+No workflow invoked `actionlint`, so workflow-YAML regressions (syntax errors,
+invalid `${{ }}` expressions, unknown runner labels, shell mistakes inside
+`run:` blocks) could merge undetected. This PR adds an **Actionlint** lint gate
+that runs on every pull request and fails the build on such regressions,
+mirroring the existing shellcheck / markdown-lint / gitleaks / semgrep gates.
+Closes #725.
+
+Changes:
+
+- **`.github/workflows/actionlint.yml`** — new gate. Runs the official
+  `rhysd/actionlint` image (entrypoint `actionlint`, `-color`) on
+  `pull_request` and pushes to `main`/`master`. It is least-privilege
+  (`contents: read`) and cancels superseded runs (Issue #139). The image is
+  pinned to an immutable `sha256` digest rather than a mutable tag, matching the
+  container pinning in `semgrep.yml` (supply-chain hardening, Issue #72). The
+  image bundles `shellcheck`, so `run:` blocks are linted too.
+- **`.github/workflows/a11y.yml`, `.github/workflows/ci.yml`** — fixed the
+  pre-existing shellcheck findings actionlint surfaced, required for the new
+  gate to pass cleanly: quoted `>> "$GITHUB_OUTPUT"` (SC2086) and replaced the
+  unused loop variable `for i` with `for _` (SC2034). Behaviour is unchanged.
+- **`README.md`** — documented the new workflow under _Workflows_ (also keeps
+  the `documentation_accuracy_test` "README references every workflow" test
+  green).
+
+### Why the official image, pinned by digest
+
+`rhysd/actionlint` publishes no `action.yml`, so `rhysd/actionlint@v1` is not a
+usable `uses:` action. The repo's house style for tools without a first-party
+action is a pinned, immutable artefact (see `semgrep.yml`'s digest-pinned
+container). A `docker://rhysd/actionlint@sha256:…` step gives exactly that:
+self-contained, no third-party review-bot dependency, and immutable.
+
+```mermaid
+flowchart LR
+    PR[Pull request] --> AL[Actionlint gate]
+    AL -->|actionlint + shellcheck| WF[".github/workflows/*.yml"]
+    WF -->|clean| Pass[✅ build passes]
+    WF -->|regression| Fail[❌ build fails]
+```
+
+## Evidence
+
+Backend/CI change — no web UI to screenshot. Verified with the pinned linter
+locally:
+
+- `actionlint -color` → exit `0` after the a11y/ci fixes (exit `1` before,
+  reporting the SC2086/SC2034 findings now fixed).
+- `deno test --allow-read tests/*.ts` → **1328 passed, 0 failed**, including the
+  7 new `tests/actionlint_workflow_test.ts` cases.
+- `deno lint` / `deno check` / `markdownlint-cli2` / `bash -n` → clean.
+
+## Test Plan
+
+Added `tests/actionlint_workflow_test.ts` (structured assertions on the parsed
+YAML, per Issue #202), covering:
+
+- workflow file exists and parses with name `Actionlint`;
+- triggers on `pull_request`;
+- declares `contents: read`;
+- declares a concurrency group that cancels superseded runs;
+- a step actually invokes `actionlint`;
+- every action is pinned to an immutable ref (40-char commit SHA or 64-char
+  `sha256` digest).
+
+These fail against the unfixed tree (no workflow file) and pass after it.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.56">
+    <meta name="app-version" content="1.1.57">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.56"></script>
+    <script src="escape.js?v=1.1.57"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.56"></script>
+    <script src="projection.js?v=1.1.57"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.56"></script>
+    <script src="volume_recommend.js?v=1.1.57"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.56"></script>
+    <script src="chart_window_settings.js?v=1.1.57"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.56"></script>
+    <script src="star_filter_settings.js?v=1.1.57"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.56"></script>
+    <script src="color_key.js?v=1.1.57"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.56"></script>
+    <script src="series_label_colour.js?v=1.1.57"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.56"></script>
+    <script src="chart_theme.js?v=1.1.57"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.56"></script>
+    <script src="chart_title.js?v=1.1.57"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.56"></script>
+    <script src="format.js?v=1.1.57"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.56"></script>
+    <script src="market_index.js?v=1.1.57"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.56"></script>
+    <script src="stock_selection.js?v=1.1.57"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.56"></script>
+    <script src="yahoo_finance.js?v=1.1.57"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.56"></script>
+    <script src="date_selection.js?v=1.1.57"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.56"></script>
+    <script src="view_selection.js?v=1.1.57"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.56"></script>
+    <script src="popover_dismiss.js?v=1.1.57"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.56"></script>
+    <script src="popover_cleanup.js?v=1.1.57"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.56"></script>
+    <script src="chart_popout.js?v=1.1.57"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.56"></script>
+    <script src="share_link.js?v=1.1.57"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.56"></script>
+    <script src="field_label.js?v=1.1.57"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.56"></script>
+    <script src="freshness_text.js?v=1.1.57"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.56"></script>
+    <script src="dashboard_boot.js?v=1.1.57"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.56"></script>
+    <script src="sw-register.js?v=1.1.57"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.56")
+    navigator.serviceWorker.register("./sw.js?v=1.1.57")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.56";
+const APP_VERSION = "1.1.57";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.56">
+    <meta name="app-version" content="1.1.57">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.56"></script>
+    <script src="chart_theme.js?v=1.1.57"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.56"></script>
+    <script src="sw-register.js?v=1.1.57"></script>
   </body>
 </html>

--- a/tests/actionlint_workflow_test.ts
+++ b/tests/actionlint_workflow_test.ts
@@ -1,0 +1,98 @@
+// Tests for the actionlint GitHub Actions lint-gate workflow (Issue #725).
+//
+// actionlint is the standard linter for workflow YAML: it catches syntax
+// errors, invalid `${{ }}` expressions, and — via its bundled shellcheck
+// integration — shell issues inside `run:` blocks. This gate fails the build
+// when a workflow regression is introduced, mirroring the shellcheck,
+// markdown-lint, gitleaks and semgrep gates already in this repo.
+//
+// The assertions operate on the parsed YAML (structured assertions, not
+// source-text greps — Issue #202) and verify the gate's invariants: the file
+// exists and parses, triggers on pull_request, is least-privilege
+// (contents: read), cancels superseded runs (Issue #139), actually invokes
+// actionlint, and pins its third-party image to an immutable sha256 digest
+// (supply-chain hardening, mirroring semgrep.yml — Issue #72).
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  loadWorkflow,
+  workflowSteps,
+  workflowTriggers,
+} from "./workflow_assertions.ts";
+
+const WORKFLOW_PATH = ".github/workflows/actionlint.yml";
+
+Deno.test("actionlint workflow file exists", async () => {
+  const stat = await Deno.stat(WORKFLOW_PATH);
+  assert(stat.isFile, `${WORKFLOW_PATH} should be a file`);
+});
+
+Deno.test("actionlint workflow parses as valid YAML with expected name", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  assertEquals(doc.name, "Actionlint");
+});
+
+Deno.test("actionlint workflow triggers on pull_request", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  const on = workflowTriggers(doc);
+  assert(on, "workflow must declare an 'on' trigger");
+  assert("pull_request" in on, "must trigger on pull_request");
+});
+
+Deno.test("actionlint workflow declares read-only contents permission", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  assert(doc.permissions, "workflow must declare top-level permissions");
+  assertEquals(doc.permissions.contents, "read");
+});
+
+// Concurrency cancellation (Issue #139): without a concurrency group, rapid
+// pushes to the same ref queue redundant overlapping runs that each hold a
+// runner. A top-level block keyed on workflow + ref with cancel-in-progress
+// leaves only the latest run for a given ref alive.
+Deno.test("actionlint workflow declares a concurrency group that cancels superseded runs", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  const concurrency = doc.concurrency as Record<string, unknown> | undefined;
+  assert(concurrency, "workflow must declare a top-level concurrency block");
+  assertEquals(
+    concurrency.group,
+    "${{ github.workflow }}-${{ github.ref }}",
+    "concurrency group must be keyed on workflow and ref",
+  );
+  assertEquals(
+    concurrency["cancel-in-progress"],
+    true,
+    "concurrency must cancel superseded in-progress runs",
+  );
+});
+
+// The whole point of the gate: some step must actually run actionlint, either
+// by invoking the binary in a `run:` block or by using the official
+// rhysd/actionlint image (whose entrypoint is actionlint).
+Deno.test("actionlint workflow actually invokes actionlint", async () => {
+  const { doc } = await loadWorkflow(WORKFLOW_PATH);
+  const steps = workflowSteps(doc);
+  const invokes = steps.some((step) => {
+    const runsBinary = /\bactionlint\b/.test(step.run ?? "");
+    const usesImage = typeof step.uses === "string" &&
+      step.uses.includes("actionlint");
+    return runsBinary || usesImage;
+  });
+  assert(invokes, "a step must invoke actionlint (run: or docker image)");
+});
+
+// Supply-chain hardening (Issue #72): every third-party action must be pinned
+// to an immutable ref. First-party actions (actions/checkout) pin to a 40-char
+// commit SHA; a `docker://` image action pins to a 64-char sha256 digest.
+// Neither may float on a mutable tag/branch.
+Deno.test("actionlint workflow pins every action to an immutable ref", async () => {
+  const { text } = await loadWorkflow(WORKFLOW_PATH);
+  const usesLines = text.split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^-?\s*uses:/.test(line));
+  assert(usesLines.length > 0, "workflow must use at least one action");
+  for (const line of usesLines) {
+    const pinned = /@[0-9a-f]{40}\s*$/.test(line) || // commit SHA
+      /@sha256:[0-9a-f]{64}\s*$/.test(line); // docker image digest
+    assert(pinned, `action not pinned to an immutable ref: ${line}`);
+  }
+});


### PR DESCRIPTION
# Add CI lint gate for `github-actions` (actionlint)

## Summary

No workflow invoked `actionlint`, so workflow-YAML regressions (syntax errors,
invalid `${{ }}` expressions, unknown runner labels, shell mistakes inside
`run:` blocks) could merge undetected. This PR adds an **Actionlint** lint gate
that runs on every pull request and fails the build on such regressions,
mirroring the existing shellcheck / markdown-lint / gitleaks / semgrep gates.
Closes #725.

Changes:

- **`.github/workflows/actionlint.yml`** — new gate. Runs the official
  `rhysd/actionlint` image (entrypoint `actionlint`, `-color`) on
  `pull_request` and pushes to `main`/`master`. It is least-privilege
  (`contents: read`) and cancels superseded runs (Issue #139). The image is
  pinned to an immutable `sha256` digest rather than a mutable tag, matching the
  container pinning in `semgrep.yml` (supply-chain hardening, Issue #72). The
  image bundles `shellcheck`, so `run:` blocks are linted too.
- **`.github/workflows/a11y.yml`, `.github/workflows/ci.yml`** — fixed the
  pre-existing shellcheck findings actionlint surfaced, required for the new
  gate to pass cleanly: quoted `>> "$GITHUB_OUTPUT"` (SC2086) and replaced the
  unused loop variable `for i` with `for _` (SC2034). Behaviour is unchanged.
- **`README.md`** — documented the new workflow under _Workflows_ (also keeps
  the `documentation_accuracy_test` "README references every workflow" test
  green).

### Why the official image, pinned by digest

`rhysd/actionlint` publishes no `action.yml`, so `rhysd/actionlint@v1` is not a
usable `uses:` action. The repo's house style for tools without a first-party
action is a pinned, immutable artefact (see `semgrep.yml`'s digest-pinned
container). A `docker://rhysd/actionlint@sha256:…` step gives exactly that:
self-contained, no third-party review-bot dependency, and immutable.

```mermaid
flowchart LR
    PR[Pull request] --> AL[Actionlint gate]
    AL -->|actionlint + shellcheck| WF[".github/workflows/*.yml"]
    WF -->|clean| Pass[✅ build passes]
    WF -->|regression| Fail[❌ build fails]
```

## Evidence

Backend/CI change — no web UI to screenshot. Verified with the pinned linter
locally:

- `actionlint -color` → exit `0` after the a11y/ci fixes (exit `1` before,
  reporting the SC2086/SC2034 findings now fixed).
- `deno test --allow-read tests/*.ts` → **1328 passed, 0 failed**, including the
  7 new `tests/actionlint_workflow_test.ts` cases.
- `deno lint` / `deno check` / `markdownlint-cli2` / `bash -n` → clean.

## Test Plan

Added `tests/actionlint_workflow_test.ts` (structured assertions on the parsed
YAML, per Issue #202), covering:

- workflow file exists and parses with name `Actionlint`;
- triggers on `pull_request`;
- declares `contents: read`;
- declares a concurrency group that cancels superseded runs;
- a step actually invokes `actionlint`;
- every action is pinned to an immutable ref (40-char commit SHA or 64-char
  `sha256` digest).

These fail against the unfixed tree (no workflow file) and pass after it.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrbyc8n1-5e9f47`<!-- vibe-worker-issue-725 -->