### PR TITLE
Remove redundant bash -n shell-syntax gate from ci.yml (Issue #791)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,14 +177,10 @@ jobs:
       # dtolnay/rust-toolchain@stable
       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
-    # Check bash script syntax
-    - name: Check Bash Script Syntax
-      run: |
-        set -euo pipefail
-        echo "Checking bash script syntax..."
-        find . -name "*.sh" -type f -exec bash -n {} \;
-        echo "All bash scripts have valid syntax"
-
+    # Shell-script syntax is gated by shellcheck.yml (scandir: ., severity:
+    # warning), which parses every *.sh before linting and reports parse errors
+    # at error level. A separate `bash -n` pass here was redundant and gave the
+    # same policy two homes, so it was removed (Issue #791).
     - name: Cache dependencies
       # actions/cache@v6.1.0
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,10 +1,15 @@
 name: ShellCheck
 
+# The `*` glob matches a single path segment and NOT `/`, so `["*"]` alone
+# skips PRs whose base is a `milestone/<slug>` branch. `milestone/**` is listed
+# explicitly so milestone integration PRs and pushes are scanned too — this is
+# the shell-syntax gate that ci.yml's removed `bash -n` step used to provide on
+# those branches (Issue #791; broader nine-workflow fix tracked in Issue #788).
 on:
   pull_request:
-    branches: ["*"]
+    branches: ["*", "milestone/**"]
   push:
-    branches: [main, master]
+    branches: [main, master, "milestone/**"]
 
 # Cancel superseded runs (Issue #139): rapid pushes to the same ref otherwise
 # queue redundant scans that each hold a runner. Keying on workflow + ref with

--- a/docs/archive/pr-summaries/pr-summary-791.md
+++ b/docs/archive/pr-summaries/pr-summary-791.md
@@ -1,0 +1,77 @@
+# Remove duplicate shell-syntax gate from ci.yml (Issue #791)
+
+## Summary
+
+The same logical check — "every `*.sh` in the repo parses" — ran in two
+workflow files:
+
+- `.github/workflows/ci.yml` (job `build`, step *Check Bash Script Syntax*):
+  `find . -name "*.sh" -type f -exec bash -n {} \;`
+- `.github/workflows/shellcheck.yml` (job `shellcheck`): `ludeeus/action-shellcheck`
+  with `scandir: .`, `severity: warning`.
+
+ShellCheck must parse each script before linting it and reports parse/syntax
+errors at error level (included at `severity: warning`), so over the identical
+scope the `bash -n` pass added no signal ShellCheck did not already provide. It
+also gave one policy two homes.
+
+**This PR removes the redundant `bash -n` step from `ci.yml`'s `build` job** and
+keeps `shellcheck.yml` as the single shell-syntax gate.
+
+**Ordering prerequisite.** The issue's ordering note warned that `shellcheck.yml`
+skipped PRs targeting `milestone/*` branches (the `["*"]` glob does not match a
+`/`), while `ci.yml`'s `build` job runs on `[main, "milestone/**"]`. Removing
+`bash -n` without addressing this would leave milestone PRs with no shell-syntax
+gate. So this PR also lists `milestone/**` in `shellcheck.yml`'s `pull_request`
+and `push` triggers, so milestone PRs keep a shell-syntax gate throughout. The
+broader nine-workflow milestone-filter fix remains tracked by
+`stSoftwareAU/GRQ-validation#788`; this PR only touches `shellcheck.yml`, the
+prerequisite for #791.
+
+Closes #791.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Verified via the Deno
+workflow unit tests below.
+
+Coverage before vs after this change:
+
+```mermaid
+flowchart LR
+    subgraph Before
+      A[milestone/** PR] --> B[ci.yml build: bash -n]
+      A -. skipped .-> C[shellcheck.yml]
+      D[main PR] --> B
+      D --> C
+    end
+    subgraph After
+      A2[milestone/** PR] --> C2[shellcheck.yml]
+      D2[main PR] --> C2
+    end
+```
+
+Test run:
+
+```
+deno test --allow-read tests/ci_workflow_test.ts tests/shellcheck_workflow_test.ts
+ok | 26 passed | 0 failed
+```
+
+## Test Plan
+
+- **`tests/ci_workflow_test.ts`**
+  - Added `CI workflow no longer runs a redundant bash -n shell-syntax step` —
+    asserts the `build` job has no *Check Bash Script Syntax* step and no step
+    running `bash -n` (guards against it reappearing under another name).
+  - Updated the existing `multi-line bash run blocks begin with set -euo pipefail`
+    test: removed the `["build", "Check Bash Script Syntax"]` target, since that
+    step no longer exists. **Business-logic change** — the step it asserted on
+    was deliberately deleted; the remaining targets (`Check for changes`,
+    `Generate CycloneDX SBOM`) still enforce the fail-fast convention.
+- **`tests/shellcheck_workflow_test.ts`**
+  - Added `ShellCheck workflow triggers on pull_request to milestone branches`.
+  - Added `ShellCheck workflow triggers on push to milestone branches`.
+
+All 26 tests pass; `deno fmt --check`, `deno lint`, and `deno check` are clean on
+the modified test files.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.80">
+    <meta name="app-version" content="1.1.81">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.80"></script>
+    <script src="escape.js?v=1.1.81"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.80"></script>
+    <script src="projection.js?v=1.1.81"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.80"></script>
+    <script src="volume_recommend.js?v=1.1.81"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.80"></script>
+    <script src="chart_window_settings.js?v=1.1.81"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.80"></script>
+    <script src="star_filter_settings.js?v=1.1.81"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.80"></script>
+    <script src="color_key.js?v=1.1.81"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.80"></script>
+    <script src="series_label_colour.js?v=1.1.81"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.80"></script>
+    <script src="chart_theme.js?v=1.1.81"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.80"></script>
+    <script src="chart_title.js?v=1.1.81"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.80"></script>
+    <script src="format.js?v=1.1.81"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.80"></script>
+    <script src="market_index.js?v=1.1.81"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.80"></script>
+    <script src="stock_selection.js?v=1.1.81"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.80"></script>
+    <script src="yahoo_finance.js?v=1.1.81"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.80"></script>
+    <script src="date_selection.js?v=1.1.81"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.80"></script>
+    <script src="view_selection.js?v=1.1.81"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.80"></script>
+    <script src="popover_dismiss.js?v=1.1.81"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.80"></script>
+    <script src="popover_cleanup.js?v=1.1.81"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.80"></script>
+    <script src="chart_popout.js?v=1.1.81"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.80"></script>
+    <script src="share_link.js?v=1.1.81"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.80"></script>
+    <script src="field_label.js?v=1.1.81"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.80"></script>
+    <script src="freshness_text.js?v=1.1.81"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.80"></script>
+    <script src="dashboard_boot.js?v=1.1.81"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.80"></script>
+    <script src="sw-register.js?v=1.1.81"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.80")
+    navigator.serviceWorker.register("./sw.js?v=1.1.81")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.80";
+const APP_VERSION = "1.1.81";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.80">
+    <meta name="app-version" content="1.1.81">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.80"></script>
+    <script src="chart_theme.js?v=1.1.81"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.80"></script>
+    <script src="sw-register.js?v=1.1.81"></script>
   </body>
 </html>

--- a/tests/ci_workflow_test.ts
+++ b/tests/ci_workflow_test.ts
@@ -276,6 +276,31 @@ Deno.test("deploy-pages stays main-only and is not widened to milestone branches
   );
 });
 
+// Redundant shell-syntax gate removed (Issue #791). The build job previously
+// ran `find . -name "*.sh" -type f -exec bash -n {} \;` to check that every
+// shell script parses. shellcheck.yml already scans the whole repo
+// (scandir: .) and reports parse/syntax errors at error level (included at
+// severity: warning), so the `bash -n` pass added no signal the ShellCheck
+// gate does not already provide. The build job must no longer declare it, so
+// one policy has a single home.
+Deno.test("CI workflow no longer runs a redundant bash -n shell-syntax step", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const jobs = doc.jobs as Record<string, { steps?: Step[] }>;
+  const buildSteps = jobs.build?.steps ?? [];
+  assert(
+    !buildSteps.some((s) => s.name === "Check Bash Script Syntax"),
+    'build job must not declare a "Check Bash Script Syntax" step',
+  );
+  // Guard against the check reappearing under a different step name.
+  assert(
+    !buildSteps.some((s) =>
+      typeof s.run === "string" && /bash\s+-n/.test(s.run)
+    ),
+    "build job must not run `bash -n` — shellcheck.yml is the single shell-syntax gate",
+  );
+});
+
 // Multi-line bash run: blocks must fail fast (Issue #73). Without
 // `set -euo pipefail` an intermediate command that fails (or an unset
 // variable) is masked by the success of the final command, so the step
@@ -300,10 +325,13 @@ function firstScriptLine(run: string): string {
 Deno.test("multi-line bash run blocks begin with set -euo pipefail", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   const doc = parseYaml(text) as Record<string, unknown>;
+  // NOTE (Issue #791): the "Check Bash Script Syntax" (`bash -n`) step was
+  // removed from the build job because shellcheck.yml already parses every
+  // *.sh in the repo (a parse error is reported at error level, included at
+  // severity: warning). It is therefore no longer a target here.
   const targets: Array<[string, string]> = [
     ["check-changes", "Check for changes"],
     ["build", "Generate CycloneDX SBOM"],
-    ["build", "Check Bash Script Syntax"],
   ];
   for (const [job, step] of targets) {
     const run = findRun(doc, job, step);

--- a/tests/shellcheck_workflow_test.ts
+++ b/tests/shellcheck_workflow_test.ts
@@ -32,6 +32,43 @@ Deno.test("ShellCheck workflow triggers on pull_request", async () => {
   assert("pull_request" in on, "must trigger on pull_request");
 });
 
+// Milestone coverage (Issue #791 ordering prerequisite, tracks Issue #788).
+// `bash -n` in ci.yml's build job used to be the shell-syntax gate for
+// milestone/** PRs (ci.yml triggers on `[main, "milestone/**"]`). Before that
+// redundant step can be removed, shellcheck.yml must itself run on milestone
+// PRs — the `["*"]` glob does not match a `/`, so `milestone/<slug>` bases were
+// skipped. The pull_request trigger must list `milestone/**` so milestone PRs
+// keep a shell-syntax gate throughout.
+Deno.test("ShellCheck workflow triggers on pull_request to milestone branches", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | { pull_request?: { branches?: string[] } }
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  const branches = on.pull_request?.branches ?? [];
+  assert(
+    branches.includes("milestone/**"),
+    "pull_request trigger must include `milestone/**` so milestone PRs are scanned",
+  );
+});
+
+Deno.test("ShellCheck workflow triggers on push to milestone branches", async () => {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  const doc = parseYaml(text) as Record<string, unknown>;
+  const on = (doc.on ?? doc["true"] ??
+    (doc as Record<string, unknown>)[true as unknown as string]) as
+      | { push?: { branches?: string[] } }
+      | undefined;
+  assert(on, "workflow must declare an 'on' trigger");
+  const branches = on.push?.branches ?? [];
+  assert(
+    branches.includes("milestone/**"),
+    "push trigger must include `milestone/**` so milestone integration pushes are scanned",
+  );
+});
+
 Deno.test("ShellCheck workflow declares read-only contents permission", async () => {
   const text = await Deno.readTextFile(WORKFLOW_PATH);
   const doc = parseYaml(text) as { permissions?: Record<string, string> };


### PR DESCRIPTION
# Remove duplicate shell-syntax gate from ci.yml (Issue #791)

## Summary

The same logical check — "every `*.sh` in the repo parses" — ran in two
workflow files:

- `.github/workflows/ci.yml` (job `build`, step *Check Bash Script Syntax*):
  `find . -name "*.sh" -type f -exec bash -n {} \;`
- `.github/workflows/shellcheck.yml` (job `shellcheck`): `ludeeus/action-shellcheck`
  with `scandir: .`, `severity: warning`.

ShellCheck must parse each script before linting it and reports parse/syntax
errors at error level (included at `severity: warning`), so over the identical
scope the `bash -n` pass added no signal ShellCheck did not already provide. It
also gave one policy two homes.

**This PR removes the redundant `bash -n` step from `ci.yml`'s `build` job** and
keeps `shellcheck.yml` as the single shell-syntax gate.

**Ordering prerequisite.** The issue's ordering note warned that `shellcheck.yml`
skipped PRs targeting `milestone/*` branches (the `["*"]` glob does not match a
`/`), while `ci.yml`'s `build` job runs on `[main, "milestone/**"]`. Removing
`bash -n` without addressing this would leave milestone PRs with no shell-syntax
gate. So this PR also lists `milestone/**` in `shellcheck.yml`'s `pull_request`
and `push` triggers, so milestone PRs keep a shell-syntax gate throughout. The
broader nine-workflow milestone-filter fix remains tracked by
`stSoftwareAU/GRQ-validation#788`; this PR only touches `shellcheck.yml`, the
prerequisite for #791.

Closes #791.

## Evidence

Backend/CI-only change — no web interface to screenshot. Verified via the Deno
workflow unit tests below.

Coverage before vs after this change:

```mermaid
flowchart LR
    subgraph Before
      A[milestone/** PR] --> B[ci.yml build: bash -n]
      A -. skipped .-> C[shellcheck.yml]
      D[main PR] --> B
      D --> C
    end
    subgraph After
      A2[milestone/** PR] --> C2[shellcheck.yml]
      D2[main PR] --> C2
    end
```

Test run:

```
deno test --allow-read tests/ci_workflow_test.ts tests/shellcheck_workflow_test.ts
ok | 26 passed | 0 failed
```

## Test Plan

- **`tests/ci_workflow_test.ts`**
  - Added `CI workflow no longer runs a redundant bash -n shell-syntax step` —
    asserts the `build` job has no *Check Bash Script Syntax* step and no step
    running `bash -n` (guards against it reappearing under another name).
  - Updated the existing `multi-line bash run blocks begin with set -euo pipefail`
    test: removed the `["build", "Check Bash Script Syntax"]` target, since that
    step no longer exists. **Business-logic change** — the step it asserted on
    was deliberately deleted; the remaining targets (`Check for changes`,
    `Generate CycloneDX SBOM`) still enforce the fail-fast convention.
- **`tests/shellcheck_workflow_test.ts`**
  - Added `ShellCheck workflow triggers on pull_request to milestone branches`.
  - Added `ShellCheck workflow triggers on push to milestone branches`.

All 26 tests pass; `deno fmt --check`, `deno lint`, and `deno check` are clean on
the modified test files.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms0o5r19-7f58c6`<!-- vibe-worker-issue-791 -->