### PR TITLE
🟠 Job `check-docs-changes` checkout persists credentials (`.github/workflows/a11y.yml`) (Issue #727)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -45,8 +45,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
-          # This job only diffs docs/ paths; it never pushes back or fetches a
-          # private submodule, so do not persist GITHUB_TOKEN into .git/config
+          # Job only runs a local `git diff`; it never pushes back or fetches
+          # private submodules, so the GITHUB_TOKEN need not persist to disk
           # where a later step could read it (Issue #727).
           persist-credentials: false
       - name: Check for docs/ changes

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -45,6 +45,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
+          # This job only diffs docs/ paths; it never pushes back or fetches a
+          # private submodule, so do not persist GITHUB_TOKEN into .git/config
+          # where a later step could read it (Issue #727).
+          persist-credentials: false
       - name: Check for docs/ changes
         id: filter
         run: |

--- a/docs/archive/pr-summaries/pr-summary-727.md
+++ b/docs/archive/pr-summaries/pr-summary-727.md
@@ -1,0 +1,34 @@
+# Harden `check-docs-changes` checkout against credential persistence
+
+## Summary
+
+The `check-docs-changes` job in `.github/workflows/a11y.yml` ran
+`actions/checkout` without `persist-credentials: false`. By default checkout
+writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where
+any later step in the job could read it and act as the token. This job only
+diffs `docs/` paths — it never pushes back to the repository or fetches a
+private submodule — so it does not need the persisted credential. Added
+`persist-credentials: false` to the checkout step to keep the token off disk and
+shrink the blast radius of a compromised step. Closes #727.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. Verified via the
+workflow-assertion test suite (`deno test --allow-read tests/a11y_workflow_test.ts`),
+16 passed / 0 failed. The new test fails against the unfixed workflow
+(`persist-credentials` is `undefined`, not `false`) and passes after the fix.
+
+```mermaid
+flowchart LR
+    A[check-docs-changes job] --> B[actions/checkout]
+    B -->|persist-credentials: false| C[.git/config has NO GITHUB_TOKEN]
+    C --> D[later steps cannot read the token]
+```
+
+## Test Plan
+
+- Added `tests/a11y_workflow_test.ts::a11y check-docs-changes checkout does not
+  persist credentials` — loads the workflow, finds the `check-docs-changes`
+  `actions/checkout` step, and asserts `with.persist-credentials === false`.
+- Re-ran the full `a11y_workflow_test.ts` suite: 16 passed, 0 failed.
+- `deno fmt`, `deno lint`, and `deno check` clean on the modified test.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.58">
+    <meta name="app-version" content="1.1.59">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.58"></script>
+    <script src="escape.js?v=1.1.59"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.58"></script>
+    <script src="projection.js?v=1.1.59"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.58"></script>
+    <script src="volume_recommend.js?v=1.1.59"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.58"></script>
+    <script src="chart_window_settings.js?v=1.1.59"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.58"></script>
+    <script src="star_filter_settings.js?v=1.1.59"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.58"></script>
+    <script src="color_key.js?v=1.1.59"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.58"></script>
+    <script src="series_label_colour.js?v=1.1.59"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.58"></script>
+    <script src="chart_theme.js?v=1.1.59"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.58"></script>
+    <script src="chart_title.js?v=1.1.59"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.58"></script>
+    <script src="format.js?v=1.1.59"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.58"></script>
+    <script src="market_index.js?v=1.1.59"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.58"></script>
+    <script src="stock_selection.js?v=1.1.59"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.58"></script>
+    <script src="yahoo_finance.js?v=1.1.59"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.58"></script>
+    <script src="date_selection.js?v=1.1.59"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.58"></script>
+    <script src="view_selection.js?v=1.1.59"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.58"></script>
+    <script src="popover_dismiss.js?v=1.1.59"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.58"></script>
+    <script src="popover_cleanup.js?v=1.1.59"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.58"></script>
+    <script src="chart_popout.js?v=1.1.59"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.58"></script>
+    <script src="share_link.js?v=1.1.59"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.58"></script>
+    <script src="field_label.js?v=1.1.59"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.58"></script>
+    <script src="freshness_text.js?v=1.1.59"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.58"></script>
+    <script src="dashboard_boot.js?v=1.1.59"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.58"></script>
+    <script src="sw-register.js?v=1.1.59"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.58")
+    navigator.serviceWorker.register("./sw.js?v=1.1.59")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.58";
+const APP_VERSION = "1.1.59";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.58">
+    <meta name="app-version" content="1.1.59">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.58"></script>
+    <script src="chart_theme.js?v=1.1.59"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.58"></script>
+    <script src="sw-register.js?v=1.1.59"></script>
   </body>
 </html>

--- a/tests/a11y_workflow_test.ts
+++ b/tests/a11y_workflow_test.ts
@@ -263,6 +263,25 @@ Deno.test("a11y multi-line bash run blocks begin with set -euo pipefail", async 
   }
 });
 
+// Issue #727: the check-docs-changes job only diffs docs/ paths — it never
+// pushes back to the repo or fetches a private submodule, so it must not let
+// actions/checkout persist GITHUB_TOKEN into .git/config, where a later
+// (possibly compromised) step could read it and act as the token.
+Deno.test("a11y check-docs-changes checkout does not persist credentials", async () => {
+  const doc = await loadWorkflow();
+  const job = doc.jobs?.["check-docs-changes"];
+  assert(job, "workflow must declare a check-docs-changes job");
+  const checkout = (job.steps ?? []).find((s) =>
+    typeof s.uses === "string" && s.uses.startsWith("actions/checkout@")
+  );
+  assert(checkout, "check-docs-changes job must have an actions/checkout step");
+  assertEquals(
+    checkout.with?.["persist-credentials"],
+    false,
+    "check-docs-changes checkout must set persist-credentials: false",
+  );
+});
+
 Deno.test("a11y workflow pins actions to 40-character commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   assertActionsPinnedToSha(text);


### PR DESCRIPTION
# Harden `check-docs-changes` checkout against credential persistence

## Summary

The `check-docs-changes` job in `.github/workflows/a11y.yml` ran
`actions/checkout` without `persist-credentials: false`. By default checkout
writes the workflow's `GITHUB_TOKEN` into `.git/config` as an auth header, where
any later step in the job could read it and act as the token. This job only
diffs `docs/` paths — it never pushes back to the repository or fetches a
private submodule — so it does not need the persisted credential. Added
`persist-credentials: false` to the checkout step to keep the token off disk and
shrink the blast radius of a compromised step. Closes #727.

## Evidence

Backend/CI change — no web interface to screenshot. Verified via the
workflow-assertion test suite (`deno test --allow-read tests/a11y_workflow_test.ts`),
16 passed / 0 failed. The new test fails against the unfixed workflow
(`persist-credentials` is `undefined`, not `false`) and passes after the fix.

```mermaid
flowchart LR
    A[check-docs-changes job] --> B[actions/checkout]
    B -->|persist-credentials: false| C[.git/config has NO GITHUB_TOKEN]
    C --> D[later steps cannot read the token]
```

## Test Plan

- Added `tests/a11y_workflow_test.ts::a11y check-docs-changes checkout does not
  persist credentials` — loads the workflow, finds the `check-docs-changes`
  `actions/checkout` step, and asserts `with.persist-credentials === false`.
- Re-ran the full `a11y_workflow_test.ts` suite: 16 passed, 0 failed.
- `deno fmt`, `deno lint`, and `deno check` clean on the modified test.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrc8z3dp-6350b3`<!-- vibe-worker-issue-727 -->