### PR TITLE
bug: analysis-sync skips hundreds of tickers — "Date is empty" WARN flood (Issue #819)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "grq-validation"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grq-validation"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 authors = ["Nigel Leck nigel@stsoftware.com.au"]
 description = "A Rust program to process daily stock scores from TSV files"

--- a/docs/archive/pr-summaries/pr-summary-819.md
+++ b/docs/archive/pr-summaries/pr-summary-819.md
@@ -1,0 +1,103 @@
+# Fix analysis-sync "Date is empty" WARN flood and silent success
+
+## Summary
+
+The `[WARN] Skipping <ticker> due to invalid Date '': Date is empty` flood in
+`GRQ-3-scorer.log` does not originate in GRQ-validation — it comes from the
+`analysis-sync` binary in **stSoftwareAU/GRQ-actual**, invoked by
+`stSoftwareAU/GRQ` `worker/score_client.sh` with the primary
+`GRQ-portfolio/best/.analysis.csv`. The fix was therefore made where the root
+cause lives (per the cross-repo root-cause rule) and is documented here.
+Closes #819.
+
+### Root cause
+
+`analysis-sync/src/csv_loader.rs` dropped every source row whose `Date` column
+would not parse, logging one `warn!` per row, and returned the (empty) row set
+as a normal success. `main.rs` then produced
+`analysis-sync completed: 1 spreadsheet(s), total updated 0, appended 0` and
+exited **0**. A feed with an entirely blank `Date` column — or a parser that
+stopped recognising the column — was therefore indistinguishable from "nothing
+needed updating". A second fail-loud violation sat alongside it: per-spreadsheet
+sync errors were logged with `error!` and then swallowed, so a run in which
+every target failed still exited 0.
+
+Whether the blank dates are an upstream feed fault or a parser regression cannot
+be determined from the log alone (the Analysis sheet is not reachable from this
+run). The fix makes the next occurrence self-diagnosing and non-silent rather
+than guessing between the two.
+
+### Change (in stSoftwareAU/GRQ-actual, branch `fix/analysis-sync-fail-loud-819`)
+
+- `csv_loader` returns a `SourceLoad` (usable rows, `data_rows`,
+  `skipped_invalid_date`, sample stocks). Per-row detail moved to `debug!`; one
+  `warn!` summarises the skipped count, the resolved `Date` column index, and
+  sample tickers — hundreds of lines become one.
+- New `source_health::assert_source_usable` exits non-zero **before any
+  spreadsheet is touched** when the CSV has no data rows, or when every data row
+  was skipped for an unparsable `Date`.
+- `main::assert_all_targets_synced` makes a failed spreadsheet sync a non-zero
+  exit instead of a logged-and-ignored error.
+- A partially skipped feed still syncs — only a feed with nothing usable is a
+  hard failure.
+- `analysis-sync` version bumped 0.2.13 → 0.2.14; README documents the failure
+  behaviour.
+
+```mermaid
+flowchart TD
+    A[Load .analysis.csv] --> B{Any data rows?}
+    B -- no --> F[Exit 1: empty feed]
+    B -- yes --> C{Any row with a usable Date?}
+    C -- no --> G["Exit 1: every row skipped<br/>(was: exit 0, updated 0)"]
+    C -- yes --> D[Sync each target spreadsheet]
+    D --> E{Any target failed?}
+    E -- yes --> H["Exit 1: names failed spreadsheets<br/>(was: exit 0)"]
+    E -- no --> I[Exit 0]
+```
+
+## Evidence
+
+No web interface is involved — `analysis-sync` is a CLI. Evidence is the
+released binary's behaviour on a CSV that reproduces the logged fault (three
+rows, all with an empty `Date`):
+
+```text
+$ analysis-sync --spreadsheet-id demo --analysis-csv /tmp/empty-dates.csv
+[WARN ] Skipped 3 of 3 row(s) in /tmp/empty-dates.csv: Date column (header index 1) did not parse; e.g. NYSE:USAC, NASDAQ:SWBI, NYSE:INN
+Error: Source analysis CSV /tmp/empty-dates.csv yielded 0 usable rows out of 3 data row(s): every row was skipped for an unparsable Date (e.g. NYSE:USAC, NASDAQ:SWBI, NYSE:INN). Check whether the Analysis sheet's Date column is populated (feed fault) or has changed format (parser fault).
+exit=1
+```
+
+Before the change the same input produced three `[WARN] Skipping …` lines,
+`total updated 0`, and exit 0. A partially skipped feed still proceeds past the
+gate (verified with a two-row CSV where one date parses).
+
+`./quality.sh` in GRQ-actual passes cleanly (fmt, clippy `-D warnings`, check,
+34 `analysis-sync` tests, doc build, release build).
+
+## Test Plan
+
+Added in `stSoftwareAU/GRQ-actual`:
+
+- `csv_loader::tests::load_source_analysis_csv_counts_rows_skipped_for_empty_dates`
+  — regression test reproducing the logged fault: three rows with blank dates
+  yield zero usable rows, `data_rows == 3`, `skipped_invalid_date == 3`.
+- `csv_loader::tests::load_source_analysis_csv_reports_zero_data_rows_for_header_only_csv`
+- `source_health::tests::errors_when_every_data_row_was_skipped` — fails against
+  the unfixed code, which returned success.
+- `source_health::tests::errors_when_csv_has_no_data_rows`
+- `source_health::tests::accepts_a_load_with_usable_rows` — a partial skip must
+  not fail.
+- `tests::assert_all_targets_synced_errors_and_names_failed_spreadsheets` and
+  `tests::assert_all_targets_synced_is_ok_when_nothing_failed`.
+
+Existing `analysis-sync` tests were updated only for the new `SourceLoad` return
+type; none were removed or disabled.
+
+## Remaining human step
+
+This run could not open the pull request in `stSoftwareAU/GRQ-actual` — the
+worker's write allowlist is limited to `stSoftwareAU/GRQ-validation`. The branch
+`fix/analysis-sync-fail-loud-819` is **pushed** and ready; a human needs to open
+and merge it against `Develop`, then redeploy the scorer host. See the
+`needs-human` comment on #819.

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.90">
+    <meta name="app-version" content="1.1.91">
     <meta name="app-title" content="GRQ Validation Dashboard">
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
     <script src="version.js"></script>
@@ -524,82 +524,82 @@
     ></script>
 
     <!-- Shared HTML/JS escaping helpers (issue #63) — must load before app.js -->
-    <script src="escape.js?v=1.1.90"></script>
+    <script src="escape.js?v=1.1.91"></script>
 
     <!-- Shared projection/scoring maths (issue #80) — must load before app.js -->
-    <script src="projection.js?v=1.1.90"></script>
+    <script src="projection.js?v=1.1.91"></script>
 
     <!-- Shared low-volume/liquidity helper (issue #576) — must load before
          app.js, which excludes flagged names from the portfolio (issue #577) -->
-    <script src="volume_recommend.js?v=1.1.90"></script>
+    <script src="volume_recommend.js?v=1.1.91"></script>
 
     <!-- Per-device mobile chart-window choice (90/180) persistence (issue #447) -->
-    <script src="chart_window_settings.js?v=1.1.90"></script>
+    <script src="chart_window_settings.js?v=1.1.91"></script>
 
     <!-- Shared min-star filter persistence + change event (issue #654) — before
          app.js, which wires the #starFilterSelect control via GRQStarFilter. -->
-    <script src="star_filter_settings.js?v=1.1.90"></script>
+    <script src="star_filter_settings.js?v=1.1.91"></script>
 
     <!-- Mobile colour-key entry builder (issue #244) — must load before app.js -->
-    <script src="color_key.js?v=1.1.90"></script>
+    <script src="color_key.js?v=1.1.91"></script>
 
     <!-- Market series title↔line colour pairing (issue #278) — before app.js -->
-    <script src="series_label_colour.js?v=1.1.90"></script>
+    <script src="series_label_colour.js?v=1.1.91"></script>
 
     <!-- AA-compliant themed colours for canvas chart text (issue #497) — before app.js -->
-    <script src="chart_theme.js?v=1.1.90"></script>
+    <script src="chart_theme.js?v=1.1.91"></script>
 
     <!-- Performance-chart heading text (issue #519) — before app.js -->
-    <script src="chart_title.js?v=1.1.90"></script>
+    <script src="chart_title.js?v=1.1.91"></script>
 
     <!-- Shared number-formatting helpers (issue #276) — must load before app.js -->
-    <script src="format.js?v=1.1.90"></script>
+    <script src="format.js?v=1.1.91"></script>
 
     <!-- Benchmark-index data extraction (issue #279) — must load before app.js -->
-    <script src="market_index.js?v=1.1.90"></script>
+    <script src="market_index.js?v=1.1.91"></script>
 
     <!-- Stock deep-link (?stock=) selection helpers (issue #281) — before app.js -->
-    <script src="stock_selection.js?v=1.1.90"></script>
+    <script src="stock_selection.js?v=1.1.91"></script>
 
     <!-- Yahoo Finance quote-link helper (issue #570) — before app.js -->
-    <script src="yahoo_finance.js?v=1.1.90"></script>
+    <script src="yahoo_finance.js?v=1.1.91"></script>
 
     <!-- Date deep-link (?date=) selection helpers (issue #436) — before app.js -->
-    <script src="date_selection.js?v=1.1.90"></script>
+    <script src="date_selection.js?v=1.1.91"></script>
 
     <!-- View deep-link (?view=portfolio|trend) selection helpers (issue #479) —
          before app.js, which routes ?view=trend to trend.html on load. -->
-    <script src="view_selection.js?v=1.1.90"></script>
+    <script src="view_selection.js?v=1.1.91"></script>
 
     <!-- Consolidated popover dismissal logic (issue #371) — before app.js -->
-    <script src="popover_dismiss.js?v=1.1.90"></script>
+    <script src="popover_dismiss.js?v=1.1.91"></script>
 
     <!-- Popover cleanup helpers (GRQPopovers, issue #370) — before app.js,
          which calls globalThis.GRQPopovers.clearAllPopovers() on every
          re-render. Without this the dashboard throws and never renders. -->
-    <script src="popover_cleanup.js?v=1.1.90"></script>
+    <script src="popover_cleanup.js?v=1.1.91"></script>
 
     <!-- Mobile chart pop-out overlay engine (issue #451) — before app.js,
          which wires it to the live chart via globalThis.GRQChartPopout. -->
-    <script src="chart_popout.js?v=1.1.90"></script>
+    <script src="chart_popout.js?v=1.1.91"></script>
 
     <!-- Footer "Share" deep-link builder (issue #495) — before app.js, which
          wires the footer button to the live selections via globalThis.GRQShare. -->
-    <script src="share_link.js?v=1.1.90"></script>
+    <script src="share_link.js?v=1.1.91"></script>
 
     <!-- "Show working" popover field labels (issue #542) — before app.js, which
          reads globalThis.GRQFieldLabel to render the working header. -->
-    <script src="field_label.js?v=1.1.90"></script>
+    <script src="field_label.js?v=1.1.91"></script>
 
     <!-- Stars popover freshness text (issue #550) — before app.js, which reads
          globalThis.GRQFreshness to append the analysis date + age. -->
-    <script src="freshness_text.js?v=1.1.90"></script>
+    <script src="freshness_text.js?v=1.1.91"></script>
 
     <!-- Dashboard bootstrap: loads app.js + debug info (CSP-safe, issue #189) -->
-    <script src="dashboard_boot.js?v=1.1.90"></script>
+    <script src="dashboard_boot.js?v=1.1.91"></script>
 
     <!-- Service Worker Registration (issue #224) — external file so the
          strict CSP can forbid 'unsafe-inline' on script-src. -->
-    <script src="sw-register.js?v=1.1.90"></script>
+    <script src="sw-register.js?v=1.1.91"></script>
   </body>
 </html>

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -18,7 +18,7 @@
   }
 
   window.addEventListener("load", () => {
-    navigator.serviceWorker.register("./sw.js?v=1.1.90")
+    navigator.serviceWorker.register("./sw.js?v=1.1.91")
       .then((registration) => {
         console.log("SW registered: ", registration);
 

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -6,7 +6,7 @@
 // app version or the SRI-pinned CDN assets below change so the service worker
 // re-fetches and re-validates everything.
 
-const APP_VERSION = "1.1.90";
+const APP_VERSION = "1.1.91";
 const CACHE_NAME = `grq-validation-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `grq-validation-static-v${APP_VERSION}`;
 const DYNAMIC_CACHE_NAME = `grq-validation-dynamic-v${APP_VERSION}`;

--- a/docs/trend.html
+++ b/docs/trend.html
@@ -26,7 +26,7 @@
     <meta name="msapplication-TileColor" content="#667eea">
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="theme-color" content="#667eea">
-    <meta name="app-version" content="1.1.90">
+    <meta name="app-version" content="1.1.91">
     <meta name="app-title" content="GRQ Validation Trend">
 
     <!-- Version/title bootstrap (CSP-safe, issue #189) -->
@@ -239,12 +239,12 @@
 
     <!-- Shared canvas theme colours + live re-theming (issues #497, #708) —
          before trend.js, which re-themes the chart on a theme switch. -->
-    <script src="chart_theme.js?v=1.1.90"></script>
+    <script src="chart_theme.js?v=1.1.91"></script>
 
     <!-- Trend view controller (issue #430) -->
     <script src="trend.js"></script>
 
     <!-- Service Worker Registration (issue #224) -->
-    <script src="sw-register.js?v=1.1.90"></script>
+    <script src="sw-register.js?v=1.1.91"></script>
   </body>
 </html>


### PR DESCRIPTION
# Fix analysis-sync "Date is empty" WARN flood and silent success

## Summary

The `[WARN] Skipping <ticker> due to invalid Date '': Date is empty` flood in
`GRQ-3-scorer.log` does not originate in GRQ-validation — it comes from the
`analysis-sync` binary in **stSoftwareAU/GRQ-actual**, invoked by
`stSoftwareAU/GRQ` `worker/score_client.sh` with the primary
`GRQ-portfolio/best/.analysis.csv`. The fix was therefore made where the root
cause lives (per the cross-repo root-cause rule) and is documented here.
Closes #819.

### Root cause

`analysis-sync/src/csv_loader.rs` dropped every source row whose `Date` column
would not parse, logging one `warn!` per row, and returned the (empty) row set
as a normal success. `main.rs` then produced
`analysis-sync completed: 1 spreadsheet(s), total updated 0, appended 0` and
exited **0**. A feed with an entirely blank `Date` column — or a parser that
stopped recognising the column — was therefore indistinguishable from "nothing
needed updating". A second fail-loud violation sat alongside it: per-spreadsheet
sync errors were logged with `error!` and then swallowed, so a run in which
every target failed still exited 0.

Whether the blank dates are an upstream feed fault or a parser regression cannot
be determined from the log alone (the Analysis sheet is not reachable from this
run). The fix makes the next occurrence self-diagnosing and non-silent rather
than guessing between the two.

### Change (in stSoftwareAU/GRQ-actual, branch `fix/analysis-sync-fail-loud-819`)

- `csv_loader` returns a `SourceLoad` (usable rows, `data_rows`,
  `skipped_invalid_date`, sample stocks). Per-row detail moved to `debug!`; one
  `warn!` summarises the skipped count, the resolved `Date` column index, and
  sample tickers — hundreds of lines become one.
- New `source_health::assert_source_usable` exits non-zero **before any
  spreadsheet is touched** when the CSV has no data rows, or when every data row
  was skipped for an unparsable `Date`.
- `main::assert_all_targets_synced` makes a failed spreadsheet sync a non-zero
  exit instead of a logged-and-ignored error.
- A partially skipped feed still syncs — only a feed with nothing usable is a
  hard failure.
- `analysis-sync` version bumped 0.2.13 → 0.2.14; README documents the failure
  behaviour.

```mermaid
flowchart TD
    A[Load .analysis.csv] --> B{Any data rows?}
    B -- no --> F[Exit 1: empty feed]
    B -- yes --> C{Any row with a usable Date?}
    C -- no --> G["Exit 1: every row skipped<br/>(was: exit 0, updated 0)"]
    C -- yes --> D[Sync each target spreadsheet]
    D --> E{Any target failed?}
    E -- yes --> H["Exit 1: names failed spreadsheets<br/>(was: exit 0)"]
    E -- no --> I[Exit 0]
```

## Evidence

No web interface is involved — `analysis-sync` is a CLI. Evidence is the
released binary's behaviour on a CSV that reproduces the logged fault (three
rows, all with an empty `Date`):

```text
$ analysis-sync --spreadsheet-id demo --analysis-csv /tmp/empty-dates.csv
[WARN ] Skipped 3 of 3 row(s) in /tmp/empty-dates.csv: Date column (header index 1) did not parse; e.g. NYSE:USAC, NASDAQ:SWBI, NYSE:INN
Error: Source analysis CSV /tmp/empty-dates.csv yielded 0 usable rows out of 3 data row(s): every row was skipped for an unparsable Date (e.g. NYSE:USAC, NASDAQ:SWBI, NYSE:INN). Check whether the Analysis sheet's Date column is populated (feed fault) or has changed format (parser fault).
exit=1
```

Before the change the same input produced three `[WARN] Skipping …` lines,
`total updated 0`, and exit 0. A partially skipped feed still proceeds past the
gate (verified with a two-row CSV where one date parses).

`./quality.sh` in GRQ-actual passes cleanly (fmt, clippy `-D warnings`, check,
34 `analysis-sync` tests, doc build, release build).

## Test Plan

Added in `stSoftwareAU/GRQ-actual`:

- `csv_loader::tests::load_source_analysis_csv_counts_rows_skipped_for_empty_dates`
  — regression test reproducing the logged fault: three rows with blank dates
  yield zero usable rows, `data_rows == 3`, `skipped_invalid_date == 3`.
- `csv_loader::tests::load_source_analysis_csv_reports_zero_data_rows_for_header_only_csv`
- `source_health::tests::errors_when_every_data_row_was_skipped` — fails against
  the unfixed code, which returned success.
- `source_health::tests::errors_when_csv_has_no_data_rows`
- `source_health::tests::accepts_a_load_with_usable_rows` — a partial skip must
  not fail.
- `tests::assert_all_targets_synced_errors_and_names_failed_spreadsheets` and
  `tests::assert_all_targets_synced_is_ok_when_nothing_failed`.

Existing `analysis-sync` tests were updated only for the new `SourceLoad` return
type; none were removed or disabled.

## Remaining human step

This run could not open the pull request in `stSoftwareAU/GRQ-actual` — the
worker's write allowlist is limited to `stSoftwareAU/GRQ-validation`. The branch
`fix/analysis-sync-fail-loud-819` is **pushed** and ready; a human needs to open
and merge it against `Develop`, then redeploy the scorer host. See the
`needs-human` comment on #819.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msg0afqq-ca43f0`<!-- vibe-worker-issue-819 -->