### PR TITLE
Wire --market-data-path / --dividend-data-path through the CLI, run.sh and process_date.sh (#803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ### Added
 
+- `--market-data-path` / `--dividend-data-path` CLI flags (each overriding
+  `GRQ_MARKET_DATA_PATH` / `GRQ_DIVIDEND_DATA_PATH`) so an operator can point
+  the pipeline at their own data tree. Both roots are resolved once into a
+  `DataRoots` value and threaded explicitly through the pipeline, validated
+  before any work begins, and a single start-up error lists every unusable
+  root. `run.sh` and `process_date.sh` check both variables before building or
+  writing anything and pass them through as flags (Issue #803).
+
 - Market-data presence quality gate (`tests/market_data_presence_test.ts`): a
   Deno test, run on every PR via `deno-quality.yml`, that iterates every
   committed `docs/scores/**/DD.tsv` prediction and fails CI when the sibling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,33 @@ cd GRQ-validation
 cargo build --release
 ```
 
+## Configuring the data roots
+
+The processor reads share prices and dividend history from two directories
+**you** supply. This repository ships no such data and names no upstream source
+for it, so before running anything point both roots at your own tree:
+
+```bash
+export GRQ_MARKET_DATA_PATH=/path/to/market-data
+export GRQ_DIVIDEND_DATA_PATH=/path/to/dividend-history
+```
+
+Each root can also be given as a flag — `--market-data-path` and
+`--dividend-data-path` — and the flag wins over the variable. There is no
+default: an absent, blank, or non-directory root fails at start-up with one
+message listing every unusable root, before any CSV is written.
+
+Both trees use the same layout, one JSON file per symbol under the upper-case
+first letter of that symbol:
+
+```text
+<root>/data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json
+```
+
+The JSON shapes are `MarketData` and `DividendData` in `src/models.rs`; the
+README's _Required data roots_ section shows a worked example of each, so you
+can construct or substitute your own tree and reproduce a run.
+
 ## Building and running
 
 ```bash
@@ -32,7 +59,10 @@ cargo build --release
 ./run.sh --process-all
 
 # Process a specific date
-./target/release/grq-validation --docs-path docs --date 2025-01-15
+./target/release/grq-validation --docs-path docs \
+    --market-data-path "$GRQ_MARKET_DATA_PATH" \
+    --dividend-data-path "$GRQ_DIVIDEND_DATA_PATH" \
+    --date 2025-01-15
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -890,37 +890,120 @@ exercised by `tests/market_data_fail_loud_test.ts`.
 
 ## Configuration
 
-### Environment Variables
+### Required data roots
 
-- `GRQ_MARKET_DATA_PATH` — **required.** Directory holding the market-data
-  `data/<letter>/<SYM>.json` tree.
-- `GRQ_DIVIDEND_DATA_PATH` — **required for dividend processing.** Directory
-  holding the dividend-history `data/<letter>/<SYM>.json` tree.
-- `RUST_LOG` — logging level (default: `info`).
-- `CARGO_TERM_COLOR` — terminal colour output.
+The processor reads share prices and dividend history from two directories the
+**caller supplies**. **This repository ships no market or dividend data, and
+names no upstream source for it** — point each root at your own tree (built by
+whatever provider or process you choose) and the run reproduces exactly.
 
-Both data roots are **caller-supplied** (issue #802): the crate names no data
-checkout of its own. An unset or blank root is a fail-loud error — the processor
-exits non-zero naming the variable rather than silently writing header-only
-market-data CSVs.
+Each root can be given as a flag or an environment variable; the **flag wins**.
+There is deliberately no default: an absent, blank, or non-directory root is a
+fail-loud start-up error listing *every* unusable root, never a silent `../…`
+guess that would write header-only CSVs (issues #802, #803).
+
+| Root          | Flag                   | Environment variable      |
+| ------------- | ---------------------- | ------------------------- |
+| Market data   | `--market-data-path`   | `GRQ_MARKET_DATA_PATH`    |
+| Dividend data | `--dividend-data-path` | `GRQ_DIVIDEND_DATA_PATH`  |
 
 ```bash
 export GRQ_MARKET_DATA_PATH=/path/to/market-data
 export GRQ_DIVIDEND_DATA_PATH=/path/to/dividend-history
-./run.sh
+./run.sh                     # or: ./process_date.sh 2025-06-20
+
+# The flag overrides the variable for a one-off run:
+./target/release/grq-validation --docs-path docs \
+    --market-data-path /other/market-data \
+    --dividend-data-path /other/dividend-history
 ```
+
+`run.sh` and `process_date.sh` check both variables before building or writing
+anything and exit non-zero naming what is missing, then pass the roots through
+as flags — so the roots are resolved in exactly one place.
+
+#### Expected on-disk layout
+
+Both trees use the same shape: a `data/` directory, one subdirectory per
+**upper-case first letter** of the symbol, and one JSON file per symbol.
+
+```text
+<root>/data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json
+```
+
+For example, `SEM` resolves to `<root>/data/S/SEM.json`. The symbol is the part
+of the score-file ticker after the last `:`, with `.` replaced by `-` (so
+`NYSE:HEI.A` → `HEI-A`).
+
+#### Expected JSON shapes
+
+Market-data files deserialise into `MarketData` (`src/models.rs`):
+
+```json
+{
+  "Meta Data": {
+    "1. Information": "Daily Prices",
+    "2. Symbol": "SEM",
+    "3. Last Refreshed": "2025-06-20",
+    "4. Output Size": "Full size",
+    "5. Time Zone": "US/Eastern"
+  },
+  "Time Series (Daily)": {
+    "2025-06-20": {
+      "1. open": "10.10",
+      "2. high": "10.50",
+      "3. low": "9.90",
+      "4. close": "10.25",
+      "5. adjusted close": "10.25",
+      "6. volume": "123456",
+      "7. dividend amount": "0.0",
+      "8. split coefficient": "1.0"
+    }
+  }
+}
+```
+
+Dividend files deserialise into `DividendData` (`src/models.rs`):
+
+```json
+{
+  "symbol": "SEM",
+  "data": [
+    {
+      "ex_dividend_date": "2025-05-15",
+      "declaration_date": "2025-05-01",
+      "record_date": "2025-05-15",
+      "payment_date": "2025-05-30",
+      "amount": "0.09375"
+    }
+  ]
+}
+```
+
+Prices and amounts are strings (they are parsed defensively); a malformed value
+is skipped with a warning rather than corrupting the derived CSV.
+
+### Other environment variables
+
+- `RUST_LOG` — logging level (default: `info`).
+- `CARGO_TERM_COLOR` — terminal colour output.
 
 ```mermaid
 flowchart LR
-    ENV["GRQ_MARKET_DATA_PATH<br/>GRQ_DIVIDEND_DATA_PATH"] --> R{{"market_data_root()<br/>dividend_data_root()"}}
-    R -- unset/blank --> F["Err naming the variable<br/>(exit non-zero)"]
-    R -- resolved root --> C["get_market_data_path_in()<br/>get_dividend_data_path_in()<br/>(traversal guards)"]
-    C --> O["&lt;root&gt;/data/&lt;letter&gt;/&lt;SYM&gt;.json"]
+    F["--market-data-path<br/>--dividend-data-path"] --> R{{"DataRoots::resolve()<br/>(flag wins over env)"}}
+    E["GRQ_MARKET_DATA_PATH<br/>GRQ_DIVIDEND_DATA_PATH"] --> R
+    R -- unset/blank/not a directory --> X["one start-up error<br/>listing every bad root<br/>(exit non-zero, no CSV written)"]
+    R -- both valid --> P["pipeline entry points<br/>(roots threaded as parameters)"]
+    P --> C["get_market_data_path_in()<br/>get_dividend_data_path_in()<br/>(traversal guards)"]
+    C --> O["&lt;root&gt;/data/&lt;LETTER&gt;/&lt;SYMBOL&gt;.json"]
 ```
 
 ### Command Line Options
 
 - `--docs-path` — path to the docs directory (default: `docs`).
+- `--market-data-path` — market-data root; overrides `GRQ_MARKET_DATA_PATH`.
+- `--dividend-data-path` — dividend-data root; overrides
+  `GRQ_DIVIDEND_DATA_PATH`.
 - `--process-all` — process every score file, not just recent ones.
 - `--calculate-performance` — calculate performance metrics for score files.
 - `--date` — process a specific date in `YYYY-MM-DD` format.

--- a/README.md
+++ b/README.md
@@ -899,7 +899,7 @@ whatever provider or process you choose) and the run reproduces exactly.
 
 Each root can be given as a flag or an environment variable; the **flag wins**.
 There is deliberately no default: an absent, blank, or non-directory root is a
-fail-loud start-up error listing *every* unusable root, never a silent `../…`
+fail-loud start-up error listing _every_ unusable root, never a silent `../…`
 guess that would write header-only CSVs (issues #802, #803).
 
 | Root          | Flag                   | Environment variable      |

--- a/docs/archive/pr-summaries/pr-summary-803.md
+++ b/docs/archive/pr-summaries/pr-summary-803.md
@@ -1,0 +1,178 @@
+# PR Summary — Issue #803
+
+## Summary
+
+Wires the caller-supplied data roots through the binary and both shell entry
+points, so an operator (public or private) can point the pipeline at their own
+data tree and `std::env::var` is read in exactly one place. Closes #803.
+
+- **CLI flags** — `--market-data-path` and `--dividend-data-path`
+  (`src/main.rs`), each overriding `GRQ_MARKET_DATA_PATH` /
+  `GRQ_DIVIDEND_DATA_PATH`. No `default_value`: an absent root is an error, not
+  a silent `../…` guess. The fallback is resolved by hand, so no new `clap`
+  feature was needed.
+- **Explicit threading** — `main` resolves both roots once into a new
+  `DataRoots { market, dividends }` (`src/data_roots.rs`) and passes them to
+  `ensure_market_data_repository_at`, `create_market_data_long_csv_for_score_file`,
+  `create_dividend_csv_for_score_file`, `calculate_portfolio_performance`,
+  `calculate_hybrid_projection` and `update_index_with_performance`. The
+  internal chain (`read_market_data`, `read_dividend_data`,
+  `calculate_dividends_for_period`, and the CSV writers) now takes the root as a
+  parameter instead of resolving it per call.
+- **Start-up validation** — both roots are validated (set, non-blank, an
+  existing directory) before any work begins, and a single error lists *every*
+  unusable root with the flag/variable and expected layout.
+- **Dead wrappers removed** — `ensure_market_data_repository()`,
+  `market_data_repository_available()` and `get_dividend_data_path()` became
+  dead once the roots are threaded, and are deleted;
+  `ensure_market_data_repository_at()` is now the public gate.
+- **Shell wiring** — `run.sh` and `process_date.sh` source a shared
+  `scripts/require_data_roots.sh` (with a fail-loud check that the helper
+  exists) and refuse to build or write anything when either variable is unset,
+  then pass both roots through as flags. Existing `set`/exit-code handling is
+  untouched.
+- **Documentation** — `README.md` and `CONTRIBUTING.md` document the two flags
+  and variables, the precedence rule, the
+  `<root>/data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json` layout, worked
+  `MarketData` / `DividendData` JSON examples, and state explicitly that this
+  repository ships no such data and names no upstream source.
+
+## Evidence
+
+This is a backend/CLI change with no web interface, so there is no screenshot.
+Evidence is the real binary's behaviour plus the test suite.
+
+### Resolution flow
+
+```mermaid
+flowchart LR
+    F["--market-data-path<br/>--dividend-data-path"] --> R{{"DataRoots::resolve()<br/>flag wins over env"}}
+    E["GRQ_MARKET_DATA_PATH<br/>GRQ_DIVIDEND_DATA_PATH"] --> R
+    R -- unset/blank/not a directory --> X["one start-up error<br/>listing every bad root<br/>exit non-zero, no CSV written"]
+    R -- both valid --> P["pipeline entry points<br/>roots threaded as parameters"]
+    P --> C["get_market_data_path_in()<br/>get_dividend_data_path_in()"]
+    C --> O["&lt;root&gt;/data/&lt;LETTER&gt;/&lt;SYMBOL&gt;.json"]
+```
+
+### `--help` documents both flags and their variables
+
+```text
+      --market-data-path <MARKET_DATA_PATH>
+          Directory holding the market-data `data/<LETTER>/<SYMBOL>.json` tree; overrides GRQ_MARKET_DATA_PATH
+      --dividend-data-path <DIVIDEND_DATA_PATH>
+          Directory holding the dividend-history `data/<LETTER>/<SYMBOL>.json` tree; overrides GRQ_DIVIDEND_DATA_PATH
+```
+
+### Missing roots fail at start-up, before any work
+
+```text
+$ env -u GRQ_MARKET_DATA_PATH -u GRQ_DIVIDEND_DATA_PATH \
+    ./target/release/grq-validation --docs-path "$WORK/docs"; echo "exit=$?"
+Error: cannot start: caller-supplied data root(s) unusable:
+  - GRQ_MARKET_DATA_PATH is not set — set it to the directory holding the market-data `data/<letter>/<SYM>.json` tree
+  - GRQ_DIVIDEND_DATA_PATH is not set — set it to the directory holding the dividend-data `data/<letter>/<SYM>.json` tree
+Pass --market-data-path/--dividend-data-path, or set GRQ_MARKET_DATA_PATH/GRQ_DIVIDEND_DATA_PATH. This
+repository ships no market or dividend data: point each root at your own directory holding a
+`data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json` tree.
+exit=1
+```
+
+Both shell entry points do the same before building anything:
+
+```text
+$ env -u GRQ_MARKET_DATA_PATH -u GRQ_DIVIDEND_DATA_PATH ./process_date.sh 2025-06-05
+ERROR: unset data root(s): GRQ_MARKET_DATA_PATH, GRQ_DIVIDEND_DATA_PATH
+Set each variable (or pass the matching --market-data-path /
+--dividend-data-path flag) to a directory holding a
+data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json tree, for example:
+  export GRQ_MARKET_DATA_PATH=/path/to/market-data
+  export GRQ_DIVIDEND_DATA_PATH=/path/to/dividend-history
+```
+
+### A caller-supplied tree reproduces a full run
+
+Against a synthetic root (one symbol, one dividend, `docs/` fixture), the run
+produced the expected CSVs and folded the dividend into the return
+(+10% price, +1.25% dividend = 11.25%), proving the dividend root is threaded
+all the way into `calculate_portfolio_performance`:
+
+```text
+$ GRQ_MARKET_DATA_PATH=$WORK/market GRQ_DIVIDEND_DATA_PATH=$WORK/dividends \
+    ./target/release/grq-validation --docs-path "$WORK/docs" --process-all
+… Performance for 2025-06-20: 11.25% (90-day), 54.13% (annualized), 1 included stocks
+
+$ cat $WORK/docs/scores/2025/June/20.csv
+date,ticker,high,low,open,close,split_coefficient,volume
+2025-06-20,NYSE:TEST,101,99,100,100,1.0,1000
+2025-09-18,NYSE:TEST,111,109,110,110,1.0,1200
+
+$ cat $WORK/docs/scores/2025/June/20-dividends.csv
+date,symbol,amount
+2025-07-15,NYSE:TEST,1.25
+```
+
+A byte-compare against today's published output for a real date needs the
+operator's own data tree, which this environment does not have; the CSV writers
+themselves are unchanged apart from taking the root as a parameter.
+
+### Single environment read site
+
+```text
+$ grep -rn 'env::var' src/
+src/utils.rs:48:    std::env::var(variable).ok()
+```
+
+### Quality gates
+
+`./quality.sh < /dev/null` passes cleanly: `cargo fmt --check`,
+`cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`
+(129 tests), the release build, `bash -n` over every script, and the Deno
+format/lint/check/test suite. `shellcheck --severity=warning run.sh
+process_date.sh scripts/require_data_roots.sh` is clean.
+
+## Test Plan
+
+### Added
+
+- `src/data_roots.rs` unit tests — `resolve_accepts_existing_directories_from_flags`,
+  `resolve_lists_every_unusable_root_in_one_error`,
+  `resolve_reports_only_the_broken_root`,
+  `resolve_rejects_a_blank_flag_rather_than_falling_back`. Hermetic: they drive
+  resolution through flags only, so they never mutate or depend on the ambient
+  environment.
+- `tests/cli_flag_cleanup_test.rs` —
+  `help_documents_both_data_root_flags_and_their_env_vars`,
+  `missing_data_roots_fails_at_startup_listing_both`,
+  `missing_data_roots_writes_no_partial_csv`,
+  `market_data_path_flag_overrides_env` (environment names a usable root, the
+  flag names a broken one, and the flag's path is what fails — proving
+  precedence), and `environment_supplies_the_roots_when_no_flag_is_given`.
+- `tests/main_error_propagation_test.rs` —
+  `missing_data_roots_fail_before_date_processing`, asserting the start-up error
+  exits non-zero and never reaches the per-date "reading TSV file" path.
+- `tests/shell_data_root_preflight_test.rs` — runs the real `run.sh` and
+  `process_date.sh` with both variables removed from the child environment and
+  asserts a non-zero exit, both variable names and the layout in the message,
+  and (for `process_date.sh`) that the guard fires before the build.
+
+### Modified (documented business-logic change)
+
+Threading the roots changes the signatures of the pipeline entry points, so the
+existing callers in tests were updated to pass a root — no test was removed or
+weakened:
+
+- `tests/cli_flag_cleanup_test.rs`, `tests/main_error_propagation_test.rs` — the
+  binary helpers now pass `--market-data-path`/`--dividend-data-path` at
+  temporary directories and clear both variables from the child environment, so
+  they still exercise their original flag and error-propagation assertions under
+  the new start-up contract.
+- `tests/create_market_data_csv_test.rs`,
+  `tests/create_market_data_long_csv_test.rs`, `tests/market_data_tests.rs`,
+  `tests/dividend_tests.rs` — pass the already-resolved root they were skipping
+  on.
+- `tests/update_index_with_performance_test.rs` — passes an absent dividend root
+  (its synthetic ticker has no dividend history), keeping the expected figures
+  price-driven.
+- `src/utils.rs` unit tests — traversal-guard and projection tests pass an
+  explicit absent root; the environment wiring test now goes through the single
+  `env_root` read site.

--- a/process_date.sh
+++ b/process_date.sh
@@ -3,11 +3,26 @@
 # Script to process a single date for GRQ validation
 # Usage: ./process_date.sh YYYY-MM-DD
 
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pre-flight guard for the caller-supplied data roots (issue #803). A missing
+# helper is itself a fault, so it fails loud rather than skipping the check.
+DATA_ROOT_GUARD="$REPO_DIR/scripts/require_data_roots.sh"
+if [ ! -f "$DATA_ROOT_GUARD" ]; then
+    echo "ERROR: missing data-root guard: $DATA_ROOT_GUARD" >&2
+    exit 1
+fi
+# shellcheck source=scripts/require_data_roots.sh
+. "$DATA_ROOT_GUARD"
+
 if [ $# -eq 0 ]; then
     echo "Usage: $0 YYYY-MM-DD"
     echo "Example: $0 2025-06-05"
     exit 1
 fi
+
+# Both roots must be configured before anything is built or written.
+require_data_roots
 
 DATE=$1
 
@@ -28,9 +43,13 @@ if ! cargo build --release; then
     exit 1
 fi
 
-# Process the specific date
+# Process the specific date. The data roots are passed explicitly so the binary
+# never guesses (issue #803).
 echo "Running processor for $DATE..."
-if ./target/release/grq-validation --docs-path docs --date "$DATE"; then
+if ./target/release/grq-validation --docs-path docs \
+    --market-data-path "$GRQ_MARKET_DATA_PATH" \
+    --dividend-data-path "$GRQ_DIVIDEND_DATA_PATH" \
+    --date "$DATE"; then
     echo "================================"
     echo "Successfully processed $DATE"
     echo "Check the list view to see the results: http://localhost:8000/list.html"

--- a/run.sh
+++ b/run.sh
@@ -41,7 +41,19 @@ setup_rust_environment() {
     fi
 }
 
+
+# Pre-flight guard for the caller-supplied data roots (issue #803). A missing
+# helper is itself a fault, so it fails loud rather than skipping the check.
+DATA_ROOT_GUARD="$REPO_DIR/scripts/require_data_roots.sh"
+if [ ! -f "$DATA_ROOT_GUARD" ]; then
+    echo "ERROR: missing data-root guard: $DATA_ROOT_GUARD" >&2
+    exit 1
+fi
+# shellcheck source=scripts/require_data_roots.sh
+. "$DATA_ROOT_GUARD"
+
 setup_rust_environment
+require_data_roots
 
 # Change to repository directory
 cd "$REPO_DIR" || exit 1
@@ -78,6 +90,12 @@ fi
 # Run the program
 log "Running GRQ validation program"
 
+# The data roots are passed explicitly so the binary never guesses (issue #803).
+DATA_ROOT_FLAGS=(
+    --market-data-path "$GRQ_MARKET_DATA_PATH"
+    --dividend-data-path "$GRQ_DIVIDEND_DATA_PATH"
+)
+
 # Check for command line arguments
 PROCESS_ALL=false
 REGENERATE_EMPTY=false
@@ -95,14 +113,14 @@ fi
 # or omit for recent dates only (within 180 days)
 if [ "$PROCESS_ALL" = true ]; then
     # For full reload, process all files (performance is calculated inline)
-    if ./target/release/grq-validation --docs-path docs --process-all; then
+    if ./target/release/grq-validation --docs-path docs "${DATA_ROOT_FLAGS[@]}" --process-all; then
         log "Program completed successfully"
     else
         log "ERROR: Program failed"
         exit 1
     fi
 elif [ "$REGENERATE_EMPTY" = true ]; then
-    if ./target/release/grq-validation --docs-path docs --regenerate-empty; then
+    if ./target/release/grq-validation --docs-path docs "${DATA_ROOT_FLAGS[@]}" --regenerate-empty; then
         log "Program completed successfully"
     else
         log "ERROR: Program failed"
@@ -110,7 +128,7 @@ elif [ "$REGENERATE_EMPTY" = true ]; then
     fi
 else
     # For recent files only, process files (performance is calculated inline)
-    if ./target/release/grq-validation --docs-path docs; then
+    if ./target/release/grq-validation --docs-path docs "${DATA_ROOT_FLAGS[@]}"; then
         log "Program completed successfully"
     else
         log "ERROR: Program failed"

--- a/scripts/require_data_roots.sh
+++ b/scripts/require_data_roots.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Shared pre-flight guard for the caller-supplied data roots (issue #803).
+#
+# The processor reads share prices and dividend history from directories the
+# operator supplies — this repository ships none. Sourced by run.sh and
+# process_date.sh so both entry points fail loud, before any build or write,
+# with identical guidance.
+
+# Exits 1 naming every unset variable when either data root is missing.
+require_data_roots() {
+    local missing=""
+
+    if [ -z "${GRQ_MARKET_DATA_PATH:-}" ]; then
+        missing="GRQ_MARKET_DATA_PATH"
+    fi
+
+    if [ -z "${GRQ_DIVIDEND_DATA_PATH:-}" ]; then
+        if [ -n "$missing" ]; then
+            missing="$missing, GRQ_DIVIDEND_DATA_PATH"
+        else
+            missing="GRQ_DIVIDEND_DATA_PATH"
+        fi
+    fi
+
+    if [ -n "$missing" ]; then
+        echo "ERROR: unset data root(s): $missing" >&2
+        echo "Set each variable (or pass the matching --market-data-path /" >&2
+        echo "--dividend-data-path flag) to a directory holding a" >&2
+        echo "data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json tree, for example:" >&2
+        echo "  export GRQ_MARKET_DATA_PATH=/path/to/market-data" >&2
+        echo "  export GRQ_DIVIDEND_DATA_PATH=/path/to/dividend-history" >&2
+        exit 1
+    fi
+}

--- a/src/data_roots.rs
+++ b/src/data_roots.rs
@@ -1,0 +1,160 @@
+//! The caller-supplied data roots, resolved once at start-up (issue #803).
+//!
+//! The pipeline reads share prices and dividend history from two directories
+//! the *caller* supplies — this repository ships no such data. `main` resolves
+//! both roots exactly once into a [`crate::data_roots::DataRoots`] value and
+//! threads it into every pipeline entry point, so no function deep in the run
+//! re-reads the environment or invents a fallback path.
+//!
+//! Resolution order per root: the CLI flag wins over the environment variable,
+//! and there is deliberately no default. Both roots are validated before any
+//! work begins, and a single error lists *every* unusable root, so an operator
+//! fixes the whole configuration in one pass instead of one failure per run.
+
+use crate::utils::{data_root_from_value, env_root, DIVIDEND_DATA_ROOT_ENV, MARKET_DATA_ROOT_ENV};
+use anyhow::{anyhow, Result};
+use std::path::PathBuf;
+
+/// The two caller-supplied data roots, resolved and validated once at start-up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataRoots {
+    /// Directory holding the market-data `data/<letter>/<SYM>.json` tree.
+    pub market: PathBuf,
+    /// Directory holding the dividend-history `data/<letter>/<SYM>.json` tree.
+    pub dividends: PathBuf,
+}
+
+impl DataRoots {
+    /// Resolves both roots from the CLI flags, falling back to the environment
+    /// variables, and validates that each names an existing directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns one error listing *every* root that is unset, blank, or not a
+    /// directory, naming the variable and the flag an operator should set.
+    pub fn resolve(market_flag: Option<&str>, dividend_flag: Option<&str>) -> Result<Self> {
+        let market = resolve_root(MARKET_DATA_ROOT_ENV, "market-data", market_flag);
+        let dividends = resolve_root(DIVIDEND_DATA_ROOT_ENV, "dividend-data", dividend_flag);
+
+        match (market, dividends) {
+            (Ok(market), Ok(dividends)) => Ok(Self { market, dividends }),
+            (market, dividends) => Err(combined_error([market.err(), dividends.err()])),
+        }
+    }
+}
+
+/// Resolves a single root: the flag wins over the environment variable, and the
+/// result must name an existing directory.
+fn resolve_root(variable: &str, kind: &str, flag: Option<&str>) -> Result<PathBuf> {
+    let raw = flag.map(str::to_owned).or_else(|| env_root(variable));
+    let root = data_root_from_value(variable, kind, raw)?;
+
+    if root.is_dir() {
+        Ok(root)
+    } else {
+        Err(anyhow!(
+            "{variable} points at {root} which is not a directory — set it to the \
+             directory holding the {kind} `data/<letter>/<SYM>.json` tree",
+            root = root.display()
+        ))
+    }
+}
+
+/// Folds the per-root failures into one actionable start-up error.
+fn combined_error(problems: [Option<anyhow::Error>; 2]) -> anyhow::Error {
+    let listed = problems
+        .into_iter()
+        .flatten()
+        .map(|problem| format!("  - {problem}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    anyhow!(
+        "cannot start: caller-supplied data root(s) unusable:\n{listed}\n\
+         Pass --market-data-path/--dividend-data-path, or set \
+         {MARKET_DATA_ROOT_ENV}/{DIVIDEND_DATA_ROOT_ENV}. This repository ships \
+         no market or dividend data: point each root at your own directory \
+         holding a `data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json` tree."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_accepts_existing_directories_from_flags() {
+        let market = tempfile::tempdir().unwrap();
+        let dividends = tempfile::tempdir().unwrap();
+
+        let roots = DataRoots::resolve(
+            Some(market.path().to_str().unwrap()),
+            Some(dividends.path().to_str().unwrap()),
+        )
+        .expect("existing directories must resolve");
+
+        assert_eq!(roots.market, market.path());
+        assert_eq!(roots.dividends, dividends.path());
+    }
+
+    #[test]
+    fn resolve_lists_every_unusable_root_in_one_error() {
+        // Both flags are supplied (so the environment is never consulted) and
+        // both point at directories that do not exist.
+        let missing = tempfile::tempdir().unwrap();
+        let absent_market = missing.path().join("no-market-tree");
+        let absent_dividends = missing.path().join("no-dividend-tree");
+
+        let error = DataRoots::resolve(
+            Some(absent_market.to_str().unwrap()),
+            Some(absent_dividends.to_str().unwrap()),
+        )
+        .expect_err("non-existent roots must fail at start-up");
+        let message = error.to_string();
+
+        assert!(
+            message.contains(MARKET_DATA_ROOT_ENV) && message.contains(DIVIDEND_DATA_ROOT_ENV),
+            "the start-up error must name both variables, got: {message}"
+        );
+        assert!(
+            message.contains(&absent_market.display().to_string())
+                && message.contains(&absent_dividends.display().to_string()),
+            "the start-up error must list both offending paths, got: {message}"
+        );
+    }
+
+    #[test]
+    fn resolve_reports_only_the_broken_root() {
+        let market = tempfile::tempdir().unwrap();
+        let absent_dividends = market.path().join("no-dividend-tree");
+
+        let error = DataRoots::resolve(
+            Some(market.path().to_str().unwrap()),
+            Some(absent_dividends.to_str().unwrap()),
+        )
+        .expect_err("a single broken root must still fail");
+        let message = error.to_string();
+
+        assert!(
+            message.contains(&absent_dividends.display().to_string()),
+            "the broken root must be listed, got: {message}"
+        );
+        assert!(
+            !message.contains(&format!("  - {}", market.path().display())),
+            "the usable root must not be reported as a problem, got: {message}"
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_a_blank_flag_rather_than_falling_back() {
+        let dividends = tempfile::tempdir().unwrap();
+
+        let error = DataRoots::resolve(Some("   "), Some(dividends.path().to_str().unwrap()))
+            .expect_err("a blank flag is a configuration error, not a fallback");
+
+        assert!(
+            error.to_string().contains(MARKET_DATA_ROOT_ENV),
+            "a blank market root must be reported, got: {error}"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,17 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 //! Processes daily stock-score TSV files and computes portfolio performance.
 //!
-//! The crate exposes two modules:
+//! The crate exposes three modules:
 //!
+//! - [`data_roots`] — the caller-supplied market- and dividend-data roots,
+//!   resolved once at start-up and threaded into every entry point.
 //! - [`models`] — serde-backed data types for score records, market data,
 //!   dividends and the computed performance results.
 //! - [`utils`] — functions to read the score/market/dividend files, build the
 //!   derived CSVs and calculate 90-day and annualised portfolio performance.
 
+/// The caller-supplied data roots, resolved once at start-up.
+pub mod data_roots;
 /// Data types shared across the crate (score records, market data, dividends
 /// and performance results).
 pub mod models;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 use anyhow::{anyhow, Context, Result};
 use chrono::{NaiveDate, Utc};
 use clap::Parser;
+use grq_validation::data_roots::DataRoots;
 use grq_validation::utils::{
     build_score_file_path, create_dividend_csv_for_score_file,
     create_market_data_long_csv_for_score_file, derive_csv_output_path,
-    ensure_market_data_repository, extract_ticker_codes_from_score_file, is_market_data_csv_empty,
-    read_index_json,
+    ensure_market_data_repository_at, extract_ticker_codes_from_score_file,
+    is_market_data_csv_empty, read_index_json,
 };
 use log::info;
 use std::path::Path;
@@ -16,6 +17,14 @@ struct Args {
     /// Path to the docs directory containing TSV files
     #[arg(short, long, default_value = "docs")]
     docs_path: String,
+
+    /// Directory holding the market-data `data/<LETTER>/<SYMBOL>.json` tree; overrides GRQ_MARKET_DATA_PATH
+    #[arg(long)]
+    market_data_path: Option<String>,
+
+    /// Directory holding the dividend-history `data/<LETTER>/<SYMBOL>.json` tree; overrides GRQ_DIVIDEND_DATA_PATH
+    #[arg(long)]
+    dividend_data_path: Option<String>,
 
     /// Enable verbose logging
     #[arg(short, long)]
@@ -50,6 +59,16 @@ fn main() -> Result<()> {
 
     info!("Starting GRQ Validation processor");
     info!("Docs path: {}", args.docs_path);
+
+    // Resolve and validate both caller-supplied data roots before any work
+    // begins, so a misconfigured host fails loudly at start-up with one message
+    // listing every unusable root — never per-ticker deep in a run (issue #803).
+    let roots = DataRoots::resolve(
+        args.market_data_path.as_deref(),
+        args.dividend_data_path.as_deref(),
+    )?;
+    info!("Market data root: {}", roots.market.display());
+    info!("Dividend data root: {}", roots.dividends.display());
 
     // Process a specific date if provided
     if let Some(date) = args.date {
@@ -97,6 +116,7 @@ fn main() -> Result<()> {
             // Use regular performance calculation. `?` propagates the error to
             // `main`, which prints the full context chain on exit.
             let performance = grq_validation::utils::calculate_portfolio_performance(
+                &roots.dividends,
                 &score_file_path,
                 score_file_date,
             )
@@ -157,6 +177,7 @@ fn main() -> Result<()> {
             .context("reading market data CSV")?
             .closes;
             let performance = grq_validation::utils::calculate_hybrid_projection(
+                &roots.dividends,
                 &stock_records,
                 score_file_date,
                 &market_data_csv,
@@ -219,7 +240,10 @@ fn main() -> Result<()> {
     // Calculate performance for all score files that are at least 90 days old
     if args.calculate_performance {
         info!("Calculating performance metrics for all score files...");
-        match grq_validation::utils::update_index_with_performance(&args.docs_path) {
+        match grq_validation::utils::update_index_with_performance(
+            &roots.dividends,
+            &args.docs_path,
+        ) {
             Ok(_) => {
                 info!("Successfully updated index.json with performance metrics");
             }
@@ -230,7 +254,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    ensure_market_data_repository()?;
+    ensure_market_data_repository_at(&roots.market)?;
 
     // Read the index to get all score files
     let index_data = read_index_json(&args.docs_path)?;
@@ -310,6 +334,7 @@ fn main() -> Result<()> {
 
                 // Create CSV file with market data in long format in the same directory as the score file
                 match create_market_data_long_csv_for_score_file(
+                    &roots.market,
                     &score_file_path,
                     &ticker_codes,
                     &score_entry.date,
@@ -325,6 +350,7 @@ fn main() -> Result<()> {
 
                 // Create dividend CSV file
                 match create_dividend_csv_for_score_file(
+                    &roots.dividends,
                     &score_file_path,
                     &ticker_codes,
                     &score_entry.date,
@@ -340,6 +366,7 @@ fn main() -> Result<()> {
                 // Calculate performance for this score file immediately after creating CSVs
                 info!("Calculating performance for {}", score_entry.date);
                 match grq_validation::utils::calculate_portfolio_performance(
+                    &roots.dividends,
                     &score_file_path,
                     &score_entry.date,
                 ) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,11 @@ pub const DIVIDEND_DATA_ROOT_ENV: &str = "GRQ_DIVIDEND_DATA_PATH";
 /// Returns an error naming only `variable` and the expected tree shape when the
 /// value is absent or blank. There is deliberately no default: a silent
 /// fallback would let the pipeline produce header-only CSVs instead of failing.
-fn data_root_from_value(variable: &str, kind: &str, raw: Option<String>) -> Result<PathBuf> {
+pub(crate) fn data_root_from_value(
+    variable: &str,
+    kind: &str,
+    raw: Option<String>,
+) -> Result<PathBuf> {
     match raw {
         Some(value) if !value.trim().is_empty() => Ok(PathBuf::from(value)),
         _ => Err(anyhow!(
@@ -35,8 +39,20 @@ fn data_root_from_value(variable: &str, kind: &str, raw: Option<String>) -> Resu
     }
 }
 
+/// Reads `variable` from the process environment.
+///
+/// This is the crate's single environment read site for the data roots (issue
+/// #803): every other function takes an already-resolved root as a parameter,
+/// so a root can never be silently re-resolved deep in a run.
+pub(crate) fn env_root(variable: &str) -> Option<String> {
+    std::env::var(variable).ok()
+}
+
 /// Resolves the market-data root from the `GRQ_MARKET_DATA_PATH` environment
 /// variable.
+///
+/// Used by [`crate::data_roots::DataRoots::resolve`] as the fallback behind
+/// `--market-data-path`, and by tests that need the operator's own tree.
 ///
 /// # Errors
 ///
@@ -45,12 +61,15 @@ pub fn market_data_root() -> Result<PathBuf> {
     data_root_from_value(
         MARKET_DATA_ROOT_ENV,
         "market-data",
-        std::env::var(MARKET_DATA_ROOT_ENV).ok(),
+        env_root(MARKET_DATA_ROOT_ENV),
     )
 }
 
 /// Resolves the dividend-data root from the `GRQ_DIVIDEND_DATA_PATH`
 /// environment variable.
+///
+/// Used by [`crate::data_roots::DataRoots::resolve`] as the fallback behind
+/// `--dividend-data-path`, and by tests that need the operator's own tree.
 ///
 /// # Errors
 ///
@@ -59,36 +78,26 @@ pub fn dividend_data_root() -> Result<PathBuf> {
     data_root_from_value(
         DIVIDEND_DATA_ROOT_ENV,
         "dividend-data",
-        std::env::var(DIVIDEND_DATA_ROOT_ENV).ok(),
+        env_root(DIVIDEND_DATA_ROOT_ENV),
     )
 }
 
 /// Returns `true` when a share-price data repository exists at `base` (i.e. it
-/// contains a `data/` subdirectory). Path-injectable core of
-/// [`market_data_repository_available`] so the guard is deterministically
-/// testable against a temporary directory.
+/// contains a `data/` subdirectory). Best-effort probe;
+/// [`ensure_market_data_repository_at`] is the fail-loud gate every batch entry
+/// point calls instead.
 fn market_data_repository_available_at(base: &Path) -> bool {
     base.join("data").is_dir()
 }
 
-/// Returns `true` when the share-price data repository is present on disk.
-///
-/// Signature note (issue #802): this stays a `bool`, so an unresolvable root
-/// reads the same as "repository absent". It is a best-effort probe only —
-/// [`ensure_market_data_repository`] is the fail-loud gate that distinguishes
-/// "[`MARKET_DATA_ROOT_ENV`] unset" from "root set but empty", and every batch
-/// entry point calls that instead.
-pub fn market_data_repository_available() -> bool {
-    market_data_root().is_ok_and(|root| market_data_repository_available_at(&root))
-}
-
-/// Ensures a share-price data repository is present at `base` before batch
-/// processing. Path-injectable core of [`ensure_market_data_repository`].
+/// Ensures a share-price data repository is present at the caller-supplied
+/// `base` before batch processing (issue #803: the root is threaded in, never
+/// re-resolved here).
 ///
 /// # Errors
 ///
 /// Returns an error when `base`/`data` is missing.
-fn ensure_market_data_repository_at(base: &Path) -> Result<()> {
+pub fn ensure_market_data_repository_at(base: &Path) -> Result<()> {
     if market_data_repository_available_at(base) {
         Ok(())
     } else {
@@ -99,16 +108,6 @@ fn ensure_market_data_repository_at(base: &Path) -> Result<()> {
             base.display()
         ))
     }
-}
-
-/// Ensures the share-price data repository is present before batch processing.
-///
-/// # Errors
-///
-/// Returns an error when [`MARKET_DATA_ROOT_ENV`] is unset or blank, or when
-/// the resolved root has no `data/` subdirectory.
-pub fn ensure_market_data_repository() -> Result<()> {
-    ensure_market_data_repository_at(&market_data_root()?)
 }
 
 /// Returns `true` when a market-data CSV is missing or contains only the header row.
@@ -421,7 +420,7 @@ pub fn extract_ticker_from_symbol(symbol: &str) -> Option<String> {
 /// TSV, which is attacker-influenceable (a contributor, a compromised upstream
 /// data step, or a malicious pull request against the data set), exactly like
 /// the `file` field guarded by [`build_score_file_path`] and the ticker guarded
-/// by [`get_dividend_data_path`]. To stop a crafted symbol such as
+/// by [`get_dividend_data_path_in`]. To stop a crafted symbol such as
 /// `"../../../../etc/hosts"` escaping the intended `<root>/data/` tree, the
 /// path is built with `Path::join` over validated components rather than plain
 /// string interpolation: any parent-directory (`..`), root, or prefix component
@@ -531,18 +530,20 @@ pub fn extract_symbol_from_ticker(ticker: &str) -> String {
     symbol.replace('.', "-")
 }
 
-/// Reads and deserialises the [`MarketData`] JSON file for `symbol`.
+/// Reads and deserialises the [`MarketData`] JSON file for `symbol` under the
+/// caller-supplied `market_root` (issue #803: the root is threaded in, never
+/// resolved per call).
 ///
 /// # Errors
 ///
 /// Returns an error if the market-data file cannot be opened or does not
 /// contain valid JSON matching [`MarketData`].
-pub fn read_market_data(symbol: &str) -> Result<MarketData> {
+pub fn read_market_data(market_root: &Path, symbol: &str) -> Result<MarketData> {
     use std::fs::File;
 
     // Build the path through the traversal-guarded helper so an attacker-supplied
     // symbol such as `"../../../../etc/hosts"` cannot escape the data root (issue #195).
-    let market_data_path = get_market_data_path(symbol)?;
+    let market_data_path = get_market_data_path_in(market_root, symbol)?;
 
     let file = File::open(&market_data_path)?;
     let market_data: MarketData = serde_json::from_reader(file)?;
@@ -716,12 +717,13 @@ pub fn derive_csv_output_path(score_file_path: &str) -> String {
 /// Returns an error if the market data cannot be read or the CSV file cannot be
 /// written (see [`create_market_data_csv`]).
 pub fn create_market_data_csv_for_score_file(
+    market_root: &Path,
     score_file_path: &str,
     symbols: &[String],
     score_file_date: &str,
 ) -> Result<()> {
     let output_path = derive_csv_output_path(score_file_path);
-    create_market_data_csv(symbols, score_file_date, &output_path)
+    create_market_data_csv(market_root, symbols, score_file_date, &output_path)
 }
 
 /// Creates a CSV file with market data for the given symbols and date range
@@ -731,6 +733,7 @@ pub fn create_market_data_csv_for_score_file(
 /// Returns an error if `score_file_date` is not a valid date, a symbol's
 /// market data cannot be read, or the output CSV cannot be written.
 pub fn create_market_data_csv(
+    market_root: &Path,
     symbols: &[String],
     score_file_date: &str,
     output_path: &str,
@@ -750,7 +753,7 @@ pub fn create_market_data_csv(
     let mut all_dates: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for symbol in symbols {
-        match read_market_data(symbol) {
+        match read_market_data(market_root, symbol) {
             Ok(market_data) => {
                 match filter_market_data_by_date_range(&market_data, score_file_date, &end_date_str)
                 {
@@ -785,7 +788,7 @@ pub fn create_market_data_csv(
     writer.write_record(["date", "symbol", "close"])?;
 
     for symbol in symbols {
-        match read_market_data(symbol) {
+        match read_market_data(market_root, symbol) {
             Ok(market_data) => {
                 match filter_market_data_by_date_range(&market_data, score_file_date, &end_date_str)
                 {
@@ -822,6 +825,7 @@ pub fn create_market_data_csv(
 /// were written. Individual tickers with missing market data are skipped rather
 /// than failing the whole file.
 pub fn create_market_data_long_csv(
+    market_root: &Path,
     tickers: &[String],
     score_file_date: &str,
     output_path: &str,
@@ -829,10 +833,10 @@ pub fn create_market_data_long_csv(
     use crate::utils::extract_symbol_from_ticker;
     use csv::Writer;
 
-    // Resolve the caller-supplied root up front so an unset root fails loud
-    // here rather than silently writing a header-only CSV (issue #802).
-    let root = market_data_root()?;
-    let root_display = root.display();
+    // The root is supplied by the caller and validated at start-up (issue
+    // #803), so an unset root can never reach this writer and silently produce
+    // a header-only CSV (issue #802).
+    let root_display = market_root.display();
 
     let score_date = NaiveDate::parse_from_str(score_file_date, "%Y-%m-%d")?;
     let end_date = score_date + Duration::days(180);
@@ -860,7 +864,7 @@ pub fn create_market_data_long_csv(
 
     for ticker in tickers {
         let symbol = extract_symbol_from_ticker(ticker);
-        let market_data = match read_market_data(&symbol) {
+        let market_data = match read_market_data(market_root, &symbol) {
             Ok(md) => md,
             Err(error) => {
                 log::warn!("Skipping {ticker} ({symbol}): {error}");
@@ -972,6 +976,7 @@ fn write_atomically(path: &str, bytes: &[u8]) -> Result<()> {
 /// Returns an error if the long-format CSV cannot be created or written (see
 /// [`create_market_data_long_csv`]).
 pub fn create_market_data_long_csv_for_score_file(
+    market_root: &Path,
     score_file_path: &str,
     tickers: &[String],
     score_file_date: &str,
@@ -985,12 +990,12 @@ pub fn create_market_data_long_csv_for_score_file(
     } else {
         derive_csv_output_path(score_file_path)
     };
-    create_market_data_long_csv(tickers, score_file_date, &output_path)?;
+    create_market_data_long_csv(market_root, tickers, score_file_date, &output_path)?;
     Ok(output_path)
 }
 
-/// Gets the dividend data path for a given ticker under `root`. Path-injectable
-/// core of [`get_dividend_data_path`].
+/// Gets the dividend data path for a given ticker under the caller-supplied
+/// `root` (issue #803: the root is threaded in, never resolved here).
 ///
 /// For example: `"SEM"` -> `<dividend-root>/data/S/SEM.json`.
 ///
@@ -1043,28 +1048,18 @@ pub fn get_dividend_data_path_in(root: &Path, ticker: &str) -> Result<String> {
     Ok(full_path.to_string_lossy().into_owned())
 }
 
-/// Gets the dividend data path for a given ticker under the caller-supplied
-/// dividend-data root, resolving [`dividend_data_root`] and delegating to
-/// [`get_dividend_data_path_in`].
-///
-/// # Errors
-///
-/// Returns an error when [`DIVIDEND_DATA_ROOT_ENV`] is unset or blank, or when
-/// `ticker` is absolute or contains a parent-directory (`..`) segment.
-pub fn get_dividend_data_path(ticker: &str) -> Result<String> {
-    get_dividend_data_path_in(&dividend_data_root()?, ticker)
-}
-
-/// Reads dividend data for a given ticker
+/// Reads dividend data for a given ticker under the caller-supplied
+/// `dividend_root` (issue #803: the root is threaded in, never resolved per
+/// call).
 ///
 /// # Errors
 ///
 /// Returns an error if the dividend file cannot be opened or does not contain
 /// valid JSON matching [`DividendData`].
-pub fn read_dividend_data(ticker: &str) -> Result<DividendData> {
+pub fn read_dividend_data(dividend_root: &Path, ticker: &str) -> Result<DividendData> {
     use std::fs::File;
 
-    let dividend_data_path = get_dividend_data_path(ticker)?;
+    let dividend_data_path = get_dividend_data_path_in(dividend_root, ticker)?;
     let file = File::open(&dividend_data_path)?;
     let dividend_data: DividendData = serde_json::from_reader(file)?;
 
@@ -1133,6 +1128,7 @@ pub fn derive_dividend_csv_output_path(score_file_path: &str) -> String {
 /// cannot be created or written. Symbols with missing dividend data are skipped
 /// with a warning rather than failing.
 pub fn create_dividend_csv(
+    dividend_root: &Path,
     symbols: &[String],
     score_file_date: &str,
     output_path: &str,
@@ -1155,7 +1151,7 @@ pub fn create_dividend_csv(
         // Extract just the symbol part (e.g., "NYSE:SEM" -> "SEM")
         let symbol_only = extract_symbol_from_ticker(symbol);
 
-        match read_dividend_data(&symbol_only) {
+        match read_dividend_data(dividend_root, &symbol_only) {
             Ok(dividend_data) => {
                 match filter_dividend_data_by_date_range(
                     &dividend_data,
@@ -1191,12 +1187,13 @@ pub fn create_dividend_csv(
 /// Returns an error if the dividend CSV cannot be created or written (see
 /// [`create_dividend_csv`]).
 pub fn create_dividend_csv_for_score_file(
+    dividend_root: &Path,
     score_file_path: &str,
     symbols: &[String],
     score_file_date: &str,
 ) -> Result<()> {
     let output_path = derive_dividend_csv_output_path(score_file_path);
-    create_dividend_csv(symbols, score_file_date, &output_path)
+    create_dividend_csv(dividend_root, symbols, score_file_date, &output_path)
 }
 
 /// Annualises a period return using compound growth over the actual number of
@@ -1222,13 +1219,20 @@ pub fn calculate_annualized_performance(performance_pct: f64, days_elapsed: i64)
 /// alongside it, then computes per-stock and portfolio-wide returns for the
 /// 90-day window starting at `score_file_date` (`YYYY-MM-DD`).
 ///
+/// Dividends for the window are read from the caller-supplied `dividend_root`
+/// (issue #803).
+///
 /// # Examples
 ///
 /// ```no_run
 /// use grq_validation::utils::calculate_portfolio_performance;
+/// use std::path::Path;
 ///
-/// let performance =
-///     calculate_portfolio_performance("docs/scores/2024/November/15.tsv", "2024-11-15")?;
+/// let performance = calculate_portfolio_performance(
+///     Path::new("/path/to/dividend-history"),
+///     "docs/scores/2024/November/15.tsv",
+///     "2024-11-15",
+/// )?;
 /// println!("90-day return: {:.2}%", performance.performance_90_day);
 /// # Ok::<(), anyhow::Error>(())
 /// ```
@@ -1238,6 +1242,7 @@ pub fn calculate_annualized_performance(performance_pct: f64, days_elapsed: i64)
 /// Returns an error if the score file or the derived market-data CSV cannot be
 /// read, or if `score_file_date` is not a valid `%Y-%m-%d` date.
 pub fn calculate_portfolio_performance(
+    dividend_root: &Path,
     score_file_path: &str,
     score_file_date: &str,
 ) -> Result<PortfolioPerformance> {
@@ -1346,9 +1351,13 @@ pub fn calculate_portfolio_performance(
                 ((current_price - adjusted_buy_price) / adjusted_buy_price) * 100.0;
 
             // Calculate dividends for the 90-day period
-            let dividends_total =
-                calculate_dividends_for_period(full_ticker, score_file_date, &end_date_str)
-                    .unwrap_or(0.0);
+            let dividends_total = calculate_dividends_for_period(
+                dividend_root,
+                full_ticker,
+                score_file_date,
+                &end_date_str,
+            )
+            .unwrap_or(0.0);
 
             // Calculate total return (price + dividends) on the same basis.
             let total_return_percent =
@@ -1400,7 +1409,8 @@ pub fn calculate_portfolio_performance(
     })
 }
 
-/// Calculates hybrid projection for scores less than 90 days old
+/// Calculates hybrid projection for scores less than 90 days old, reading
+/// dividends from the caller-supplied `dividend_root` (issue #803).
 ///
 /// # Errors
 ///
@@ -1408,6 +1418,7 @@ pub fn calculate_portfolio_performance(
 /// the score is already 90 days or more old (use
 /// [`calculate_portfolio_performance`] instead).
 pub fn calculate_hybrid_projection(
+    dividend_root: &Path,
     stock_records: &[StockRecord],
     score_file_date: &str,
     market_data_csv: &HashMap<String, HashMap<String, f64>>,
@@ -1539,9 +1550,13 @@ pub fn calculate_hybrid_projection(
                 // Calculate dividends for the period
                 let end_date = score_date + chrono::Duration::days(90);
                 let end_date_str = end_date.format("%Y-%m-%d").to_string();
-                let dividends_total =
-                    calculate_dividends_for_period(full_ticker, score_file_date, &end_date_str)
-                        .unwrap_or(0.0);
+                let dividends_total = calculate_dividends_for_period(
+                    dividend_root,
+                    full_ticker,
+                    score_file_date,
+                    &end_date_str,
+                )
+                .unwrap_or(0.0);
 
                 // Calculate total return including dividends
                 let total_return_percent = projected_90_day + (dividends_total / buy_price * 100.0);
@@ -1598,9 +1613,15 @@ pub fn calculate_hybrid_projection(
     })
 }
 
-/// Calculates total dividends for a stock in a given date range
-fn calculate_dividends_for_period(symbol: &str, start_date: &str, end_date: &str) -> Result<f64> {
-    match read_dividend_data(symbol) {
+/// Calculates total dividends for a stock in a given date range, reading the
+/// dividend history from the caller-supplied `dividend_root`.
+fn calculate_dividends_for_period(
+    dividend_root: &Path,
+    symbol: &str,
+    start_date: &str,
+    end_date: &str,
+) -> Result<f64> {
+    match read_dividend_data(dividend_root, symbol) {
         Ok(dividend_data) => {
             let filtered_data =
                 filter_dividend_data_by_date_range(&dividend_data, start_date, end_date)?;
@@ -1613,13 +1634,14 @@ fn calculate_dividends_for_period(symbol: &str, start_date: &str, end_date: &str
     }
 }
 
-/// Updates the index.json file with performance metrics
+/// Updates the index.json file with performance metrics, reading dividends from
+/// the caller-supplied `dividend_root` (issue #803).
 ///
 /// # Errors
 ///
 /// Returns an error if the index file cannot be read, or if the updated index
 /// cannot be serialised or written back to disk.
-pub fn update_index_with_performance(docs_path: &str) -> Result<()> {
+pub fn update_index_with_performance(dividend_root: &Path, docs_path: &str) -> Result<()> {
     let mut index_data = read_index_json(docs_path)?;
 
     for score_entry in &mut index_data.scores {
@@ -1640,7 +1662,11 @@ pub fn update_index_with_performance(docs_path: &str) -> Result<()> {
         let days_since_score = (current_date - score_date).num_days();
 
         if days_since_score >= 90 {
-            match calculate_portfolio_performance(&score_file_path, &score_entry.date) {
+            match calculate_portfolio_performance(
+                dividend_root,
+                &score_file_path,
+                &score_entry.date,
+            ) {
                 Ok(performance) => {
                     score_entry.performance_90_day = Some(performance.performance_90_day);
                     score_entry.performance_annualized = Some(performance.performance_annualized);
@@ -1660,6 +1686,7 @@ pub fn update_index_with_performance(docs_path: &str) -> Result<()> {
                     match read_market_data_from_csv(&derive_csv_output_path(&score_file_path)) {
                         Ok(market) => {
                             match calculate_hybrid_projection(
+                                dividend_root,
                                 &stock_records,
                                 &score_entry.date,
                                 &market.closes,
@@ -1708,6 +1735,29 @@ pub fn update_index_with_performance(docs_path: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A caller-supplied root that deliberately holds no data (issue #803).
+    ///
+    /// Used by the traversal-guard tests (which must fail before touching disk)
+    /// and by the projection/performance tests, which assert on price behaviour
+    /// only: an absent dividend tree contributes exactly zero dividends, so the
+    /// expected figures stay independent of any operator's data.
+    fn absent_data_root() -> &'static Path {
+        Path::new("target/test-fixtures/absent-data-root")
+    }
+
+    /// The operator's market-data root when one is configured *and* present on
+    /// disk, else `None` after printing why `test` is being skipped. Smoke
+    /// tests against real share prices can only run where that tree exists.
+    fn configured_market_root(test: &str) -> Option<PathBuf> {
+        match market_data_root() {
+            Ok(root) if root.exists() => Some(root),
+            _ => {
+                println!("Skipping {test}: external data repository not available");
+                None
+            }
+        }
+    }
 
     #[test]
     fn test_validate_stock_symbol() {
@@ -1849,15 +1899,16 @@ mod tests {
     /// Read-only wiring check: the public resolvers must read their environment
     /// variable and must not fall back to a default when it is absent. Asserted
     /// against whatever the ambient environment holds, so it never mutates
-    /// process state that the parallel tests around it read.
+    /// process state that the parallel tests around it read. It goes through
+    /// [`env_root`] — the crate's single environment read site (issue #803).
     #[test]
     fn test_data_roots_resolve_from_environment() {
         for (variable, resolved) in [
             (MARKET_DATA_ROOT_ENV, market_data_root()),
             (DIVIDEND_DATA_ROOT_ENV, dividend_data_root()),
         ] {
-            match std::env::var(variable) {
-                Ok(value) if !value.trim().is_empty() => {
+            match env_root(variable) {
+                Some(value) if !value.trim().is_empty() => {
                     assert_eq!(resolved.unwrap(), PathBuf::from(value));
                 }
                 _ => {
@@ -2023,7 +2074,7 @@ mod tests {
     fn test_read_market_data_rejects_traversal_symbol() {
         // The read must fail at the path-validation stage rather than opening an
         // out-of-tree file. We assert it errors for a traversal symbol.
-        let result = read_market_data("../../../../etc/hosts");
+        let result = read_market_data(absent_data_root(), "../../../../etc/hosts");
         assert!(
             result.is_err(),
             "expected read_market_data to reject a traversal symbol, got ok"
@@ -2173,13 +2224,11 @@ mod tests {
 
     #[test]
     fn test_read_market_data() {
-        // Skip test if external data repository is not available
-        if !market_data_root().is_ok_and(|root| root.exists()) {
-            println!("Skipping test_read_market_data: external data repository not available");
+        let Some(root) = configured_market_root("test_read_market_data") else {
             return;
-        }
+        };
 
-        let result = read_market_data("SEM");
+        let result = read_market_data(&root, "SEM");
         assert!(
             result.is_ok(),
             "Failed to read market data: {:?}",
@@ -2197,13 +2246,11 @@ mod tests {
 
     #[test]
     fn test_filter_market_data_by_date_range() {
-        // Skip test if external data repository is not available
-        if !market_data_root().is_ok_and(|root| root.exists()) {
-            println!("Skipping test_filter_market_data_by_date_range: external data repository not available");
+        let Some(root) = configured_market_root("test_filter_market_data_by_date_range") else {
             return;
-        }
+        };
 
-        let result = read_market_data("SEM");
+        let result = read_market_data(&root, "SEM");
         if result.is_err() {
             println!("Market data file not found, skipping test");
             return;
@@ -2288,7 +2335,7 @@ mod tests {
     fn test_read_dividend_data_rejects_traversal_ticker() {
         // The read must fail at the path-validation stage rather than opening an
         // out-of-tree file. We assert it errors for a traversal ticker.
-        let result = read_dividend_data("X/../../../../../../etc/some");
+        let result = read_dividend_data(absent_data_root(), "X/../../../../../../etc/some");
         assert!(
             result.is_err(),
             "expected read_dividend_data to reject a traversal ticker, got ok"
@@ -2301,6 +2348,7 @@ mod tests {
         // calculate_dividends_for_period) must not read out-of-tree files for a
         // crafted ticker; it returns 0.0 dividends instead.
         let total = calculate_dividends_for_period(
+            absent_data_root(),
             "X/../../../../../../etc/some",
             "2025-01-01",
             "2025-04-01",
@@ -2323,16 +2371,19 @@ mod tests {
 
     #[test]
     fn test_calculate_performance_november_15_2024() {
-        // Skip test if external data repository is not available
-        if !market_data_root().is_ok_and(|root| root.exists()) {
-            println!("Skipping test_calculate_performance_november_15_2024: external data repository not available");
+        if configured_market_root("test_calculate_performance_november_15_2024").is_none() {
             return;
         }
 
         let score_file_path = "docs/scores/2024/November/15.tsv";
         let score_file_date = "2024-11-15";
 
-        let result = calculate_portfolio_performance(score_file_path, score_file_date);
+        // Dividends come from the operator's tree when configured; without one
+        // the price figures asserted below are unaffected.
+        let dividend_root =
+            dividend_data_root().unwrap_or_else(|_| absent_data_root().to_path_buf());
+        let result =
+            calculate_portfolio_performance(&dividend_root, score_file_path, score_file_date);
         assert!(
             result.is_ok(),
             "Failed to calculate performance: {:?}",
@@ -2900,7 +2951,8 @@ mod tests {
         let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 110.0)]);
         let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
 
         // gain = 10% over 40 market days -> daily_rate = 0.25%/day.
         // raw = 0.25 * 90 = 22.5; dampening (30..60) = 0.5 -> 11.25; within [-40, 80].
@@ -2940,7 +2992,8 @@ mod tests {
         let market = hybrid_market_data(ticker, &[(buy_date, 50.0), (latest_date, 55.0)]);
         let records = vec![StockRecord::new(ticker.to_string(), 5.0, 60.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
 
         // Fallback buy price = 50 (next trading day). gain = 10% over 10 market
         // days -> daily_rate = 1.0%/day; raw = 90; dampening (7..14) = 0.2 -> 18;
@@ -2967,7 +3020,8 @@ mod tests {
         let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 200.0)]);
         let records = vec![StockRecord::new(ticker.to_string(), 5.0, 250.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
 
         // gain = 100% over 8 days -> daily_rate = 12.5; raw = 1125; dampened
         // (0.2) = 225; clamped to the 7..14 upper bound of 20%.
@@ -2992,7 +3046,8 @@ mod tests {
         let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 10.0)]);
         let records = vec![StockRecord::new(ticker.to_string(), 5.0, 90.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
 
         // gain = -90% over 8 days -> daily_rate = -11.25; raw = -1012.5; dampened
         // (0.2) = -202.5; clamped to the 7..14 lower bound of -10%.
@@ -3015,7 +3070,7 @@ mod tests {
         let market = hybrid_market_data(ticker, &[(score_date, 100.0)]);
         let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market);
+        let result = calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market);
         assert!(
             result.is_err(),
             "scores >= 90 days old must be rejected by the hybrid projection"
@@ -3032,7 +3087,8 @@ mod tests {
         let market: HashMap<String, HashMap<String, f64>> = HashMap::new();
         let records = vec![StockRecord::new("TEST:HYBRIDF".to_string(), 5.0, 50.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
         assert_eq!(result.performance_90_day, 0.0);
         assert_eq!(result.performance_annualized, 0.0);
         // With no market data, the stock is unpriceable and excluded, so included count is 0
@@ -3081,7 +3137,8 @@ mod tests {
         let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 110.0)]);
         let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
 
         assert_eq!(result.total_stocks, 1, "priceable stock must be included");
         assert_eq!(result.individual_performances.len(), 1);
@@ -3103,7 +3160,8 @@ mod tests {
         let market = hybrid_market_data(ticker, &[(score_date, 0.0), (latest_date, 110.0)]);
         let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
 
         assert_eq!(
             result.total_stocks, 0,
@@ -3125,7 +3183,8 @@ mod tests {
         let market = hybrid_market_data(ticker, &[(score_date, 100.0), (latest_date, 0.0)]);
         let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
 
         assert_eq!(
             result.total_stocks, 0,
@@ -3147,7 +3206,8 @@ mod tests {
         let market = hybrid_market_data(ticker, &[(score_date, 0.0), (latest_date, 0.0)]);
         let records = vec![StockRecord::new(ticker.to_string(), 5.0, 120.0)];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
 
         assert_eq!(
             result.total_stocks, 0,
@@ -3180,7 +3240,8 @@ mod tests {
             StockRecord::new(excluded.to_string(), 5.0, 120.0),
         ];
 
-        let result = calculate_hybrid_projection(&records, &score_str, &market).unwrap();
+        let result =
+            calculate_hybrid_projection(absent_data_root(), &records, &score_str, &market).unwrap();
 
         // Count is over included stocks only.
         assert_eq!(result.total_stocks, 2);
@@ -3523,7 +3584,8 @@ mod tests {
         );
         let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
 
-        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+        let result =
+            calculate_portfolio_performance(absent_data_root(), &score_path, "2024-11-15").unwrap();
 
         assert_eq!(result.total_stocks, 1, "a clean split stock stays included");
         assert!(result.excluded_tickers.is_empty());
@@ -3563,7 +3625,8 @@ mod tests {
         );
         let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
 
-        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+        let result =
+            calculate_portfolio_performance(absent_data_root(), &score_path, "2024-11-15").unwrap();
 
         assert_eq!(
             result.total_stocks, 1,
@@ -3600,7 +3663,8 @@ mod tests {
         );
         let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
 
-        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+        let result =
+            calculate_portfolio_performance(absent_data_root(), &score_path, "2024-11-15").unwrap();
 
         assert_eq!(
             result.total_stocks, 1,
@@ -3631,7 +3695,8 @@ mod tests {
         );
         let (_dir, score_path) = write_portfolio_fixture(&tsv, &csv);
 
-        let result = calculate_portfolio_performance(&score_path, "2024-11-15").unwrap();
+        let result =
+            calculate_portfolio_performance(absent_data_root(), &score_path, "2024-11-15").unwrap();
 
         assert_eq!(result.total_stocks, 1);
         assert!(result.excluded_tickers.is_empty());

--- a/tests/cli_flag_cleanup_test.rs
+++ b/tests/cli_flag_cleanup_test.rs
@@ -1,4 +1,5 @@
-//! Tests for the CLI-flag cleanup in issue #99.
+//! Tests for the CLI-flag cleanup in issue #99, and for the caller-supplied
+//! data-root flags added in issue #803.
 //!
 //! Two pieces of dead code were removed from `src/main.rs`:
 //!   1. The `--performance-only` flag, which was parsed but never read.
@@ -7,15 +8,61 @@
 //!
 //! These tests exercise the real binary end-to-end and assert on observable
 //! behaviour (accepted/rejected flags and exit codes), not implementation.
+//!
+//! Issue #803 made both data roots caller-supplied, so every invocation below
+//! passes `--market-data-path`/`--dividend-data-path` at temporary directories
+//! (the pre-existing tests were updated for that new start-up contract) and the
+//! child environment is cleared of both variables so the assertions never
+//! depend on the developer's or runner's configuration.
 
+use std::path::Path;
 use std::process::Command;
 
-/// Run the binary with the given arguments and capture its output.
+const MARKET_DATA_ROOT_ENV: &str = "GRQ_MARKET_DATA_PATH";
+const DIVIDEND_DATA_ROOT_ENV: &str = "GRQ_DIVIDEND_DATA_PATH";
+
+/// Builds a command with both data-root environment variables removed, so a
+/// test controls resolution entirely through flags and explicit `env` calls.
+fn binary() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_grq-validation"));
+    command
+        .env_remove(MARKET_DATA_ROOT_ENV)
+        .env_remove(DIVIDEND_DATA_ROOT_ENV);
+    command
+}
+
+/// Creates a usable market-data root (an empty `data/` tree) inside `base`.
+fn market_root_in(base: &Path) -> std::path::PathBuf {
+    let root = base.join("market-data");
+    std::fs::create_dir_all(root.join("data")).expect("create market data tree");
+    root
+}
+
+/// Creates a usable dividend-data root inside `base`.
+fn dividend_root_in(base: &Path) -> std::path::PathBuf {
+    let root = base.join("dividend-data");
+    std::fs::create_dir_all(root.join("data")).expect("create dividend data tree");
+    root
+}
+
+/// Run the binary with the given arguments and capture its output. Both data
+/// roots are supplied as flags pointing at temporary trees.
 fn run_with_args(extra: &[&str]) -> std::process::Output {
     let docs_dir = tempfile::tempdir().expect("create temp docs dir");
-    let mut args = vec!["--docs-path", docs_dir.path().to_str().unwrap()];
+    let roots_dir = tempfile::tempdir().expect("create temp roots dir");
+    let market = market_root_in(roots_dir.path());
+    let dividends = dividend_root_in(roots_dir.path());
+
+    let mut args = vec![
+        "--docs-path",
+        docs_dir.path().to_str().unwrap(),
+        "--market-data-path",
+        market.to_str().unwrap(),
+        "--dividend-data-path",
+        dividends.to_str().unwrap(),
+    ];
     args.extend_from_slice(extra);
-    Command::new(env!("CARGO_BIN_EXE_grq-validation"))
+    binary()
         .args(&args)
         .output()
         .expect("run grq-validation binary")
@@ -55,5 +102,147 @@ fn calculate_performance_flag_is_still_accepted() {
     assert!(
         !stderr.contains("no longer needed for normal operation"),
         "unreachable calculate-performance block should be gone, stderr: {stderr}"
+    );
+}
+
+// --- Caller-supplied data roots (issue #803) ---
+
+#[test]
+fn help_documents_both_data_root_flags_and_their_env_vars() {
+    let output = binary().arg("--help").output().expect("run --help");
+    let help = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "--help must exit zero: {help}");
+    for expected in [
+        "--market-data-path",
+        "--dividend-data-path",
+        MARKET_DATA_ROOT_ENV,
+        DIVIDEND_DATA_ROOT_ENV,
+    ] {
+        assert!(
+            help.contains(expected),
+            "--help must document {expected}, got:\n{help}"
+        );
+    }
+}
+
+#[test]
+fn missing_data_roots_fails_at_startup_listing_both() {
+    // Neither flag nor environment variable: the run must stop before any work,
+    // naming both variables in a single actionable message.
+    let docs_dir = tempfile::tempdir().expect("create temp docs dir");
+    let output = binary()
+        .args(["--docs-path", docs_dir.path().to_str().unwrap()])
+        .output()
+        .expect("run grq-validation binary");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "expected a non-zero exit with no data roots, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(MARKET_DATA_ROOT_ENV) && stderr.contains(DIVIDEND_DATA_ROOT_ENV),
+        "the start-up error must name both variables, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json")
+            || stderr.contains("data/<letter>/<SYM>.json"),
+        "the start-up error must describe the expected layout, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn missing_data_roots_writes_no_partial_csv() {
+    // The start-up guard runs before any score file is touched, so a run
+    // without roots leaves the docs tree exactly as it found it.
+    let docs_dir = tempfile::tempdir().expect("create temp docs dir");
+    let scores = docs_dir.path().join("scores/2025/June");
+    std::fs::create_dir_all(&scores).expect("create score dir");
+    std::fs::write(scores.join("20.tsv"), "Stock\tScore\n").expect("write score file");
+
+    let output = binary()
+        .args(["--docs-path", docs_dir.path().to_str().unwrap()])
+        .output()
+        .expect("run grq-validation binary");
+
+    assert!(!output.status.success(), "expected a non-zero exit");
+    assert!(
+        !scores.join("20.csv").exists() && !scores.join("20-dividends.csv").exists(),
+        "no CSV may be written when the data roots are unusable"
+    );
+}
+
+#[test]
+fn market_data_path_flag_overrides_env() {
+    // The environment names a usable root while the flag names a directory that
+    // does not exist. The flag must win, so the run fails naming the flag's
+    // path — proving the environment value was not silently preferred.
+    let roots_dir = tempfile::tempdir().expect("create temp roots dir");
+    let docs_dir = tempfile::tempdir().expect("create temp docs dir");
+    let env_market = market_root_in(roots_dir.path());
+    let dividends = dividend_root_in(roots_dir.path());
+    let flag_market = roots_dir.path().join("flag-market-data");
+
+    let output = binary()
+        .env(MARKET_DATA_ROOT_ENV, &env_market)
+        .env(DIVIDEND_DATA_ROOT_ENV, &dividends)
+        .args([
+            "--docs-path",
+            docs_dir.path().to_str().unwrap(),
+            "--market-data-path",
+            flag_market.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run grq-validation binary");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "the flag's non-existent root must fail the run, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(&flag_market.display().to_string()),
+        "the error must name the flag's root, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains(&format!("  - {}", env_market.display())),
+        "the environment's root must not be reported as the problem, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn environment_supplies_the_roots_when_no_flag_is_given() {
+    // The converse of the precedence test: with no flags, the variables are the
+    // fallback and a run against an empty docs tree starts successfully.
+    let roots_dir = tempfile::tempdir().expect("create temp roots dir");
+    let docs_dir = tempfile::tempdir().expect("create temp docs dir");
+    let market = market_root_in(roots_dir.path());
+    let dividends = dividend_root_in(roots_dir.path());
+    std::fs::write(
+        docs_dir.path().join("scores-index-placeholder"),
+        "not an index",
+    )
+    .expect("write placeholder");
+
+    let output = binary()
+        .env(MARKET_DATA_ROOT_ENV, &market)
+        .env(DIVIDEND_DATA_ROOT_ENV, &dividends)
+        .args([
+            "--docs-path",
+            docs_dir.path().to_str().unwrap(),
+            "--calculate-performance",
+        ])
+        .output()
+        .expect("run grq-validation binary");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "environment-supplied roots must satisfy the start-up guard, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("cannot start"),
+        "no start-up failure expected, stderr: {stderr}"
     );
 }

--- a/tests/create_market_data_csv_test.rs
+++ b/tests/create_market_data_csv_test.rs
@@ -160,7 +160,12 @@ fn create_market_data_csv_writes_windowed_rows() -> Result<()> {
     let out_path = out_dir.path().join("md.csv");
     let out = out_path.to_str().expect("temp path is valid UTF-8");
 
-    create_market_data_csv(&[FIXTURE_SYMBOL_DIRECT.to_string()], SCORE_DATE, out)?;
+    create_market_data_csv(
+        &market_data_root()?,
+        &[FIXTURE_SYMBOL_DIRECT.to_string()],
+        SCORE_DATE,
+        out,
+    )?;
 
     let csv = std::fs::read_to_string(&out_path)?;
 
@@ -205,6 +210,7 @@ fn create_market_data_csv_for_score_file_writes_derived_csv() -> Result<()> {
     let score_file_str = score_file.to_str().expect("temp path is valid UTF-8");
 
     create_market_data_csv_for_score_file(
+        &market_data_root()?,
         score_file_str,
         &[FIXTURE_SYMBOL_WRAPPER.to_string()],
         SCORE_DATE,

--- a/tests/create_market_data_long_csv_test.rs
+++ b/tests/create_market_data_long_csv_test.rs
@@ -182,7 +182,12 @@ fn create_market_data_long_csv_writes_eight_column_rows() -> Result<()> {
     let out_path = out_dir.path().join("long.csv");
     let out = out_path.to_str().expect("temp path is valid UTF-8");
 
-    create_market_data_long_csv(&[FIXTURE_TICKER.to_string()], SCORE_DATE, out)?;
+    create_market_data_long_csv(
+        &market_data_root()?,
+        &[FIXTURE_TICKER.to_string()],
+        SCORE_DATE,
+        out,
+    )?;
 
     let csv = std::fs::read_to_string(&out_path)?;
 
@@ -228,8 +233,12 @@ fn create_market_data_long_csv_errors_when_all_tickers_skipped() -> Result<()> {
     let out_path = out_dir.path().join("empty.csv");
     let out = out_path.to_str().expect("temp path is valid UTF-8");
 
-    let result =
-        create_market_data_long_csv(&["NYSE:GRQVTEST634MISSING".to_string()], SCORE_DATE, out);
+    let result = create_market_data_long_csv(
+        &market_data_root()?,
+        &["NYSE:GRQVTEST634MISSING".to_string()],
+        SCORE_DATE,
+        out,
+    );
 
     assert!(
         result.is_err(),
@@ -262,8 +271,12 @@ fn create_market_data_long_csv_preserves_existing_rows_when_no_fresh_data() -> R
     std::fs::write(&out_path, existing)?;
 
     // No fixture installed -> the only ticker is skipped -> zero rows written.
-    let result =
-        create_market_data_long_csv(&["NYSE:GRQVTEST687MISSING".to_string()], SCORE_DATE, out);
+    let result = create_market_data_long_csv(
+        &market_data_root()?,
+        &["NYSE:GRQVTEST687MISSING".to_string()],
+        SCORE_DATE,
+        out,
+    );
 
     // The writer still signals that no fresh data was available...
     assert!(
@@ -306,7 +319,12 @@ fn create_market_data_long_csv_replaces_existing_when_fresh_data_available() -> 
     // Stale content that must be fully replaced by the fresh write.
     std::fs::write(&out_path, "stale,garbage\n1,2\n")?;
 
-    create_market_data_long_csv(&[FIXTURE_TICKER_REPLACE.to_string()], SCORE_DATE, out)?;
+    create_market_data_long_csv(
+        &market_data_root()?,
+        &[FIXTURE_TICKER_REPLACE.to_string()],
+        SCORE_DATE,
+        out,
+    )?;
 
     let csv = std::fs::read_to_string(&out_path)?;
     assert_eq!(

--- a/tests/dividend_tests.rs
+++ b/tests/dividend_tests.rs
@@ -7,10 +7,13 @@ use grq_validation::utils::{
 fn test_create_dividend_csv_for_first_score_file() -> Result<()> {
     // Skip test if the caller-supplied dividend root is unset or absent
     // (issue #802).
-    if !dividend_data_root().is_ok_and(|root| root.exists()) {
-        println!("Skipping test_create_dividend_csv_for_first_score_file: external data repository not available");
-        return Ok(());
-    }
+    let dividend_root = match dividend_data_root() {
+        Ok(root) if root.exists() => root,
+        _ => {
+            println!("Skipping test_create_dividend_csv_for_first_score_file: external data repository not available");
+            return Ok(());
+        }
+    };
 
     // Test with the March 5 score file which is older and should have dividends
     let score_file_path = "docs/scores/2025/March/5.tsv";
@@ -25,7 +28,12 @@ fn test_create_dividend_csv_for_first_score_file() -> Result<()> {
     );
 
     // Create dividend CSV
-    create_dividend_csv_for_score_file(score_file_path, &ticker_codes, score_file_date)?;
+    create_dividend_csv_for_score_file(
+        &dividend_root,
+        score_file_path,
+        &ticker_codes,
+        score_file_date,
+    )?;
 
     // Verify the dividend file was created
     let dividend_output_path = "docs/scores/2025/March/5-dividends.csv";

--- a/tests/main_error_propagation_test.rs
+++ b/tests/main_error_propagation_test.rs
@@ -16,17 +16,64 @@ fn date_days_ago(days: i64) -> String {
 }
 
 /// Run the binary for a single date against an empty docs directory.
+///
+/// Both data roots are supplied as flags at temporary directories (issue #803):
+/// the start-up guard now validates them before any date processing, so these
+/// tests pass usable roots to keep exercising the *date* error paths below.
 fn run_for_date(date: &str) -> std::process::Output {
     let docs_dir = tempfile::tempdir().expect("create temp docs dir");
+    let roots_dir = tempfile::tempdir().expect("create temp roots dir");
+    let market = roots_dir.path().join("market-data");
+    let dividends = roots_dir.path().join("dividend-data");
+    std::fs::create_dir_all(market.join("data")).expect("create market data tree");
+    std::fs::create_dir_all(dividends.join("data")).expect("create dividend data tree");
+
     Command::new(env!("CARGO_BIN_EXE_grq-validation"))
         .args([
             "--date",
             date,
             "--docs-path",
             docs_dir.path().to_str().unwrap(),
+            "--market-data-path",
+            market.to_str().unwrap(),
+            "--dividend-data-path",
+            dividends.to_str().unwrap(),
         ])
         .output()
         .expect("run grq-validation binary")
+}
+
+/// A run with no data roots at all must fail at start-up — before the date
+/// branches run — so the operator sees the configuration fault rather than a
+/// per-ticker failure deep in the run (issue #803).
+#[test]
+fn missing_data_roots_fail_before_date_processing() {
+    let docs_dir = tempfile::tempdir().expect("create temp docs dir");
+    let output = Command::new(env!("CARGO_BIN_EXE_grq-validation"))
+        .env_remove("GRQ_MARKET_DATA_PATH")
+        .env_remove("GRQ_DIVIDEND_DATA_PATH")
+        .args([
+            "--date",
+            &date_days_ago(10),
+            "--docs-path",
+            docs_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run grq-validation binary");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("GRQ_MARKET_DATA_PATH") && stderr.contains("GRQ_DIVIDEND_DATA_PATH"),
+        "expected the start-up error naming both roots, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("reading TSV file"),
+        "the run must stop before any date processing, stderr: {stderr}"
+    );
 }
 
 #[test]

--- a/tests/market_data_tests.rs
+++ b/tests/market_data_tests.rs
@@ -73,6 +73,7 @@ fn test_create_market_data_long_csv_for_first_score_file() -> Result<()> {
     // covered directly by the fixture-based tests in
     // `create_market_data_long_csv_test.rs`.
     let output_path = match create_market_data_long_csv_for_score_file(
+        &market_data_root,
         score_file_path,
         &ticker_codes,
         score_file_date,

--- a/tests/shell_data_root_preflight_test.rs
+++ b/tests/shell_data_root_preflight_test.rs
@@ -1,0 +1,69 @@
+//! Behaviour tests for the shell entry points' data-root pre-flight (issue
+//! #803).
+//!
+//! `run.sh` and `process_date.sh` now pass `--market-data-path` /
+//! `--dividend-data-path` through to the binary, so an unset root must stop the
+//! run *before* anything is built or written. These tests execute the real
+//! scripts with both variables removed from the child environment and assert on
+//! observable behaviour — a non-zero exit and a message naming both variables
+//! and the expected on-disk layout.
+
+use std::process::Command;
+
+/// Runs `script` under bash with both data-root variables removed, from the
+/// repository root, and returns `(success, combined output)`.
+fn run_script_without_roots(script: &str, args: &[&str]) -> (bool, String) {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let output = Command::new("bash")
+        .arg(script)
+        .args(args)
+        .current_dir(repo_root)
+        .env_remove("GRQ_MARKET_DATA_PATH")
+        .env_remove("GRQ_DIVIDEND_DATA_PATH")
+        .output()
+        .unwrap_or_else(|error| panic!("run {script}: {error}"));
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    (output.status.success(), combined)
+}
+
+/// Asserts the shared fail-loud guidance: both variable names and the layout.
+fn assert_names_both_roots_and_layout(script: &str, message: &str) {
+    for expected in [
+        "GRQ_MARKET_DATA_PATH",
+        "GRQ_DIVIDEND_DATA_PATH",
+        "data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json",
+    ] {
+        assert!(
+            message.contains(expected),
+            "{script} must name {expected} when a data root is unset, got:\n{message}"
+        );
+    }
+}
+
+#[test]
+fn run_sh_fails_loudly_without_data_roots() {
+    let (success, message) = run_script_without_roots("run.sh", &[]);
+
+    assert!(
+        !success,
+        "run.sh must exit non-zero without data roots, got:\n{message}"
+    );
+    assert_names_both_roots_and_layout("run.sh", &message);
+}
+
+#[test]
+fn process_date_sh_fails_loudly_without_data_roots() {
+    let (success, message) = run_script_without_roots("process_date.sh", &["2025-06-05"]);
+
+    assert!(
+        !success,
+        "process_date.sh must exit non-zero without data roots, got:\n{message}"
+    );
+    assert_names_both_roots_and_layout("process_date.sh", &message);
+    assert!(
+        !message.contains("Building project"),
+        "the guard must run before the build, got:\n{message}"
+    );
+}

--- a/tests/update_index_with_performance_test.rs
+++ b/tests/update_index_with_performance_test.rs
@@ -85,8 +85,12 @@ fn update_index_with_performance_writes_settled_and_open_entries() {
     );
     write_file(&scores.join("index.json"), &index_json);
 
-    // Act: run the real write path against the fixture.
-    update_index_with_performance(docs.to_str().unwrap())
+    // Act: run the real write path against the fixture. The dividend root is
+    // caller-supplied (issue #803); this fixture's synthetic ticker has no
+    // dividend history, so an absent root keeps the expected figures purely
+    // price-driven.
+    let dividend_root = dir.path().join("absent-dividend-root");
+    update_index_with_performance(&dividend_root, docs.to_str().unwrap())
         .expect("update_index_with_performance should succeed");
 
     // Assert on the persisted output, located by `file` rather than position.


### PR DESCRIPTION
# PR Summary — Issue #803

## Summary

Wires the caller-supplied data roots through the binary and both shell entry
points, so an operator (public or private) can point the pipeline at their own
data tree and `std::env::var` is read in exactly one place. Closes #803.

- **CLI flags** — `--market-data-path` and `--dividend-data-path`
  (`src/main.rs`), each overriding `GRQ_MARKET_DATA_PATH` /
  `GRQ_DIVIDEND_DATA_PATH`. No `default_value`: an absent root is an error, not
  a silent `../…` guess. The fallback is resolved by hand, so no new `clap`
  feature was needed.
- **Explicit threading** — `main` resolves both roots once into a new
  `DataRoots { market, dividends }` (`src/data_roots.rs`) and passes them to
  `ensure_market_data_repository_at`, `create_market_data_long_csv_for_score_file`,
  `create_dividend_csv_for_score_file`, `calculate_portfolio_performance`,
  `calculate_hybrid_projection` and `update_index_with_performance`. The
  internal chain (`read_market_data`, `read_dividend_data`,
  `calculate_dividends_for_period`, and the CSV writers) now takes the root as a
  parameter instead of resolving it per call.
- **Start-up validation** — both roots are validated (set, non-blank, an
  existing directory) before any work begins, and a single error lists *every*
  unusable root with the flag/variable and expected layout.
- **Dead wrappers removed** — `ensure_market_data_repository()`,
  `market_data_repository_available()` and `get_dividend_data_path()` became
  dead once the roots are threaded, and are deleted;
  `ensure_market_data_repository_at()` is now the public gate.
- **Shell wiring** — `run.sh` and `process_date.sh` source a shared
  `scripts/require_data_roots.sh` (with a fail-loud check that the helper
  exists) and refuse to build or write anything when either variable is unset,
  then pass both roots through as flags. Existing `set`/exit-code handling is
  untouched.
- **Documentation** — `README.md` and `CONTRIBUTING.md` document the two flags
  and variables, the precedence rule, the
  `<root>/data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json` layout, worked
  `MarketData` / `DividendData` JSON examples, and state explicitly that this
  repository ships no such data and names no upstream source.

## Evidence

This is a backend/CLI change with no web interface, so there is no screenshot.
Evidence is the real binary's behaviour plus the test suite.

### Resolution flow

```mermaid
flowchart LR
    F["--market-data-path<br/>--dividend-data-path"] --> R{{"DataRoots::resolve()<br/>flag wins over env"}}
    E["GRQ_MARKET_DATA_PATH<br/>GRQ_DIVIDEND_DATA_PATH"] --> R
    R -- unset/blank/not a directory --> X["one start-up error<br/>listing every bad root<br/>exit non-zero, no CSV written"]
    R -- both valid --> P["pipeline entry points<br/>roots threaded as parameters"]
    P --> C["get_market_data_path_in()<br/>get_dividend_data_path_in()"]
    C --> O["&lt;root&gt;/data/&lt;LETTER&gt;/&lt;SYMBOL&gt;.json"]
```

### `--help` documents both flags and their variables

```text
      --market-data-path <MARKET_DATA_PATH>
          Directory holding the market-data `data/<LETTER>/<SYMBOL>.json` tree; overrides GRQ_MARKET_DATA_PATH
      --dividend-data-path <DIVIDEND_DATA_PATH>
          Directory holding the dividend-history `data/<LETTER>/<SYMBOL>.json` tree; overrides GRQ_DIVIDEND_DATA_PATH
```

### Missing roots fail at start-up, before any work

```text
$ env -u GRQ_MARKET_DATA_PATH -u GRQ_DIVIDEND_DATA_PATH \
    ./target/release/grq-validation --docs-path "$WORK/docs"; echo "exit=$?"
Error: cannot start: caller-supplied data root(s) unusable:
  - GRQ_MARKET_DATA_PATH is not set — set it to the directory holding the market-data `data/<letter>/<SYM>.json` tree
  - GRQ_DIVIDEND_DATA_PATH is not set — set it to the directory holding the dividend-data `data/<letter>/<SYM>.json` tree
Pass --market-data-path/--dividend-data-path, or set GRQ_MARKET_DATA_PATH/GRQ_DIVIDEND_DATA_PATH. This
repository ships no market or dividend data: point each root at your own directory holding a
`data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json` tree.
exit=1
```

Both shell entry points do the same before building anything:

```text
$ env -u GRQ_MARKET_DATA_PATH -u GRQ_DIVIDEND_DATA_PATH ./process_date.sh 2025-06-05
ERROR: unset data root(s): GRQ_MARKET_DATA_PATH, GRQ_DIVIDEND_DATA_PATH
Set each variable (or pass the matching --market-data-path /
--dividend-data-path flag) to a directory holding a
data/<UPPERCASE-FIRST-LETTER>/<SYMBOL>.json tree, for example:
  export GRQ_MARKET_DATA_PATH=/path/to/market-data
  export GRQ_DIVIDEND_DATA_PATH=/path/to/dividend-history
```

### A caller-supplied tree reproduces a full run

Against a synthetic root (one symbol, one dividend, `docs/` fixture), the run
produced the expected CSVs and folded the dividend into the return
(+10% price, +1.25% dividend = 11.25%), proving the dividend root is threaded
all the way into `calculate_portfolio_performance`:

```text
$ GRQ_MARKET_DATA_PATH=$WORK/market GRQ_DIVIDEND_DATA_PATH=$WORK/dividends \
    ./target/release/grq-validation --docs-path "$WORK/docs" --process-all
… Performance for 2025-06-20: 11.25% (90-day), 54.13% (annualized), 1 included stocks

$ cat $WORK/docs/scores/2025/June/20.csv
date,ticker,high,low,open,close,split_coefficient,volume
2025-06-20,NYSE:TEST,101,99,100,100,1.0,1000
2025-09-18,NYSE:TEST,111,109,110,110,1.0,1200

$ cat $WORK/docs/scores/2025/June/20-dividends.csv
date,symbol,amount
2025-07-15,NYSE:TEST,1.25
```

A byte-compare against today's published output for a real date needs the
operator's own data tree, which this environment does not have; the CSV writers
themselves are unchanged apart from taking the root as a parameter.

### Single environment read site

```text
$ grep -rn 'env::var' src/
src/utils.rs:48:    std::env::var(variable).ok()
```

### Quality gates

`./quality.sh < /dev/null` passes cleanly: `cargo fmt --check`,
`cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`
(129 tests), the release build, `bash -n` over every script, and the Deno
format/lint/check/test suite. `shellcheck --severity=warning run.sh
process_date.sh scripts/require_data_roots.sh` is clean.

## Test Plan

### Added

- `src/data_roots.rs` unit tests — `resolve_accepts_existing_directories_from_flags`,
  `resolve_lists_every_unusable_root_in_one_error`,
  `resolve_reports_only_the_broken_root`,
  `resolve_rejects_a_blank_flag_rather_than_falling_back`. Hermetic: they drive
  resolution through flags only, so they never mutate or depend on the ambient
  environment.
- `tests/cli_flag_cleanup_test.rs` —
  `help_documents_both_data_root_flags_and_their_env_vars`,
  `missing_data_roots_fails_at_startup_listing_both`,
  `missing_data_roots_writes_no_partial_csv`,
  `market_data_path_flag_overrides_env` (environment names a usable root, the
  flag names a broken one, and the flag's path is what fails — proving
  precedence), and `environment_supplies_the_roots_when_no_flag_is_given`.
- `tests/main_error_propagation_test.rs` —
  `missing_data_roots_fail_before_date_processing`, asserting the start-up error
  exits non-zero and never reaches the per-date "reading TSV file" path.
- `tests/shell_data_root_preflight_test.rs` — runs the real `run.sh` and
  `process_date.sh` with both variables removed from the child environment and
  asserts a non-zero exit, both variable names and the layout in the message,
  and (for `process_date.sh`) that the guard fires before the build.

### Modified (documented business-logic change)

Threading the roots changes the signatures of the pipeline entry points, so the
existing callers in tests were updated to pass a root — no test was removed or
weakened:

- `tests/cli_flag_cleanup_test.rs`, `tests/main_error_propagation_test.rs` — the
  binary helpers now pass `--market-data-path`/`--dividend-data-path` at
  temporary directories and clear both variables from the child environment, so
  they still exercise their original flag and error-propagation assertions under
  the new start-up contract.
- `tests/create_market_data_csv_test.rs`,
  `tests/create_market_data_long_csv_test.rs`, `tests/market_data_tests.rs`,
  `tests/dividend_tests.rs` — pass the already-resolved root they were skipping
  on.
- `tests/update_index_with_performance_test.rs` — passes an absent dividend root
  (its synthetic ticker has no dividend history), keeping the expected figures
  price-driven.
- `src/utils.rs` unit tests — traversal-guard and projection tests pass an
  explicit absent root; the environment wiring test now goes through the single
  `env_root` read site.



## Milestone
This PR is part of the **#780 🟠 Remove hard-coded private sibling checkout paths ../GRQ-shareprices2026Q2 and ../GRQ-dividends** milestone and targets the `milestone/780-remove-hard-coded-private-sibling-checkout-pat` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms7i1328-01fb05`<!-- vibe-worker-issue-803 -->