### PR TITLE
Stop ShellCheck checkout persisting credentials (Issue #738)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,6 +23,12 @@ jobs:
     steps:
       # actions/checkout@v6.0.2
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # The shellcheck job only reads the repo to scan it — it never pushes
+          # back or fetches a private submodule, so the workflow GITHUB_TOKEN
+          # need not be written into .git/config (Issue #738). Not persisting
+          # it keeps a compromised later step from reading the token off disk.
+          persist-credentials: false
       # ludeeus/action-shellcheck pinned to commit SHA (Issue #27)
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca

--- a/docs/archive/pr-summaries/pr-summary-738.md
+++ b/docs/archive/pr-summaries/pr-summary-738.md
@@ -1,0 +1,40 @@
+## Summary
+
+The `shellcheck` job's `actions/checkout` step ran without
+`persist-credentials: false`, so `actions/checkout` wrote the workflow
+`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job —
+including a compromised dependency or injected script — could read it and act as
+the token. The job only reads the repo to scan it (it never pushes back or
+fetches a private submodule), so the persisted credential is unnecessary and
+only widens the blast radius.
+
+Added `persist-credentials: false` to the checkout step in
+`.github/workflows/shellcheck.yml`, mirroring the pattern already proven in
+`semgrep.yml` and other workflows in this repo. Closes #738.
+
+## Evidence
+
+Backend/CI-config change only — no web interface to screenshot. Verified via the
+Deno workflow test suite:
+
+- New test `ShellCheck checkout does not persist credentials` failed against the
+  unfixed workflow (`persist-credentials` was `undefined`) and passes after the
+  fix.
+- Full Deno suite: `1340 passed | 0 failed`.
+
+```mermaid
+flowchart LR
+    A[checkout without flag] -->|writes GITHUB_TOKEN| B[.git/config on disk]
+    B -->|readable by later steps| C[Token exfil risk]
+    D[checkout persist-credentials: false] -->|no token written| E[Reduced blast radius]
+```
+
+## Test Plan
+
+- Added `tests/shellcheck_workflow_test.ts::ShellCheck checkout does not persist credentials`
+  — parses the workflow YAML, finds the `actions/checkout` step in the
+  `shellcheck` job, and asserts `with.persist-credentials === false`. This
+  reproduces #738 (fails pre-fix, passes post-fix).
+- Existing ShellCheck workflow tests (file exists, valid YAML, `pull_request`
+  trigger, read-only `contents` permission, concurrency cancellation) continue
+  to pass.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.70">
+    <meta name="app-version" content="1.1.71">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.70"></script>
+    <script src="escape.js?v=1.1.71"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.70"></script>
+    <script src="projection.js?v=1.1.71"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.70"></script>
+    <script src="volume_recommend.js?v=1.1.71"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.70"></script>
+    <script src="chart_window_settings.js?v=1.1.71"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.70"></script>
+    <script src="star_filter_settings.js?v=1.1.71"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.70"></script>
+    <script src="color_key.js?v=1.1.71"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.70"></script>
+    <script src="series_label_colour.js?v=1.1.71"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.70"></script>
+    <script src="chart_theme.js?v=1.1.71"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.70"></script>
+    <script src="chart_title.js?v=1.1.71"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.70"></script>
+    <script src="format.js?v=1.1.71"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.70"></script>
+    <script src="market_index.js?v=1.1.71"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.70"></script>
+    <script src="stock_selection.js?v=1.1.71"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.70"></script>
+    <script src="yahoo_finance.js?v=1.1.71"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.70"></script>
+    <script src="date_selection.js?v=1.1.71"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.70"></script>
+    <script src="view_selection.js?v=1.1.71"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.70"></script>
+    <script src="popover_dismiss.js?v=1.1.71"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.70"></script>
+    <script src="popover_cleanup.js?v=1.1.71"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.70"></script>
+    <script src="chart_popout.js?v=1.1.71"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.70"></script>
+    <script src="share_link.js?v=1.1.71"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.70"></script>
+    <script src="field_label.js?v=1.1.71"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.70"></script>
+    <script src="freshness_text.js?v=1.1.71"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.70"></script>
+    <script src="dashboard_boot.js?v=1.1.71"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.70"></script>
+    <script src="sw-register.js?v=1.1.71"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.70")
+    navigator.serviceWorker.register("./sw.js?v=1.1.71")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.70";
+const APP_VERSION = "1.1.71";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.70">
+    <meta name="app-version" content="1.1.71">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.70"></script>
+    <script src="chart_theme.js?v=1.1.71"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.70"></script>
+    <script src="sw-register.js?v=1.1.71"></script>
   </body>
 </html>

--- a/tests/shellcheck_workflow_test.ts
+++ b/tests/shellcheck_workflow_test.ts
@@ -39,6 +39,30 @@ Deno.test("ShellCheck workflow declares read-only contents permission", async ()
   assertEquals(doc.permissions.contents, "read");
 });
 
+// Credential hygiene (Issue #738). By default actions/checkout writes the
+// workflow GITHUB_TOKEN into .git/config as an auth header, where any later
+// step in the job could read it and act as the token. The shellcheck job only
+// reads the repo to scan it, so it must set persist-credentials: false.
+Deno.test("ShellCheck checkout does not persist credentials", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as {
+    jobs: Record<string, { steps?: Array<Record<string, unknown>> }>;
+  };
+  const job = doc.jobs.shellcheck;
+  assert(job, "workflow must declare a shellcheck job");
+  const checkout = (job.steps ?? []).find((s) =>
+    typeof s.uses === "string" &&
+    (s.uses as string).startsWith("actions/checkout@")
+  );
+  assert(checkout, "shellcheck job must have an actions/checkout step");
+  const withBlock = checkout.with as Record<string, unknown> | undefined;
+  assertEquals(
+    withBlock?.["persist-credentials"],
+    false,
+    "shellcheck checkout must set persist-credentials: false so GITHUB_TOKEN is not written to .git/config",
+  );
+});
+
 // Concurrency cancellation (Issue #139). Without a concurrency group, rapid
 // pushes to the same ref queue redundant, overlapping runs that each hold a
 // runner. A top-level concurrency block keyed on workflow + ref with


### PR DESCRIPTION
## Summary

The `shellcheck` job's `actions/checkout` step ran without
`persist-credentials: false`, so `actions/checkout` wrote the workflow
`GITHUB_TOKEN` into `.git/config` as an auth header. Any later step in the job —
including a compromised dependency or injected script — could read it and act as
the token. The job only reads the repo to scan it (it never pushes back or
fetches a private submodule), so the persisted credential is unnecessary and
only widens the blast radius.

Added `persist-credentials: false` to the checkout step in
`.github/workflows/shellcheck.yml`, mirroring the pattern already proven in
`semgrep.yml` and other workflows in this repo. Closes #738.

## Evidence

Backend/CI-config change only — no web interface to screenshot. Verified via the
Deno workflow test suite:

- New test `ShellCheck checkout does not persist credentials` failed against the
  unfixed workflow (`persist-credentials` was `undefined`) and passes after the
  fix.
- Full Deno suite: `1340 passed | 0 failed`.

```mermaid
flowchart LR
    A[checkout without flag] -->|writes GITHUB_TOKEN| B[.git/config on disk]
    B -->|readable by later steps| C[Token exfil risk]
    D[checkout persist-credentials: false] -->|no token written| E[Reduced blast radius]
```

## Test Plan

- Added `tests/shellcheck_workflow_test.ts::ShellCheck checkout does not persist credentials`
  — parses the workflow YAML, finds the `actions/checkout` step in the
  `shellcheck` job, and asserts `with.persist-credentials === false`. This
  reproduces #738 (fails pre-fix, passes post-fix).
- Existing ShellCheck workflow tests (file exists, valid YAML, `pull_request`
  trigger, read-only `contents` permission, concurrency cancellation) continue
  to pass.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mre4nnuv-7d7277`<!-- vibe-worker-issue-738 -->