### PR TITLE
🟡 Reword GRQ src path citations in diagnostic scripts to concept level (Issue #783)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -373,9 +373,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -397,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",

--- a/docs/archive/pr-summaries/pr-summary-783.md
+++ b/docs/archive/pr-summaries/pr-summary-783.md
@@ -1,0 +1,86 @@
+## Summary
+
+Reworded every citation of the **private** upstream training/prediction
+repository's internal source paths out of the seven diagnostic scripts, taking
+each one down to concept level. A public repository must not point readers at
+files they cannot see: the old comments named `GRQ/src/LearnUtil.ts`,
+`GRQ/src/CoreFeatures.ts`, `GRQ/src/LearnUtilTypes.ts` and
+`GRQ/src/portfolio/ScoreApp.ts` (several with line numbers), which is
+unverifiable and useless to every public reader. Closes #783.
+
+The comments still document the ported training semantics — only the private
+path pointers were replaced, so no explanation was lost.
+
+### Reword convention applied
+
+Follows the convention already established for `docs/archive/` in #784.
+
+| Was                                                                    | Now                                                                            |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts` (denominator)         | "upstream training divides the 90-day return by `monthsAgoPrice` — the CLOSE on the score date" |
+| `GRQ/src/LearnUtil.ts:147-148` (dividend basis)                        | "upstream training bakes a FLAT quarter of the trailing annual dividend"       |
+| `GRQ/src/LearnUtil.ts -> market.lowPrice(symbol, targetDate)`          | "upstream training reads the low price at the target date"                     |
+| `GRQ/src/LearnUtilTypes.ts:19-39`, `GRQ/src/portfolio/ScoreApp.ts:473` | "the upstream decoder the scoring app applies to every emitted score"          |
+| "they live upstream in `GRQ`, not in this repo"                        | "they live in the training platform, not in this repo"                         |
+
+### Files reworded (7)
+
+`scripts/buy_price_denominator_diagnostic.ts`,
+`scripts/diagnose_buy_price_denominator.ts`,
+`scripts/diagnose_dividend_basis.ts`, `scripts/diagnose_price_basis.ts`,
+`scripts/diagnose_score_target_decoding.ts`,
+`scripts/dividend_basis_diagnostic.ts`,
+`scripts/score_target_decoding_diagnostic.ts`.
+
+Out of scope and deliberately untouched: the dashboard JS citations
+(issue #782), the scorer-job references (issue #781), the hard-coded private
+sibling checkout paths (issue #780), and this repo's own public paths
+(`GRQ-validation/src/utils.rs`, `docs/projection.js`).
+
+## Evidence
+
+Comment-only change to CLI diagnostics — there is no web interface to
+screenshot. Verified by the new regression test plus the full Deno suite.
+
+```
+$ deno test --allow-read tests/private_repo_reference_scripts_test.ts
+diagnostic scripts cite no private GRQ/src source paths ... ok
+diagnostic scripts do not point at the private repo by name ... ok
+the scripts still document the ported training semantics ... ok
+ok | 3 passed | 0 failed
+
+$ deno test --allow-read tests/*.ts
+ok | 1403 passed (79 steps) | 0 failed (28s)
+```
+
+Before the reword the first two guards failed with 11 path citations across the
+seven scripts plus the "in `GRQ`" pointer — the TDD red state.
+
+### Quality gate
+
+`./quality.sh` passes cargo fmt, clippy and check, then fails on the
+**pre-existing, environment-dependent** `utils::tests::test_read_market_data`,
+which needs the local market-data checkout to contain the `SEM` symbol. Verified
+pre-existing: the same test fails identically on a stashed (unmodified) tree.
+This change touches no Rust. The Deno half of the gate (`deno fmt --check`,
+`deno lint`, `deno check`, `deno test`) was run directly and passes clean.
+
+`Cargo.lock` carries the transitive bumps `quality.sh`'s own `cargo update`
+produced (`cc` 1.2.66 → 1.4.0, `jiff`/`jiff-static` 0.2.34 → 0.2.35). Both are
+older than the 24h external-dependency quarantine (published 2026-07-24 and
+2026-07-25) and `cargo audit` reports no vulnerabilities.
+
+## Test Plan
+
+- Added `tests/private_repo_reference_scripts_test.ts`:
+  - `diagnostic scripts cite no private GRQ/src source paths` — scans every
+    `scripts/*.ts` for `GRQ/src/…` path citations and reports file:line for any
+    hit. Fails against the unfixed code (11 hits), passes after.
+  - `diagnostic scripts do not point at the private repo by name` — collapses
+    comment continuations so a pointer split across two `//` lines is still
+    caught, then rejects "in `GRQ`" style pointers at the private repo.
+  - `the scripts still document the ported training semantics` — asserts each
+    reworded script retains its concept-level description, so the fix cannot
+    regress into simply deleting the explanation.
+- Full suite re-run: `deno test --allow-read tests/*.ts` → 1403 passed, 0
+  failed.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.82">
+    <meta name="app-version" content="1.1.83">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.82"></script>
+    <script src="escape.js?v=1.1.83"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.82"></script>
+    <script src="projection.js?v=1.1.83"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.82"></script>
+    <script src="volume_recommend.js?v=1.1.83"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.82"></script>
+    <script src="chart_window_settings.js?v=1.1.83"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.82"></script>
+    <script src="star_filter_settings.js?v=1.1.83"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.82"></script>
+    <script src="color_key.js?v=1.1.83"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.82"></script>
+    <script src="series_label_colour.js?v=1.1.83"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.82"></script>
+    <script src="chart_theme.js?v=1.1.83"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.82"></script>
+    <script src="chart_title.js?v=1.1.83"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.82"></script>
+    <script src="format.js?v=1.1.83"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.82"></script>
+    <script src="market_index.js?v=1.1.83"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.82"></script>
+    <script src="stock_selection.js?v=1.1.83"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.82"></script>
+    <script src="yahoo_finance.js?v=1.1.83"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.82"></script>
+    <script src="date_selection.js?v=1.1.83"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.82"></script>
+    <script src="view_selection.js?v=1.1.83"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.82"></script>
+    <script src="popover_dismiss.js?v=1.1.83"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.82"></script>
+    <script src="popover_cleanup.js?v=1.1.83"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.82"></script>
+    <script src="chart_popout.js?v=1.1.83"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.82"></script>
+    <script src="share_link.js?v=1.1.83"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.82"></script>
+    <script src="field_label.js?v=1.1.83"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.82"></script>
+    <script src="freshness_text.js?v=1.1.83"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.82"></script>
+    <script src="dashboard_boot.js?v=1.1.83"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.82"></script>
+    <script src="sw-register.js?v=1.1.83"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.82")
+    navigator.serviceWorker.register("./sw.js?v=1.1.83")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.82";
+const APP_VERSION = "1.1.83";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.82">
+    <meta name="app-version" content="1.1.83">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.82"></script>
+    <script src="chart_theme.js?v=1.1.83"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.82"></script>
+    <script src="sw-register.js?v=1.1.83"></script>
   </body>
 </html>

--- a/scripts/buy_price_denominator_diagnostic.ts
+++ b/scripts/buy_price_denominator_diagnostic.ts
@@ -6,12 +6,11 @@
 // diagnostic measures the dashboard's own denominator rather than a
 // re-implementation.
 //
-// The question: training divides the 90-day return by `monthsAgoPrice` (the
-// CLOSE on the score date — GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts),
-// while the dashboard divides BOTH Target and Actual by `buyPrice` (the
-// split-adjusted MIDPOINT of the first usable point). This module quantifies the
-// denominator offset and the gap it contributes when Target and Actual are
-// restated onto the trained close basis.
+// The question: upstream training divides the 90-day return by `monthsAgoPrice`
+// — the CLOSE on the score date — while the dashboard divides BOTH Target and
+// Actual by `buyPrice` (the split-adjusted MIDPOINT of the first usable point).
+// This module quantifies the denominator offset and the gap it contributes when
+// Target and Actual are restated onto the trained close basis.
 
 import "../docs/projection.js";
 import "../docs/volume_recommend.js";

--- a/scripts/diagnose_buy_price_denominator.ts
+++ b/scripts/diagnose_buy_price_denominator.ts
@@ -2,9 +2,9 @@
 // that comes purely from the buy-price DENOMINATOR mismatch between training and
 // the dashboard.
 //
-//   - The GRQ model is trained on a 90-day return divided by `monthsAgoPrice`,
-//     which is the CLOSE on the score date (GRQ/src/CoreFeatures.ts builds
-//     `monthsAgoPrice = closePrices[0]`; GRQ/src/LearnUtil.ts divides by it).
+//   - The model is trained on a 90-day return divided by `monthsAgoPrice`,
+//     which is the CLOSE on the score date (upstream training takes the first
+//     close of the series as `monthsAgoPrice` and divides the return by it).
 //   - The dashboard divides BOTH Target and Actual by `buyPrice`, the
 //     split-adjusted MIDPOINT (high + low) / 2 of the first usable point
 //     (docs/projection.js -> getBuyPrice).

--- a/scripts/diagnose_dividend_basis.ts
+++ b/scripts/diagnose_dividend_basis.ts
@@ -2,9 +2,9 @@
 // that comes purely from the DIVIDEND basis mismatch between training and the
 // dashboard.
 //
-//   - The GRQ model bakes a FLAT quarter of the trailing annual dividend,
+//   - Upstream training bakes a FLAT quarter of the trailing annual dividend,
 //     `core.yearOfDividends / 4`, into the total-return training label for EVERY
-//     stock (GRQ/src/LearnUtil.ts:147-148, GRQ/src/CoreFeatures.ts).
+//     stock, whether or not a dividend actually falls in the forward window.
 //   - The dashboard/validation side credits only the ACTUAL ex-dividends inside
 //     the 90-day window (GRQ-validation/src/utils.rs
 //     `calculate_dividends_for_period`, mirrored by the shipped JS kernels

--- a/scripts/diagnose_price_basis.ts
+++ b/scripts/diagnose_price_basis.ts
@@ -2,8 +2,8 @@
 // that comes purely from the price BASIS mismatch between training and the
 // dashboard.
 //
-//   - The GRQ model is trained on the intraday LOW of the trading day 90 days
-//     ahead (GRQ/src/LearnUtil.ts -> market.lowPrice(symbol, targetDate)).
+//   - The model is trained on the intraday LOW of the trading day 90 days
+//     ahead (upstream training reads the low price at the target date).
 //   - The dashboard measures Actual at the MIDPOINT (high + low) / 2 of the last
 //     point on or before the 90-day horizon (docs/projection.js).
 //

--- a/scripts/diagnose_score_target_decoding.ts
+++ b/scripts/diagnose_score_target_decoding.ts
@@ -2,9 +2,9 @@
 // decoding `reverseProfitRecommend` adds a systematic bias to the dashboard's
 // Target.
 //
-//   - The AI emits a score in [-1, 1]; the GRQ dashboard derives Target via
-//     reverseProfitRecommend(price, score) (GRQ/src/portfolio/ScoreApp.ts:473,
-//     defined in GRQ/src/LearnUtilTypes.ts:19-39).
+//   - The AI emits a score in [-1, 1]; the dashboard derives Target via
+//     reverseProfitRecommend(price, score), the upstream decoder that inverts
+//     the training-side profitRecommend encode.
 //   - Forward (training) encode:  profitRecommend(pct) = tanh((pct - 1.5) / 3).
 //   - Reverse (dashboard) decode: pct = 3*atanh(score) + 1.5, then
 //     target = price * (1 + pct/100), with clamps score>=1 → +50%,

--- a/scripts/dividend_basis_diagnostic.ts
+++ b/scripts/dividend_basis_diagnostic.ts
@@ -3,10 +3,9 @@
 // Quantifies the Target/Actual bias that comes from the DIVIDEND basis mismatch
 // between training and the dashboard:
 //
-//   - Training (GRQ/src/LearnUtil.ts:147-148) bakes a FLAT quarter of the
-//     trailing annual dividend, `core.yearOfDividends / 4`, into the
-//     total-return label for EVERY stock, whether or not a dividend actually
-//     falls in the forward window.
+//   - Upstream training bakes a FLAT quarter of the trailing annual dividend,
+//     `core.yearOfDividends / 4`, into the total-return label for EVERY stock,
+//     whether or not a dividend actually falls in the forward window.
 //   - The dashboard/validation side credits only the ACTUAL ex-dividends that
 //     fall inside the 90-day window
 //     (GRQ-validation/src/utils.rs `calculate_dividends_for_period`, mirrored on

--- a/scripts/score_target_decoding_diagnostic.ts
+++ b/scripts/score_target_decoding_diagnostic.ts
@@ -2,9 +2,9 @@
 // (milestone #544 — one candidate source of the systematic Target-over-Actual
 // measurement gap).
 //
-// The question: the AI emits a score in [-1, 1]; the GRQ dashboard derives the
-// Target from it via `reverseProfitRecommend(price, score)`
-// (GRQ/src/LearnUtilTypes.ts:19-39, called at GRQ/src/portfolio/ScoreApp.ts:473).
+// The question: the AI emits a score in [-1, 1]; the dashboard derives the
+// Target from it via `reverseProfitRecommend(price, score)`, the upstream
+// decoder the scoring app applies to every emitted score.
 // The FORWARD mapping used in training is
 //   profitRecommend(pct) = tanh((pct - 1.5) / 3)            (encode: pct → score)
 // and the REVERSE is
@@ -20,11 +20,11 @@
 // over the REALISED score distribution, decoding introduces a consistent
 // same-direction (plausibly upward) Target shift.
 //
-// This module ports the two GRQ functions faithfully (they live upstream in
-// `GRQ`, not in this repo) and measures the round-trip Target shift purely in
-// score↔return-percent space — the per-row pp shift is price-independent, so no
-// market data is needed. It also takes a census of how often the realised
-// scores land in each clamped region.
+// This module ports the two upstream functions faithfully (they live in the
+// training platform, not in this repo) and measures the round-trip Target shift
+// purely in score↔return-percent space — the per-row pp shift is
+// price-independent, so no market data is needed. It also takes a census of
+// how often the realised scores land in each clamped region.
 //
 // The score parsing is delegated to the SHIPPED dashboard kernel
 // (docs/trend_predictions.js → GRQTrendPredictions.parseScoreTsv), so the
@@ -38,12 +38,12 @@ const TP = (globalThis as any).GRQTrendPredictions;
 
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 
-/** The +50% cap / -50% interior cap magnitude from GRQ's LearnUtilTypes. */
+/** The +50% cap / -50% interior cap magnitude used by the upstream decoder. */
 export const MAX_REVERSE_PERCENT = 50;
 
 /**
  * Forward training encode: a candidate return percentage → score in (-1, 1).
- * Mirrors GRQ `profitRecommend` (GRQ/src/LearnUtilTypes.ts:12-15).
+ * Mirrors the upstream training-side `profitRecommend` encode.
  */
 export function profitRecommend(pct: number): number {
   return Math.tanh((pct - 1.5) / 3);
@@ -64,11 +64,11 @@ export interface DecodeResult {
 }
 
 /**
- * Reverse decode: score → return percentage, with GRQ's three clamps.
- * Mirrors the percentage half of GRQ `reverseProfitRecommend`
- * (GRQ/src/LearnUtilTypes.ts:19-39). The `target = price * (1 + pct/100)` step
- * is split out into {@link reverseProfitTarget} so the round-trip can be
- * measured in price-independent return-percent space.
+ * Reverse decode: score → return percentage, with the upstream three clamps.
+ * Mirrors the percentage half of the upstream `reverseProfitRecommend` decoder.
+ * The `target = price * (1 + pct/100)` step is split out into
+ * {@link reverseProfitTarget} so the round-trip can be measured in
+ * price-independent return-percent space.
  */
 export function reverseProfitPct(score: number): DecodeResult {
   if (score >= 1) {

--- a/tests/diagnostic_private_path_test.ts
+++ b/tests/diagnostic_private_path_test.ts
@@ -69,7 +69,7 @@ Deno.test("diagnostic scripts still explain the ported training semantics", asyn
     "scripts/buy_price_denominator_diagnostic.ts": ["training", "CLOSE"],
     "scripts/diagnose_buy_price_denominator.ts": ["training", "CLOSE"],
     "scripts/diagnose_dividend_basis.ts": ["training", "yearOfDividends"],
-    "scripts/dividend_basis_diagnostic.ts": ["Training", "yearOfDividends"],
+    "scripts/dividend_basis_diagnostic.ts": ["training", "yearOfDividends"],
     "scripts/diagnose_price_basis.ts": ["trained", "LOW"],
     "scripts/diagnose_score_target_decoding.ts": [
       "training",

--- a/tests/diagnostic_private_path_test.ts
+++ b/tests/diagnostic_private_path_test.ts
@@ -1,0 +1,92 @@
+// Guards issue #783: the diagnostic scripts must not cite internal source-file
+// paths of the private upstream prediction/training repository.
+//
+// This public repository cannot point readers at files they are unable to see,
+// so every header comment that documented the ported training semantics by
+// naming `GRQ/src/…` (often with line numbers) is reworded to concept level.
+// The tests read the shipped script text — the text IS the artefact under test
+// — and assert both halves of the fix: the private citations are gone, and the
+// concept-level explanation that replaced them survives.
+
+import { assert } from "@std/assert";
+
+const SCRIPTS_DIR = "scripts";
+
+/** Internal file names of the private upstream repository. */
+const PRIVATE_SOURCE_FILES = [
+  "LearnUtil.ts",
+  "LearnUtilTypes.ts",
+  "CoreFeatures.ts",
+  "ScoreApp.ts",
+];
+
+async function scriptFiles(): Promise<string[]> {
+  const names: string[] = [];
+  for await (const entry of Deno.readDir(SCRIPTS_DIR)) {
+    if (entry.isFile && entry.name.endsWith(".ts")) {
+      names.push(`${SCRIPTS_DIR}/${entry.name}`);
+    }
+  }
+  names.sort();
+  assert(names.length > 0, "expected TypeScript files under scripts/");
+  return names;
+}
+
+Deno.test("diagnostic scripts cite no private upstream source paths", async () => {
+  for (const file of await scriptFiles()) {
+    const text = await Deno.readTextFile(file);
+    assert(
+      !/GRQ\/src/.test(text),
+      `${file} must not cite a private "GRQ/src/…" source path`,
+    );
+    for (const sourceFile of PRIVATE_SOURCE_FILES) {
+      assert(
+        !text.includes(sourceFile),
+        `${file} must not name the private upstream source file "${sourceFile}"`,
+      );
+    }
+  }
+});
+
+Deno.test("diagnostic scripts cite no line numbers of private upstream sources", async () => {
+  // e.g. "LearnUtilTypes.ts:19-39" or "ScoreApp.ts:473" — a `.ts` file name
+  // followed by a line number is only ever an upstream citation here; this
+  // repo's own scripts are referenced by path alone.
+  for (const file of await scriptFiles()) {
+    const text = await Deno.readTextFile(file);
+    const match = text.match(/[\w/.]+\.ts:\d+/);
+    assert(
+      match === null,
+      `${file} must not cite a source line number (found "${match?.[0]}")`,
+    );
+  }
+});
+
+Deno.test("diagnostic scripts still explain the ported training semantics", async () => {
+  // Each reworded header must keep describing the training-side behaviour it
+  // used to document by path, so the concept-level rewrite loses no meaning.
+  const expectations: Record<string, string[]> = {
+    "scripts/buy_price_denominator_diagnostic.ts": ["training", "CLOSE"],
+    "scripts/diagnose_buy_price_denominator.ts": ["training", "CLOSE"],
+    "scripts/diagnose_dividend_basis.ts": ["training", "yearOfDividends"],
+    "scripts/dividend_basis_diagnostic.ts": ["Training", "yearOfDividends"],
+    "scripts/diagnose_price_basis.ts": ["trained", "LOW"],
+    "scripts/diagnose_score_target_decoding.ts": [
+      "training",
+      "profitRecommend",
+    ],
+    "scripts/score_target_decoding_diagnostic.ts": [
+      "training",
+      "profitRecommend",
+    ],
+  };
+  for (const [file, phrases] of Object.entries(expectations)) {
+    const text = await Deno.readTextFile(file);
+    for (const phrase of phrases) {
+      assert(
+        text.includes(phrase),
+        `${file} must still describe the training behaviour (missing "${phrase}")`,
+      );
+    }
+  }
+});

--- a/tests/private_repo_reference_scripts_test.ts
+++ b/tests/private_repo_reference_scripts_test.ts
@@ -1,0 +1,82 @@
+// Issue #783: the diagnostic scripts must not cite internal source-file paths
+// of the PRIVATE upstream training/prediction repository. A public repo cannot
+// point readers at files they are unable to see, so every such citation has to
+// be reworded to concept level (describe the training-side behaviour instead).
+
+import { assertEquals } from "@std/assert";
+
+const SCRIPTS_DIR = new URL("../scripts/", import.meta.url);
+
+/** Path citations into the private upstream repository's source tree. */
+const PRIVATE_PATH_PATTERN = /GRQ\/src\/[A-Za-z0-9_./-]+/g;
+
+/** "lives upstream in `GRQ`" style pointers at the private repo itself. */
+const PRIVATE_REPO_POINTER_PATTERN = /\bin\s+`GRQ`/g;
+
+async function scriptSources(): Promise<Array<[string, string]>> {
+  const sources: Array<[string, string]> = [];
+  for await (const entry of Deno.readDir(SCRIPTS_DIR)) {
+    if (!entry.isFile || !entry.name.endsWith(".ts")) continue;
+    sources.push([
+      `scripts/${entry.name}`,
+      await Deno.readTextFile(new URL(entry.name, SCRIPTS_DIR)),
+    ]);
+  }
+  return sources.sort(([a], [b]) => a.localeCompare(b));
+}
+
+function offenders(pattern: RegExp, sources: Array<[string, string]>) {
+  const hits: string[] = [];
+  for (const [name, text] of sources) {
+    text.split("\n").forEach((line, i) => {
+      const matches = line.match(pattern);
+      if (matches) hits.push(`${name}:${i + 1}: ${matches.join(", ")}`);
+    });
+  }
+  return hits;
+}
+
+Deno.test("diagnostic scripts cite no private GRQ/src source paths", async () => {
+  const hits = offenders(PRIVATE_PATH_PATTERN, await scriptSources());
+  assertEquals(
+    hits,
+    [],
+    `Private source-path citations found:\n${hits.join("\n")}`,
+  );
+});
+
+Deno.test("diagnostic scripts do not point at the private repo by name", async () => {
+  // Collapse comment continuations so a pointer split across two `//` lines is
+  // still caught (that is exactly how the issue #783 line 23 citation read).
+  const hits: string[] = [];
+  for (const [name, text] of await scriptSources()) {
+    const flat = text.replace(/\n\s*(\/\/|\*)?[ \t]*/g, " ");
+    const matches = flat.match(PRIVATE_REPO_POINTER_PATTERN);
+    if (matches) hits.push(`${name}: ${matches.join(", ")}`);
+  }
+  assertEquals(hits, [], `Private repo pointers found:\n${hits.join("\n")}`);
+});
+
+Deno.test("the scripts still document the ported training semantics", async () => {
+  const sources = new Map(await scriptSources());
+  // Rewording must not silently delete the explanation: each diagnostic keeps
+  // a concept-level description of the training behaviour it is comparing.
+  const expectations: Array<[string, RegExp]> = [
+    ["scripts/buy_price_denominator_diagnostic.ts", /CLOSE on the score date/],
+    ["scripts/diagnose_buy_price_denominator.ts", /CLOSE on the score date/],
+    ["scripts/diagnose_dividend_basis.ts", /yearOfDividends/],
+    ["scripts/dividend_basis_diagnostic.ts", /yearOfDividends/],
+    ["scripts/diagnose_price_basis.ts", /intraday LOW/],
+    ["scripts/diagnose_score_target_decoding.ts", /reverseProfitRecommend/],
+    ["scripts/score_target_decoding_diagnostic.ts", /reverseProfitRecommend/],
+  ];
+  for (const [name, pattern] of expectations) {
+    const text = sources.get(name);
+    assertEquals(typeof text, "string", `${name} should exist`);
+    assertEquals(
+      pattern.test(text ?? ""),
+      true,
+      `${name} should still describe the training-side behaviour (${pattern})`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Reworded every citation of the **private** upstream training/prediction
repository's internal source paths out of the seven diagnostic scripts, taking
each one down to concept level. A public repository must not point readers at
files they cannot see: the old comments named `GRQ/src/LearnUtil.ts`,
`GRQ/src/CoreFeatures.ts`, `GRQ/src/LearnUtilTypes.ts` and
`GRQ/src/portfolio/ScoreApp.ts` (several with line numbers), which is
unverifiable and useless to every public reader. Closes #783.

The comments still document the ported training semantics — only the private
path pointers were replaced, so no explanation was lost.

### Reword convention applied

Follows the convention already established for `docs/archive/` in #784.

| Was                                                                    | Now                                                                            |
| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| `GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts` (denominator)         | "upstream training divides the 90-day return by `monthsAgoPrice` — the CLOSE on the score date" |
| `GRQ/src/LearnUtil.ts:147-148` (dividend basis)                        | "upstream training bakes a FLAT quarter of the trailing annual dividend"       |
| `GRQ/src/LearnUtil.ts -> market.lowPrice(symbol, targetDate)`          | "upstream training reads the low price at the target date"                     |
| `GRQ/src/LearnUtilTypes.ts:19-39`, `GRQ/src/portfolio/ScoreApp.ts:473` | "the upstream decoder the scoring app applies to every emitted score"          |
| "they live upstream in `GRQ`, not in this repo"                        | "they live in the training platform, not in this repo"                         |

### Files reworded (7)

`scripts/buy_price_denominator_diagnostic.ts`,
`scripts/diagnose_buy_price_denominator.ts`,
`scripts/diagnose_dividend_basis.ts`, `scripts/diagnose_price_basis.ts`,
`scripts/diagnose_score_target_decoding.ts`,
`scripts/dividend_basis_diagnostic.ts`,
`scripts/score_target_decoding_diagnostic.ts`.

Out of scope and deliberately untouched: the dashboard JS citations
(issue #782), the scorer-job references (issue #781), the hard-coded private
sibling checkout paths (issue #780), and this repo's own public paths
(`GRQ-validation/src/utils.rs`, `docs/projection.js`).

## Evidence

Comment-only change to CLI diagnostics — there is no web interface to
screenshot. Verified by the new regression test plus the full Deno suite.

```
$ deno test --allow-read tests/private_repo_reference_scripts_test.ts
diagnostic scripts cite no private GRQ/src source paths ... ok
diagnostic scripts do not point at the private repo by name ... ok
the scripts still document the ported training semantics ... ok
ok | 3 passed | 0 failed

$ deno test --allow-read tests/*.ts
ok | 1403 passed (79 steps) | 0 failed (28s)
```

Before the reword the first two guards failed with 11 path citations across the
seven scripts plus the "in `GRQ`" pointer — the TDD red state.

### Quality gate

`./quality.sh` passes cargo fmt, clippy and check, then fails on the
**pre-existing, environment-dependent** `utils::tests::test_read_market_data`,
which needs the local market-data checkout to contain the `SEM` symbol. Verified
pre-existing: the same test fails identically on a stashed (unmodified) tree.
This change touches no Rust. The Deno half of the gate (`deno fmt --check`,
`deno lint`, `deno check`, `deno test`) was run directly and passes clean.

`Cargo.lock` carries the transitive bumps `quality.sh`'s own `cargo update`
produced (`cc` 1.2.66 → 1.4.0, `jiff`/`jiff-static` 0.2.34 → 0.2.35). Both are
older than the 24h external-dependency quarantine (published 2026-07-24 and
2026-07-25) and `cargo audit` reports no vulnerabilities.

## Test Plan

- Added `tests/private_repo_reference_scripts_test.ts`:
  - `diagnostic scripts cite no private GRQ/src source paths` — scans every
    `scripts/*.ts` for `GRQ/src/…` path citations and reports file:line for any
    hit. Fails against the unfixed code (11 hits), passes after.
  - `diagnostic scripts do not point at the private repo by name` — collapses
    comment continuations so a pointer split across two `//` lines is still
    caught, then rejects "in `GRQ`" style pointers at the private repo.
  - `the scripts still document the ported training semantics` — asserts each
    reworded script retains its concept-level description, so the fix cannot
    regress into simply deleting the explanation.
- Full suite re-run: `deno test --allow-read tests/*.ts` → 1403 passed, 0
  failed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms58t6k7-bf75a5`<!-- vibe-worker-issue-783 -->