### PR TITLE
Disable credential persistence on check-changes checkout (Issue #731)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0  # Fetch full history for proper diffs
-        
+        # check-changes only reads history for diffs; it never pushes back, so
+        # the GITHUB_TOKEN must not be persisted into .git/config (issue #731).
+        persist-credentials: false
+
     - name: Check for changes
       id: filter
       run: |

--- a/docs/archive/pr-summaries/pr-summary-731.md
+++ b/docs/archive/pr-summaries/pr-summary-731.md
@@ -1,0 +1,41 @@
+## Summary
+
+Hardened the `check-changes` job in `.github/workflows/ci.yml` so its
+`actions/checkout` step no longer persists the workflow `GITHUB_TOKEN` into
+`.git/config`. Added `persist-credentials: false` to the existing `with:` block
+(alongside `fetch-depth: 0`). The `check-changes` job only reads git history to
+compute diffs — it never pushes back to the repository or fetches private
+submodules — so the persisted credential is unnecessary and only widens the
+blast radius of a compromised later step (defence in depth, least privilege).
+
+Closes #731.
+
+## Evidence
+
+Backend/CI configuration change — no web interface to screenshot.
+
+- **YAML validity**: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → `YAML OK`.
+- The repository's own `actionlint` workflow (`.github/workflows/actionlint.yml`)
+  is the enforcing per-repo gate on this change.
+- This mirrors the already-hardened checkout steps in the same repo, e.g.
+  `ci.yml:166`, `cargo-audit.yml:36`, and `a11y.yml:51`.
+
+Diff (job `check-changes`):
+
+```yaml
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      with:
+        fetch-depth: 0  # Fetch full history for proper diffs
+        # check-changes only reads history for diffs; it never pushes back, so
+        # the GITHUB_TOKEN must not be persisted into .git/config (issue #731).
+        persist-credentials: false
+```
+
+## Test Plan
+
+This is a single-line workflow-YAML security hardening change with no Rust code
+surface, so no unit test applies. Validation performed:
+
+- Parsed the workflow with a YAML loader to confirm it remains well-formed.
+- Confirmed the change is scoped to the `check-changes` job's checkout step only
+  (line 43); other jobs are untouched.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.62">
+    <meta name="app-version" content="1.1.63">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.62"></script>
+    <script src="escape.js?v=1.1.63"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.62"></script>
+    <script src="projection.js?v=1.1.63"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.62"></script>
+    <script src="volume_recommend.js?v=1.1.63"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.62"></script>
+    <script src="chart_window_settings.js?v=1.1.63"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.62"></script>
+    <script src="star_filter_settings.js?v=1.1.63"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.62"></script>
+    <script src="color_key.js?v=1.1.63"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.62"></script>
+    <script src="series_label_colour.js?v=1.1.63"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.62"></script>
+    <script src="chart_theme.js?v=1.1.63"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.62"></script>
+    <script src="chart_title.js?v=1.1.63"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.62"></script>
+    <script src="format.js?v=1.1.63"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.62"></script>
+    <script src="market_index.js?v=1.1.63"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.62"></script>
+    <script src="stock_selection.js?v=1.1.63"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.62"></script>
+    <script src="yahoo_finance.js?v=1.1.63"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.62"></script>
+    <script src="date_selection.js?v=1.1.63"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.62"></script>
+    <script src="view_selection.js?v=1.1.63"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.62"></script>
+    <script src="popover_dismiss.js?v=1.1.63"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.62"></script>
+    <script src="popover_cleanup.js?v=1.1.63"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.62"></script>
+    <script src="chart_popout.js?v=1.1.63"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.62"></script>
+    <script src="share_link.js?v=1.1.63"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.62"></script>
+    <script src="field_label.js?v=1.1.63"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.62"></script>
+    <script src="freshness_text.js?v=1.1.63"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.62"></script>
+    <script src="dashboard_boot.js?v=1.1.63"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.62"></script>
+    <script src="sw-register.js?v=1.1.63"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.62")
+    navigator.serviceWorker.register("./sw.js?v=1.1.63")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.62";
+const APP_VERSION = "1.1.63";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.62">
+    <meta name="app-version" content="1.1.63">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.62"></script>
+    <script src="chart_theme.js?v=1.1.63"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.62"></script>
+    <script src="sw-register.js?v=1.1.63"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Hardened the `check-changes` job in `.github/workflows/ci.yml` so its
`actions/checkout` step no longer persists the workflow `GITHUB_TOKEN` into
`.git/config`. Added `persist-credentials: false` to the existing `with:` block
(alongside `fetch-depth: 0`). The `check-changes` job only reads git history to
compute diffs — it never pushes back to the repository or fetches private
submodules — so the persisted credential is unnecessary and only widens the
blast radius of a compromised later step (defence in depth, least privilege).

Closes #731.

## Evidence

Backend/CI configuration change — no web interface to screenshot.

- **YAML validity**: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → `YAML OK`.
- The repository's own `actionlint` workflow (`.github/workflows/actionlint.yml`)
  is the enforcing per-repo gate on this change.
- This mirrors the already-hardened checkout steps in the same repo, e.g.
  `ci.yml:166`, `cargo-audit.yml:36`, and `a11y.yml:51`.

Diff (job `check-changes`):

```yaml
      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
      with:
        fetch-depth: 0  # Fetch full history for proper diffs
        # check-changes only reads history for diffs; it never pushes back, so
        # the GITHUB_TOKEN must not be persisted into .git/config (issue #731).
        persist-credentials: false
```

## Test Plan

This is a single-line workflow-YAML security hardening change with no Rust code
surface, so no unit test applies. Validation performed:

- Parsed the workflow with a YAML loader to confirm it remains well-formed.
- Confirmed the change is scoped to the `check-changes` job's checkout step only
  (line 43); other jobs are untouched.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrcrfjdn-8ee80a`<!-- vibe-worker-issue-731 -->