### PR TITLE
Stop cargo-audit checkout persisting credentials (Issue #729)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -29,6 +29,11 @@ jobs:
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # Issue #729: audit only reads the tree to run cargo-audit; it never
+          # pushes back or fetches a private submodule, so don't persist the
+          # GITHUB_TOKEN into .git/config where a later step could read it.
+          persist-credentials: false
       # dtolnay/rust-toolchain@stable
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
       - name: Install cargo-audit

--- a/docs/archive/pr-summaries/pr-summary-729.md
+++ b/docs/archive/pr-summaries/pr-summary-729.md
@@ -1,0 +1,42 @@
+## Summary
+
+The `audit` job in `.github/workflows/cargo-audit.yml` ran `actions/checkout`
+without `persist-credentials: false`. By default checkout writes the workflow's
+`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
+job — including a compromised dependency or injected script — can read it and
+act as the token. The audit job only reads the tree to run `cargo-audit`; it
+never pushes back to the repository or fetches a private submodule, so it does
+not need the persisted credential.
+
+Added `persist-credentials: false` to the audit checkout step so the token is no
+longer written to disk, shrinking the blast radius of any compromised later
+step. Closes #729.
+
+## Evidence
+
+Backend/CI change only — no web interface to screenshot. Verified via the Deno
+workflow test suite, which parses the workflow YAML and asserts the invariant.
+
+```mermaid
+flowchart LR
+    A[audit job] --> B[actions/checkout]
+    B -->|persist-credentials: false| C[.git/config has no GITHUB_TOKEN]
+    C --> D[cargo install cargo-audit]
+    D --> E[cargo audit]
+```
+
+Test run:
+
+```
+deno test --allow-read tests/cargo_audit_workflow_test.ts
+ok | 8 passed | 0 failed
+```
+
+## Test Plan
+
+- Added `tests/cargo_audit_workflow_test.ts::Cargo Audit audit checkout does not
+  persist credentials`, which fails against the unfixed workflow (checkout has
+  no `with.persist-credentials`) and passes once `persist-credentials: false` is
+  set on the audit checkout step.
+- Existing Cargo Audit workflow tests (YAML validity, triggers, permissions,
+  job structure, SHA pinning, concurrency) continue to pass.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.60">
+    <meta name="app-version" content="1.1.61">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.60"></script>
+    <script src="escape.js?v=1.1.61"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.60"></script>
+    <script src="projection.js?v=1.1.61"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.60"></script>
+    <script src="volume_recommend.js?v=1.1.61"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.60"></script>
+    <script src="chart_window_settings.js?v=1.1.61"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.60"></script>
+    <script src="star_filter_settings.js?v=1.1.61"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.60"></script>
+    <script src="color_key.js?v=1.1.61"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.60"></script>
+    <script src="series_label_colour.js?v=1.1.61"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.60"></script>
+    <script src="chart_theme.js?v=1.1.61"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.60"></script>
+    <script src="chart_title.js?v=1.1.61"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.60"></script>
+    <script src="format.js?v=1.1.61"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.60"></script>
+    <script src="market_index.js?v=1.1.61"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.60"></script>
+    <script src="stock_selection.js?v=1.1.61"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.60"></script>
+    <script src="yahoo_finance.js?v=1.1.61"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.60"></script>
+    <script src="date_selection.js?v=1.1.61"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.60"></script>
+    <script src="view_selection.js?v=1.1.61"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.60"></script>
+    <script src="popover_dismiss.js?v=1.1.61"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.60"></script>
+    <script src="popover_cleanup.js?v=1.1.61"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.60"></script>
+    <script src="chart_popout.js?v=1.1.61"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.60"></script>
+    <script src="share_link.js?v=1.1.61"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.60"></script>
+    <script src="field_label.js?v=1.1.61"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.60"></script>
+    <script src="freshness_text.js?v=1.1.61"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.60"></script>
+    <script src="dashboard_boot.js?v=1.1.61"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.60"></script>
+    <script src="sw-register.js?v=1.1.61"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.60")
+    navigator.serviceWorker.register("./sw.js?v=1.1.61")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.60";
+const APP_VERSION = "1.1.61";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.60">
+    <meta name="app-version" content="1.1.61">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.60"></script>
+    <script src="chart_theme.js?v=1.1.61"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.60"></script>
+    <script src="sw-register.js?v=1.1.61"></script>
   </body>
 </html>

--- a/tests/cargo_audit_workflow_test.ts
+++ b/tests/cargo_audit_workflow_test.ts
@@ -86,6 +86,32 @@ Deno.test("Cargo Audit workflow pins actions to commit SHAs", async () => {
   assertActionsPinnedToSha(text);
 });
 
+// Issue #729: the audit job only checks out the repo to run cargo-audit — it
+// never pushes back or fetches a private submodule, so it does not need the
+// workflow's GITHUB_TOKEN persisted into .git/config. Leaving it there widens
+// the blast radius of any compromised later step (a malicious dependency could
+// read the token from disk and act as it). Require persist-credentials: false
+// on the audit checkout step.
+Deno.test("Cargo Audit audit checkout does not persist credentials", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as {
+    jobs: Record<string, { steps?: Array<Record<string, unknown>> }>;
+  };
+  const job = doc.jobs.audit;
+  assert(job, "workflow must declare an audit job");
+  const checkout = (job.steps ?? []).find((s) =>
+    typeof s.uses === "string" &&
+    (s.uses as string).startsWith("actions/checkout@")
+  );
+  assert(checkout, "audit job must have an actions/checkout step");
+  const withBlock = checkout.with as Record<string, unknown> | undefined;
+  assertEquals(
+    withBlock?.["persist-credentials"],
+    false,
+    "audit checkout must set persist-credentials: false so GITHUB_TOKEN is not written to .git/config",
+  );
+});
+
 // Concurrency cancellation (Issue #139). Without a concurrency group, rapid
 // pushes to the same ref queue redundant, overlapping runs that each hold a
 // runner. A top-level concurrency block keyed on workflow + ref with


### PR DESCRIPTION
## Summary

The `audit` job in `.github/workflows/cargo-audit.yml` ran `actions/checkout`
without `persist-credentials: false`. By default checkout writes the workflow's
`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
job — including a compromised dependency or injected script — can read it and
act as the token. The audit job only reads the tree to run `cargo-audit`; it
never pushes back to the repository or fetches a private submodule, so it does
not need the persisted credential.

Added `persist-credentials: false` to the audit checkout step so the token is no
longer written to disk, shrinking the blast radius of any compromised later
step. Closes #729.

## Evidence

Backend/CI change only — no web interface to screenshot. Verified via the Deno
workflow test suite, which parses the workflow YAML and asserts the invariant.

```mermaid
flowchart LR
    A[audit job] --> B[actions/checkout]
    B -->|persist-credentials: false| C[.git/config has no GITHUB_TOKEN]
    C --> D[cargo install cargo-audit]
    D --> E[cargo audit]
```

Test run:

```
deno test --allow-read tests/cargo_audit_workflow_test.ts
ok | 8 passed | 0 failed
```

## Test Plan

- Added `tests/cargo_audit_workflow_test.ts::Cargo Audit audit checkout does not
  persist credentials`, which fails against the unfixed workflow (checkout has
  no `with.persist-credentials`) and passes once `persist-credentials: false` is
  set on the audit checkout step.
- Existing Cargo Audit workflow tests (YAML validity, triggers, permissions,
  job structure, SHA pinning, concurrency) continue to pass.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrcoysq8-c5605c`<!-- vibe-worker-issue-729 -->