### PR TITLE
Harden deploy-pages checkout: do not persist credentials (Issue #732)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,11 @@ jobs:
     - name: Checkout code
       # actions/checkout@v4.2.2
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      with:
+        # deploy-pages only reads ./docs to build the Pages artifact; it never
+        # pushes back or fetches private submodules, so the GITHUB_TOKEN must
+        # not be persisted into .git/config (Issue #732).
+        persist-credentials: false
 
     - name: Setup Pages
       # actions/configure-pages@v4.0.0

--- a/docs/archive/pr-summaries/pr-summary-732.md
+++ b/docs/archive/pr-summaries/pr-summary-732.md
@@ -1,0 +1,43 @@
+## Summary
+
+The `deploy-pages` job in `.github/workflows/ci.yml` ran `actions/checkout`
+without `persist-credentials: false`. By default checkout writes the workflow's
+`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
+job could read it. The job only checks out `./docs` to build the GitHub Pages
+artifact — it never pushes back to the repository or fetches a private
+submodule — so it does not need the persisted credential.
+
+Added `persist-credentials: false` to the `deploy-pages` checkout step so the
+token is not written to disk, matching the existing hardening on the
+`check-changes` (Issue #731) and `build` (Issue #730) checkouts. Closes #732.
+
+```mermaid
+flowchart LR
+    A[checkout GITHUB_TOKEN] -->|default: persisted| B[.git/config auth header]
+    B --> C[readable by any later step]
+    A -->|persist-credentials: false| D[token not written to disk]
+    D --> E[reduced blast radius]
+```
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the Deno
+workflow tests:
+
+```
+running 15 tests from ./tests/ci_workflow_test.ts
+...
+deploy-pages checkout does not persist credentials ... ok
+...
+ok | 15 passed | 0 failed
+```
+
+## Test Plan
+
+- Added `tests/ci_workflow_test.ts::deploy-pages checkout does not persist credentials`,
+  which parses the workflow YAML and asserts the `deploy-pages` checkout step
+  sets `persist-credentials: false`. It fails against the unfixed workflow
+  (no `with` block) and passes after the fix.
+- All 15 existing `ci_workflow_test.ts` tests continue to pass, including
+  `deploy-pages keeps its elevated per-job permissions` and
+  `deploy-pages stays main-only`, confirming no regression to the Pages deploy.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.63">
+    <meta name="app-version" content="1.1.64">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.63"></script>
+    <script src="escape.js?v=1.1.64"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.63"></script>
+    <script src="projection.js?v=1.1.64"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.63"></script>
+    <script src="volume_recommend.js?v=1.1.64"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.63"></script>
+    <script src="chart_window_settings.js?v=1.1.64"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.63"></script>
+    <script src="star_filter_settings.js?v=1.1.64"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.63"></script>
+    <script src="color_key.js?v=1.1.64"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.63"></script>
+    <script src="series_label_colour.js?v=1.1.64"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.63"></script>
+    <script src="chart_theme.js?v=1.1.64"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.63"></script>
+    <script src="chart_title.js?v=1.1.64"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.63"></script>
+    <script src="format.js?v=1.1.64"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.63"></script>
+    <script src="market_index.js?v=1.1.64"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.63"></script>
+    <script src="stock_selection.js?v=1.1.64"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.63"></script>
+    <script src="yahoo_finance.js?v=1.1.64"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.63"></script>
+    <script src="date_selection.js?v=1.1.64"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.63"></script>
+    <script src="view_selection.js?v=1.1.64"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.63"></script>
+    <script src="popover_dismiss.js?v=1.1.64"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.63"></script>
+    <script src="popover_cleanup.js?v=1.1.64"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.63"></script>
+    <script src="chart_popout.js?v=1.1.64"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.63"></script>
+    <script src="share_link.js?v=1.1.64"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.63"></script>
+    <script src="field_label.js?v=1.1.64"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.63"></script>
+    <script src="freshness_text.js?v=1.1.64"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.63"></script>
+    <script src="dashboard_boot.js?v=1.1.64"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.63"></script>
+    <script src="sw-register.js?v=1.1.64"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.63")
+    navigator.serviceWorker.register("./sw.js?v=1.1.64")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.63";
+const APP_VERSION = "1.1.64";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.63">
+    <meta name="app-version" content="1.1.64">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.63"></script>
+    <script src="chart_theme.js?v=1.1.64"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.63"></script>
+    <script src="sw-register.js?v=1.1.64"></script>
   </body>
 </html>

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -141,6 +141,31 @@ Deno.test("build job checkout does not persist credentials", async () => {
   );
 });
 
+// Issue #732: the deploy-pages job only checks out to build the ./docs Pages
+// artifact — it never pushes back to the repo or fetches a private submodule,
+// so it does not need the workflow's GITHUB_TOKEN persisted into .git/config.
+// Leaving it there widens the blast radius of any compromised later step.
+// Require persist-credentials: false on the deploy-pages checkout step.
+Deno.test("deploy-pages checkout does not persist credentials", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const jobs = doc.jobs as Record<
+    string,
+    { steps?: Array<{ uses?: string; with?: Record<string, unknown> }> }
+  >;
+  const job = jobs["deploy-pages"];
+  assert(job, "workflow must declare a deploy-pages job");
+  const checkout = (job.steps ?? []).find((s) =>
+    typeof s.uses === "string" && s.uses.startsWith("actions/checkout@")
+  );
+  assert(checkout, "deploy-pages job must have an actions/checkout step");
+  assertEquals(
+    checkout.with?.["persist-credentials"],
+    false,
+    "deploy-pages checkout must set persist-credentials: false so GITHUB_TOKEN is not written to .git/config",
+  );
+});
+
 // Concurrency control (Issue #69). The pipeline triggers on push to main and
 // pull_request to main but, without a concurrency group, successive pushes or
 // rapid PR updates start a fresh full run (test, release build, SBOM, Pages


### PR DESCRIPTION
## Summary

The `deploy-pages` job in `.github/workflows/ci.yml` ran `actions/checkout`
without `persist-credentials: false`. By default checkout writes the workflow's
`GITHUB_TOKEN` into `.git/config` as an auth header, where any later step in the
job could read it. The job only checks out `./docs` to build the GitHub Pages
artifact — it never pushes back to the repository or fetches a private
submodule — so it does not need the persisted credential.

Added `persist-credentials: false` to the `deploy-pages` checkout step so the
token is not written to disk, matching the existing hardening on the
`check-changes` (Issue #731) and `build` (Issue #730) checkouts. Closes #732.

```mermaid
flowchart LR
    A[checkout GITHUB_TOKEN] -->|default: persisted| B[.git/config auth header]
    B --> C[readable by any later step]
    A -->|persist-credentials: false| D[token not written to disk]
    D --> E[reduced blast radius]
```

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the Deno
workflow tests:

```
running 15 tests from ./tests/ci_workflow_test.ts
...
deploy-pages checkout does not persist credentials ... ok
...
ok | 15 passed | 0 failed
```

## Test Plan

- Added `tests/ci_workflow_test.ts::deploy-pages checkout does not persist credentials`,
  which parses the workflow YAML and asserts the `deploy-pages` checkout step
  sets `persist-credentials: false`. It fails against the unfixed workflow
  (no `with` block) and passes after the fix.
- All 15 existing `ci_workflow_test.ts` tests continue to pass, including
  `deploy-pages keeps its elevated per-job permissions` and
  `deploy-pages stays main-only`, confirming no regression to the Pages deploy.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrd8pj0g-9b8dc8`<!-- vibe-worker-issue-732 -->