### PR TITLE
Make the Rust market-data/dividend integration tests hermetic (Issue #804)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,13 @@ jobs:
     - name: Run tests
       run: cargo test --locked --all-targets --all-features --verbose
 
+    # Hermetic-test gate (Issue #804): the market-data/dividend integration
+    # tests must run for real on a public runner with no data root configured.
+    # The gate fails if any of them skips, names the private data tree, or
+    # leaves the working tree dirty — the silent-skip escape hatch is gone.
+    - name: Verify the integration tests are hermetic
+      run: ./scripts/check_hermetic_tests.sh
+
     - name: Generate test coverage
       # Pin the tool to an explicit version with --locked so CI does not
       # compile and run an arbitrary newest cargo-tarpaulin dependency tree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,18 @@ and this project adheres to
 
 ### Changed
 
+- The four market-data/dividend integration tests
+  (`tests/create_market_data_csv_test.rs`,
+  `tests/create_market_data_long_csv_test.rs`, `tests/market_data_tests.rs`,
+  `tests/dividend_tests.rs`) are now **hermetic**: each builds a synthetic
+  fixture tree in its own `tempfile::tempdir()` root via the shared builders in
+  `tests/common/mod.rs`, so none reads or writes a configured data root, none
+  skips, and `tests/dividend_tests.rs` no longer rewrites the committed
+  `docs/scores/2025/March/5-dividends.csv`. `scripts/check_hermetic_tests.sh`
+  gates this on every PR — it runs the four tests with no data root configured
+  and fails on a skip, a private data-tree reference under `tests/`, or a
+  dirtied working tree (Issue #804).
+
 - Markdown Lint workflow (`.github/workflows/markdown-lint.yml`) no longer
   triggers on push to the default branch. As a PR-gating lint check, a
   post-merge push run only duplicated the run that already passed on the pull

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,17 @@ cargo test test_name
 
 # Run the Deno test suite (dashboard / workflow tests)
 deno test --allow-read tests/
+
+# Verify the market-data/dividend tests stayed hermetic (also run by CI)
+./scripts/check_hermetic_tests.sh
 ```
+
+The Rust tests are **hermetic**: they never read the data roots you configured
+above. Every market-data and dividend fixture is synthetic, hand-written in
+`tests/common/mod.rs`, and built inside the test's own `tempfile::tempdir()`, so
+`cargo test` behaves identically on CI and on a maintainer's machine and leaves
+`git status` clean. Keep it that way — a new test must not skip when a data root
+is absent, and must not write outside its temp directory (Issue #804).
 
 ## Formatting and linting
 

--- a/README.md
+++ b/README.md
@@ -841,6 +841,34 @@ cargo test test_name
 
 # Run the Deno test suite (dashboard / workflow tests)
 deno test --allow-read tests/
+
+# Verify the market-data/dividend tests stayed hermetic (also run by CI)
+./scripts/check_hermetic_tests.sh
+```
+
+#### Hermetic Rust tests
+
+The Rust tests never touch the data roots configured below: every market-data
+and dividend fixture is synthetic, hand-written in `tests/common/mod.rs`, and
+built inside the test's own `tempfile::tempdir()` through the same
+`get_market_data_path_in` / `get_dividend_data_path_in` resolvers the code under
+test uses. So `cargo test` asserts identically on CI and on a maintainer's
+machine, never skips for a missing data tree, and leaves `git status` clean
+(Issue #804).
+
+`scripts/check_hermetic_tests.sh` — run by `quality.sh` and by the CI Rust job —
+is the gate: it runs the four market-data/dividend integration tests with both
+root variables unset and fails if any of them skips, if `tests/` names a private
+data tree, or if the run dirties the working tree.
+
+```mermaid
+flowchart LR
+    T["tests/common/mod.rs<br/>synthetic fixtures"] --> R["tempfile::tempdir()<br/>&lt;temp&gt;/data/&lt;LETTER&gt;/&lt;SYM&gt;.json"]
+    R --> W["writers under test<br/>(root passed as a parameter)"]
+    W --> O["CSV written inside the temp dir"]
+    O --> G{{"check_hermetic_tests.sh"}}
+    G -- "skip, private-tree ref, or dirty tree" --> X["CI fails loud"]
+    G -- clean --> P[green]
 ```
 
 The Deno suite includes a **dashboard "Limited data mode" smoke test**

--- a/docs/archive/pr-summaries/pr-summary-804.md
+++ b/docs/archive/pr-summaries/pr-summary-804.md
@@ -1,0 +1,114 @@
+# PR Summary — Issue #804
+
+## Summary
+
+Makes the four Rust market-data/dividend integration tests hermetic: each now
+builds a **synthetic** fixture tree inside its own `tempfile::tempdir()` root
+instead of reading — or, in two cases, installing fixtures into — the operator's
+private data checkout. The skip guards are gone, so the tests genuinely run and
+assert on CI, and `cargo test` no longer rewrites a committed file.
+Closes #804.
+
+- **Shared fixture builders** (`tests/common/mod.rs`) — `write_market_data`,
+  `write_dividend_data`, and `write_score_file`, all hand-written synthetic
+  data. Fixture paths are built through the crate's own
+  `get_market_data_path_in` / `get_dividend_data_path_in` cores (#802), so a
+  fixture always lands exactly where the code under test looks for it.
+- **No skips** — the `market_data_root_configured` guards, the
+  presence guard in `tests/market_data_tests.rs`, and the "external data
+  repository not available" messages are deleted. With a temp root the data is
+  always available.
+- **No shared-tree mutation** — the RAII `MarketDataFixture` guards (which
+  created and deleted directories inside the operator's live tree) and their
+  `first_missing_ancestor` cleanup helper are deleted.
+- **Clean working tree** — `tests/dividend_tests.rs` writes beside a synthetic
+  score file in its temp dir, so it no longer overwrites the committed
+  `docs/scores/2025/March/5-dividends.csv`.
+- **Stronger assertions** — `tests/market_data_tests.rs` previously skipped
+  everywhere; it now asserts ticker extraction order, per-ticker path resolution
+  under the supplied root (including the `NYSE:X.A` → `X-A` mapping), the
+  derived output path, and the exact row set.
+  `tests/dividend_tests.rs` additionally pins the 180-day window filter and that
+  a symbol with no dividend file is skipped rather than fatal.
+- **Automated gate** — `scripts/check_hermetic_tests.sh`, run by `quality.sh`
+  and by the CI Rust job, runs the four tests with **both root variables unset**
+  and fails loud on a skip line, a private data-tree reference under `tests/`,
+  a binary that ran zero tests, or a working tree dirtied by the run.
+
+## Evidence
+
+No web interface is involved — this is a test-hermeticity and CI change, so
+there is no screenshot. The evidence is the test run itself, executed with no
+data root configured and no sibling data directory present.
+
+```text
+$ env -u GRQ_MARKET_DATA_PATH -u GRQ_DIVIDEND_DATA_PATH \
+      cargo test --all-targets --all-features
+...
+running 2 tests (create_market_data_csv_test) ...... ok
+running 4 tests (create_market_data_long_csv_test) . ok
+running 1 test  (dividend_tests) .................... ok
+running 1 test  (market_data_tests) ................. ok
+test result: ok. 95 passed; 0 failed; 0 ignored   (lib)
+exit=0
+
+$ grep -nE '^Skipping |external data repository not available' <test output>
+(no matches)
+
+$ git status --porcelain
+(empty)
+
+$ grep -rn 'GRQ-shareprices|GRQ-dividends|MARKET_DATA_BASE_PATH|DIVIDEND_DATA_BASE_PATH' tests/
+(no matches)
+
+$ ./scripts/check_hermetic_tests.sh
+✅ Hermetic integration tests verified.
+```
+
+Where the data comes from before and after — what is asserted is unchanged; only
+the source of the fixtures moved:
+
+```mermaid
+flowchart LR
+    subgraph Before
+        P["private sibling checkout<br/>(shared, mutable)"] --> B1["fixture installed<br/>in the live tree"]
+        B1 --> B2{"root configured?"}
+        B2 -- no --> B3["println! skip<br/>(green, asserts nothing)"]
+        B2 -- yes --> B4["assert + delete fixture<br/>+ write into docs/scores/"]
+    end
+    subgraph After
+        C["tests/common/mod.rs<br/>synthetic fixtures"] --> A1["tempfile::tempdir()<br/>&lt;temp&gt;/data/&lt;LETTER&gt;/&lt;SYM&gt;.json"]
+        A1 --> A2["writers under test<br/>(root passed as a parameter)"]
+        A2 --> A3["CSV written inside the temp dir"]
+        A3 --> A4{{"check_hermetic_tests.sh"}}
+        A4 -- "skip / private ref / dirty tree" --> A5["CI fails loud"]
+        A4 -- clean --> A6[green]
+    end
+```
+
+## Test Plan
+
+Rewritten (same assertions, hermetic fixtures):
+
+- `tests/create_market_data_csv_test.rs` — `date,symbol,close` header and the
+  inclusive 180-day window, direct writer and score-file wrapper.
+- `tests/create_market_data_long_csv_test.rs` — the 8-column header, per-column
+  field mapping, the "no rows written → error" guard, and the #687
+  preserve/replace atomic-write behaviour.
+- `tests/market_data_tests.rs` — ticker extraction, per-ticker path resolution
+  under the supplied root, derived output path, and the exact row set.
+- `tests/dividend_tests.rs` — `date,symbol,amount` header, dividend presence,
+  row count, window filter, and missing-symbol tolerance; output lands in the
+  temp dir.
+
+Added:
+
+- `tests/common/mod.rs` — shared synthetic fixture builders.
+- `tests/hermetic_test_gate_test.ts` — asserts the gate script exists, is
+  executable, rejects every private data-tree marker, compares
+  `git status --porcelain` around the run, and is wired into the `ci.yml` test
+  job exactly once.
+- `scripts/check_hermetic_tests.sh` — the gate itself.
+
+Full `./quality.sh` passes (fmt, clippy `-D warnings`, check, `cargo test`, the
+new hermetic gate, tarpaulin, release build, and the 1416-test Deno suite).

--- a/quality.sh
+++ b/quality.sh
@@ -29,6 +29,9 @@ cargo check --all-targets --all-features
 echo "🧪 Running tests..."
 cargo test --all-targets --all-features --verbose
 
+echo "🔒 Verifying the integration tests are hermetic..."
+./scripts/check_hermetic_tests.sh
+
 echo "📊 Running tests with coverage..."
 # Install tarpaulin if not available
 if ! command -v cargo-tarpaulin &> /dev/null; then

--- a/scripts/check_hermetic_tests.sh
+++ b/scripts/check_hermetic_tests.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Hermetic-test gate for the market-data/dividend integration tests (issue #804).
+#
+# These four tests used to read — and in two cases write — the operator's
+# private data checkout, and silently skipped everywhere else, so they were no
+# safety net on CI. They now build synthetic fixtures in temporary directories.
+# This gate keeps them that way: it runs them with *no* data root configured and
+# fails loud if any of them skips, references the private tree, or leaves the
+# working tree dirty.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Test binaries that must run without any data root.
+HERMETIC_TESTS=(
+    create_market_data_csv_test
+    create_market_data_long_csv_test
+    market_data_tests
+    dividend_tests
+)
+
+# Private-tree checkout names and the base-path constants deleted in #802.
+PRIVATE_TREE_PATTERN='GRQ-shareprices|GRQ-dividends|MARKET_DATA_BASE_PATH|DIVIDEND_DATA_BASE_PATH'
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+echo "🔍 Checking tests/ for private data-tree references..."
+if grep -rEn "$PRIVATE_TREE_PATTERN" tests/; then
+    fail "tests/ must not reference the private data tree or a deleted base-path constant (issue #804)"
+fi
+
+# Snapshot the working tree so an unrelated local edit cannot be blamed on the
+# test run, and a file written by it cannot hide among them.
+status_before="$(git status --porcelain)"
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+test_args=()
+for test_name in "${HERMETIC_TESTS[@]}"; do
+    test_args+=(--test "$test_name")
+done
+
+echo "🧪 Running the hermetic integration tests with no data root configured..."
+if ! env -u GRQ_MARKET_DATA_PATH -u GRQ_DIVIDEND_DATA_PATH \
+    cargo test "${test_args[@]}" -- --nocapture >"$log" 2>&1 </dev/null; then
+    cat "$log" >&2
+    fail "the hermetic integration tests must pass with no data root configured (issue #804)"
+fi
+cat "$log"
+
+if grep -nE '^Skipping |external data repository not available' "$log"; then
+    fail "no hermetic integration test may skip — the fixtures are synthetic (issue #804)"
+fi
+
+if grep -n 'running 0 tests' "$log"; then
+    fail "every hermetic integration test binary must run at least one test (issue #804)"
+fi
+
+status_after="$(git status --porcelain)"
+if [ "$status_before" != "$status_after" ]; then
+    echo "--- git status before ---" >&2
+    echo "$status_before" >&2
+    echo "--- git status after ---" >&2
+    echo "$status_after" >&2
+    fail "the tests must leave the working tree unchanged — write to a temp dir (issue #804)"
+fi
+
+echo "✅ Hermetic integration tests verified."

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,173 @@
+//! Synthetic fixture builders shared by the Rust integration tests (issue #804).
+//!
+//! Every fixture is written under a caller-supplied root — in practice a
+//! `tempfile::tempdir()` owned by the test — and every value is hand-written
+//! here, so no test reads or writes the operator's live market-data or
+//! dividend tree and none of them can skip for want of one.
+//!
+//! Paths are built through the crate's own `get_market_data_path_in` /
+//! `get_dividend_data_path_in` cores, so a fixture always lands exactly where
+//! the code under test looks for it.
+
+// Each integration test uses only the builders it needs; the module is shared,
+// so unused-in-this-binary helpers are expected rather than dead code.
+#![allow(dead_code)]
+
+use anyhow::Result;
+use grq_validation::utils::{get_dividend_data_path_in, get_market_data_path_in};
+use serde_json::{json, Map, Value};
+use std::path::{Path, PathBuf};
+
+/// TSV header of a daily score file, matching `StockRecord` in `src/models.rs`.
+const SCORE_FILE_HEADER: &str = "Stock\tScore\tTarget\tExDividendDate\tDividendPerShare\tNotes\tintrinsicValuePerShareBasic\tintrinsicValuePerShareAdjusted";
+
+/// One synthetic daily price point, in the fields the long-format writer maps
+/// onto its eight CSV columns.
+pub struct PricePoint<'a> {
+    pub date: &'a str,
+    pub open: &'a str,
+    pub high: &'a str,
+    pub low: &'a str,
+    pub close: &'a str,
+    pub volume: &'a str,
+    pub split: &'a str,
+}
+
+impl<'a> PricePoint<'a> {
+    /// A point whose open/high/low/close all equal `close` — enough for the
+    /// short-format writer, which reads only the close.
+    pub fn flat(date: &'a str, close: &'a str) -> Self {
+        Self {
+            date,
+            open: close,
+            high: close,
+            low: close,
+            close,
+            volume: "1000",
+            split: "1.0",
+        }
+    }
+
+    /// A point with a distinct value per column, so a test can prove each
+    /// long-format column is mapped to the right field.
+    pub fn detailed(
+        date: &'a str,
+        open: &'a str,
+        high: &'a str,
+        low: &'a str,
+        close: &'a str,
+        volume: &'a str,
+    ) -> Self {
+        Self {
+            date,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            split: "1.0",
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        json!({
+            "1. open": self.open,
+            "2. high": self.high,
+            "3. low": self.low,
+            "4. close": self.close,
+            "5. adjusted close": self.close,
+            "6. volume": self.volume,
+            "7. dividend amount": "0.0",
+            "8. split coefficient": self.split,
+        })
+    }
+}
+
+/// Writes an Alpha Vantage-shaped market-data document for `symbol` at
+/// `<root>/data/<LETTER>/<SYMBOL>.json` and returns that path.
+///
+/// # Errors
+///
+/// Returns an error if the path cannot be built (see `get_market_data_path_in`)
+/// or the fixture cannot be written.
+pub fn write_market_data(root: &Path, symbol: &str, points: &[PricePoint]) -> Result<PathBuf> {
+    let series: Map<String, Value> = points
+        .iter()
+        .map(|point| (point.date.to_string(), point.to_json()))
+        .collect();
+
+    let document = json!({
+        "Meta Data": {
+            "1. Information": "Daily Prices (synthetic fixture)",
+            "2. Symbol": symbol,
+            "3. Last Refreshed": points.last().map_or("1970-01-01", |point| point.date),
+            "4. Output Size": "Full size",
+            "5. Time Zone": "US/Eastern",
+        },
+        "Time Series (Daily)": series,
+    });
+
+    write_json(&get_market_data_path_in(root, symbol)?, &document)
+}
+
+/// Writes a `DividendData`-shaped document for `symbol` at
+/// `<root>/data/<LETTER>/<SYMBOL>.json` and returns that path. Each event is an
+/// `(ex-dividend date, amount)` pair.
+///
+/// # Errors
+///
+/// Returns an error if the path cannot be built (see
+/// `get_dividend_data_path_in`) or the fixture cannot be written.
+pub fn write_dividend_data(root: &Path, symbol: &str, events: &[(&str, &str)]) -> Result<PathBuf> {
+    let data: Vec<Value> = events
+        .iter()
+        .map(|(ex_dividend_date, amount)| {
+            json!({
+                "ex_dividend_date": ex_dividend_date,
+                "declaration_date": Value::Null,
+                "record_date": Value::Null,
+                "payment_date": Value::Null,
+                "amount": amount,
+            })
+        })
+        .collect();
+
+    let document = json!({ "symbol": symbol, "data": data });
+
+    write_json(&get_dividend_data_path_in(root, symbol)?, &document)
+}
+
+/// Writes a minimal score TSV listing `tickers` at `path` and returns it, so a
+/// test can exercise the score-file readers without touching `docs/`.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be written.
+pub fn write_score_file(path: &Path, tickers: &[&str]) -> Result<PathBuf> {
+    let mut tsv = String::from(SCORE_FILE_HEADER);
+    for (index, ticker) in tickers.iter().enumerate() {
+        // Scores descend from 0.9 so every row is distinct and priceable.
+        let score = 0.9 - (index as f64) * 0.1;
+        tsv.push_str(&format!("\n{ticker}\t{score}\t10.00\t\t\t\t9.00\t9.50"));
+    }
+    tsv.push('\n');
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, tsv)?;
+
+    Ok(path.to_path_buf())
+}
+
+/// Writes `document` to `path`, creating the bucket directories beneath the
+/// fixture root as needed.
+fn write_json(path: &str, document: &Value) -> Result<PathBuf> {
+    let path = PathBuf::from(path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, document.to_string())?;
+
+    Ok(path)
+}

--- a/tests/create_market_data_csv_test.rs
+++ b/tests/create_market_data_csv_test.rs
@@ -2,27 +2,24 @@
 //! `create_market_data_csv_for_score_file` (issue #265).
 //!
 //! These were previously the only market-data writers with no test exercising
-//! them, directly or indirectly. Each test drops a small, fully controlled
-//! market-data fixture at the location the function reads from, asserts the
-//! observable CSV output, then removes the fixture again. The assertions pin
-//! the public contract — the `date,symbol,close` header and the inclusive
-//! 180-day window filter — without caring how the function computes them.
+//! them, directly or indirectly. Each test builds a small, fully controlled
+//! market-data fixture inside its own `tempfile::tempdir()` root and asserts
+//! the observable CSV output. The assertions pin the public contract — the
+//! `date,symbol,close` header and the inclusive 180-day window filter — without
+//! caring how the function computes them.
 //!
-//! The fixtures live under the caller-supplied market-data root (issue #802),
-//! so each test skips when `GRQ_MARKET_DATA_PATH` is unset. Making them
-//! hermetic against a temporary root is tracked separately.
+//! The fixtures are synthetic and hermetic (issue #804): every read and write
+//! stays inside the test's temporary directory, so the tests run identically on
+//! CI and on a maintainer's machine and never touch a configured data root.
+
+mod common;
 
 use anyhow::Result;
-use grq_validation::utils::{
-    create_market_data_csv, create_market_data_csv_for_score_file, market_data_root,
-};
-use std::path::{Path, PathBuf};
+use common::{write_market_data, PricePoint};
+use grq_validation::utils::{create_market_data_csv, create_market_data_csv_for_score_file};
 
-/// Clearly-synthetic symbols so a fixture can never collide with a real symbol
-/// in an existing market-data repository. Each test uses a
-/// distinct symbol so the fixtures live at distinct paths and never race when
-/// the test harness runs them in parallel (one test's `Drop` must not delete a
-/// fixture another test is still reading).
+/// Clearly-synthetic symbols, one per test, so a fixture is always read back
+/// from the file the same test wrote.
 const FIXTURE_SYMBOL_DIRECT: &str = "GRQVTEST265A";
 const FIXTURE_SYMBOL_WRAPPER: &str = "GRQVTEST265B";
 
@@ -30,138 +27,27 @@ const FIXTURE_SYMBOL_WRAPPER: &str = "GRQVTEST265B";
 /// `2025-04-15` to `2025-10-12` inclusive.
 const SCORE_DATE: &str = "2025-04-15";
 
-/// RAII guard that installs a market-data fixture for a given symbol under the
-/// caller-supplied market-data root and removes exactly what it created on
-/// drop, so the test leaves no trace whether or not the data tree pre-exists.
-struct MarketDataFixture {
-    json_path: PathBuf,
-    /// The outermost directory this guard created (and must remove on drop), or
-    /// `None` when the whole tree already existed.
-    created_root: Option<PathBuf>,
-}
-
-impl MarketDataFixture {
-    /// Writes a fixture for `symbol` whose daily series contains one row inside
-    /// the 180-day window, one row before it, and one row after it, so a test
-    /// can assert both inclusion and exclusion.
-    fn install(symbol: &str) -> Result<Self> {
-        let base = market_data_root()?;
-        let first_letter = symbol.chars().next().unwrap().to_string();
-        let symbol_dir = base.join("data").join(&first_letter);
-
-        // Track the outermost component we create so cleanup removes no more
-        // than the test added.
-        let created_root = first_missing_ancestor(&symbol_dir);
-        std::fs::create_dir_all(&symbol_dir)?;
-
-        let json_path = symbol_dir.join(format!("{symbol}.json"));
-        std::fs::write(&json_path, fixture_json(symbol))?;
-
-        Ok(Self {
-            json_path,
-            created_root,
-        })
-    }
-}
-
-impl Drop for MarketDataFixture {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.json_path);
-
-        // Prune the directories we created, bottom-up, removing each only when
-        // it is empty. `remove_dir` (not `remove_dir_all`) means a directory
-        // shared with a concurrently-running test's fixture is left intact
-        // until that test has cleaned up too, so cleanup never races.
-        if let Some(root) = &self.created_root {
-            let mut dir = self.json_path.parent().map(Path::to_path_buf);
-            while let Some(current) = dir {
-                if std::fs::remove_dir(&current).is_err() {
-                    break; // non-empty (another fixture present) or already gone
-                }
-                if current == *root {
-                    break;
-                }
-                dir = current.parent().map(Path::to_path_buf);
-            }
-        }
-    }
-}
-
-/// Returns `true` when a market-data root is configured, otherwise prints a
-/// skip line for `test_name` and returns `false` (issue #802).
-fn market_data_root_configured(test_name: &str) -> bool {
-    match market_data_root() {
-        Ok(_) => true,
-        Err(error) => {
-            println!("Skipping {test_name}: {error}");
-            false
-        }
-    }
-}
-
-/// Returns the shallowest ancestor of `dir` (including `dir` itself) that does
-/// not yet exist, i.e. the outermost directory `create_dir_all` would create.
-/// Returns `None` when `dir` already exists.
-fn first_missing_ancestor(dir: &Path) -> Option<PathBuf> {
-    if dir.exists() {
-        return None;
-    }
-    let mut candidate = dir.to_path_buf();
-    while let Some(parent) = candidate.parent() {
-        if parent.exists() {
-            return Some(candidate);
-        }
-        candidate = parent.to_path_buf();
-    }
-    Some(candidate)
-}
-
-/// Builds an Alpha Vantage-shaped market-data JSON document with three dated
-/// rows: before, inside, and after the 180-day window from [`SCORE_DATE`].
-fn fixture_json(symbol: &str) -> String {
-    fn daily(close: &str) -> serde_json::Value {
-        serde_json::json!({
-            "1. open": close,
-            "2. high": close,
-            "3. low": close,
-            "4. close": close,
-            "5. adjusted close": close,
-            "6. volume": "1000",
-            "7. dividend amount": "0.0",
-            "8. split coefficient": "1.0",
-        })
-    }
-
-    serde_json::json!({
-        "Meta Data": {
-            "1. Information": "Daily Prices (fixture)",
-            "2. Symbol": symbol,
-            "3. Last Refreshed": "2025-10-12",
-            "4. Output Size": "Full size",
-            "5. Time Zone": "US/Eastern",
-        },
-        "Time Series (Daily)": {
-            "2024-01-01": daily("11.11"), // before the window -> excluded
-            "2025-04-15": daily("100.5"), // window start (inclusive) -> included
-            "2025-12-01": daily("99.99"), // after the window -> excluded
-        },
-    })
-    .to_string()
+/// Three hand-written daily rows: before, inside, and after the 180-day window
+/// from [`SCORE_DATE`], so a test can assert both inclusion and exclusion.
+fn fixture_points() -> Vec<PricePoint<'static>> {
+    vec![
+        PricePoint::flat("2024-01-01", "11.11"), // before the window -> excluded
+        PricePoint::flat("2025-04-15", "100.5"), // window start (inclusive) -> included
+        PricePoint::flat("2025-12-01", "99.99"), // after the window -> excluded
+    ]
 }
 
 #[test]
 fn create_market_data_csv_writes_windowed_rows() -> Result<()> {
-    if !market_data_root_configured("create_market_data_csv_writes_windowed_rows") {
-        return Ok(());
-    }
-    let _fixture = MarketDataFixture::install(FIXTURE_SYMBOL_DIRECT)?;
+    let root = tempfile::tempdir()?;
+    write_market_data(root.path(), FIXTURE_SYMBOL_DIRECT, &fixture_points())?;
 
     let out_dir = tempfile::tempdir()?;
     let out_path = out_dir.path().join("md.csv");
     let out = out_path.to_str().expect("temp path is valid UTF-8");
 
     create_market_data_csv(
-        &market_data_root()?,
+        root.path(),
         &[FIXTURE_SYMBOL_DIRECT.to_string()],
         SCORE_DATE,
         out,
@@ -197,10 +83,8 @@ fn create_market_data_csv_writes_windowed_rows() -> Result<()> {
 
 #[test]
 fn create_market_data_csv_for_score_file_writes_derived_csv() -> Result<()> {
-    if !market_data_root_configured("create_market_data_csv_for_score_file_writes_derived_csv") {
-        return Ok(());
-    }
-    let _fixture = MarketDataFixture::install(FIXTURE_SYMBOL_WRAPPER)?;
+    let root = tempfile::tempdir()?;
+    write_market_data(root.path(), FIXTURE_SYMBOL_WRAPPER, &fixture_points())?;
 
     // The wrapper derives the output path by swapping the score file's
     // extension to `.csv` in the same directory.
@@ -210,7 +94,7 @@ fn create_market_data_csv_for_score_file_writes_derived_csv() -> Result<()> {
     let score_file_str = score_file.to_str().expect("temp path is valid UTF-8");
 
     create_market_data_csv_for_score_file(
-        &market_data_root()?,
+        root.path(),
         score_file_str,
         &[FIXTURE_SYMBOL_WRAPPER.to_string()],
         SCORE_DATE,

--- a/tests/create_market_data_long_csv_test.rs
+++ b/tests/create_market_data_long_csv_test.rs
@@ -1,38 +1,31 @@
 //! Behaviour tests for `create_market_data_long_csv` (issue #634).
 //!
-//! The long-format market-data writer previously had no unconditional test:
-//! its only test-adjacent reference (`create_market_data_long_csv_for_score_file`
-//! in `tests/market_data_tests.rs`) early-returns unless an external
-//! share-price repository exists, so on CI and most machines it never runs. These tests drop a small, fully controlled market-data fixture
-//! at the location the function reads from and assert the observable contract —
-//! the 8-column `date,ticker,high,low,open,close,split_coefficient,volume`
-//! output and the "no rows written → error" guard — without caring how the
-//! writer is implemented. They mirror `tests/create_market_data_csv_test.rs`.
+//! Each test builds a small, fully controlled market-data fixture inside its
+//! own `tempfile::tempdir()` root and asserts the observable contract — the
+//! 8-column `date,ticker,high,low,open,close,split_coefficient,volume` output
+//! and the "no rows written → error" guard — without caring how the writer is
+//! implemented. They mirror `tests/create_market_data_csv_test.rs`.
 //!
-//! The fixtures live under the caller-supplied market-data root (issue #802),
-//! so each test skips when `GRQ_MARKET_DATA_PATH` is unset. Making them
-//! hermetic against a temporary root is tracked separately.
+//! The fixtures are synthetic and hermetic (issue #804): every read and write
+//! stays inside the test's temporary directory, so the tests run identically on
+//! CI and on a maintainer's machine and never touch a configured data root.
+
+mod common;
 
 use anyhow::Result;
-use grq_validation::utils::{create_market_data_long_csv, market_data_root};
-use std::path::{Path, PathBuf};
+use common::{write_market_data, PricePoint};
+use grq_validation::utils::create_market_data_long_csv;
+use std::path::Path;
 
-/// Clearly-synthetic symbol so a fixture can never collide with a real symbol
-/// in an existing market-data repository.
-///
-/// Each fixture-installing test uses a *distinct* symbol so their fixture files
-/// never share a path: cargo runs tests in parallel by default, and a shared
-/// symbol meant one test's `Drop` could delete the JSON file out from under a
-/// concurrently-running test, leaving it with zero rows and a spurious "No
-/// market data rows written" failure.
+/// Clearly-synthetic symbol for the happy-path test. Each fixture-installing
+/// test uses a *distinct* symbol under its own temporary root.
 const FIXTURE_SYMBOL: &str = "GRQVTEST634A";
 
 /// Full ticker code as it appears in a scores file. The long writer keeps the
 /// whole code (exchange prefix included) in the `ticker` column.
 const FIXTURE_TICKER: &str = "NYSE:GRQVTEST634A";
 
-/// Distinct fixture symbol for the replacement test, so its fixture file never
-/// collides with [`FIXTURE_SYMBOL`]'s under parallel execution.
+/// Distinct fixture symbol for the replacement test.
 const FIXTURE_SYMBOL_REPLACE: &str = "GRQVTEST634B";
 
 /// Full ticker code for the replacement test's fixture symbol.
@@ -42,152 +35,31 @@ const FIXTURE_TICKER_REPLACE: &str = "NYSE:GRQVTEST634B";
 /// runs from `2025-04-15` to `2025-10-12` inclusive.
 const SCORE_DATE: &str = "2025-04-15";
 
-/// RAII guard that installs a market-data fixture for a given symbol under the
-/// caller-supplied market-data root and removes exactly what it created on
-/// drop, so the test leaves no trace whether or not the data tree pre-exists.
-struct MarketDataFixture {
-    json_path: PathBuf,
-    /// The outermost directory this guard created (and must remove on drop), or
-    /// `None` when the whole tree already existed.
-    created_root: Option<PathBuf>,
-}
-
-impl MarketDataFixture {
-    /// Writes a fixture for `symbol` whose daily series contains one row inside
-    /// the 180-day window, one row before it, and one row after it, so a test
-    /// can assert both inclusion and exclusion.
-    fn install(symbol: &str) -> Result<Self> {
-        let base = market_data_root()?;
-        let first_letter = symbol.chars().next().unwrap().to_string();
-        let symbol_dir = base.join("data").join(&first_letter);
-
-        let created_root = first_missing_ancestor(&symbol_dir);
-        std::fs::create_dir_all(&symbol_dir)?;
-
-        let json_path = symbol_dir.join(format!("{symbol}.json"));
-        std::fs::write(&json_path, fixture_json(symbol))?;
-
-        Ok(Self {
-            json_path,
-            created_root,
-        })
-    }
-}
-
-impl Drop for MarketDataFixture {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.json_path);
-
-        // Prune the directories we created, bottom-up, removing each only when
-        // it is empty. `remove_dir` (not `remove_dir_all`) means a directory
-        // shared with a concurrently-running test's fixture is left intact
-        // until that test has cleaned up too, so cleanup never races.
-        if let Some(root) = &self.created_root {
-            let mut dir = self.json_path.parent().map(Path::to_path_buf);
-            while let Some(current) = dir {
-                if std::fs::remove_dir(&current).is_err() {
-                    break; // non-empty (another fixture present) or already gone
-                }
-                if current == *root {
-                    break;
-                }
-                dir = current.parent().map(Path::to_path_buf);
-            }
-        }
-    }
-}
-
-/// Returns `true` when a market-data root is configured, otherwise prints a
-/// skip line for `test_name` and returns `false` (issue #802).
-fn market_data_root_configured(test_name: &str) -> bool {
-    match market_data_root() {
-        Ok(_) => true,
-        Err(error) => {
-            println!("Skipping {test_name}: {error}");
-            false
-        }
-    }
-}
-
-/// Returns the shallowest ancestor of `dir` (including `dir` itself) that does
-/// not yet exist, i.e. the outermost directory `create_dir_all` would create.
-/// Returns `None` when `dir` already exists.
-fn first_missing_ancestor(dir: &Path) -> Option<PathBuf> {
-    if dir.exists() {
-        return None;
-    }
-    let mut candidate = dir.to_path_buf();
-    while let Some(parent) = candidate.parent() {
-        if parent.exists() {
-            return Some(candidate);
-        }
-        candidate = parent.to_path_buf();
-    }
-    Some(candidate)
-}
-
-/// Builds an Alpha Vantage-shaped market-data JSON document with three dated
-/// rows: before, inside, and after the 180-day window from [`SCORE_DATE`]. The
-/// in-window row uses distinct open/high/low/close/volume/split values so a
-/// test can verify each long-format column is mapped to the right field.
-fn fixture_json(symbol: &str) -> String {
-    fn daily(
-        open: &str,
-        high: &str,
-        low: &str,
-        close: &str,
-        volume: &str,
-        split: &str,
-    ) -> serde_json::Value {
-        serde_json::json!({
-            "1. open": open,
-            "2. high": high,
-            "3. low": low,
-            "4. close": close,
-            "5. adjusted close": close,
-            "6. volume": volume,
-            "7. dividend amount": "0.0",
-            "8. split coefficient": split,
-        })
-    }
-
-    serde_json::json!({
-        "Meta Data": {
-            "1. Information": "Daily Prices (fixture)",
-            "2. Symbol": symbol,
-            "3. Last Refreshed": "2025-10-12",
-            "4. Output Size": "Full size",
-            "5. Time Zone": "US/Eastern",
-        },
-        "Time Series (Daily)": {
-            // before the window -> excluded
-            "2024-01-01": daily("1.0", "1.0", "1.0", "1.0", "10", "1.0"),
-            // window start (inclusive) -> included, with distinct columns
-            "2025-04-15": daily("100.5", "105.25", "98.75", "102.0", "123456", "1.0"),
-            // after the window -> excluded
-            "2025-12-01": daily("9.0", "9.0", "9.0", "9.0", "20", "1.0"),
-        },
-    })
-    .to_string()
+/// Three hand-written daily rows: before, inside, and after the 180-day window
+/// from [`SCORE_DATE`]. The in-window row uses distinct
+/// open/high/low/close/volume values so a test can verify each long-format
+/// column is mapped to the right field.
+fn fixture_points() -> Vec<PricePoint<'static>> {
+    vec![
+        // before the window -> excluded
+        PricePoint::detailed("2024-01-01", "1.0", "1.0", "1.0", "1.0", "10"),
+        // window start (inclusive) -> included, with distinct columns
+        PricePoint::detailed("2025-04-15", "100.5", "105.25", "98.75", "102.0", "123456"),
+        // after the window -> excluded
+        PricePoint::detailed("2025-12-01", "9.0", "9.0", "9.0", "9.0", "20"),
+    ]
 }
 
 #[test]
 fn create_market_data_long_csv_writes_eight_column_rows() -> Result<()> {
-    if !market_data_root_configured("create_market_data_long_csv_writes_eight_column_rows") {
-        return Ok(());
-    }
-    let _fixture = MarketDataFixture::install(FIXTURE_SYMBOL)?;
+    let root = tempfile::tempdir()?;
+    write_market_data(root.path(), FIXTURE_SYMBOL, &fixture_points())?;
 
     let out_dir = tempfile::tempdir()?;
     let out_path = out_dir.path().join("long.csv");
     let out = out_path.to_str().expect("temp path is valid UTF-8");
 
-    create_market_data_long_csv(
-        &market_data_root()?,
-        &[FIXTURE_TICKER.to_string()],
-        SCORE_DATE,
-        out,
-    )?;
+    create_market_data_long_csv(root.path(), &[FIXTURE_TICKER.to_string()], SCORE_DATE, out)?;
 
     let csv = std::fs::read_to_string(&out_path)?;
 
@@ -222,19 +94,17 @@ fn create_market_data_long_csv_writes_eight_column_rows() -> Result<()> {
 
 #[test]
 fn create_market_data_long_csv_errors_when_all_tickers_skipped() -> Result<()> {
-    if !market_data_root_configured("create_market_data_long_csv_errors_when_all_tickers_skipped") {
-        return Ok(());
-    }
-    // No fixture installed: the symbol has no market-data file, so the only
+    // An empty fixture root: the symbol has no market-data file, so the only
     // ticker is skipped and no data rows are written. The documented guard at
     // `src/utils.rs` must turn this into an error rather than a silent
-    // header-only CSV. A synthetic symbol guarantees no real data file exists.
+    // header-only CSV.
+    let root = tempfile::tempdir()?;
     let out_dir = tempfile::tempdir()?;
     let out_path = out_dir.path().join("empty.csv");
     let out = out_path.to_str().expect("temp path is valid UTF-8");
 
     let result = create_market_data_long_csv(
-        &market_data_root()?,
+        root.path(),
         &["NYSE:GRQVTEST634MISSING".to_string()],
         SCORE_DATE,
         out,
@@ -250,17 +120,13 @@ fn create_market_data_long_csv_errors_when_all_tickers_skipped() -> Result<()> {
 
 #[test]
 fn create_market_data_long_csv_preserves_existing_rows_when_no_fresh_data() -> Result<()> {
-    if !market_data_root_configured(
-        "create_market_data_long_csv_preserves_existing_rows_when_no_fresh_data",
-    ) {
-        return Ok(());
-    }
     // Regression for issue #687 (recurrences #672/#674/#685): when the upstream
     // share-price data is unavailable for a date, the writer must NOT clobber an
     // already-populated CSV with a bare header row. The external scorer pipeline
     // runs this generator and commits its output straight to `main`, so a
     // destructive truncation here wipes the dashboard's market data and forces
     // "Limited data mode".
+    let root = tempfile::tempdir()?;
     let out_dir = tempfile::tempdir()?;
     let out_path = out_dir.path().join("populated.csv");
     let out = out_path.to_str().expect("temp path is valid UTF-8");
@@ -270,9 +136,9 @@ fn create_market_data_long_csv_preserves_existing_rows_when_no_fresh_data() -> R
         2026-04-02,NYSE:GRQVTEST687,10.0,9.0,9.5,9.8,1.0,1000\n";
     std::fs::write(&out_path, existing)?;
 
-    // No fixture installed -> the only ticker is skipped -> zero rows written.
+    // Empty fixture root -> the only ticker is skipped -> zero rows written.
     let result = create_market_data_long_csv(
-        &market_data_root()?,
+        root.path(),
         &["NYSE:GRQVTEST687MISSING".to_string()],
         SCORE_DATE,
         out,
@@ -302,15 +168,11 @@ fn create_market_data_long_csv_preserves_existing_rows_when_no_fresh_data() -> R
 
 #[test]
 fn create_market_data_long_csv_replaces_existing_when_fresh_data_available() -> Result<()> {
-    if !market_data_root_configured(
-        "create_market_data_long_csv_replaces_existing_when_fresh_data_available",
-    ) {
-        return Ok(());
-    }
     // Complement to the preservation test: when fresh data IS available, the
     // destination is replaced atomically with the new content — no stale rows
     // and no leftover temp file (issue #687).
-    let _fixture = MarketDataFixture::install(FIXTURE_SYMBOL_REPLACE)?;
+    let root = tempfile::tempdir()?;
+    write_market_data(root.path(), FIXTURE_SYMBOL_REPLACE, &fixture_points())?;
 
     let out_dir = tempfile::tempdir()?;
     let out_path = out_dir.path().join("replace.csv");
@@ -320,7 +182,7 @@ fn create_market_data_long_csv_replaces_existing_when_fresh_data_available() -> 
     std::fs::write(&out_path, "stale,garbage\n1,2\n")?;
 
     create_market_data_long_csv(
-        &market_data_root()?,
+        root.path(),
         &[FIXTURE_TICKER_REPLACE.to_string()],
         SCORE_DATE,
         out,

--- a/tests/dividend_tests.rs
+++ b/tests/dividend_tests.rs
@@ -1,49 +1,92 @@
+//! End-to-end test of the score-file → dividend CSV path (issue #804).
+//!
+//! This previously skipped unless the operator's private dividend checkout was
+//! present and, when it was, wrote `docs/scores/2025/March/5-dividends.csv` into
+//! the committed tree from real private data. It now builds a synthetic score
+//! file and a synthetic dividend tree inside its own temporary directory, so it
+//! runs everywhere, asserts for real, and leaves the working tree untouched.
+
+mod common;
+
 use anyhow::Result;
+use common::{write_dividend_data, write_score_file};
 use grq_validation::utils::{
-    create_dividend_csv_for_score_file, dividend_data_root, extract_ticker_codes_from_score_file,
+    create_dividend_csv_for_score_file, extract_ticker_codes_from_score_file,
 };
+
+/// Synthetic tickers: the first pays dividends inside the window, the second
+/// has no dividend file at all — a missing symbol must be skipped, not fatal.
+const PAYING_TICKER: &str = "NYSE:GRQVTEST804D";
+const SILENT_TICKER: &str = "NYSE:GRQVTEST804N";
+
+/// The March 5 date the original test used; the dividend window therefore runs
+/// from `2025-03-05` to `2025-09-01` inclusive.
+const SCORE_DATE: &str = "2025-03-05";
 
 #[test]
 fn test_create_dividend_csv_for_first_score_file() -> Result<()> {
-    // Skip test if the caller-supplied dividend root is unset or absent
-    // (issue #802).
-    let dividend_root = match dividend_data_root() {
-        Ok(root) if root.exists() => root,
-        _ => {
-            println!("Skipping test_create_dividend_csv_for_first_score_file: external data repository not available");
-            return Ok(());
-        }
-    };
+    let workspace = tempfile::tempdir()?;
+    let dividend_root = tempfile::tempdir()?;
 
-    // Test with the March 5 score file which is older and should have dividends
-    let score_file_path = "docs/scores/2025/March/5.tsv";
-    let score_file_date = "2025-03-05";
+    // The wrapper derives `<dir>/5-dividends.csv` from the score file, so a
+    // score file inside the temp workspace keeps the output there too.
+    let score_file = write_score_file(
+        &workspace.path().join("5.tsv"),
+        &[PAYING_TICKER, SILENT_TICKER],
+    )?;
+    let score_file_path = score_file.to_str().expect("temp path is valid UTF-8");
 
-    // Extract ticker codes from the score file
-    let ticker_codes = extract_ticker_codes_from_score_file(score_file_path)?;
-    println!(
-        "Found {} ticker codes: {:?}",
-        ticker_codes.len(),
-        ticker_codes
-    );
-
-    // Create dividend CSV
-    create_dividend_csv_for_score_file(
-        &dividend_root,
-        score_file_path,
-        &ticker_codes,
-        score_file_date,
+    // Two events inside the 180-day window and one after it, so the CSV proves
+    // both dividend presence and the window filter.
+    write_dividend_data(
+        dividend_root.path(),
+        "GRQVTEST804D",
+        &[
+            ("2025-03-20", "0.09375"),
+            ("2025-06-20", "0.10"),
+            ("2025-12-01", "0.25"), // after the window -> excluded
+        ],
     )?;
 
-    // Verify the dividend file was created
-    let dividend_output_path = "docs/scores/2025/March/5-dividends.csv";
-    let content = std::fs::read_to_string(dividend_output_path)?;
+    let ticker_codes = extract_ticker_codes_from_score_file(score_file_path)?;
+    assert_eq!(ticker_codes, vec![PAYING_TICKER, SILENT_TICKER]);
+
+    create_dividend_csv_for_score_file(
+        dividend_root.path(),
+        score_file_path,
+        &ticker_codes,
+        SCORE_DATE,
+    )?;
+
+    let dividend_output_path = workspace.path().join("5-dividends.csv");
+    let content = std::fs::read_to_string(&dividend_output_path)?;
     assert!(!content.is_empty());
     assert!(content.contains("date,symbol,amount"));
 
-    // Check if we have any dividend data (SEM should have dividends)
     let lines: Vec<&str> = content.lines().collect();
     assert!(lines.len() > 1, "Should have at least header and some data");
+
+    // Dividend presence: both in-window events, keyed by the full ticker code.
+    assert!(
+        content.contains(&format!("2025-03-20,{PAYING_TICKER},0.09375")),
+        "expected the first in-window dividend in:\n{content}"
+    );
+    assert!(
+        content.contains(&format!("2025-06-20,{PAYING_TICKER},0.1")),
+        "expected the second in-window dividend in:\n{content}"
+    );
+
+    // The out-of-window event is filtered, and a symbol with no dividend file
+    // is skipped rather than failing the run.
+    assert!(
+        !content.contains("2025-12-01"),
+        "dividend after the window must be excluded in:\n{content}"
+    );
+    assert_eq!(
+        lines.len(),
+        3,
+        "expected the header plus exactly the two in-window dividends in:\n{content}"
+    );
 
     Ok(())
 }

--- a/tests/hermetic_test_gate_test.ts
+++ b/tests/hermetic_test_gate_test.ts
@@ -1,0 +1,75 @@
+// Wiring tests for the hermetic-test gate (Issue #804).
+//
+// The four market-data/dividend integration tests used to read — and in two
+// cases write — the operator's private data checkout, and skipped silently
+// everywhere else. `scripts/check_hermetic_tests.sh` is the gate that keeps
+// them synthetic: it runs them with no data root configured and fails on a
+// skip, a private-tree reference, or a dirtied working tree. These tests assert
+// the gate exists and that CI actually runs it, so the guarantee is enforced by
+// the build rather than by reviewer memory.
+
+import { assert, assertEquals } from "@std/assert";
+import { parse as parseYaml } from "@std/yaml";
+
+const GATE_SCRIPT = "scripts/check_hermetic_tests.sh";
+const WORKFLOW_PATH = ".github/workflows/ci.yml";
+
+// The markers the gate greps for, split so this file — which lives under
+// `tests/` — never matches the very grep it is describing.
+const PRIVATE_TREE_MARKERS = [
+  "GRQ-share" + "prices",
+  "GRQ-divid" + "ends",
+  "MARKET_DATA_BASE" + "_PATH",
+  "DIVIDEND_DATA_BASE" + "_PATH",
+];
+
+type WorkflowStep = { name?: string; run?: string; uses?: string };
+type Workflow = {
+  jobs: Record<string, { steps?: WorkflowStep[] }>;
+};
+
+async function readWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(WORKFLOW_PATH);
+  return parseYaml(text) as Workflow;
+}
+
+Deno.test("hermetic-test gate script exists and is executable", async () => {
+  const stat = await Deno.stat(GATE_SCRIPT);
+  assert(stat.isFile, `${GATE_SCRIPT} should be a file`);
+  // Owner-execute bit, so CI and quality.sh can invoke it directly.
+  assert(
+    (stat.mode ?? 0) & 0o100,
+    `${GATE_SCRIPT} should be executable`,
+  );
+});
+
+Deno.test("hermetic-test gate rejects every private data-tree marker", async () => {
+  const script = await Deno.readTextFile(GATE_SCRIPT);
+  for (const marker of PRIVATE_TREE_MARKERS) {
+    assert(
+      script.includes(marker),
+      `${GATE_SCRIPT} should reject the ${marker} marker`,
+    );
+  }
+});
+
+Deno.test("hermetic-test gate checks the tests left the working tree clean", async () => {
+  const script = await Deno.readTextFile(GATE_SCRIPT);
+  assert(
+    script.includes("git status --porcelain"),
+    `${GATE_SCRIPT} should compare git status before and after the test run`,
+  );
+});
+
+Deno.test("CI runs the hermetic-test gate in the Rust test job", async () => {
+  const workflow = await readWorkflow();
+  const steps = workflow.jobs?.test?.steps ?? [];
+  const gateSteps = steps.filter((step) =>
+    (step.run ?? "").includes(GATE_SCRIPT)
+  );
+  assertEquals(
+    gateSteps.length,
+    1,
+    `the ci.yml test job should run ${GATE_SCRIPT} exactly once`,
+  );
+});

--- a/tests/market_data_tests.rs
+++ b/tests/market_data_tests.rs
@@ -1,100 +1,109 @@
+//! End-to-end test of the score-file → market-data CSV path (issue #804).
+//!
+//! This was a best-effort smoke test against the operator's private share-price
+//! checkout: it skipped unless that tree happened to hold a data file for one of
+//! the committed score file's tickers, so on CI and any public checkout it never
+//! asserted anything. It now builds a synthetic score file and a synthetic
+//! market-data tree inside its own temporary directories, so it runs everywhere
+//! and genuinely covers ticker extraction, per-ticker path resolution, and the
+//! long-format writer's score-file wrapper.
+
+mod common;
+
 use anyhow::Result;
+use common::{write_market_data, write_score_file, PricePoint};
 use grq_validation::utils::{
     create_market_data_long_csv_for_score_file, extract_symbol_from_ticker,
-    extract_ticker_codes_from_score_file, get_market_data_path, market_data_root,
+    extract_ticker_codes_from_score_file, get_market_data_path_in,
 };
+use std::path::Path;
 
-/// Best-effort smoke test against the external share-price repository. It only
-/// asserts when real market data for this score file's date is genuinely
-/// present; otherwise it skips.
-///
-/// The guard must NOT be a bare market-data-root existence check.
-/// Sibling tests (`create_market_data_csv_test.rs`,
-/// `create_market_data_long_csv_test.rs`) drop synthetic fixtures under that
-/// same base directory, so a bare existence check is a shared, mutable sentinel
-/// that another test can transiently satisfy — making this test run against a
-/// directory that exists but holds none of its tickers. Combined with the
-/// non-destructive writer's "no rows written → error" guard (#687), that race
-/// turned this test into an intermittent CI failure. The current share-price
-/// repo also spans a single quarter and need not contain this file's date at
-/// all. We therefore gate on a real data file for one of this file's tickers,
-/// which a synthetic `GRQVTEST…` fixture never creates.
+/// Synthetic tickers, including a dotted code so the `.` → `-` symbol mapping
+/// (`NYSE:GRQVTEST804.A` → `GRQVTEST804-A`) is exercised end to end.
+const TICKERS: [&str; 2] = ["NYSE:GRQVTEST804A", "NYSE:GRQVTEST804.A"];
+
+/// Score-file date; the 180-day window runs from `2025-06-20` to `2025-12-17`.
+const SCORE_DATE: &str = "2025-06-20";
+
 #[test]
 fn test_create_market_data_long_csv_for_first_score_file() -> Result<()> {
-    // The market-data root is caller-supplied (issue #802); without it there is
-    // nothing to smoke-test against, so skip exactly as when the tree is absent.
-    let market_data_root = match market_data_root() {
-        Ok(root) => root,
-        Err(error) => {
-            println!("Skipping test_create_market_data_long_csv_for_first_score_file: {error}");
-            return Ok(());
-        }
-    };
+    let workspace = tempfile::tempdir()?;
+    let market_root = tempfile::tempdir()?;
 
-    let score_file_path = "docs/scores/2025/June/20.tsv";
-    let score_file_date = "2025-06-20";
-    let output_dir = "target/test_output";
+    // A synthetic score file stands in for a committed `docs/scores/**/DD.tsv`,
+    // so the test reads nothing outside its own temporary directory.
+    let score_file = write_score_file(&workspace.path().join("20.tsv"), &TICKERS)?;
+    let score_file_path = score_file.to_str().expect("temp path is valid UTF-8");
 
-    // Extract ticker codes from the score file (the file itself is committed, so
-    // this works regardless of the external repository's availability).
     let ticker_codes = extract_ticker_codes_from_score_file(score_file_path)?;
-
-    // Skip unless the external repository genuinely holds a data file for one of
-    // these tickers. This distinguishes a real clone from an empty or
-    // fixture-polluted base directory.
-    let has_real_data = ticker_codes.iter().any(|ticker| {
-        let symbol = extract_symbol_from_ticker(ticker);
-        get_market_data_path(&symbol)
-            .map(|path| std::path::Path::new(&path).exists())
-            .unwrap_or(false)
-    });
-    if !has_real_data {
-        println!(
-            "Skipping test_create_market_data_long_csv_for_first_score_file: \
-             no market data for this score file's tickers under {root}",
-            root = market_data_root.display()
-        );
-        return Ok(());
-    }
-
-    println!(
-        "Found {} ticker codes: {:?}",
-        ticker_codes.len(),
-        ticker_codes
+    assert_eq!(
+        ticker_codes,
+        TICKERS.map(String::from).to_vec(),
+        "every ticker in the score file must be extracted, in file order"
     );
 
-    // Create output directory if it doesn't exist.
-    std::fs::create_dir_all(output_dir)?;
+    // One in-window fixture per ticker, written at the path the writer resolves.
+    for ticker in &ticker_codes {
+        let symbol = extract_symbol_from_ticker(ticker);
+        write_market_data(
+            market_root.path(),
+            &symbol,
+            &[PricePoint::detailed(
+                SCORE_DATE, "10.10", "10.50", "9.90", "10.25", "123456",
+            )],
+        )?;
+    }
 
-    // Create market data CSV. When the repository holds ticker files but no rows
-    // fall inside this date's 180-day window, the non-destructive writer returns
-    // a "no rows written" error (#687). That means the data is present but not
-    // for this date, so skip rather than fail — the writer's error contract is
-    // covered directly by the fixture-based tests in
-    // `create_market_data_long_csv_test.rs`.
-    let output_path = match create_market_data_long_csv_for_score_file(
-        &market_data_root,
+    // Per-ticker path resolution: each symbol resolves to the bucketed JSON file
+    // just written, under the caller-supplied root and nowhere else.
+    for ticker in &ticker_codes {
+        let symbol = extract_symbol_from_ticker(ticker);
+        let resolved = get_market_data_path_in(market_root.path(), &symbol)?;
+        assert!(
+            Path::new(&resolved).starts_with(market_root.path()),
+            "{symbol} must resolve under the supplied root, got {resolved}"
+        );
+        assert!(
+            Path::new(&resolved).exists(),
+            "expected the fixture for {symbol} at {resolved}"
+        );
+    }
+
+    let output_dir = workspace.path().join("out");
+    std::fs::create_dir_all(&output_dir)?;
+    let output_dir_str = output_dir.to_str().expect("temp path is valid UTF-8");
+
+    let output_path = create_market_data_long_csv_for_score_file(
+        market_root.path(),
         score_file_path,
         &ticker_codes,
-        score_file_date,
-        Some(output_dir),
-    ) {
-        Ok(path) => path,
-        Err(error) => {
-            println!("Skipping test_create_market_data_long_csv_for_first_score_file: {error}");
-            return Ok(());
-        }
-    };
+        SCORE_DATE,
+        Some(output_dir_str),
+    )?;
 
-    println!("Created market data CSV: {output_path}");
+    // The wrapper names the CSV after the score file's stem, inside output_dir.
+    assert_eq!(
+        Path::new(&output_path),
+        output_dir.join("20.csv"),
+        "unexpected derived output path"
+    );
 
-    // Verify the file was created and has content.
     let content = std::fs::read_to_string(&output_path)?;
     assert!(!content.is_empty());
     assert!(content.contains("date,ticker,high,low,open,close"));
 
-    // Clean up.
-    let _ = std::fs::remove_file(&output_path);
+    // A row per ticker, keyed by the full ticker code, plus the header.
+    for ticker in &ticker_codes {
+        assert!(
+            content.contains(&format!("{SCORE_DATE},{ticker},10.50,9.90,10.10,10.25")),
+            "expected a fully-mapped row for {ticker} in:\n{content}"
+        );
+    }
+    assert_eq!(
+        content.lines().count(),
+        TICKERS.len() + 1,
+        "expected one header row plus one row per ticker in:\n{content}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
# PR Summary — Issue #804

## Summary

Makes the four Rust market-data/dividend integration tests hermetic: each now
builds a **synthetic** fixture tree inside its own `tempfile::tempdir()` root
instead of reading — or, in two cases, installing fixtures into — the operator's
private data checkout. The skip guards are gone, so the tests genuinely run and
assert on CI, and `cargo test` no longer rewrites a committed file.
Closes #804.

- **Shared fixture builders** (`tests/common/mod.rs`) — `write_market_data`,
  `write_dividend_data`, and `write_score_file`, all hand-written synthetic
  data. Fixture paths are built through the crate's own
  `get_market_data_path_in` / `get_dividend_data_path_in` cores (#802), so a
  fixture always lands exactly where the code under test looks for it.
- **No skips** — the `market_data_root_configured` guards, the
  presence guard in `tests/market_data_tests.rs`, and the "external data
  repository not available" messages are deleted. With a temp root the data is
  always available.
- **No shared-tree mutation** — the RAII `MarketDataFixture` guards (which
  created and deleted directories inside the operator's live tree) and their
  `first_missing_ancestor` cleanup helper are deleted.
- **Clean working tree** — `tests/dividend_tests.rs` writes beside a synthetic
  score file in its temp dir, so it no longer overwrites the committed
  `docs/scores/2025/March/5-dividends.csv`.
- **Stronger assertions** — `tests/market_data_tests.rs` previously skipped
  everywhere; it now asserts ticker extraction order, per-ticker path resolution
  under the supplied root (including the `NYSE:X.A` → `X-A` mapping), the
  derived output path, and the exact row set.
  `tests/dividend_tests.rs` additionally pins the 180-day window filter and that
  a symbol with no dividend file is skipped rather than fatal.
- **Automated gate** — `scripts/check_hermetic_tests.sh`, run by `quality.sh`
  and by the CI Rust job, runs the four tests with **both root variables unset**
  and fails loud on a skip line, a private data-tree reference under `tests/`,
  a binary that ran zero tests, or a working tree dirtied by the run.

## Evidence

No web interface is involved — this is a test-hermeticity and CI change, so
there is no screenshot. The evidence is the test run itself, executed with no
data root configured and no sibling data directory present.

```text
$ env -u GRQ_MARKET_DATA_PATH -u GRQ_DIVIDEND_DATA_PATH \
      cargo test --all-targets --all-features
...
running 2 tests (create_market_data_csv_test) ...... ok
running 4 tests (create_market_data_long_csv_test) . ok
running 1 test  (dividend_tests) .................... ok
running 1 test  (market_data_tests) ................. ok
test result: ok. 95 passed; 0 failed; 0 ignored   (lib)
exit=0

$ grep -nE '^Skipping |external data repository not available' <test output>
(no matches)

$ git status --porcelain
(empty)

$ grep -rn 'GRQ-shareprices|GRQ-dividends|MARKET_DATA_BASE_PATH|DIVIDEND_DATA_BASE_PATH' tests/
(no matches)

$ ./scripts/check_hermetic_tests.sh
✅ Hermetic integration tests verified.
```

Where the data comes from before and after — what is asserted is unchanged; only
the source of the fixtures moved:

```mermaid
flowchart LR
    subgraph Before
        P["private sibling checkout<br/>(shared, mutable)"] --> B1["fixture installed<br/>in the live tree"]
        B1 --> B2{"root configured?"}
        B2 -- no --> B3["println! skip<br/>(green, asserts nothing)"]
        B2 -- yes --> B4["assert + delete fixture<br/>+ write into docs/scores/"]
    end
    subgraph After
        C["tests/common/mod.rs<br/>synthetic fixtures"] --> A1["tempfile::tempdir()<br/>&lt;temp&gt;/data/&lt;LETTER&gt;/&lt;SYM&gt;.json"]
        A1 --> A2["writers under test<br/>(root passed as a parameter)"]
        A2 --> A3["CSV written inside the temp dir"]
        A3 --> A4{{"check_hermetic_tests.sh"}}
        A4 -- "skip / private ref / dirty tree" --> A5["CI fails loud"]
        A4 -- clean --> A6[green]
    end
```

## Test Plan

Rewritten (same assertions, hermetic fixtures):

- `tests/create_market_data_csv_test.rs` — `date,symbol,close` header and the
  inclusive 180-day window, direct writer and score-file wrapper.
- `tests/create_market_data_long_csv_test.rs` — the 8-column header, per-column
  field mapping, the "no rows written → error" guard, and the #687
  preserve/replace atomic-write behaviour.
- `tests/market_data_tests.rs` — ticker extraction, per-ticker path resolution
  under the supplied root, derived output path, and the exact row set.
- `tests/dividend_tests.rs` — `date,symbol,amount` header, dividend presence,
  row count, window filter, and missing-symbol tolerance; output lands in the
  temp dir.

Added:

- `tests/common/mod.rs` — shared synthetic fixture builders.
- `tests/hermetic_test_gate_test.ts` — asserts the gate script exists, is
  executable, rejects every private data-tree marker, compares
  `git status --porcelain` around the run, and is wired into the `ci.yml` test
  job exactly once.
- `scripts/check_hermetic_tests.sh` — the gate itself.

Full `./quality.sh` passes (fmt, clippy `-D warnings`, check, `cargo test`, the
new hermetic gate, tarpaulin, release build, and the 1416-test Deno suite).



## Milestone
This PR is part of the **#780 🟠 Remove hard-coded private sibling checkout paths ../GRQ-shareprices2026Q2 and ../GRQ-dividends** milestone and targets the `milestone/780-remove-hard-coded-private-sibling-checkout-pat` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms7ls4et-0a85de`<!-- vibe-worker-issue-804 -->