### PR TITLE
🟡 Reword GRQ src path citations in dashboard JS to concept level (Issue #782)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-782.md
+++ b/docs/archive/pr-summaries/pr-summary-782.md
@@ -1,0 +1,52 @@
+# Reword GRQ src path citations in dashboard JS to concept level
+
+## Summary
+
+The dashboard JavaScript served to every visitor cited internal source-file
+paths of the **private** upstream `GRQ` repository in code comments —
+`docs/projection.js` (3 citations) and `docs/volume_recommend.js` (4 citations,
+two with line numbers). Those references point the public at files nobody
+outside the private repo can open, and they publish its internal file layout.
+
+Each citation is reworded to concept level (e.g. "training labels the 90-day
+return off the intraday LOW at the target date" in place of the
+`GRQ/src/LearnUtil.ts` path). No behaviour changes — comments only. Closes #782.
+
+## Evidence
+
+Comment-only change to two shipped JS files; there is nothing visually different
+to screenshot. Verified by the new regression tests, which read the shipped
+script text (the text IS the artefact under test) and assert both halves of the
+fix: the private citations are gone, and the concept-level explanations that
+replaced them survive.
+
+Before → after (all seven citations removed):
+
+| File                       | Before                                        | After                                        |
+| -------------------------- | --------------------------------------------- | -------------------------------------------- |
+| `docs/projection.js:756`   | `GRQ/src/LearnUtil.ts uses market.lowPrice(…)` | "training labels the 90-day return off the intraday LOW at the target date" |
+| `docs/projection.js:799`   | `(GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts)` | dropped; "the close on the score date" stands alone |
+| `docs/projection.js:929`   | `GRQ/src/CoreFeatures.ts builds …; GRQ/src/LearnUtil.ts bakes …` | "training builds the trailing annual dividend total … then bakes a flat `yearOfDividends / 4` …" |
+| `docs/volume_recommend.js:5,8` | `(GRQ/src/CoreFeatures.ts)`, `(GRQ/src/LearnUtilTypes.ts)` | "GRQ training's `volumeRecommend` feature", "matching the training-side budget" |
+| `docs/volume_recommend.js:22` | `(GRQ/src/LearnUtilTypes.ts:69)`           | "the training-side budget constant, unchanged" |
+| `docs/volume_recommend.js:99` | `(GRQ/src/LearnUtil.ts:155)`               | dropped; the ported score-cap expression stands alone |
+
+`./quality.sh` passes cleanly.
+
+## Test Plan
+
+Added `tests/dashboard_private_path_test.ts` (fails against the unfixed
+comments, passes after the reword):
+
+- `dashboard JS cites no private GRQ/src source paths` — scans every
+  `docs/*.js` for `GRQ/src/…` path citations.
+- `dashboard JS names no private upstream source files` — bans the bare private
+  source-file names (`LearnUtil.ts`, `LearnUtilTypes.ts`, `CoreFeatures.ts`,
+  `ScoreApp.ts`).
+- `dashboard JS cites no upstream source line numbers` — bans `<file>.ts:<line>`
+  citations.
+- `the dashboard JS still documents the ported training semantics` — asserts the
+  concept-level explanations survived, so the fix cannot be satisfied by simply
+  deleting the comments.
+
+This mirrors the equivalent guard added for `scripts/` under issue #783.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.84">
+    <meta name="app-version" content="1.1.85">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.84"></script>
+    <script src="escape.js?v=1.1.85"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.84"></script>
+    <script src="projection.js?v=1.1.85"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.84"></script>
+    <script src="volume_recommend.js?v=1.1.85"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.84"></script>
+    <script src="chart_window_settings.js?v=1.1.85"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.84"></script>
+    <script src="star_filter_settings.js?v=1.1.85"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.84"></script>
+    <script src="color_key.js?v=1.1.85"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.84"></script>
+    <script src="series_label_colour.js?v=1.1.85"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.84"></script>
+    <script src="chart_theme.js?v=1.1.85"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.84"></script>
+    <script src="chart_title.js?v=1.1.85"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.84"></script>
+    <script src="format.js?v=1.1.85"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.84"></script>
+    <script src="market_index.js?v=1.1.85"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.84"></script>
+    <script src="stock_selection.js?v=1.1.85"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.84"></script>
+    <script src="yahoo_finance.js?v=1.1.85"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.84"></script>
+    <script src="date_selection.js?v=1.1.85"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.84"></script>
+    <script src="view_selection.js?v=1.1.85"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.84"></script>
+    <script src="popover_dismiss.js?v=1.1.85"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.84"></script>
+    <script src="popover_cleanup.js?v=1.1.85"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.84"></script>
+    <script src="chart_popout.js?v=1.1.85"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.84"></script>
+    <script src="share_link.js?v=1.1.85"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.84"></script>
+    <script src="field_label.js?v=1.1.85"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.84"></script>
+    <script src="freshness_text.js?v=1.1.85"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.84"></script>
+    <script src="dashboard_boot.js?v=1.1.85"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.84"></script>
+    <script src="sw-register.js?v=1.1.85"></script>
   </body>
 </html>

--- a/docs/projection.js
+++ b/docs/projection.js
@@ -753,8 +753,8 @@ function priceAtNinetyDayHorizon(marketData, scoreDate) {
 }
 
 // Intraday LOW of the last market-data point on or before the 90-day horizon —
-// the price basis the GRQ model is TRAINED on (GRQ/src/LearnUtil.ts uses
-// `market.lowPrice(symbol, targetDate)` for the 90-day return label). The
+// the price basis the GRQ model is TRAINED on (training labels the 90-day
+// return off the intraday LOW at the target date). The
 // dashboard measures Actual at the midpoint (priceAtNinetyDayHorizon); this
 // helper exposes the matching low so a like-for-like, same-basis comparison can
 // be made (issue #552). Mirrors priceAtNinetyDayHorizon's horizon selection
@@ -795,8 +795,8 @@ function priceBasisOffsetPercent(buyPrice, midPrice, lowPrice) {
 // Buy-price denominator on the model's TRAINED basis: the split-adjusted
 // CLOSE of the first usable market-data point on or within five days after the
 // score date (issue #554). The GRQ training label divides the 90-day return by
-// `core.monthsAgoPrice`, which is `closePrices[0]` — the close on the score date
-// (GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts). The dashboard instead
+// `core.monthsAgoPrice`, which is `closePrices[0]` — the close on the score
+// date. The dashboard instead
 // divides by `getBuyPrice`, the split-adjusted MIDPOINT `(high + low) / 2` of
 // the same first point. This helper mirrors `getBuyPrice`'s point selection and
 // split adjustment EXACTLY — only the close replaces the midpoint — so a
@@ -926,8 +926,9 @@ function horizonAsOfBasisOffsetPercent(buyPrice, rawHorizonMid, currentBasisHori
 
 // Trailing-365-day dividend total as of the score date — the quantity the GRQ
 // model turns into a FLAT training credit of `yearOfDividends / 4`
-// (GRQ/src/CoreFeatures.ts builds `yearOfDividends`; GRQ/src/LearnUtil.ts bakes
-// `yearOfDividends / 4` into the total-return label for EVERY stock). Sums the
+// (training builds the trailing annual dividend total `yearOfDividends`, then
+// bakes a flat `yearOfDividends / 4` into the total-return label for EVERY
+// stock). Sums the
 // cash amount of every dividend whose ex-dividend date falls in the year ending
 // at the score date (`scoreDate - 365 days < exDivDate <= scoreDate`). Mirrors
 // the shape `filterDividendsWithin90Days`/`sumDividends` consume so the

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.84")
+    navigator.serviceWorker.register("./sw.js?v=1.1.85")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.84";
+const APP_VERSION = "1.1.85";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.84">
+    <meta name="app-version" content="1.1.85">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.84"></script>
+    <script src="chart_theme.js?v=1.1.85"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.84"></script>
+    <script src="sw-register.js?v=1.1.85"></script>
   </body>
 </html>

--- a/docs/volume_recommend.js
+++ b/docs/volume_recommend.js
@@ -2,10 +2,9 @@
 // dashboard's "is this name too illiquid to trade?" decision (issue #576,
 // consumed by the exclusion sub-issue #577 and the valuation sub-issue #578).
 //
-// Ported from GRQ training's `volumeRecommend` (GRQ/src/CoreFeatures.ts) so the
-// dashboard and the trainer agree on ONE definition — do not invent a new
-// threshold. The only constant is `BUDGET_DOLLARS = 10000`
-// (GRQ/src/LearnUtilTypes.ts).
+// Ported from GRQ training's `volumeRecommend` feature so the dashboard and
+// the trainer agree on ONE definition — do not invent a new threshold. The only
+// constant is `BUDGET_DOLLARS = 10000`, matching the training-side budget.
 //
 // UNITS CAVEAT (critical correctness note): GRQ stores prices in CENTS and so
 // divides dollar volume by 100 before comparing to BUDGET_DOLLARS. The
@@ -19,7 +18,8 @@
 // browser dashboard and the tests exercise the exact same code. The helpers are
 // published on `globalThis.GRQVolume`.
 
-// The single liquidity threshold, in DOLLARS (GRQ/src/LearnUtilTypes.ts:69).
+// The single liquidity threshold, in DOLLARS — the training-side budget
+// constant, unchanged.
 const BUDGET_DOLLARS = 10000;
 
 // GRQ's "last 10 weekdays" lookback. Daily market-data rows are already
@@ -96,8 +96,7 @@ function isLowVolume(window) {
 
 // Fold low volume into a prediction's VALUATION (issue #578). Ported from GRQ
 // training's score cap `Math.min(core.volumeRecommend, priceRecommend, 1)`
-// (GRQ/src/LearnUtil.ts:155) so the dashboard's recommendation strength and the
-// trainer agree on ONE definition — an illiquid name can never score as a
+// so the dashboard's recommendation strength and the trainer agree on ONE definition — an illiquid name can never score as a
 // strong recommendation. `baseScore` is the dashboard's price-based prediction
 // score; `window` is a trailing volume window (buildTrailingVolumeWindow).
 //

--- a/tests/dashboard_private_path_test.ts
+++ b/tests/dashboard_private_path_test.ts
@@ -1,0 +1,130 @@
+// Guards issue #782: the dashboard JavaScript served to every visitor must not
+// cite internal source-file paths of the PRIVATE upstream prediction/training
+// repository. Those files ship to the public, so naming `GRQ/src/…` paths (and
+// line numbers within them) points readers at code they cannot see.
+//
+// The comments must still explain the ported training semantics — the fix is a
+// reword to concept level, not a deletion — so both halves are asserted here.
+
+import { assert, assertEquals } from "@std/assert";
+
+const DOCS_DIR = "docs";
+
+/** Path citations into the private upstream repository's source tree. */
+const PRIVATE_PATH_PATTERN = /GRQ\/src\/[A-Za-z0-9_./-]+/g;
+
+/** Internal file names of the private upstream repository. */
+const PRIVATE_SOURCE_FILES = [
+  "LearnUtil.ts",
+  "LearnUtilTypes.ts",
+  "CoreFeatures.ts",
+  "ScoreApp.ts",
+];
+
+async function dashboardSources(): Promise<Array<[string, string]>> {
+  const sources: Array<[string, string]> = [];
+  for await (const entry of Deno.readDir(DOCS_DIR)) {
+    if (!entry.isFile || !entry.name.endsWith(".js")) continue;
+    sources.push([
+      `${DOCS_DIR}/${entry.name}`,
+      await Deno.readTextFile(`${DOCS_DIR}/${entry.name}`),
+    ]);
+  }
+  assert(sources.length > 0, "expected JavaScript files under docs/");
+  return sources.sort(([a], [b]) => a.localeCompare(b));
+}
+
+Deno.test("dashboard JS cites no private GRQ/src source paths", async () => {
+  const hits: string[] = [];
+  for (const [name, text] of await dashboardSources()) {
+    text.split("\n").forEach((line, i) => {
+      const matches = line.match(PRIVATE_PATH_PATTERN);
+      if (matches) hits.push(`${name}:${i + 1}: ${matches.join(", ")}`);
+    });
+  }
+  assertEquals(
+    hits,
+    [],
+    `Private source-path citations found:\n${hits.join("\n")}`,
+  );
+});
+
+Deno.test("dashboard JS names no private upstream source files", async () => {
+  const hits: string[] = [];
+  for (const [name, text] of await dashboardSources()) {
+    text.split("\n").forEach((line, i) => {
+      for (const sourceFile of PRIVATE_SOURCE_FILES) {
+        if (line.includes(sourceFile)) {
+          hits.push(`${name}:${i + 1}: ${sourceFile}`);
+        }
+      }
+    });
+  }
+  assertEquals(
+    hits,
+    [],
+    `Private source-file names found:\n${hits.join("\n")}`,
+  );
+});
+
+Deno.test("dashboard JS cites no upstream source line numbers", async () => {
+  // A `.ts` file name followed by a line number is only ever an upstream
+  // citation here; this repo's own files are referenced by path alone.
+  const hits: string[] = [];
+  for (const [name, text] of await dashboardSources()) {
+    text.split("\n").forEach((line, i) => {
+      const match = line.match(/[\w/.-]+\.ts:\d+/);
+      if (match) hits.push(`${name}:${i + 1}: ${match[0]}`);
+    });
+  }
+  assertEquals(
+    hits,
+    [],
+    `Source line-number citations found:\n${hits.join("\n")}`,
+  );
+});
+
+/** Collapse `//` comment wrapping so a phrase split across lines still matches. */
+function flatten(text: string): string {
+  return text.replace(/\n\s*(\/\/|\*)?[ \t]*/g, " ");
+}
+
+Deno.test("the dashboard JS still documents the ported training semantics", async () => {
+  const projection = flatten(
+    await Deno.readTextFile(`${DOCS_DIR}/projection.js`),
+  );
+  const volume = flatten(
+    await Deno.readTextFile(`${DOCS_DIR}/volume_recommend.js`),
+  );
+
+  // projection.js keeps the three concept-level explanations that replaced the
+  // path citations: the trained low-price basis, the close denominator and the
+  // flat quarterly dividend credit.
+  assert(
+    /price basis the GRQ model is TRAINED on/.test(projection),
+    "projection.js must still explain the trained intraday-low price basis",
+  );
+  assert(
+    /close on the score date/.test(projection),
+    "projection.js must still explain the trained close denominator",
+  );
+  assert(
+    /yearOfDividends \/ 4/.test(projection),
+    "projection.js must still explain the flat quarterly dividend credit",
+  );
+
+  // volume_recommend.js keeps its ported-definition provenance and the single
+  // liquidity threshold explanation.
+  assert(
+    /Ported from GRQ training's `volumeRecommend`/.test(volume),
+    "volume_recommend.js must still record that volumeRecommend is ported",
+  );
+  assert(
+    /single liquidity threshold, in DOLLARS/.test(volume),
+    "volume_recommend.js must still explain BUDGET_DOLLARS",
+  );
+  assert(
+    /Math\.min\(core\.volumeRecommend, priceRecommend, 1\)/.test(volume),
+    "volume_recommend.js must still document the training-side score cap",
+  );
+});


### PR DESCRIPTION
# Reword GRQ src path citations in dashboard JS to concept level

## Summary

The dashboard JavaScript served to every visitor cited internal source-file
paths of the **private** upstream `GRQ` repository in code comments —
`docs/projection.js` (3 citations) and `docs/volume_recommend.js` (4 citations,
two with line numbers). Those references point the public at files nobody
outside the private repo can open, and they publish its internal file layout.

Each citation is reworded to concept level (e.g. "training labels the 90-day
return off the intraday LOW at the target date" in place of the
`GRQ/src/LearnUtil.ts` path). No behaviour changes — comments only. Closes #782.

## Evidence

Comment-only change to two shipped JS files; there is nothing visually different
to screenshot. Verified by the new regression tests, which read the shipped
script text (the text IS the artefact under test) and assert both halves of the
fix: the private citations are gone, and the concept-level explanations that
replaced them survive.

Before → after (all seven citations removed):

| File                       | Before                                        | After                                        |
| -------------------------- | --------------------------------------------- | -------------------------------------------- |
| `docs/projection.js:756`   | `GRQ/src/LearnUtil.ts uses market.lowPrice(…)` | "training labels the 90-day return off the intraday LOW at the target date" |
| `docs/projection.js:799`   | `(GRQ/src/CoreFeatures.ts -> GRQ/src/LearnUtil.ts)` | dropped; "the close on the score date" stands alone |
| `docs/projection.js:929`   | `GRQ/src/CoreFeatures.ts builds …; GRQ/src/LearnUtil.ts bakes …` | "training builds the trailing annual dividend total … then bakes a flat `yearOfDividends / 4` …" |
| `docs/volume_recommend.js:5,8` | `(GRQ/src/CoreFeatures.ts)`, `(GRQ/src/LearnUtilTypes.ts)` | "GRQ training's `volumeRecommend` feature", "matching the training-side budget" |
| `docs/volume_recommend.js:22` | `(GRQ/src/LearnUtilTypes.ts:69)`           | "the training-side budget constant, unchanged" |
| `docs/volume_recommend.js:99` | `(GRQ/src/LearnUtil.ts:155)`               | dropped; the ported score-cap expression stands alone |

`./quality.sh` passes cleanly.

## Test Plan

Added `tests/dashboard_private_path_test.ts` (fails against the unfixed
comments, passes after the reword):

- `dashboard JS cites no private GRQ/src source paths` — scans every
  `docs/*.js` for `GRQ/src/…` path citations.
- `dashboard JS names no private upstream source files` — bans the bare private
  source-file names (`LearnUtil.ts`, `LearnUtilTypes.ts`, `CoreFeatures.ts`,
  `ScoreApp.ts`).
- `dashboard JS cites no upstream source line numbers` — bans `<file>.ts:<line>`
  citations.
- `the dashboard JS still documents the ported training semantics` — asserts the
  concept-level explanations survived, so the fix cannot be satisfied by simply
  deleting the comments.

This mirrors the equivalent guard added for `scripts/` under issue #783.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms5u9she-d183ec`<!-- vibe-worker-issue-782 -->