### PR TITLE
Disable credential persistence on deno-quality checkout (Issue #734)

### DIFF
--- a/.github/workflows/deno-quality.yml
+++ b/.github/workflows/deno-quality.yml
@@ -24,6 +24,12 @@ jobs:
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # This job only runs Deno quality checks and uploads coverage — it
+          # never pushes back to the repo or fetches a private submodule, so the
+          # GITHUB_TOKEN must not be persisted into .git/config where a later
+          # compromised step could read it (Issue #734).
+          persist-credentials: false
       # denoland/setup-deno@v2.0.4
       - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
         with:

--- a/docs/archive/pr-summaries/pr-summary-734.md
+++ b/docs/archive/pr-summaries/pr-summary-734.md
@@ -1,0 +1,41 @@
+## Summary
+
+The `quality` job in `.github/workflows/deno-quality.yml` checked out the
+repository with `actions/checkout` but did not set `persist-credentials: false`.
+By default checkout writes the workflow's `GITHUB_TOKEN` into `.git/config` as an
+auth header, where any later step in the job — including a compromised dependency
+or an injected script — can read it and act as the token. This job only runs the
+Deno quality checks (lint, fmt, check, audit, test) and uploads coverage; it
+never pushes back to the repository or fetches a private submodule, so it does
+not need the persisted credential. Adding `persist-credentials: false` keeps the
+token off disk and narrows the blast radius of any compromised step.
+
+Closes #734.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the Deno
+workflow test suite, which parses the workflow YAML and asserts the checkout
+step sets `persist-credentials: false`.
+
+Before → after (checkout step of the `quality` job):
+
+```mermaid
+flowchart LR
+    A["checkout (no options)"] -->|GITHUB_TOKEN written to .git/config| B["later steps can read token"]
+    C["checkout + persist-credentials: false"] -->|token not persisted| D["later steps cannot read token"]
+```
+
+Test run:
+
+```
+deno test --allow-read tests/deno_quality_workflow_test.ts
+ok | 10 passed | 0 failed
+```
+
+## Test Plan
+
+- Added `tests/deno_quality_workflow_test.ts::"Deno Quality workflow checkout does not persist credentials"`,
+  which reproduces #734 — it fails against the unfixed workflow (`persist-credentials`
+  is `undefined`) and passes once the option is set to `false`.
+- Full `./quality.sh` gate passes cleanly (lint, fmt, type check, tests).

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.65">
+    <meta name="app-version" content="1.1.66">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.65"></script>
+    <script src="escape.js?v=1.1.66"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.65"></script>
+    <script src="projection.js?v=1.1.66"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.65"></script>
+    <script src="volume_recommend.js?v=1.1.66"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.65"></script>
+    <script src="chart_window_settings.js?v=1.1.66"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.65"></script>
+    <script src="star_filter_settings.js?v=1.1.66"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.65"></script>
+    <script src="color_key.js?v=1.1.66"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.65"></script>
+    <script src="series_label_colour.js?v=1.1.66"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.65"></script>
+    <script src="chart_theme.js?v=1.1.66"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.65"></script>
+    <script src="chart_title.js?v=1.1.66"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.65"></script>
+    <script src="format.js?v=1.1.66"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.65"></script>
+    <script src="market_index.js?v=1.1.66"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.65"></script>
+    <script src="stock_selection.js?v=1.1.66"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.65"></script>
+    <script src="yahoo_finance.js?v=1.1.66"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.65"></script>
+    <script src="date_selection.js?v=1.1.66"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.65"></script>
+    <script src="view_selection.js?v=1.1.66"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.65"></script>
+    <script src="popover_dismiss.js?v=1.1.66"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.65"></script>
+    <script src="popover_cleanup.js?v=1.1.66"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.65"></script>
+    <script src="chart_popout.js?v=1.1.66"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.65"></script>
+    <script src="share_link.js?v=1.1.66"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.65"></script>
+    <script src="field_label.js?v=1.1.66"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.65"></script>
+    <script src="freshness_text.js?v=1.1.66"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.65"></script>
+    <script src="dashboard_boot.js?v=1.1.66"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.65"></script>
+    <script src="sw-register.js?v=1.1.66"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.65")
+    navigator.serviceWorker.register("./sw.js?v=1.1.66")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.65";
+const APP_VERSION = "1.1.66";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.65">
+    <meta name="app-version" content="1.1.66">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.65"></script>
+    <script src="chart_theme.js?v=1.1.66"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.65"></script>
+    <script src="sw-register.js?v=1.1.66"></script>
   </body>
 </html>

--- a/tests/deno_quality_workflow_test.ts
+++ b/tests/deno_quality_workflow_test.ts
@@ -132,6 +132,33 @@ Deno.test("Deno Quality workflow triggers on a weekly schedule (Issue #59)", asy
   );
 });
 
+// Issue #734: the quality job only checks out to run the Deno quality checks
+// (lint, fmt, check, audit, test) and upload coverage — it never pushes back to
+// the repo or fetches a private submodule, so it does not need the workflow's
+// GITHUB_TOKEN persisted into .git/config. Leaving it there widens the blast
+// radius of any compromised later step (a malicious dependency could read the
+// token from disk and act as it). Require persist-credentials: false on the
+// checkout step.
+Deno.test("Deno Quality workflow checkout does not persist credentials", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const jobs = doc.jobs as Record<
+    string,
+    { steps?: Array<{ uses?: string; with?: Record<string, unknown> }> }
+  >;
+  const job = jobs.quality;
+  assert(job, "workflow must declare a quality job");
+  const checkout = (job.steps ?? []).find((s) =>
+    typeof s.uses === "string" && s.uses.startsWith("actions/checkout@")
+  );
+  assert(checkout, "quality job must have an actions/checkout step");
+  assertEquals(
+    checkout.with?.["persist-credentials"],
+    false,
+    "quality checkout must set persist-credentials: false so GITHUB_TOKEN is not written to .git/config",
+  );
+});
+
 Deno.test("Deno Quality workflow pins actions to commit SHAs", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   assertActionsPinnedToSha(text);


### PR DESCRIPTION
## Summary

The `quality` job in `.github/workflows/deno-quality.yml` checked out the
repository with `actions/checkout` but did not set `persist-credentials: false`.
By default checkout writes the workflow's `GITHUB_TOKEN` into `.git/config` as an
auth header, where any later step in the job — including a compromised dependency
or an injected script — can read it and act as the token. This job only runs the
Deno quality checks (lint, fmt, check, audit, test) and uploads coverage; it
never pushes back to the repository or fetches a private submodule, so it does
not need the persisted credential. Adding `persist-credentials: false` keeps the
token off disk and narrows the blast radius of any compromised step.

Closes #734.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the Deno
workflow test suite, which parses the workflow YAML and asserts the checkout
step sets `persist-credentials: false`.

Before → after (checkout step of the `quality` job):

```mermaid
flowchart LR
    A["checkout (no options)"] -->|GITHUB_TOKEN written to .git/config| B["later steps can read token"]
    C["checkout + persist-credentials: false"] -->|token not persisted| D["later steps cannot read token"]
```

Test run:

```
deno test --allow-read tests/deno_quality_workflow_test.ts
ok | 10 passed | 0 failed
```

## Test Plan

- Added `tests/deno_quality_workflow_test.ts::"Deno Quality workflow checkout does not persist credentials"`,
  which reproduces #734 — it fails against the unfixed workflow (`persist-credentials`
  is `undefined`) and passes once the option is set to `false`.
- Full `./quality.sh` gate passes cleanly (lint, fmt, type check, tests).



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mrdxzo9y-a5b3e9`<!-- vibe-worker-issue-734 -->