### PR TITLE
🟡 Reword stSoftwareAU/GRQ worker/score.sh scorer-job references to concept level (Issue #781)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ and committed, so a visitor's browser never calls an untrusted third-party relay
 
 ### Daily benchmark refresh (in lockstep with the scores)
 
-The actuals stay current because an external daily **scorer** job
-(`stSoftwareAU/GRQ`, `worker/score.sh`) checks out this repo and commits new
+The actuals stay current because an external daily **scorer** job (run from the
+upstream prediction platform) checks out this repo and commits new
 `docs/scores/...` and `docs/USDAUD.json` with a message like
 `Add scores for 2026-06-20`. To stop the benchmark indices drifting behind the
 actuals (issue #238), that same job now refreshes `docs/market-indices.json`
@@ -141,7 +141,7 @@ indices reach the last trading day in lockstep with the actuals.
 
 ```mermaid
 sequenceDiagram
-    participant Scorer as Scorer job (GRQ/worker/score.sh)
+    participant Scorer as External daily scorer job
     participant Repo as GRQ-validation checkout
     participant Yahoo as Yahoo Finance
     Scorer->>Repo: write docs/scores/... + docs/USDAUD.json
@@ -152,7 +152,7 @@ sequenceDiagram
     else fetch fails
         Repo-->>Repo: log + exit 0, keep last-good file
     end
-    Scorer->>Repo: model_checkin.sh "Add scores for YYYY-MM-DD"
+    Scorer->>Repo: commit "Add scores for YYYY-MM-DD"
     Note over Repo: scores + USDAUD + indices in one commit
 ```
 

--- a/docs/archive/pr-summaries/pr-summary-781.md
+++ b/docs/archive/pr-summaries/pr-summary-781.md
@@ -1,0 +1,55 @@
+## Summary
+
+Reworded the external daily **scorer** job references down to concept level so
+this public repository no longer names the **private** upstream repository slug
+or its internal script paths. A public reader cannot open either, and the
+mentions leaked the private repository's internal layout. Closes #781.
+
+Four mentions were reworded (the private tokens are deliberately not repeated
+here, so this summary does not reintroduce what it removes):
+
+| Where | Now reads |
+| --- | --- |
+| `README.md` prose (daily benchmark refresh) | "an external daily **scorer** job (run from the upstream prediction platform) checks out this repo and commits new `docs/scores/...` and `docs/USDAUD.json`" |
+| `README.md` mermaid participant | `participant Scorer as External daily scorer job` |
+| `README.md` mermaid check-in step | `Scorer->>Repo: commit "Add scores for YYYY-MM-DD"` |
+| `scripts/refresh_market_indices.ts` header comment | `// The external "scorer" job, run from the upstream prediction platform, checks out this repo …` |
+
+The third row was the same class of leak (a private internal script name) inside
+the very sequence diagram being fixed, so it was reworded in the same pass rather
+than left behind.
+
+Deliberately **kept** (not private): this repo's own public slug
+`stSoftwareAU/GRQ-validation`, the public product/acronym name, and the whole
+described behaviour — an upstream job checks out this repo, refreshes the
+benchmark indices via `deno task refresh-indices`, and commits scores + USDAUD +
+indices together.
+
+## Evidence
+
+Documentation/comment-only change with no web interface to screenshot. Verified
+by the new regression test plus a repository grep for the private slug,
+`GRQ/<path>` citations, and the internal script names across both audited files
+→ **no matches**. `./quality.sh` passes cleanly (cargo fmt/clippy/check/test plus
+`deno test`, `deno lint`, `deno check`).
+
+```mermaid
+flowchart LR
+    A["README + wrapper name<br/>private slug and script paths"] --> B["Reword to concept level"]
+    B --> C["Same behaviour documented,<br/>no private slug or layout"]
+    B --> D["Regression test guards<br/>both files"]
+```
+
+## Test Plan
+
+- Added `tests/private_repo_scorer_reference_test.ts`:
+  - `public docs and the refresh wrapper name no private scorer repo or script`
+    — scans `README.md` and `scripts/refresh_market_indices.ts` for the private
+    upstream slug (while allowing the public `-validation` siblings), path
+    citations into the private tree, and the internal scorer/check-in script
+    names, failing with `file:line` detail. This test reproduced the issue: it
+    listed all five offending lines before the rewording and passes after it.
+  - `the external scorer job is still documented at concept level` — asserts the
+    rewording did not silently delete the explanation (the scorer job, its
+    checkout-and-commit behaviour, and the diagram participant all survive).
+- Full `./quality.sh` run passes, so no existing test regressed.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.83">
+    <meta name="app-version" content="1.1.84">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.83"></script>
+    <script src="escape.js?v=1.1.84"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.83"></script>
+    <script src="projection.js?v=1.1.84"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.83"></script>
+    <script src="volume_recommend.js?v=1.1.84"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.83"></script>
+    <script src="chart_window_settings.js?v=1.1.84"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.83"></script>
+    <script src="star_filter_settings.js?v=1.1.84"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.83"></script>
+    <script src="color_key.js?v=1.1.84"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.83"></script>
+    <script src="series_label_colour.js?v=1.1.84"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.83"></script>
+    <script src="chart_theme.js?v=1.1.84"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.83"></script>
+    <script src="chart_title.js?v=1.1.84"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.83"></script>
+    <script src="format.js?v=1.1.84"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.83"></script>
+    <script src="market_index.js?v=1.1.84"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.83"></script>
+    <script src="stock_selection.js?v=1.1.84"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.83"></script>
+    <script src="yahoo_finance.js?v=1.1.84"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.83"></script>
+    <script src="date_selection.js?v=1.1.84"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.83"></script>
+    <script src="view_selection.js?v=1.1.84"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.83"></script>
+    <script src="popover_dismiss.js?v=1.1.84"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.83"></script>
+    <script src="popover_cleanup.js?v=1.1.84"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.83"></script>
+    <script src="chart_popout.js?v=1.1.84"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.83"></script>
+    <script src="share_link.js?v=1.1.84"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.83"></script>
+    <script src="field_label.js?v=1.1.84"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.83"></script>
+    <script src="freshness_text.js?v=1.1.84"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.83"></script>
+    <script src="dashboard_boot.js?v=1.1.84"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.83"></script>
+    <script src="sw-register.js?v=1.1.84"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.83")
+    navigator.serviceWorker.register("./sw.js?v=1.1.84")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.83";
+const APP_VERSION = "1.1.84";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.83">
+    <meta name="app-version" content="1.1.84">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.83"></script>
+    <script src="chart_theme.js?v=1.1.84"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.83"></script>
+    <script src="sw-register.js?v=1.1.84"></script>
   </body>
 </html>

--- a/scripts/refresh_market_indices.ts
+++ b/scripts/refresh_market_indices.ts
@@ -2,11 +2,11 @@
 //
 // Daily lockstep wrapper for the benchmark indices (issue #238).
 //
-// The external "scorer" job (stSoftwareAU/GRQ, worker/score.sh) checks out this
-// repo and, once a day, commits new docs/scores/... and docs/USDAUD.json with a
-// message like "Add scores for 2026-06-20". Before #238 the benchmark indices
-// (docs/market-indices.json) were not part of that job, so they drifted days
-// behind the actuals.
+// The external "scorer" job, run from the upstream prediction platform, checks
+// out this repo and, once a day, commits new docs/scores/... and
+// docs/USDAUD.json with a message like "Add scores for 2026-06-20".
+// Before #238 the benchmark indices (docs/market-indices.json) were not part of
+// that job, so they drifted days behind the actuals.
 //
 // This wrapper is the stable entry point the scorer invokes immediately before
 // that commit, so the indices reach the last trading day in lockstep with the

--- a/tests/private_repo_scorer_reference_test.ts
+++ b/tests/private_repo_scorer_reference_test.ts
@@ -1,0 +1,69 @@
+// Issue #781: the docs and the daily-refresh wrapper must describe the external
+// scorer job at concept level only. Naming the PRIVATE upstream repository slug
+// (`stSoftwareAU/GRQ`) or its internal script paths (`worker/score.sh`) is dead
+// weight to every public reader — who cannot open either — and it maps out the
+// private repository's internal layout.
+
+import { assertEquals, assertMatch } from "@std/assert";
+
+const ROOT = new URL("../", import.meta.url);
+
+/** Files that describe the external scorer job for a public audience. */
+const AUDITED = [
+  "README.md",
+  "scripts/refresh_market_indices.ts",
+];
+
+/**
+ * Private-repository references: the bare `stSoftwareAU/GRQ` slug (but not the
+ * public `stSoftwareAU/GRQ-validation` / `-FX-validation` siblings), any
+ * `GRQ/<path>` citation into its tree, and its internal shell script names.
+ */
+const PRIVATE_PATTERNS: Array<[string, RegExp]> = [
+  ["private repo slug", /stSoftwareAU\/GRQ(?![-\w])/g],
+  ["private repo path", /\bGRQ\/[A-Za-z0-9_.-]+/g],
+  ["private script name", /\b(?:worker\/)?(?:score|model_checkin)\.sh\b/g],
+];
+
+async function auditedSources(): Promise<Array<[string, string]>> {
+  const sources: Array<[string, string]> = [];
+  for (const name of AUDITED) {
+    sources.push([name, await Deno.readTextFile(new URL(name, ROOT))]);
+  }
+  return sources;
+}
+
+Deno.test("public docs and the refresh wrapper name no private scorer repo or script", async () => {
+  const hits: string[] = [];
+  for (const [name, text] of await auditedSources()) {
+    text.split("\n").forEach((line, i) => {
+      for (const [label, pattern] of PRIVATE_PATTERNS) {
+        const matches = line.match(pattern);
+        if (matches) {
+          hits.push(`${name}:${i + 1}: ${label}: ${matches.join(", ")}`);
+        }
+      }
+    });
+  }
+  assertEquals(
+    hits,
+    [],
+    `Private scorer references found:\n${hits.join("\n")}`,
+  );
+});
+
+Deno.test("the external scorer job is still documented at concept level", async () => {
+  const sources = new Map(await auditedSources());
+
+  const readme = sources.get("README.md") ?? "";
+  // The behaviour being documented (an upstream job checks out this repo and
+  // commits new predictions/actuals) must survive the rewording.
+  assertMatch(readme, /external daily \*\*scorer\*\* job/);
+  assertMatch(readme, /checks out this\s+repo and commits new/);
+  // The sequence diagram keeps a scorer participant, just without the slug.
+  assertMatch(readme, /participant Scorer as [^\n]*\n/);
+
+  const wrapper = sources.get("scripts/refresh_market_indices.ts") ?? "";
+  assertMatch(wrapper, /external "scorer" job/);
+  assertMatch(wrapper, /checks\n\/\/ out this repo/);
+});


### PR DESCRIPTION
## Summary

Reworded the external daily **scorer** job references down to concept level so
this public repository no longer names the **private** upstream repository slug
or its internal script paths. A public reader cannot open either, and the
mentions leaked the private repository's internal layout. Closes #781.

Four mentions were reworded (the private tokens are deliberately not repeated
here, so this summary does not reintroduce what it removes):

| Where | Now reads |
| --- | --- |
| `README.md` prose (daily benchmark refresh) | "an external daily **scorer** job (run from the upstream prediction platform) checks out this repo and commits new `docs/scores/...` and `docs/USDAUD.json`" |
| `README.md` mermaid participant | `participant Scorer as External daily scorer job` |
| `README.md` mermaid check-in step | `Scorer->>Repo: commit "Add scores for YYYY-MM-DD"` |
| `scripts/refresh_market_indices.ts` header comment | `// The external "scorer" job, run from the upstream prediction platform, checks out this repo …` |

The third row was the same class of leak (a private internal script name) inside
the very sequence diagram being fixed, so it was reworded in the same pass rather
than left behind.

Deliberately **kept** (not private): this repo's own public slug
`stSoftwareAU/GRQ-validation`, the public product/acronym name, and the whole
described behaviour — an upstream job checks out this repo, refreshes the
benchmark indices via `deno task refresh-indices`, and commits scores + USDAUD +
indices together.

## Evidence

Documentation/comment-only change with no web interface to screenshot. Verified
by the new regression test plus a repository grep for the private slug,
`GRQ/<path>` citations, and the internal script names across both audited files
→ **no matches**. `./quality.sh` passes cleanly (cargo fmt/clippy/check/test plus
`deno test`, `deno lint`, `deno check`).

```mermaid
flowchart LR
    A["README + wrapper name<br/>private slug and script paths"] --> B["Reword to concept level"]
    B --> C["Same behaviour documented,<br/>no private slug or layout"]
    B --> D["Regression test guards<br/>both files"]
```

## Test Plan

- Added `tests/private_repo_scorer_reference_test.ts`:
  - `public docs and the refresh wrapper name no private scorer repo or script`
    — scans `README.md` and `scripts/refresh_market_indices.ts` for the private
    upstream slug (while allowing the public `-validation` siblings), path
    citations into the private tree, and the internal scorer/check-in script
    names, failing with `file:line` detail. This test reproduced the issue: it
    listed all five offending lines before the rewording and passes after it.
  - `the external scorer job is still documented at concept level` — asserts the
    rewording did not silently delete the explanation (the scorer job, its
    checkout-and-commit behaviour, and the diagram participant all survive).
- Full `./quality.sh` run passes, so no existing test regressed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms5riv34-751d5c`<!-- vibe-worker-issue-781 -->