### PR TITLE
🟡 SHA-pinned actions/cache runs on the deprecated node20 runtime (ci.yml) (Issue #790)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         components: rustfmt, clippy
         
     - name: Cache dependencies
-      # actions/cache@v4.3.0
+      # actions/cache@v6.1.0
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: |
@@ -186,7 +186,7 @@ jobs:
         echo "All bash scripts have valid syntax"
 
     - name: Cache dependencies
-      # actions/cache@v4.3.0
+      # actions/cache@v6.1.0
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
       with:
         path: |

--- a/docs/archive/pr-summaries/pr-summary-790.md
+++ b/docs/archive/pr-summaries/pr-summary-790.md
@@ -1,0 +1,57 @@
+## Summary
+
+`ci.yml` pins `actions/cache` at two call sites (job `test` L110-111, job `build`
+L189-190). Both were annotated `# actions/cache@v4.3.0`, which the
+`github-actions-audit` idle-task reads to judge the action's Actions runtime —
+`actions/cache` v4 ships the deprecated **node20** runtime that GitHub removes on
+2026-09-16.
+
+Investigation showed the SHA pin itself was **already safe**: the pinned commit
+`55cc8345863c7cc4c66a329aec7e433d2d1c52a9` is the `v6.1.0` tag, whose `action.yml`
+declares `using: 'node24'`. The defect was purely the **mislabelled version
+comment** — it recorded `v4.3.0` (whose real SHA is `0057852…`, node20) against a
+SHA that actually points at `v6.1.0`. A drifted annotation misleads the runtime
+audit (see `annotatedActionMajors`, Issue #789).
+
+Fix: correct both trailing comments to `# actions/cache@v6.1.0` so the annotation
+matches the SHA it records. The 40-character SHA pin is unchanged, so CI runtime
+behaviour is identical — `v6.1.0` is the newest `actions/cache` release (published
+2026-06-26, well past the 24h quarantine) and runs on node24.
+
+This mirrors the sibling `actions/setup-node` runtime guard (Issue #789): a new
+`assertCacheRuntimeSupported` helper reuses the existing `annotatedActionMajors`
+parser to require every `actions/cache` pin be annotated with a node24-era major
+(v5+), preventing any future regression to a node20-runtime pin.
+
+Closes #790.
+
+## Evidence
+
+Backend/CLI + CI-config change — no web interface to screenshot. Verified via the
+Deno test suite.
+
+- `action.yml` at the pinned SHA `55cc834…` declares `using: 'node24'` (verified
+  against `repos/actions/cache/contents/action.yml?ref=<sha>`); the mislabelled
+  `v4.3.0` tag's real SHA `0057852…` declares `using: 'node20'`.
+- New test failed against the mislabelled comment
+  (`found v4, which maps to the removed node20 runtime`) and passes after the
+  comment fix.
+
+```mermaid
+flowchart LR
+    A["uses: actions/cache@55cc834…"] --> B{"annotated major"}
+    B -->|"# @v4.3.0 (was)"| C["audit reads v4 → node20 → flagged"]
+    B -->|"# @v6.1.0 (now)"| D["audit reads v6 → node24 → OK"]
+    A -.->|"SHA already = v6.1.0 tag"| E["runtime: node24 (unchanged)"]
+```
+
+## Test Plan
+
+- Added `tests/workflow_assertions.ts::assertCacheRuntimeSupported` — asserts every
+  SHA-pinned `actions/cache` step carries a `# actions/cache@vX.Y.Z` annotation with
+  a node24-era major (v5+).
+- Added `tests/ci_workflow_test.ts::"CI workflow pins actions/cache to a node24-runtime release"`
+  — reproduces #790 (failed with `found v4` before the fix, passes after).
+- Full Deno suite green: `deno test --allow-read tests/*.ts` → 1356 passed, 0 failed.
+- `deno fmt` / `deno lint` / `deno check` clean on both changed files; bash syntax
+  check passes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.79">
+    <meta name="app-version" content="1.1.80">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.79"></script>
+    <script src="escape.js?v=1.1.80"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.79"></script>
+    <script src="projection.js?v=1.1.80"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.79"></script>
+    <script src="volume_recommend.js?v=1.1.80"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.79"></script>
+    <script src="chart_window_settings.js?v=1.1.80"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.79"></script>
+    <script src="star_filter_settings.js?v=1.1.80"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.79"></script>
+    <script src="color_key.js?v=1.1.80"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.79"></script>
+    <script src="series_label_colour.js?v=1.1.80"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.79"></script>
+    <script src="chart_theme.js?v=1.1.80"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.79"></script>
+    <script src="chart_title.js?v=1.1.80"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.79"></script>
+    <script src="format.js?v=1.1.80"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.79"></script>
+    <script src="market_index.js?v=1.1.80"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.79"></script>
+    <script src="stock_selection.js?v=1.1.80"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.79"></script>
+    <script src="yahoo_finance.js?v=1.1.80"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.79"></script>
+    <script src="date_selection.js?v=1.1.80"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.79"></script>
+    <script src="view_selection.js?v=1.1.80"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.79"></script>
+    <script src="popover_dismiss.js?v=1.1.80"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.79"></script>
+    <script src="popover_cleanup.js?v=1.1.80"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.79"></script>
+    <script src="chart_popout.js?v=1.1.80"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.79"></script>
+    <script src="share_link.js?v=1.1.80"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.79"></script>
+    <script src="field_label.js?v=1.1.80"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.79"></script>
+    <script src="freshness_text.js?v=1.1.80"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.79"></script>
+    <script src="dashboard_boot.js?v=1.1.80"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.79"></script>
+    <script src="sw-register.js?v=1.1.80"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.79")
+    navigator.serviceWorker.register("./sw.js?v=1.1.80")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.79";
+const APP_VERSION = "1.1.80";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.79">
+    <meta name="app-version" content="1.1.80">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.79"></script>
+    <script src="chart_theme.js?v=1.1.80"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.79"></script>
+    <script src="sw-register.js?v=1.1.80"></script>
   </body>
 </html>

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -9,7 +9,10 @@
 
 import { assert, assertEquals } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
-import { assertActionsPinnedToSha } from "./workflow_assertions.ts";
+import {
+  assertActionsPinnedToSha,
+  assertCacheRuntimeSupported,
+} from "./workflow_assertions.ts";
 
 const WORKFLOW_PATH = ".github/workflows/ci.yml";
 
@@ -27,6 +30,16 @@ Deno.test("CI workflow parses as valid YAML", async () => {
 Deno.test("CI workflow pins every action to a 40-char commit SHA", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   assertActionsPinnedToSha(text);
+});
+
+// Issue #790: actions/cache v4.x ships the deprecated node20 Actions runtime,
+// force-removed 2026-09-16. Both "Cache dependencies" steps (jobs `test` and
+// `build`) must be annotated with — and, via the SHA the annotation records,
+// pinned to — a node24-era release (v5+) so the merge gate keeps working after
+// runtime removal. Mirrors the setup-node guard for Issue #789.
+Deno.test("CI workflow pins actions/cache to a node24-runtime release", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  assertCacheRuntimeSupported(text);
 });
 
 Deno.test("CI workflow no longer references the mutable rust-toolchain stable branch", async () => {

--- a/tests/workflow_assertions.ts
+++ b/tests/workflow_assertions.ts
@@ -228,6 +228,28 @@ export function assertSetupNodeRuntimeSupported(text: string): void {
 }
 
 /**
+ * Assert every SHA-pinned `actions/cache` step is annotated with a node24-era
+ * major (v5 or newer). actions/cache v4 and older ship the `node20` Actions
+ * runtime, which GitHub removes on 2026-09-16; an annotation still claiming v4
+ * either pins the removed runtime or misrecords the release the SHA points at,
+ * misleading the runtime audit (Issue #790).
+ */
+export function assertCacheRuntimeSupported(text: string): void {
+  const majors = annotatedActionMajors(text, "actions/cache");
+  assert(majors.length > 0, "workflow must pin actions/cache");
+  for (const major of majors) {
+    assert(
+      Number.isFinite(major),
+      "each actions/cache pin must carry a `# actions/cache@vX.Y.Z` version annotation recording the release it points at",
+    );
+    assert(
+      major >= 5,
+      `actions/cache must be annotated with a node24-era major (v5+); found v${major}, which maps to the removed node20 runtime`,
+    );
+  }
+}
+
+/**
  * Assert every `uses:` action in the workflow source is pinned to a 40-char
  * commit SHA, not a mutable tag/branch. SHA pinning is a genuine source-text
  * invariant (the literal ref is what runs), so this is the one grep we keep —


### PR DESCRIPTION
## Summary

`ci.yml` pins `actions/cache` at two call sites (job `test` L110-111, job `build`
L189-190). Both were annotated `# actions/cache@v4.3.0`, which the
`github-actions-audit` idle-task reads to judge the action's Actions runtime —
`actions/cache` v4 ships the deprecated **node20** runtime that GitHub removes on
2026-09-16.

Investigation showed the SHA pin itself was **already safe**: the pinned commit
`55cc8345863c7cc4c66a329aec7e433d2d1c52a9` is the `v6.1.0` tag, whose `action.yml`
declares `using: 'node24'`. The defect was purely the **mislabelled version
comment** — it recorded `v4.3.0` (whose real SHA is `0057852…`, node20) against a
SHA that actually points at `v6.1.0`. A drifted annotation misleads the runtime
audit (see `annotatedActionMajors`, Issue #789).

Fix: correct both trailing comments to `# actions/cache@v6.1.0` so the annotation
matches the SHA it records. The 40-character SHA pin is unchanged, so CI runtime
behaviour is identical — `v6.1.0` is the newest `actions/cache` release (published
2026-06-26, well past the 24h quarantine) and runs on node24.

This mirrors the sibling `actions/setup-node` runtime guard (Issue #789): a new
`assertCacheRuntimeSupported` helper reuses the existing `annotatedActionMajors`
parser to require every `actions/cache` pin be annotated with a node24-era major
(v5+), preventing any future regression to a node20-runtime pin.

Closes #790.

## Evidence

Backend/CLI + CI-config change — no web interface to screenshot. Verified via the
Deno test suite.

- `action.yml` at the pinned SHA `55cc834…` declares `using: 'node24'` (verified
  against `repos/actions/cache/contents/action.yml?ref=<sha>`); the mislabelled
  `v4.3.0` tag's real SHA `0057852…` declares `using: 'node20'`.
- New test failed against the mislabelled comment
  (`found v4, which maps to the removed node20 runtime`) and passes after the
  comment fix.

```mermaid
flowchart LR
    A["uses: actions/cache@55cc834…"] --> B{"annotated major"}
    B -->|"# @v4.3.0 (was)"| C["audit reads v4 → node20 → flagged"]
    B -->|"# @v6.1.0 (now)"| D["audit reads v6 → node24 → OK"]
    A -.->|"SHA already = v6.1.0 tag"| E["runtime: node24 (unchanged)"]
```

## Test Plan

- Added `tests/workflow_assertions.ts::assertCacheRuntimeSupported` — asserts every
  SHA-pinned `actions/cache` step carries a `# actions/cache@vX.Y.Z` annotation with
  a node24-era major (v5+).
- Added `tests/ci_workflow_test.ts::"CI workflow pins actions/cache to a node24-runtime release"`
  — reproduces #790 (failed with `found v4` before the fix, passes after).
- Full Deno suite green: `deno test --allow-read tests/*.ts` → 1356 passed, 0 failed.
- `deno fmt` / `deno lint` / `deno check` clean on both changed files; bash syntax
  check passes.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms0glyks-f3ea48`<!-- vibe-worker-issue-790 -->