### PR TITLE
Stop pa11y checkout persisting credentials (Issue #728)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -68,6 +68,12 @@ jobs:
     steps:
       # actions/checkout@v4.2.2
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # The pa11y job only reads the tree (serves docs/, runs pa11y-ci); it
+          # never pushes back or fetches a private submodule, so it does not need
+          # GITHUB_TOKEN persisted into .git/config. Not persisting it keeps a
+          # compromised later step from reading the token off disk (Issue #728).
+          persist-credentials: false
       # actions/setup-node@v4
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/docs/archive/pr-summaries/pr-summary-728.md
+++ b/docs/archive/pr-summaries/pr-summary-728.md
@@ -1,0 +1,39 @@
+## Summary
+
+The `pa11y` job in `.github/workflows/a11y.yml` checked out the repo with
+`actions/checkout` but did not set `persist-credentials: false`. By default
+checkout writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth
+header, where any later step — including a compromised dependency or injected
+script — can read it and act as the token. This job only serves `docs/` and runs
+`pa11y-ci`; it never pushes back to the repository or fetches a private
+submodule, so it does not need the persisted credential. Added
+`persist-credentials: false` to the pa11y checkout step to keep the token off
+disk and shrink the blast radius of a compromised step. Closes #728.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the
+workflow's Deno test suite (all 16 tests pass) and `actionlint`.
+
+```mermaid
+flowchart LR
+    A[pa11y checkout] -->|before| B[GITHUB_TOKEN written to .git/config]
+    A -->|after: persist-credentials false| C[No token on disk]
+    B --> D[Compromised later step can read token]
+    C --> E[Reduced blast radius]
+```
+
+Test output:
+
+```
+ok | 16 passed | 0 failed
+```
+
+## Test Plan
+
+- Added `tests/a11y_workflow_test.ts::"a11y pa11y checkout does not persist
+  credentials"` — parses the workflow, finds the pa11y job's `actions/checkout`
+  step, and asserts `with.persist-credentials === false`. Confirmed it fails
+  against the unfixed workflow (`undefined`) and passes after the fix.
+- Re-ran the full `tests/a11y_workflow_test.ts` suite — all 16 tests pass.
+- Ran `actionlint` on the workflow — clean.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.59">
+    <meta name="app-version" content="1.1.60">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.59"></script>
+    <script src="escape.js?v=1.1.60"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.59"></script>
+    <script src="projection.js?v=1.1.60"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.59"></script>
+    <script src="volume_recommend.js?v=1.1.60"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.59"></script>
+    <script src="chart_window_settings.js?v=1.1.60"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.59"></script>
+    <script src="star_filter_settings.js?v=1.1.60"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.59"></script>
+    <script src="color_key.js?v=1.1.60"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.59"></script>
+    <script src="series_label_colour.js?v=1.1.60"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.59"></script>
+    <script src="chart_theme.js?v=1.1.60"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.59"></script>
+    <script src="chart_title.js?v=1.1.60"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.59"></script>
+    <script src="format.js?v=1.1.60"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.59"></script>
+    <script src="market_index.js?v=1.1.60"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.59"></script>
+    <script src="stock_selection.js?v=1.1.60"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.59"></script>
+    <script src="yahoo_finance.js?v=1.1.60"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.59"></script>
+    <script src="date_selection.js?v=1.1.60"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.59"></script>
+    <script src="view_selection.js?v=1.1.60"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.59"></script>
+    <script src="popover_dismiss.js?v=1.1.60"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.59"></script>
+    <script src="popover_cleanup.js?v=1.1.60"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.59"></script>
+    <script src="chart_popout.js?v=1.1.60"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.59"></script>
+    <script src="share_link.js?v=1.1.60"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.59"></script>
+    <script src="field_label.js?v=1.1.60"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.59"></script>
+    <script src="freshness_text.js?v=1.1.60"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.59"></script>
+    <script src="dashboard_boot.js?v=1.1.60"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.59"></script>
+    <script src="sw-register.js?v=1.1.60"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.59")
+    navigator.serviceWorker.register("./sw.js?v=1.1.60")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.59";
+const APP_VERSION = "1.1.60";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.59">
+    <meta name="app-version" content="1.1.60">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.59"></script>
+    <script src="chart_theme.js?v=1.1.60"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.59"></script>
+    <script src="sw-register.js?v=1.1.60"></script>
   </body>
 </html>

--- a/tests/a11y_workflow_test.ts
+++ b/tests/a11y_workflow_test.ts
@@ -286,3 +286,23 @@ Deno.test("a11y workflow pins actions to 40-character commit SHAs", async () => 
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   assertActionsPinnedToSha(text);
 });
+
+// Issue #728: the pa11y job checks out the repo but never pushes back or fetches
+// a private submodule, so it does not need the workflow's GITHUB_TOKEN persisted
+// into .git/config. Leaving it there widens the blast radius of any compromised
+// later step (a malicious dependency could read the token from disk and act as
+// it). Require persist-credentials: false on the pa11y checkout step.
+Deno.test("a11y pa11y checkout does not persist credentials", async () => {
+  const doc = await loadWorkflow();
+  const job = doc.jobs?.pa11y;
+  assert(job, "workflow must declare a pa11y job");
+  const checkout = (job.steps ?? []).find((s) =>
+    typeof s.uses === "string" && s.uses.startsWith("actions/checkout@")
+  );
+  assert(checkout, "pa11y job must have an actions/checkout step");
+  assertEquals(
+    checkout.with?.["persist-credentials"],
+    false,
+    "pa11y checkout must set persist-credentials: false so GITHUB_TOKEN is not written to .git/config",
+  );
+});


### PR DESCRIPTION
## Summary

The `pa11y` job in `.github/workflows/a11y.yml` checked out the repo with
`actions/checkout` but did not set `persist-credentials: false`. By default
checkout writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth
header, where any later step — including a compromised dependency or injected
script — can read it and act as the token. This job only serves `docs/` and runs
`pa11y-ci`; it never pushes back to the repository or fetches a private
submodule, so it does not need the persisted credential. Added
`persist-credentials: false` to the pa11y checkout step to keep the token off
disk and shrink the blast radius of a compromised step. Closes #728.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the
workflow's Deno test suite (all 16 tests pass) and `actionlint`.

```mermaid
flowchart LR
    A[pa11y checkout] -->|before| B[GITHUB_TOKEN written to .git/config]
    A -->|after: persist-credentials false| C[No token on disk]
    B --> D[Compromised later step can read token]
    C --> E[Reduced blast radius]
```

Test output:

```
ok | 16 passed | 0 failed
```

## Test Plan

- Added `tests/a11y_workflow_test.ts::"a11y pa11y checkout does not persist
  credentials"` — parses the workflow, finds the pa11y job's `actions/checkout`
  step, and asserts `with.persist-credentials === false`. Confirmed it fails
  against the unfixed workflow (`undefined`) and passes after the fix.
- Re-ran the full `tests/a11y_workflow_test.ts` suite — all 16 tests pass.
- Ran `actionlint` on the workflow — clean.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrcjrh8l-92f45b`<!-- vibe-worker-issue-728 -->