### PR TITLE
🟡 Test/lint workflow triggers on push to `main` (`.github/workflows/markdown-lint.yml`) (Issue #726)

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -3,8 +3,10 @@ name: Markdown Lint
 on:
   pull_request:
     branches: ["*"]
-  push:
-    branches: [main, master]
+  # Issue #726: this lint/checker gates the PR, so it no longer runs on push to
+  # the default branch — that re-ran the same check the PR already passed and
+  # wasted CI minutes. Manual dispatch stays available for ad-hoc runs.
+  workflow_dispatch:
 
 # Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
 # queue redundant scans that each hold a runner. Keying on workflow + ref with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ and this project adheres to
 
 ### Changed
 
+- Markdown Lint workflow (`.github/workflows/markdown-lint.yml`) no longer
+  triggers on push to the default branch. As a PR-gating lint check, a
+  post-merge push run only duplicated the run that already passed on the pull
+  request, wasting CI minutes; the `push:` trigger is replaced with
+  `workflow_dispatch` so the check still gates every PR and can be run manually
+  on demand (Issue #726).
 - Chart window now defaults to **180 days on every form factor** (previously 90
   on mobile, 180 on desktop). A fresh device shows the full 180-day window; the
   90/180 toggle, the per-device saved choice, and the transient `?window=` deep

--- a/docs/archive/pr-summaries/pr-summary-726.md
+++ b/docs/archive/pr-summaries/pr-summary-726.md
@@ -1,0 +1,63 @@
+# PR Summary — Issue #726
+
+## Summary
+
+The Markdown Lint workflow (`.github/workflows/markdown-lint.yml`) is a
+lint/checker that gates the pull request, but it still triggered on push to the
+default branch (`main`/`master`). Once it becomes a required status check, every
+merge re-ran the exact check that already passed on the PR — wasting CI minutes
+and risking a red tick on the default branch for an already-green check.
+
+This PR drops the `push:` trigger and replaces it with `workflow_dispatch`,
+keeping the `pull_request` trigger so the linter still gates every PR and can be
+run manually on demand. Deploy/publish workflows are unaffected — only this
+checker changed.
+
+Closes #726.
+
+## Change
+
+```diff
+ on:
+   pull_request:
+     branches: ["*"]
+-  push:
+-    branches: [main, master]
++  workflow_dispatch:
+```
+
+```mermaid
+flowchart LR
+    PR[Pull request] --> Lint[Markdown Lint gate]
+    Merge[Merge to main] -. no longer re-runs .-> Lint
+    Manual[workflow_dispatch] --> Lint
+```
+
+## Evidence
+
+Backend/CI-config change — no web interface to screenshot. Verified via the
+workflow's Deno test suite (`tests/markdown_lint_workflow_test.ts`), which
+parses the YAML and asserts the trigger invariants:
+
+```
+running 11 tests from ./tests/markdown_lint_workflow_test.ts
+Markdown Lint workflow has correct triggers ... ok
+Markdown Lint workflow does not trigger on push to the default branch ... ok
+...
+ok | 11 passed | 0 failed
+```
+
+`deno lint`, `deno check`, and `deno fmt` all pass on the modified test file.
+
+## Test Plan
+
+- Updated `tests/markdown_lint_workflow_test.ts::Markdown Lint workflow has
+  correct triggers` — was asserting `"push" in on`; now asserts the checker
+  keeps `pull_request` and gains `workflow_dispatch`. This existing test was
+  modified because the business rule changed: a PR-gating linter must no longer
+  fire on push to the default branch.
+- Added `tests/markdown_lint_workflow_test.ts::Markdown Lint workflow does not
+  trigger on push to the default branch` — a regression test that fails against
+  the unfixed workflow (which had `push: branches: [main, master]`) and passes
+  after the fix. It also tolerates a narrowed `push:` filter that excludes
+  `main`/`master`, per the issue's alternative fix.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.57">
+    <meta name="app-version" content="1.1.58">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.57"></script>
+    <script src="escape.js?v=1.1.58"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.57"></script>
+    <script src="projection.js?v=1.1.58"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.57"></script>
+    <script src="volume_recommend.js?v=1.1.58"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.57"></script>
+    <script src="chart_window_settings.js?v=1.1.58"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.57"></script>
+    <script src="star_filter_settings.js?v=1.1.58"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.57"></script>
+    <script src="color_key.js?v=1.1.58"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.57"></script>
+    <script src="series_label_colour.js?v=1.1.58"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.57"></script>
+    <script src="chart_theme.js?v=1.1.58"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.57"></script>
+    <script src="chart_title.js?v=1.1.58"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.57"></script>
+    <script src="format.js?v=1.1.58"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.57"></script>
+    <script src="market_index.js?v=1.1.58"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.57"></script>
+    <script src="stock_selection.js?v=1.1.58"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.57"></script>
+    <script src="yahoo_finance.js?v=1.1.58"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.57"></script>
+    <script src="date_selection.js?v=1.1.58"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.57"></script>
+    <script src="view_selection.js?v=1.1.58"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.57"></script>
+    <script src="popover_dismiss.js?v=1.1.58"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.57"></script>
+    <script src="popover_cleanup.js?v=1.1.58"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.57"></script>
+    <script src="chart_popout.js?v=1.1.58"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.57"></script>
+    <script src="share_link.js?v=1.1.58"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.57"></script>
+    <script src="field_label.js?v=1.1.58"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.57"></script>
+    <script src="freshness_text.js?v=1.1.58"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.57"></script>
+    <script src="dashboard_boot.js?v=1.1.58"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.57"></script>
+    <script src="sw-register.js?v=1.1.58"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.57")
+    navigator.serviceWorker.register("./sw.js?v=1.1.58")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.57";
+const APP_VERSION = "1.1.58";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.57">
+    <meta name="app-version" content="1.1.58">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.57"></script>
+    <script src="chart_theme.js?v=1.1.58"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.57"></script>
+    <script src="sw-register.js?v=1.1.58"></script>
   </body>
 </html>

--- a/tests/markdown_lint_workflow_test.ts
+++ b/tests/markdown_lint_workflow_test.ts
@@ -35,7 +35,37 @@ Deno.test("Markdown Lint workflow has correct triggers", async () => {
       | undefined;
   assert(on, "workflow must declare an 'on' trigger");
   assert("pull_request" in on, "must trigger on pull_request");
-  assert("push" in on, "must trigger on push");
+  // Issue #726: this is a lint/checker workflow that gates the PR. It must not
+  // re-run on push to the default branch — that duplicates the run which
+  // already gated the PR and wastes CI minutes. Allow manual dispatch instead.
+  assert("workflow_dispatch" in on, "must allow manual workflow_dispatch");
+});
+
+// Issue #726: a lint/checker gates the PR, so it must not fire on push to the
+// default branch. If the workflow keeps a `push:` trigger at all, its branch
+// filter must exclude `main` (and `master`); a bare `push:` reaching the
+// default branch re-runs the same check that already passed on the PR.
+Deno.test("Markdown Lint workflow does not trigger on push to the default branch", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | Record<string, unknown>
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  if (!("push" in on)) return; // No push trigger at all — compliant.
+  const push = on.push as { branches?: string[] } | null;
+  const branches = push?.branches ?? [];
+  assert(
+    branches.length > 0,
+    "a bare `push:` reaches the default branch — narrow its branches or drop push",
+  );
+  for (const branch of branches) {
+    assert(
+      branch !== "main" && branch !== "master",
+      `push trigger must not include the default branch (found "${branch}")`,
+    );
+  }
 });
 
 Deno.test("Markdown Lint workflow defines markdownlint job", async () => {


### PR DESCRIPTION
# PR Summary — Issue #726

## Summary

The Markdown Lint workflow (`.github/workflows/markdown-lint.yml`) is a
lint/checker that gates the pull request, but it still triggered on push to the
default branch (`main`/`master`). Once it becomes a required status check, every
merge re-ran the exact check that already passed on the PR — wasting CI minutes
and risking a red tick on the default branch for an already-green check.

This PR drops the `push:` trigger and replaces it with `workflow_dispatch`,
keeping the `pull_request` trigger so the linter still gates every PR and can be
run manually on demand. Deploy/publish workflows are unaffected — only this
checker changed.

Closes #726.

## Change

```diff
 on:
   pull_request:
     branches: ["*"]
-  push:
-    branches: [main, master]
+  workflow_dispatch:
```

```mermaid
flowchart LR
    PR[Pull request] --> Lint[Markdown Lint gate]
    Merge[Merge to main] -. no longer re-runs .-> Lint
    Manual[workflow_dispatch] --> Lint
```

## Evidence

Backend/CI-config change — no web interface to screenshot. Verified via the
workflow's Deno test suite (`tests/markdown_lint_workflow_test.ts`), which
parses the YAML and asserts the trigger invariants:

```
running 11 tests from ./tests/markdown_lint_workflow_test.ts
Markdown Lint workflow has correct triggers ... ok
Markdown Lint workflow does not trigger on push to the default branch ... ok
...
ok | 11 passed | 0 failed
```

`deno lint`, `deno check`, and `deno fmt` all pass on the modified test file.

## Test Plan

- Updated `tests/markdown_lint_workflow_test.ts::Markdown Lint workflow has
  correct triggers` — was asserting `"push" in on`; now asserts the checker
  keeps `pull_request` and gains `workflow_dispatch`. This existing test was
  modified because the business rule changed: a PR-gating linter must no longer
  fire on push to the default branch.
- Added `tests/markdown_lint_workflow_test.ts::Markdown Lint workflow does not
  trigger on push to the default branch` — a regression test that fails against
  the unfixed workflow (which had `push: branches: [main, master]`) and passes
  after the fix. It also tolerates a narrowed `push:` filter that excludes
  `main`/`master`, per the issue's alternative fix.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrc5eg9f-5a53cf`<!-- vibe-worker-issue-726 -->